### PR TITLE
fix: use USER_FACING_TYPES in claim_and_ack to prevent spurious observations (issue #660)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4122,13 +4122,14 @@ async def handle_claim_and_ack(args: dict) -> list[TextContent]:
     except Exception:
         pass  # non-fatal; stale recovery falls back to mtime
 
-    # Queue background observation (non-blocking, best-effort)
+    # Queue background observation (non-blocking, best-effort).
+    # Only queue for user-facing message types — system-generated types
+    # (cron_reminder, consolidation, subagent_result, etc.) must not
+    # feed the user model. Use USER_FACING_TYPES as the single source of
+    # truth (issue #660).
     msg_text = msg_data.get("text", "") or msg_data.get("transcription", "")
     msg_type = msg_data.get("type", "")
-    _SKIP_OBSERVATION_TYPES = (
-        "subagent_result", "subagent_error", "self_check", "subagent_observation"
-    )
-    if msg_text and msg_type not in _SKIP_OBSERVATION_TYPES:
+    if msg_text and msg_type in USER_FACING_TYPES:
         _queue_observation(
             msg_text, message_id,
             source=msg_data.get("source"),


### PR DESCRIPTION
## Summary

Implements fix from SiderealPress/lobster#660.

The `_SKIP_OBSERVATION_TYPES` blocklist in `claim_and_ack` was incomplete — system-generated types like `cron_reminder`, `consolidation`, `subagent_notification`, etc. could still feed the user model, contaminating tier-1 signal extraction.

**Change:** Replace the local 4-item blocklist with `USER_FACING_TYPES` (already imported, already used by `mark_processing` for the same purpose). Only user-facing types (text, voice, photo, callback, reaction, etc.) now trigger observation queuing.

**Files changed:**
- `src/mcp/inbox_server.py`: `claim_and_ack` observation gate now uses `USER_FACING_TYPES` (positive allowlist) instead of `_SKIP_OBSERVATION_TYPES` (incomplete blocklist)

This brings `claim_and_ack` in line with `mark_processing`, which already uses `USER_FACING_TYPES`.

Closes SiderealPress/lobster#660