### PR TITLE
docs: add table-row gate to epistemic hooks

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -142,6 +142,8 @@ When wait_for_messages() returns a subagent_result/subagent_error:
 
 Named steps at fixed positions in the message loop. Each has a specific trigger — skip outside it.
 
+**Before adding a row:** State the verifiable difference in one sentence. If you cannot, the step is not yet specified — do not add it.
+
 | Hook | Trigger | Action | Verifiable difference |
 |------|---------|--------|----------------------|
 | **Pre-routing pass** | Any message routable to a subagent | Before composing task prompt: (1) what is literally in this message? (2) what is it pointing toward? (3) is the design question settled — can you state the output in one sentence? If not: Design Gate fires — ask one question before spawning. | Exploratory/design-phase messages caught before subagent spawned |


### PR DESCRIPTION
## What this solves

The epistemic hooks table can currently be extended without the author having stated what verifiable behavior change the new row produces. The oracle catches underspecified rows at review time — but it cannot catch what is never submitted. This is the addition-time gap.

## What changed

A single constraint line added immediately before the hooks table:

> **Before adding a row:** State the verifiable difference in one sentence. If you cannot, the step is not yet specified — do not add it.

The design intent from issue #23: the constraint uses the same format language as the table it governs — the gate eats its own format rather than sitting in a separate prose section.

## Verifiable behavioral difference

Without this gate: a dispatcher step can be added to the table with a vague or absent "Verifiable difference" column and reach review. With the gate: the author must articulate the behavioral difference at the moment of addition. Steps that cannot be specified in one sentence are blocked before they enter the table.

## What is out of scope

This does not add any code. It does not change existing hook behavior. It does not modify any hook rows. It is purely an addition-time structural constraint on future table authorship.

## Functional patterns

Pure structural constraint via the format itself — no procedural logic. The gate is declarative and collocated with what it governs.

## Tests run

- [x] Manual review of rendered table — gate sentence reads correctly, table structure intact
- [ ] No automated tests exist for bootup doc content

Relates to dcetlin/lobster-instance#23 (table-row gate deliverable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)