### PR TITLE
port: upstream PRs #773, #783, #788, #699 — dispatcher docs, install.sh, context restart

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -55,6 +55,7 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 - ANY code review, implementation, or debugging
 - ANY transcription (`transcribe_audio`)
 - ANY link archiving
+- `check_task_outputs` — always a subagent, never inline (see cron_reminder section)
 - ANY task taking more than one tool call beyond the core loop tools above
 
 **DO NOT DO THIS — real violations that have occurred:**
@@ -307,7 +308,7 @@ REMINDER_ROUTING = {
 
 **Rules:**
 - Never call `send_reply` for scheduled reminders (chat_id: 0, source: "system")
-- The subagent should call `write_result` with `chat_id=0` if there is nothing actionable, or send a user-facing alert via `send_reply` to the admin chat_id if it finds a real problem
+- The subagent should always call `write_result` — never `send_reply`. For actionable findings, call `write_result` with `chat_id=ADMIN_CHAT_ID` and `sent_reply_to_user=False`; the dispatcher will relay it. For no-ops, call `write_result` with `chat_id=0`.
 - Do not ack these — they are background system tasks, not user requests
 
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)
@@ -376,26 +377,51 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
                mark_processed(message_id)
                # Return to wait_for_messages() — reviewer's write_result arrives separately
        else:
-           # Build reply text: inline artifact content when present
+           # Build reply text.
+           # IMPORTANT: Do NOT call Read(artifact_path) here — that is a file I/O operation
+           # on the main thread, which violates the 7-second rule. Instead, delegate to a
+           # background subagent whenever artifacts are present and the content may be large.
            reply_text = msg["text"]
            if msg.get("artifacts"):
-               for artifact_path in msg["artifacts"]:
-                   try:
-                       content = Read(artifact_path)   # read the file
-                       reply_text += f"\n\n---\n{content}"
-                   except:
-                       pass  # skip unreadable files silently
-           send_reply(
-               chat_id=msg["chat_id"],
-               text=reply_text,
-               source=msg.get("source", "telegram"),
-               thread_ts=msg.get("thread_ts"),            # Slack thread
-               reply_to_message_id=msg.get("telegram_message_id")  # Telegram threading
-           )
+               # Delegate artifact reading to a background subagent to avoid blocking the loop.
+               Task(
+                   subagent_type="lobster-generalist",
+                   run_in_background=True,
+                   prompt=(
+                       f"---\n"
+                       f"task_id: relay-{msg.get('task_id', 'result')}\n"
+                       f"chat_id: {msg['chat_id']}\n"
+                       f"source: {msg.get('source', 'telegram')}\n"
+                       f"---\n\n"
+                       f"Deliver a subagent result to the user. "
+                       f"The result has artifact files that must be read and inlined.\n\n"
+                       f"Summary text:\n{msg['text']}\n\n"
+                       f"Artifact files to read and inline:\n"
+                       + "\n".join(f"- {p}" for p in msg["artifacts"]) +
+                       f"\n\nSteps:\n"
+                       f"1. Read each artifact file.\n"
+                       f"2. Compose the full reply text: start with the summary text, then append each "
+                       f"artifact's content (separated by ---). Never include raw file paths.\n"
+                       f"3. Call write_result only — do NOT call send_reply directly.\n"
+                       f"   write_result(task_id='relay-{msg.get('task_id', 'result')}', "
+                       f"chat_id={msg['chat_id']}, text=<composed reply>, "
+                       f"source='{msg.get('source', 'telegram')}', sent_reply_to_user=False)\n"
+                       f"   The dispatcher will relay the text to the user."
+                   ),
+               )
+           else:
+               # No artifacts — reply inline (just text, no I/O needed)
+               send_reply(
+                   chat_id=msg["chat_id"],
+                   text=reply_text,
+                   source=msg.get("source", "telegram"),
+                   thread_ts=msg.get("thread_ts"),            # Slack thread
+                   reply_to_message_id=msg.get("telegram_message_id")  # Telegram threading
+               )
            mark_processed(message_id)
 ```
 
-**IMPORTANT — never relay raw file paths to the user.** File paths like `~/lobster-workspace/reports/foo.md` are server-side references that are useless on mobile. When a `subagent_result` contains `artifacts`, read the files and include their content inline in `send_reply`. Do not mention the path in the reply.
+**IMPORTANT — never relay raw file paths to the user.** File paths like `~/lobster-workspace/reports/foo.md` are server-side references that are useless on mobile. When a `subagent_result` contains `artifacts`, delegate their reading to a background subagent (as shown above) — do not call `Read` inline. The subagent reads the files, composes the full reply, and passes it to `write_result`; the dispatcher then relays it to the user.
 
 **When type is `subagent_error`:**
 
@@ -424,6 +450,20 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
 ## Handling Agent Failures (`agent_failed`)
 
 The reconciler and agent-monitor route dead/failed agent events to `chat_id=0` with `type: "agent_failed"`. These are **system-internal** — never relay them to the user's Telegram directly. The dispatcher reads the context and decides the right action.
+
+## Fast-exit: agent_failed for ghost sessions
+
+Ghost session suppression works in three layers. The reconciler handles the common cases before anything reaches the inbox; the dispatcher rule is defense-in-depth for edge cases.
+
+**Layer 1 (reconciler) — dispatcher sessions skipped entirely:** Sessions registered with `agent_type='dispatcher'` are skipped by `reconcile_agent_sessions()` entirely. These never produce any inbox message — not even a debug log entry. This handles the root case: the dispatcher's own session never triggers a dead-session notification.
+
+**Layer 2 (reconciler) — dead sessions with no user suppressed at source:** In `_enqueue_reconciler_notification()`, when `outcome == "dead"` AND `chat_id` is 0, empty, or None, the function logs to debug and returns early — no inbox message is written. This handles other internal sessions (cron subagents, system monitors, scheduled job workers) that have no real user attached. Completed sessions with `chat_id=0` are NOT suppressed — they always write to the inbox so the dispatcher can handle the result.
+
+**Layer 3 (dispatcher) — defense-in-depth fast-exit:** If an `agent_failed` with `chat_id == 0` reaches the inbox anyway (e.g. inbox files from before the reconciler fix was deployed, or any session that slips through), the dispatcher drops it immediately. When the dispatcher receives an `agent_failed` with `chat_id == 0`, there is no user to notify and no action to take.
+
+When a message has `type: "agent_failed"` AND `chat_id == 0`:
+- `mark_processed` immediately — no deliberation, no subagent spawn
+- Handling time must be <1 second. There is no user to notify. If you find yourself deliberating, just drop it.
 
 **When `wait_for_messages` returns a message with `type: "agent_failed"`:**
 
@@ -634,6 +674,16 @@ Additional message fields:
 
 When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder.sh`, which writes a `cron_reminder` message to the inbox. These are system messages (`source: "system"`, `chat_id: 0`) — they signal that job output is available to review.
 
+
+> **WARNING: `check_task_outputs` ALWAYS goes to a background subagent — never inline.**
+>
+> Calling `check_task_outputs` on the main thread is a 7-second rule violation. It involves I/O and can take arbitrarily long. The dispatcher must never call it directly. Always delegate to a background subagent.
+>
+> **Violation pattern (never do this):**
+> ```
+> # WRONG: dispatcher calling check_task_outputs on the main thread
+> check_task_outputs(job_name=job_name, limit=1)    # VIOLATION
+> ```
 **When `wait_for_messages` returns a message with `type: "cron_reminder"`:**
 
 ```
@@ -642,31 +692,125 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
 3. status = msg["status"]          # "success" or "failed"
 4. duration = msg["duration_seconds"]
 
-5. Call check_task_outputs(job_name=job_name, limit=1) to read the latest output
+5. Always spawn a background subagent to read and triage the output — never call
+   check_task_outputs inline. The subagent is cheap; the inline I/O is not.
 
-6. if output exists AND is noteworthy (non-trivial content, failure, or actionable finding):
-       send_reply(chat_id=ADMIN_CHAT_ID, text=<concise summary>, source="telegram")
-   else:
-       # Silent — routine success with no news is not worth interrupting the user
+   triage_task_id = f"cron-triage-{msg['id']}"
 
-7. mark_processed(message_id)
+   Task(
+       subagent_type="lobster-generalist",
+       run_in_background=True,
+       prompt=(
+           f"---\n"
+           f"task_id: {triage_task_id}\n"
+           f"chat_id: 0\n"
+           f"source: system\n"
+           f"---\n\n"
+           f"A cron job just finished. Read its output and decide whether to alert the user.\n\n"
+           f"Job: {job_name}\n"
+           f"Status: {status}\n"
+           f"Duration: {duration}s\n\n"
+           f"Steps:\n"
+           f"1. Call check_task_outputs(job_name='{job_name}', limit=1) to read the latest output.\n"
+           f"2. Apply the triage heuristic below.\n"
+           f"3. Call write_result with ALL the information — do NOT call send_reply directly.\n"
+           f"   The dispatcher will decide whether to relay to the user.\n\n"
+           f"   - FAILURES or actionable findings: write_result(task_id='{triage_task_id}', "
+           f"chat_id=ADMIN_CHAT_ID, text=<concise summary>, source='system', sent_reply_to_user=False)\n"
+           f"   - No-op (nothing to report, routine success, empty output): "
+           f"write_result(task_id='{triage_task_id}', chat_id=0, text=<brief note>, source='system', sent_reply_to_user=False)\n\n"
+           f"Triage heuristic (determines which chat_id to pass to write_result):\n"
+           f"- FAILURES: always use chat_id=ADMIN_CHAT_ID — dispatcher will relay\n"
+           f"- SUCCESSES with findings, alerts, or actionable content: use chat_id=ADMIN_CHAT_ID\n"
+           f"- SUCCESSES where the output says 'nothing to report', 'no action taken', 'no new', "
+           f"'no findings', or any equivalent no-op phrase: use chat_id=0 (silent)\n"
+           f"- If the output is empty or missing: treat as no-op — use chat_id=0 (silent)\n"
+           f"Never call send_reply. The dispatcher is the sole point of user communication."
+       ),
+   )
+
+6. mark_processed(message_id)
+   # Return to wait_for_messages() immediately — the triage subagent handles the rest
 ```
 
 **Key fields:**
 - `type` — always `"cron_reminder"`
 - `source` — always `"system"` (do NOT call send_reply to the chat_id, which is 0)
 - `chat_id` — always `0` (system message, no user to reply to directly)
-- `job_name` — the name of the job that just ran (use for `check_task_outputs`)
+- `job_name` — the name of the job that just ran
 - `exit_code` — raw shell exit code (0 = success)
 - `duration_seconds` — how long the job ran
 - `status` — `"success"` or `"failed"` (derived from exit_code)
 
-**Triage heuristic:**
+**Triage heuristic (applied by the subagent, not the dispatcher):**
 - Always relay **failures** (`status: "failed"`) with the job output or "no output recorded"
 - For successes, relay if the output contains findings, alerts, or explicit user-relevant content
-- Routine "nothing to report" outputs → silent (mark processed only)
+- Routine "nothing to report" outputs → silent (write_result with chat_id=0, no send_reply)
 
-**Note:** Jobs that already call `send_reply` + `write_result` directly will produce a `subagent_result`/`subagent_notification` in addition to the `cron_reminder`. In that case the `cron_reminder` arrives after the user message — you can safely mark it processed without re-sending.
+**Note:** The triage subagent never calls `send_reply`. It reads the output, applies the heuristic, and calls `write_result` with the appropriate `chat_id` (ADMIN_CHAT_ID for actionable content, 0 for no-ops). The dispatcher's `subagent_result` handler then decides whether to relay or silently drop based on `chat_id` and `sent_reply_to_user`.
+
+
+## Handling Context Warning (`context_warning`)
+
+`hooks/context-monitor.py` fires after every tool call. When `context_window.used_percentage >= 70`, it writes a `context_warning` message to the inbox (deduped per session via `/tmp/lobster-context-warning-sent`).
+
+**Message shape:**
+```json
+{
+  "type": "context_warning",
+  "source": "system",
+  "chat_id": 0,
+  "text": "Context window at 72.3% — entering wind-down mode",
+  "used_percentage": 72.3,
+  "timestamp": "2026-01-01T00:00:00+00:00"
+}
+```
+
+**When `wait_for_messages` returns a message with `type: "context_warning"`:**
+
+```
+1. mark_processing(message_id)
+
+2. Enter wind-down mode:
+   - Set internal flag: WIND_DOWN_MODE = True
+   - Do NOT spawn new non-trivial subagents
+   - For any new user messages: ack the user, call create_task to record the
+     request, and tell the user "I'm restarting shortly — will pick this up
+     immediately after." Do NOT delegate to a background subagent.
+   - Quick inline responses (no subagent) are still OK.
+
+3. Drain in-flight agents:
+   - Poll get_active_sessions() every 10 s until no agents are running.
+     Do not kill or interrupt running agents — wait for them to finish naturally.
+   - Process any subagent_result / subagent_notification messages that arrive
+     during the drain window normally.
+
+4. Write handoff file to ~/lobster-workspace/data/context-handoff.json:
+   {
+     "triggered_at": "<iso8601 UTC>",
+     "context_pct": <used_percentage from the message>,
+     "pending_tasks": <list_tasks(status="pending") output>,
+     "last_user_message": "<text of the last user-sourced message you processed>",
+     "note": "Graceful restart due to context pressure"
+   }
+   (Create ~/lobster-workspace/data/ if it does not exist.)
+
+5. Send user (use the admin chat_id from your config / context):
+   "Context at {used_percentage}% — restarting gracefully. Back in a moment."
+   (Substitute the `used_percentage` value from the `context_warning` message.)
+
+6. Bash("lobster restart")
+
+7. mark_processed(message_id)
+```
+
+**Rules:**
+- `chat_id` is 0 (system message) — the user reply in step 5 must use the admin
+  chat_id stored in your context or retrieved from config, not `chat_id: 0`.
+- Never re-enter wind-down mode for a second `context_warning` in the same
+  session (the dedup flag prevents a second write, but guard defensively).
+- If `lobster restart` fails or is unavailable, log the error and continue
+  processing normally — a failed restart is better than an unhandled crash.
 
 ## Message Flow
 
@@ -711,6 +855,19 @@ When you first start (or after reading this file), immediately begin your main l
 1. Read `~/lobster-user-config/memory/canonical/handoff.md` to load user context, active projects, key people, git rules, and available integrations. This is a single file — fast and essential.
 2. Read `~/lobster-workspace/user-model/_context.md` if it exists — this is a pre-computed summary of the user's values, preferences, constraints, emotional baseline, active projects, and attention stack. It's auto-generated by nightly consolidation and helps you understand what matters to the user. Skip if the file doesn't exist (model is still learning).
 2a. Call `get_proprioceptive_context(limit=3)` at the start of any session where Dan's epistemic principles are likely to be relevant (substantive conversation, decisions, anything touching the mirroring framework). This surfaces the 3 most recent alignment/misalignment instances — concrete proprioceptive signal, not preference summaries. Skip for pure logistics or quick lookups where context is clearly irrelevant.
+2b. Check for context-handoff file `~/lobster-workspace/data/context-handoff.json`:
+    - If the file exists, read it and check `triggered_at`.
+    - If the file is **recent** (< 10 minutes old based on `triggered_at`):
+        - Read the `context_pct`, `pending_tasks`, and `last_user_message` fields
+        - Notify the user:
+          "Restarted — context was at {context_pct}%. Resuming from where we left off."
+          (Substitute the `context_pct` value from the handoff JSON.)
+        - Re-queue any stuck messages: scan `~/messages/processing/` for files left
+          over from the previous session and move them back to `~/messages/inbox/`
+          so they are reprocessed. Do NOT attempt to re-spawn subagents directly —
+          the dispatcher re-queues the message and lets normal processing handle it.
+        - Delete the file after reading it
+    - If the file is **stale** (>= 10 minutes old) or absent: normal startup, ignore it.
 3. Run: `~/lobster/scripts/record-catchup-state.sh start`
    (tells health check a catchup is starting — suppresses WFM freshness check for 15 min)
 4. Spawn the `compact-catchup` agent in the background to recover recent activity from the message gap (see prompt below). Like the post-compaction handler, the startup version is internal-only — the dispatcher reads the result to update context and handoff, not relay to the user.

--- a/hooks/context-monitor.py
+++ b/hooks/context-monitor.py
@@ -1,36 +1,89 @@
 #!/usr/bin/env python3
 """
-PostToolUse hook: logs context window usage percentage.
-Proof-of-concept to verify context_window data is available in hook stdin.
+PostToolUse hook: context window guard.
+
+Below the warning threshold (default 70%): logs usage to context-monitor.log.
+At or above the threshold: writes a context_warning message to ~/messages/inbox/
+so the dispatcher can enter wind-down mode and trigger a graceful restart.
+
+Dedup: once a warning is written, /tmp/lobster-context-warning-sent is touched
+so subsequent hook firings skip the write until the flag is cleared on restart.
 """
 import json
 import sys
+import uuid
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
+
+WARNING_THRESHOLD = 70.0
+DEDUP_FLAG = Path("/tmp/lobster-context-warning-sent")
 
 
-def main():
+def _log_usage(log_dir: Path, entry: dict) -> None:
+    """Append a usage entry to the context-monitor log."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "context-monitor.log"
+    with open(log_file, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _build_log_entry(tool_name: str, used_pct: float, remaining_pct: float, context: dict) -> dict:
+    """Return an immutable log entry dict from raw context data."""
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tool": tool_name,
+        "used_percentage": used_pct,
+        "remaining_percentage": remaining_pct,
+        "full_context_window": context,
+    }
+
+
+def _build_warning_message(used_pct: float) -> dict:
+    """Return the context_warning inbox message payload."""
+    return {
+        "id": str(uuid.uuid4()),
+        "type": "context_warning",
+        "source": "system",
+        "chat_id": 0,
+        "text": f"Context window at {used_pct:.1f}% — entering wind-down mode",
+        "used_percentage": used_pct,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _write_warning_to_inbox(inbox_dir: Path, message: dict) -> None:
+    """Write the warning message JSON to the inbox directory."""
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"context-warning-{message['id']}.json"
+    (inbox_dir / filename).write_text(json.dumps(message, indent=2))
+
+
+def main() -> None:
     try:
         data = json.load(sys.stdin)
         context = data.get("context_window", {})
         used_pct = context.get("used_percentage")
         remaining_pct = context.get("remaining_percentage")
 
-        if used_pct is not None:
-            log_dir = Path.home() / "lobster-workspace" / "logs"
-            log_dir.mkdir(parents=True, exist_ok=True)
-            log_file = log_dir / "context-monitor.log"
+        if used_pct is None:
+            return
 
-            entry = {
-                "timestamp": datetime.utcnow().isoformat(),
-                "tool": data.get("tool_name", "unknown"),
-                "used_percentage": used_pct,
-                "remaining_percentage": remaining_pct,
-                "full_context_window": context,
-            }
+        log_dir = Path.home() / "lobster-workspace" / "logs"
+        entry = _build_log_entry(data.get("tool_name", "unknown"), used_pct, remaining_pct, context)
+        _log_usage(log_dir, entry)
 
-            with open(log_file, "a") as f:
-                f.write(json.dumps(entry) + "\n")
+        if used_pct < WARNING_THRESHOLD:
+            return
+
+        # At or above threshold — write a context_warning to inbox (once per session)
+        if DEDUP_FLAG.exists():
+            return
+
+        inbox_dir = Path.home() / "messages" / "inbox"
+        message = _build_warning_message(used_pct)
+        _write_warning_to_inbox(inbox_dir, message)
+        DEDUP_FLAG.touch()
+
     except Exception:
         pass  # Never block tool use
 

--- a/install.sh
+++ b/install.sh
@@ -38,12 +38,10 @@ error() { echo -e "${RED}[ERROR]${NC} $1"; }
 step() { echo -e "\n${CYAN}${BOLD}▶ $1${NC}"; }
 
 # Parse install mode from arguments
-DEV_MODE=false
 NON_INTERACTIVE=false
 CONTAINER_SETUP=false
 for arg in "$@"; do
     case "$arg" in
-        --dev) DEV_MODE=true ;;
         --non-interactive|--skip-config) NON_INTERACTIVE=true ;;
         --container-setup)
             CONTAINER_SETUP=true
@@ -323,7 +321,7 @@ if [ "$CONTAINER_SETUP" = true ]; then
     mkdir -p "$MESSAGES_DIR"/{inbox,outbox,processed,processing,failed,config,audio,task-outputs}
     mkdir -p "$CONFIG_DIR"
     mkdir -p "$PROJECTS_DIR"
-    mkdir -p "$USER_CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests,proprioceptive}
+    mkdir -p "$USER_CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests}
     mkdir -p "$USER_CONFIG_DIR/agents/subagents"
     # Safety: remove orphan agents.db if it was created (real store is agent_sessions.db)
     rm -f "$MESSAGES_DIR/config/agents.db" "$WORKSPACE_DIR/data/agents.db"
@@ -807,8 +805,10 @@ if [ "$CLAUDE_INSTALLED" = false ]; then
 
     curl -fsSL https://claude.ai/install.sh | bash
 
-    # Add to PATH for current session
+    # Add to PATH for current session and clear bash's command hash table so
+    # command -v picks up the newly installed binary immediately.
     export PATH="$HOME/.local/bin:$PATH"
+    hash -r 2>/dev/null || true
 
     # Persist ~/.local/bin to PATH in shell config files
     PATH_LINE="export PATH=\"\$HOME/.local/bin:\$PATH\""
@@ -821,7 +821,7 @@ if [ "$CLAUDE_INSTALLED" = false ]; then
         fi
     done
 
-    if command -v claude &>/dev/null; then
+    if command -v claude &>/dev/null || [ -x "$HOME/.local/bin/claude" ]; then
         success "Claude Code installed"
     else
         error "Claude Code installation failed"
@@ -853,16 +853,17 @@ fi
 # Install Lobster Code
 #===============================================================================
 
-# Detect install mode: --dev flag, existing .git, or tarball
+# Detect install mode: existing .git -> update; otherwise clone from git.
+# Tarball is kept as a last-resort fallback only when git is not available.
 if [ -d "$INSTALL_DIR/.git" ]; then
     INSTALL_MODE="git"
     info "Existing git install detected"
-elif $DEV_MODE; then
+elif command -v git >/dev/null 2>&1; then
     INSTALL_MODE="git"
-    info "Developer mode requested"
+    info "Cloning from git (default)"
 else
     INSTALL_MODE="tarball"
-    info "Tarball install mode"
+    warn "git not found — falling back to tarball install"
 fi
 
 if [ "$INSTALL_MODE" = "git" ]; then
@@ -991,7 +992,7 @@ mkdir -p "$WORKSPACE_DIR/reports"
 mkdir -p "$MESSAGES_DIR"/{inbox,outbox,processed,processing,failed,config,audio,task-outputs}
 mkdir -p "$CONFIG_DIR"
 mkdir -p "$PROJECTS_DIR"
-mkdir -p "$USER_CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests,proprioceptive}
+mkdir -p "$USER_CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests}
 mkdir -p "$USER_CONFIG_DIR/agents/subagents"
 # Safety: remove orphan agents.db if it was created (real store is agent_sessions.db)
 rm -f "$MESSAGES_DIR/config/agents.db" "$WORKSPACE_DIR/data/agents.db"
@@ -1099,8 +1100,8 @@ done
 
 success "Global env store configured"
 info "  File: $GLOBAL_ENV_FILE"
-info "  Use 'lobster env set KEY VALUE' to store API tokens"
-info "  Use 'lobster env list' to see stored keys"
+info "  Edit directly: $GLOBAL_ENV_FILE"
+info "  (Use 'lobster env set KEY VALUE' after install to update tokens)"
 info "  See docs/GLOBAL-ENV.md for full documentation"
 
 #===============================================================================
@@ -1710,7 +1711,7 @@ if [ -f "$CLAUDE_SETTINGS" ]; then
     if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("secret-scanner"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
         TMP_SETTINGS=$(mktemp)
         jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
-            "matcher": "mcp__lobster-inbox__send_reply|mcp__github__add_issue_comment|mcp__github__issue_write|mcp__github__create_pull_request|mcp__github__update_pull_request|mcp__github__pull_request_review_write|mcp__github__add_reply_to_pull_request_comment|mcp__github__create_or_update_file|mcp__github__push_files|mcp__github__merge_pull_request|mcp__github__add_comment_to_pending_review|mcp__github__create_pull_request_with_copilot|mcp__github__delete_file|Bash",
+            "matcher": "mcp__lobster-inbox__send_reply|Bash",
             "hooks": [{
                 "type": "command",
                 "command": "python3 '"$INSTALL_DIR"'/hooks/secret-scanner.py",
@@ -2045,6 +2046,51 @@ EOF
 fi
 
 #===============================================================================
+# GitHub Personal Access Token
+#===============================================================================
+
+if [ -f "$GLOBAL_ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$GLOBAL_ENV_FILE"
+    set +a
+fi
+
+GITHUB_TOKEN_SET=false
+if [ -z "${GITHUB_TOKEN:-}" ] || [ "$GITHUB_TOKEN" = "your_github_pat_here" ]; then
+    if [ "$NON_INTERACTIVE" = false ]; then
+        echo ""
+        echo -e "${BOLD}GitHub Personal Access Token${NC}"
+        echo ""
+        echo "Required for: PR creation, issue tracking, repo operations"
+        echo "Create one at: https://github.com/settings/tokens/new"
+        echo "Required scopes: repo, write:discussion, admin:repo_hook"
+        echo ""
+        read -p "Enter your GitHub PAT (or press Enter to skip): " GH_TOKEN
+        if [ -n "$GH_TOKEN" ]; then
+            # Write to global.env, replacing any existing GITHUB_TOKEN line (commented or not)
+            if grep -q "^#\? *GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
+                awk -v token="$GH_TOKEN" \
+                    '/^#? *GITHUB_TOKEN=/ { print "GITHUB_TOKEN=" token; next } { print }' \
+                    "$GLOBAL_ENV_FILE" > "$GLOBAL_ENV_FILE.tmp" && mv "$GLOBAL_ENV_FILE.tmp" "$GLOBAL_ENV_FILE"
+            else
+                printf '\nGITHUB_TOKEN=%s\n' "$GH_TOKEN" >> "$GLOBAL_ENV_FILE"
+            fi
+            GITHUB_TOKEN_SET=true
+            success "GitHub token saved to $GLOBAL_ENV_FILE"
+        else
+            warn "Skipped — set GITHUB_TOKEN in $GLOBAL_ENV_FILE later"
+        fi
+    else
+        info "Skipping GitHub token prompt (non-interactive mode)"
+        info "Set GITHUB_TOKEN in $GLOBAL_ENV_FILE when ready"
+    fi
+else
+    GITHUB_TOKEN_SET=true
+    success "GitHub token already configured"
+fi
+
+#===============================================================================
 # Generate LOBSTER_INTERNAL_SECRET (required for Google Calendar token refresh)
 #===============================================================================
 
@@ -2063,84 +2109,6 @@ if [ -f "$CONFIG_FILE" ]; then
         success "LOBSTER_INTERNAL_SECRET already set"
     fi
 fi
-
-#===============================================================================
-# GitHub MCP Server (Optional)
-#===============================================================================
-
-step "GitHub Integration (Optional)..."
-
-# Check if GitHub MCP is already configured
-GITHUB_MCP_CONFIGURED=false
-if command -v claude &>/dev/null && claude mcp list 2>/dev/null | grep -q "github"; then
-    GITHUB_MCP_CONFIGURED=true
-    success "GitHub MCP server already configured"
-fi
-
-if [ "$GITHUB_MCP_CONFIGURED" = true ]; then
-    : # Already configured, skip
-elif [ -n "${GITHUB_PAT:-}" ]; then
-    # PAT available from config.env or environment — auto-configure
-    info "Using GITHUB_PAT from environment to set up GitHub MCP server..."
-    if command -v claude &>/dev/null; then
-        claude mcp add-json github "{\"type\":\"http\",\"url\":\"https://api.githubcopilot.com/mcp\",\"headers\":{\"Authorization\":\"Bearer $GITHUB_PAT\"}}" --scope user 2>/dev/null
-        success "GitHub MCP server configured"
-    else
-        warn "Claude Code not found. Configure GitHub MCP manually after install."
-    fi
-elif [ "$NON_INTERACTIVE" = true ]; then
-    info "Skipping GitHub integration (non-interactive mode)."
-elif true; then
-
-echo ""
-echo -e "${BOLD}GitHub MCP Server Setup${NC}"
-echo ""
-echo "The GitHub MCP server lets Lobster:"
-echo "  - Read and manage GitHub issues & PRs"
-echo "  - Browse repositories and code"
-echo "  - Access project boards"
-echo "  - Monitor GitHub Actions workflows"
-echo ""
-read -p "Set up GitHub integration? [y/N] " -n 1 -r
-echo
-
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    echo ""
-    echo "You need a GitHub Personal Access Token (PAT)."
-    echo ""
-    echo "To create one:"
-    echo "  1. Go to https://github.com/settings/tokens"
-    echo "  2. Click 'Generate new token (classic)'"
-    echo "  3. Select scopes: repo, read:org, read:project"
-    echo "  4. Copy the generated token"
-    echo ""
-
-    read -p "Enter your GitHub PAT (or press Enter to skip): " GITHUB_PAT
-
-    if [ -n "$GITHUB_PAT" ]; then
-        # Add GitHub MCP server to Claude Code
-        if command -v claude &> /dev/null; then
-            claude mcp add-json github "{\"type\":\"http\",\"url\":\"https://api.githubcopilot.com/mcp\",\"headers\":{\"Authorization\":\"Bearer $GITHUB_PAT\"}}" --scope user 2>/dev/null
-            success "GitHub MCP server configured"
-
-            # Save PAT to config (optional, for reference)
-            if [ -f "$CONFIG_FILE" ]; then
-                echo "" >> "$CONFIG_FILE"
-                echo "# GitHub Integration" >> "$CONFIG_FILE"
-                echo "GITHUB_PAT_CONFIGURED=true" >> "$CONFIG_FILE"
-            fi
-        else
-            warn "Claude Code not found. Configure GitHub MCP manually after install:"
-            echo "  claude mcp add-json github '{\"type\":\"http\",\"url\":\"https://api.githubcopilot.com/mcp\",\"headers\":{\"Authorization\":\"Bearer YOUR_PAT\"}}'"
-        fi
-    else
-        info "Skipped GitHub integration. You can set it up later:"
-        echo "  claude mcp add-json github '{\"type\":\"http\",\"url\":\"https://api.githubcopilot.com/mcp\",\"headers\":{\"Authorization\":\"Bearer YOUR_PAT\"}}'"
-    fi
-else
-    info "Skipped GitHub integration. You can set it up later - see README.md"
-fi
-fi  # end non-interactive guard for GitHub integration
 
 #===============================================================================
 # GitHub CLI Authentication
@@ -2817,6 +2785,16 @@ DONE
 echo -e "${NC}"
 
 echo "Test it by sending a message to your Telegram bot!"
+echo ""
+echo -e "${BOLD}Required post-install steps:${NC}"
+if [ "$GITHUB_TOKEN_SET" = false ]; then
+echo "  1. Set your GitHub PAT:    lobster env set GITHUB_TOKEN <your-token>"
+echo "  2. Authenticate Claude:    sudo -u lobster claude  (then follow OAuth prompts)"
+echo "  3. Start services:         sudo systemctl start lobster-claude lobster-mcp lobster-router"
+else
+echo "  1. Authenticate Claude:    sudo -u lobster claude  (then follow OAuth prompts)"
+echo "  2. Start services:         sudo systemctl start lobster-claude lobster-mcp lobster-router"
+fi
 echo ""
 echo -e "${BOLD}Commands:${NC}"
 echo "  lobster status    Check service status"


### PR DESCRIPTION
## Summary

Ports four upstream SiderealPress/lobster PRs to dcetlin/Lobster.

**PR #773 — fix: enforce 7-second rule for cron_reminder and artifact-read paths (#768)**
- Add `check_task_outputs` to the 7-second rule banned list
- Delegate artifact reading to background subagent (replace inline `Read()` calls)
- Add WARNING box in cron_reminder section
- Rewrite cron_reminder protocol to use triage subagent pattern
- Update write_result rule for scheduled reminders

**PR #783 — docs: add fast-exit rule for agent_failed ghost-session messages**
- Document three-layer ghost session suppression design
- Layer 1: reconciler skips `agent_type='dispatcher'` sessions
- Layer 2: dead sessions with no real user suppressed in `_enqueue_reconciler_notification`
- Layer 3: dispatcher fast-exits `agent_failed` with `chat_id==0`

**PR #788 — fix(install): default to git clone, add GitHub token prompt, improve post-install guidance**
- Remove `--dev` flag (git clone is now the default)
- Remove GitHub MCP server setup section (use `gh` CLI instead)
- Remove `proprioceptive/` from mkdir paths
- Add `hash -r` after PATH export, fix Claude install check
- Simplify secret scanner matcher
- Add GitHub token prompt section
- Add post-install required steps guidance

**PR #699 — Context-aware graceful restart (issue #698)**
- Upgrade `hooks/context-monitor.py` from logging PoC to production context guard (writes `context_warning` to inbox at ≥70% usage)
- Add `context_warning` handling section to dispatcher bootup (wind-down → drain → handoff → restart protocol)
- Add startup step 2b: check for `context-handoff.json` and resume gracefully

Note: Token doesn't have write access to SiderealPress/lobster so these are ported here instead.