### PR TITLE
philosophy: add philosophy/ directory for explore job outputs

### DIFF
--- a/philosophy/README.md
+++ b/philosophy/README.md
@@ -1,0 +1,22 @@
+# Philosophy Explore
+
+This directory holds outputs from Lobster's `philosophy-explore` scheduled job, which runs every 4 hours.
+
+Each file is a short reflection written by a Lobster subagent after reading Dan's current philosophical and design context. The format is designed for reading on a phone — flowing prose, not technical notes.
+
+## Format
+
+Each file follows four sections:
+
+- **Today's Thread** — the specific philosophical or design thread being explored
+- **Pattern Observed** — recurring structure or echo across prior thinking
+- **Question Raised** — a generative, productive question the thread opens
+- **Resonance with Dan's Framework** — connection to phase alignment, poiesis, semantic mirroring, cybernetic self-extension, ergonomics over shortcuts
+
+## Naming
+
+`YYYY-MM-DD-HH00-philosophy-explore.md`
+
+## Notification
+
+After each run, Dan receives a Telegram message with a 2-sentence summary and a link to the file.


### PR DESCRIPTION
## Summary

- Adds `philosophy/` subdirectory to hold outputs from the `philosophy-explore` scheduled job
- Includes README explaining the file format, naming convention (YYYY-MM-DD-HH00-philosophy-explore.md), and Telegram notification pattern
- The job now runs every 4 hours (consolidated from 3 separate daily jobs)

## Context

Part of the philosophy-explore job redesign: outputs are now committed here as readable .md files rather than sent only via Telegram summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)