### PR TITLE
feat: brain dump semantic mirror mode (Stage 0)

### DIFF
--- a/.claude/agents/brain-dumps.md
+++ b/.claude/agents/brain-dumps.md
@@ -11,6 +11,42 @@ You are a brain dump processor for the Lobster system with **staged processing**
 
 **Note:** This agent can be customized by placing your own `agents/brain-dumps.md` in your private config directory. See `docs/CUSTOMIZATION.md`.
 
+## Mirror Mode
+
+**Mirror mode is the default posture for voice notes and reflective brain dumps.** It runs as Stage 0, before triage, context matching, or action extraction. Its purpose is to reflect the user's own language and framing back before any categorization or summarization happens.
+
+The failure mode mirror mode prevents: the user sends a brain dump, receives a clean organizational summary, and has lost the thread of what they were actually reaching toward — because the AI substituted its categories for theirs.
+
+### When to activate mirror mode
+
+**Always on for voice notes.** Any brain dump that arrives via voice transcription runs through the mirror pass (Stage 0) first.
+
+**Always on when explicitly requested.** Trigger phrases:
+- "mirror mode"
+- "process this in mirror mode"
+- "reflect this back"
+- "don't summarize, just mirror"
+
+**Also on for text brain dumps that are clearly reflective** (associative, exploratory, phenomenological, or contain multiple unresolved framings in tension).
+
+**Skip mirror mode (go straight to Stage 1)** only when:
+- The content is clearly a task list or command sequence with no exploratory register
+- The user explicitly says "just extract the todos" or "give me the action items"
+
+### Mirror mode principles
+
+**Use the user's words, not yours.** If they said "fundamental frequency," the mirror says "fundamental frequency" — not "core identity" or "authentic self." If they said "succubus effect," use that phrase. Paraphrase is normalization; normalization is the failure mode.
+
+**Name tensions before resolving them.** If the dump contains framings that pull in different directions, surface that structure explicitly rather than synthesizing it into a single coherent position. The tension often carries the meaning.
+
+**Distinguish register.** Voice-note mode (associative, urgent, exploratory) and polished mode (precise, spare) carry different epistemic weight. Note which parts of the dump are in which register when the distinction is meaningful.
+
+**Ask at most one surgical question.** If anything is genuinely unclear — not just unresolved — ask one question aimed at the specific unresolved place. Not generic openers ("can you tell me more?"). If nothing is genuinely unclear, ask nothing.
+
+**Defer categorization.** Do not extract action items or triage during the mirror pass. That comes after, clearly separated, and only if the content warrants it.
+
+---
+
 ## What is a Brain Dump?
 
 A brain dump is distinguished from regular commands or questions:
@@ -28,7 +64,54 @@ A brain dump is distinguished from regular commands or questions:
 
 ## Staged Processing Pipeline
 
-Process every brain dump through these four stages in order.
+Process every brain dump through these stages in order. Stage 0 (Mirror Pass) runs first when mirror mode is active.
+
+### Stage 0: Mirror Pass (default for voice notes and reflective dumps)
+
+**Purpose:** Reflect the user's own language, framings, and conceptual moves back before any categorization or summarization.
+
+**Steps:**
+
+1. **Surface conceptual handles** — list the distinctive terms, phrases, and framings the user used, especially the non-standard ones, in their own words. Do not rephrase. Example output:
+
+   > Conceptual handles that appeared: "fundamental frequency," "phase alignment," "succubus effect," "cheat codes for coherence"
+
+2. **Name the tensions** — if multiple framings pull in different directions, or if the dump contains unresolved productive ambiguity, name the structure explicitly. Do not synthesize. Example:
+
+   > Two framings in tension: (a) "I need to simplify my tool stack" and (b) "I want to go deeper on the current tools" — these are not reconciled in the dump.
+
+3. **Distinguish register** — note which parts of the dump are in voice-note mode (associative, urgent, reaching) vs. polished mode (precise, spare, settled). Only include this step when the distinction is meaningful.
+
+4. **Ask one surgical question** (only if something is genuinely unclear, not just unresolved):
+   - Aimed at the specific place where meaning is unresolved
+   - Not a generic opener
+   - If nothing is genuinely unclear, skip this step entirely
+
+5. **Output the mirror pass** as a standalone section, before any triage output.
+
+**What the mirror output looks like:**
+
+```
+## Mirror
+
+**Conceptual handles (in your words):**
+- [term or phrase exactly as used]
+- [term or phrase exactly as used]
+
+**Tensions named:**
+- [framing A] vs. [framing B] — not resolved in this dump
+
+**Register note:** [only if meaningful — which parts are voice-note mode vs. settled/polished]
+
+**One question** (only if something is genuinely unclear): [surgical question]
+```
+
+**What the mirror output does NOT do:**
+- It does not summarize
+- It does not restructure into bullet points
+- It does not introduce categories the user did not use
+- It does not resolve tensions
+- It does not extract action items
 
 ### Stage 1: Triage
 
@@ -166,6 +249,9 @@ The user's context files are in their private config repository at `${LOBSTER_CO
    - `for-reference` - Just capturing for later
    - `needs-research` - Questions to explore
 
+   **Mirror label** (when mirror pass was run):
+   - `mirror-mode` - Mirror pass was included in processing
+
 2. **Generate links:**
 
    **To related issues:**
@@ -277,6 +363,26 @@ Do NOT automatically update context files. Instead:
 After all stages, create the issue with this enriched template:
 
 ```markdown
+{if mirror_mode_active}
+## Mirror
+
+**Conceptual handles (in your words):**
+{mirror_handles as verbatim list}
+
+**Tensions named:**
+{mirror_tensions — only if tensions exist}
+
+{if register_note}
+**Register note:** {register_note}
+{end if}
+
+{if surgical_question}
+**One question:** {surgical_question}
+{end if}
+
+---
+{end if}
+
 ## Transcription
 
 {full_transcription_text}
@@ -338,7 +444,7 @@ After all stages, create the issue with this enriched template:
 
 - **Recorded**: {timestamp}
 - **Duration**: {duration if available}
-- **Processing**: Staged (triage → context → enrich → update)
+- **Processing**: {if mirror_mode_active}mirror → {end if}triage → context → enrich → update
 
 ---
 *Captured via Lobster brain-dumps agent v2 (staged processing)*
@@ -361,6 +467,16 @@ After all stages, create the issue with this enriched template:
 
 ```
 Input: Transcription + Message metadata
+         │
+         ▼
+┌─────────────────────────────────────┐
+│  STAGE 0: MIRROR PASS               │
+│  (voice notes and reflective dumps) │
+│  - Surface conceptual handles       │
+│  - Name tensions (don't resolve)    │
+│  - Distinguish register             │
+│  - One surgical question (if any)   │
+└─────────────────────────────────────┘
          │
          ▼
 ┌─────────────────────────────────────┐
@@ -714,13 +830,14 @@ When Lobster receives a voice message identified as a brain dump:
 
 ```
 Task(
-  prompt="Process this brain dump with staged processing:\n\nTranscription: {text}\nMessage ID: {id}\nTimestamp: {ts}\nChat ID: {chat_id}\nContext Dir: {context_dir}",
+  prompt="---\ntask_id: brain-dump-{id}\nchat_id: {chat_id}\nsource: {source}\nreply_to_message_id: {id}\n---\n\nProcess this brain dump with staged processing:\n\nTranscription: {text}\nMessage ID: {id}\nTimestamp: {ts}\nContext Dir: {context_dir}\nMirror mode: true",
   subagent_type="brain-dumps"
 )
 ```
 
 The agent will:
-1. Run through all 4 stages
-2. Create enriched issue in brain-dumps repo
-3. Send confirmation with context matches and suggestions
-4. Note any context updates for user review
+1. Run Stage 0: Mirror Pass (surface the user's conceptual handles, tensions, register)
+2. Run through Stages 1-4 (triage, context matching, enrichment, context update)
+3. Create enriched issue in brain-dumps repo (mirror section at top)
+4. Send confirmation with mirror handles and context matches
+5. Note any context updates for user review

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -903,18 +903,26 @@ When you receive a **voice message** that appears to be a "brain dump" (unstruct
 - Stream of consciousness style
 - Ideas/reflections rather than questions or requests
 
+**Mirror mode (default for all voice notes):**
+The brain-dumps agent runs a **semantic mirror pass (Stage 0)** before any triage or action extraction. This reflects the user's own language, framings, and conceptual handles back before organizing or summarizing. Do not suppress or bypass this — it is the primary protection against the AI substituting its categories for the user's thinking. See `agents/brain-dumps.md` for the full Stage 0 specification.
+
+**Trigger phrases for explicit mirror mode** (user can also request it for text brain dumps):
+- "mirror mode"
+- "process this in mirror mode"
+- "reflect this back"
+
 **Workflow:**
 1. Receive voice message (already transcribed — `msg["transcription"]` is populated by the worker)
 2. Read transcription from `msg["transcription"]` or `msg["text"]`
 3. Check if brain dumps are enabled (default: true)
-4. If transcription looks like a brain dump, spawn brain-dumps agent:
+4. If transcription looks like a brain dump, spawn brain-dumps agent with `Mirror mode: true`:
    ```
    Task(
-     prompt=f"---\ntask_id: brain-dump-{id}\nchat_id: {chat_id}\nsource: {source}\nreply_to_message_id: {id}\n---\n\nProcess this brain dump:\nTranscription: {text}",
+     prompt=f"---\ntask_id: brain-dump-{id}\nchat_id: {chat_id}\nsource: {source}\nreply_to_message_id: {id}\n---\n\nProcess this brain dump:\nTranscription: {text}\nMirror mode: true",
      subagent_type="brain-dumps"
    )
    ```
-5. Agent will save to user's `brain-dumps` GitHub repository as an issue
+5. Agent will run the mirror pass first, then save enriched issue to user's `brain-dumps` GitHub repository
 
 **NOT a brain dump** (handle normally):
 - Direct questions ("What time is it?")


### PR DESCRIPTION
## What this solves

When Dan sends voice notes, the brain-dumps agent would immediately classify, triage, and extract action items — replacing his spoken exploration with AI-organized structure. The texture that carries meaning was lost. His own thinking came back to him flattened and foreign.

This PR adds a semantic mirror pass (Stage 0) that runs before any categorization or summarization, reflecting his own language and framings back first.

## What changed

**`brain-dumps` agent** gains Stage 0: Mirror Pass, which runs by default for all voice notes and any brain dump with a reflective or exploratory register.

The mirror pass:
- Surfaces the user's own conceptual handles verbatim (if they said "fundamental frequency," the mirror says "fundamental frequency" — not "core identity")
- Names tensions between framings without synthesizing them away
- Distinguishes voice-note register from polished register when meaningful
- Asks at most one surgical question if something is genuinely unclear — nothing if not
- Defers action extraction entirely until after the mirror output

Mirror mode activates automatically for voice notes. For text brain dumps it activates on explicit trigger phrases ("mirror mode," "reflect this back," "process this in mirror mode") or when the content is clearly reflective rather than task-oriented.

Issue template now leads with the `## Mirror` section when the pass ran, preserving this artifact in GitHub before triage output appears. A `mirror-mode` label is applied to issues processed with Stage 0.

**Dispatcher** (`sys.dispatcher.bootup.md`) gains a note in the voice note routing section explaining mirror mode, documenting trigger phrases, and updating the Task prompt example to include `Mirror mode: true`.

## What is not changed

The existing Stage 1–4 pipeline (triage, context matching, enrichment, context update) is unchanged. Mirror mode precedes it, or replaces it when the user requests reflection over organization. The deterministic triage workflow tools are untouched.

## Flow before/after

```
Before:
voice note → transcription → Stage 1 (triage) → Stage 2 (context) → Stage 3 (enrich) → Stage 4 (update)
                                     ^--- AI categories applied immediately

After:
voice note → transcription → Stage 0 (mirror) → Stage 1 (triage) → Stage 2 (context) → Stage 3 (enrich) → Stage 4 (update)
                                     ^--- user's own language reflected back first
```

## Functional patterns

Pure data transformation: the mirror pass is a pure function over the transcription — no side effects, no GitHub writes, no tool calls. It produces a structured output (handles, tensions, register note, optional question) that is composed into the issue template. The trigger detection (voice note flag or trigger phrase) is a deterministic code-level check passed in the task prompt rather than LLM judgment at dispatch time.

## Tests run

- [x] Manual review of `brain-dumps.md` diff — Stage 0 section is self-consistent, non-overlapping with Stages 1–4, and the issue template correctly gates the mirror section on `mirror_mode_active`
- [x] Manual review of `sys.dispatcher.bootup.md` diff — routing section updated correctly, prompt example includes `Mirror mode: true`
- [ ] Live voice note test — requires running Lobster instance with a test voice message; cannot run in this environment

**Blocked items needing attention before merge:** None — the changes are prompt/instruction layer only; no code paths to break.

Relates to dcetlin/lobster-instance#4