### PR TITLE
fix: stop slow_reclassifier from re-processing events on every cycle

### DIFF
--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -711,7 +711,7 @@ def build_passthrough_tag(event_id: int, quick_tag: dict | None) -> Classificati
         signal_c=sig_c,
         signal_d=sig_d,
         signal_e=sig_e,
-        confidence="medium",
+        confidence="low",
         signal_type=quick_tag.get("signal_type", "system_observation") if quick_tag else "system_observation",
         urgency=quick_tag.get("urgency", "normal") if quick_tag else "normal",
         posture_hint=quick_tag.get("posture_hint", "minimal_cognitive_friction") if quick_tag else "minimal_cognitive_friction",


### PR DESCRIPTION
Closes #65

## What was broken

The slow-reclassifier-loop produced identical output on every 15-minute cycle:
> 11 events processed, 4 tags revised, 2 patterns found (meta_thread on events [14,15] and [20,21])

And the quick-classifier-loop reported new tagged events every 2 minutes despite no new messages. The DB was growing with synthetic `pattern_observation` events on each run — 278 accumulated for just 20 real user events.

## Root cause: three compounding bugs in `read_recent_events()` and `run_pass()`

**Bug 1 — self-reinforcing pattern_observation loop:**
`write_pattern_event()` inserts rows into the `events` table. The content of these rows contains "pattern", "meta", and similar words that the quick_classifier's heuristic tags as `signal_type='meta_reflection'`. On the next slow_reclassifier pass, `read_recent_events()` picks up these new events, `detect_meta_thread()` fires again (2+ meta_reflection events within 2 hours), and more `pattern_observation` events are written — indefinitely.

**Bug 2 — already-tagged events never skipped:**
`read_recent_events()` returned all events with a `quick-v1` tag in the 6-hour lookback window, including events that already had a `slow-v1` tag from a prior pass. Every cycle re-ran pattern detection against the full set and called `ON CONFLICT DO UPDATE` with identical data — wasted work producing identical output.

**Bug 3 — no-pattern events left permanently untagged:**
Events examined by `run_pass()` that matched no cross-event pattern never received a `slow-v1` tag. The Bug 2 fix (skip events with existing slow-v1) only helps events that _were_ part of a pattern. Events with no pattern match kept appearing in the query on every subsequent cycle.

## Flow: before vs. after

```
BEFORE (each 15-min cycle):
  read_recent_events()
    → returns all quick-v1 tagged events in 6h window  ← no skip for slow-v1
    → includes pattern_observation events               ← no filter
  detect_meta_thread() fires on pattern_observation content
    → writes more pattern_observation events to DB      ← loop!
  write_tag() overwrites slow-v1 with identical data
    → same output, same tags, growing DB

AFTER:
  read_recent_events()
    → skips events with existing slow-v1 tag            ← Bug 2 fix
    → skips e.type = 'pattern_observation'              ← Bug 1 fix
  For events with no pattern match:
    → writes passthrough slow-v1 tag (no pattern)       ← Bug 3 fix
  Second pass → 0 events returned, exits immediately
```

## What changed

All changes are in `src/classifiers/slow_reclassifier.py`:

- `read_recent_events()`: added LEFT JOIN on `slow-v1` and two WHERE conditions (`e.type != 'pattern_observation'`, `slow.entry_id IS NULL`)
- `build_passthrough_tag()`: new pure function — builds a slow-v1 tag for examined-but-unmatched events, carrying forward quick-v1 dimensions
- `run_pass()`: tracks `pattern_event_ids`, then writes passthrough tags for `processed_event_ids - pattern_event_ids`

`quick_classifier.py` is not changed — its dedup logic (LEFT JOIN on `quick-v1`) was already correct.

## Functional patterns used

Pure functions (`build_passthrough_tag`, `build_revised_tag`), set difference for unmatched-event tracking (`processed_event_ids - pattern_event_ids`), LEFT JOIN for idempotent skip logic.

## Tests run

- [x] `uv run src/classifiers/slow_reclassifier.py --once --db ~/lobster-workspace/data/memory.db` — first run: "1 events processed, 0 tags revised, 0 patterns found"; second run: "0 events processed" — idempotent
- [x] `uv run src/classifiers/quick_classifier.py --once --db ~/lobster-workspace/data/memory.db` — "No unclassified events found (already tagged: 298)" — unaffected
- [x] Verified passthrough slow-v1 tag written for event 90 with correct `notes` and inherited signal flags
- [ ] Automated unit tests — none exist for classifiers yet; no test suite to run