### PR TITLE
fix: surface upstream-sync hard failures to observations.log + restore meta-thread embedding

### DIFF
--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -79,8 +79,32 @@ log() {
 
 die() {
     log ERROR "$1"
+    write_observations_error "$1"
     cleanup_lock
     exit "${2:-2}"
+}
+
+# ---------------------------------------------------------------------------
+# observations.log writer — surfaces system_error to the dispatcher
+#
+# Mirrors the format written by inbox_server.py's write_observation handler
+# so the dispatcher can surface upstream-sync failures in the same way as
+# other system errors (e.g. transcription worker failures).
+# ---------------------------------------------------------------------------
+
+write_observations_error() {
+    local msg="$1"
+    local obs_log="$WORKSPACE_DIR/logs/observations.log"
+    local ts
+    ts=$(python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat())')
+
+    local json_msg
+    json_msg=$(printf '%s' "upstream-sync failure: $msg" \
+        | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+
+    mkdir -p "$(dirname "$obs_log")"
+    printf '{"ts":"%s","category":"system_error","content":%s,"source":"upstream-sync","task_id":"upstream-sync"}\n' \
+        "$ts" "$json_msg" >> "$obs_log"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

Two of the three wave-1 silent failures identified in the structural audit. The third (Fix 3) is a design gap opened as issue #14.

### Fix 1 — Upstream-sync hard failures were invisible to the dispatcher

Before this PR, if `sync-upstream.sh` hit a hard error (failed `git fetch`, failed push after clean merge), it exited with code 2 and logged to `upstream-sync.log` only. The dispatcher never reads that file. The failure was completely silent from the user's perspective.

The conflict path (exit code 1) already writes directly to the inbox — this was not the problem. The problem was the general error path (`die()`) had no alerting mechanism.

After this PR: `die()` calls `write_observations_error()`, which appends a `system_error` entry to `~/lobster-workspace/logs/observations.log` in the same JSON format as `inbox_server.py`'s `write_observation` handler. The dispatcher reads this file during self-checks and surfaces system errors.

### Fix 2 — epistemic-principles meta-thread had empty inquiry_embedding

The `epistemic-principles` meta-thread was created with `inquiry_embedding: []`. Because `search()` in `meta_threads.py` skips threads with empty or wrong-dimension embeddings, this thread could never match any incoming message — it was structurally invisible to the dispatcher's context injection loop.

Fix: ran `uv run scripts/meta_threads.py update epistemic-principles --question "..."` to regenerate the 384-dim embedding from the thread's open question. Verified the thread now has `len(inquiry_embedding) == 384`. This is a runtime data file — not committed to the repo, applied directly to the live instance.

### Fix 3 — Design gap (not in this PR)

The proprioceptive calibration system has no dispatcher-side trigger wiring for live sessions. The write tool exists; the read path exists; the dispatcher never calls the write tool. Opened as issue #14 with specific design questions for Dan.

## Functional patterns

The `write_observations_error` function is pure in structure: takes a message string, derives the timestamp independently, produces a single side-effecting write to an append-only log. No mutation of existing state. `die()` composes it as a step before `cleanup_lock`.

## Tests run

- [x] Manual test of `write_observations_error` logic in a subshell — JSON output format matches existing observations.log entries exactly
- [x] `bash -n scripts/sync-upstream.sh` — syntax check passes
- [x] Verified `meta_threads.py update` regenerated 384-dim embedding for epistemic-principles thread
- [ ] End-to-end test of sync failure path — skipped: would require breaking git auth; safe to merge, change only appends to observations.log on error path

## Areas to review

- `write_observations_error` is defined after `die()` in the script. Valid bash (functions registered before `main()` runs), but worth a second look.
- The observations.log format uses `"content"` key matching the first JSON format in the existing log. A second format uses `"text"`. If there is a canonical reader, confirm it handles both keys.

Closes part of the wave-1 audit. Fix 3 depends on design decision in #14.