### PR TITLE
fix: raise COMPACTION_SUPPRESS_SECONDS from 300 to 420 (issue #694)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -78,7 +78,7 @@ RESTART_WINDOW_BUFFER_SECONDS=120    # Pre-mark messages within this window of t
 
 MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - stale maintenance flag is auto-cleared and checks resume
 
-COMPACTION_SUPPRESS_SECONDS=300      # 5 minutes - skip stale-inbox check after a compaction event
+COMPACTION_SUPPRESS_SECONDS=420      # 7 minutes - skip stale-inbox check after a compaction event (covers worst-case post-compaction chain of 3-4 subagent results)
 CATCHUP_SUPPRESS_SECONDS=900         # 15 minutes - skip WFM freshness check while catchup subagent is running
 RESTART_COOLDOWN_SUPPRESS_SECONDS=240 # 4 minutes - suppress stale-inbox RED after a recent restart
 

--- a/tests/smoke/test_health_check.py
+++ b/tests/smoke/test_health_check.py
@@ -48,8 +48,8 @@ import pytest
 HEALTH_SCRIPT = Path(__file__).parents[2] / "scripts" / "health-check-v3.sh"
 
 # How long the script suppresses stale-inbox checks after a compaction.
-# Must match COMPACTION_SUPPRESS_SECONDS in health-check-v3.sh (300).
-COMPACTION_SUPPRESS_SECONDS = 300
+# Must match COMPACTION_SUPPRESS_SECONDS in health-check-v3.sh (420).
+COMPACTION_SUPPRESS_SECONDS = 420
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test-health-check-boot-grace.sh
+++ b/tests/test-health-check-boot-grace.sh
@@ -104,7 +104,7 @@ source_health_check_functions() {
     # Assign directly from test paths rather than re-evaluating the config block,
     # so that overrides are always in effect regardless of script structure.
     BOOT_GRACE_SECONDS=90
-    COMPACTION_SUPPRESS_SECONDS=300
+    COMPACTION_SUPPRESS_SECONDS=420
     LOBSTER_STATE_FILE="${LOBSTER_STATE_FILE_OVERRIDE:-$TEST_STATE_FILE}"
     LOG_FILE="$TEST_LOG"
 


### PR DESCRIPTION
## Summary

Implements fix from SiderealPress/lobster#694.

Post-compaction processing chains of 3-4 subagent results can exceed the previous 5-minute window, causing false-positive health check restarts.

- `scripts/health-check-v3.sh`: COMPACTION_SUPPRESS_SECONDS 300 → 420
- `tests/smoke/test_health_check.py`: mirror constant updated
- `tests/test-health-check-boot-grace.sh`: mirror constant updated

Raises the window from 5 minutes to 7 minutes to cover realistic worst-case post-compaction chains.

Closes SiderealPress/lobster#694