### PR TITLE
Fix: passthrough slow-v1 tags use confidence=low (not medium)

### DIFF
--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -616,7 +616,7 @@ def build_passthrough_tag(event_id: int, quick_tag: dict | None) -> Classificati
         signal_c=sig_c,
         signal_d=sig_d,
         signal_e=sig_e,
-        confidence="medium",
+        confidence="low",
         signal_type=quick_tag.get("signal_type", "system_observation") if quick_tag else "system_observation",
         urgency=quick_tag.get("urgency", "normal") if quick_tag else "normal",
         posture_hint=quick_tag.get("posture_hint", "minimal_cognitive_friction") if quick_tag else "minimal_cognitive_friction",


### PR DESCRIPTION
## What this fixes

When the slow-reclassifier examines an event and finds no cross-event pattern, it writes a passthrough slow-v1 tag via `build_passthrough_tag()`. Before this change, that passthrough tag used `confidence="medium"`.

"medium" is wrong here. It suggests some signal was detected but at a moderate confidence level — the same confidence level used when a pattern *is* detected (see `build_revised_tag()`). A passthrough tag means the opposite: the event was reviewed and nothing notable was found.

`confidence="low"` correctly signals "examined, no pattern detected," which downstream gates can distinguish from "detected something with moderate confidence."

## What changed

One line in `build_passthrough_tag()` in `src/classifiers/slow_reclassifier.py`: `confidence="medium"` → `confidence="low"`.

`build_revised_tag()` (written when a pattern is detected) is unchanged — it correctly retains `confidence="medium"`.

## Context

Follow-up to PR #66 (classifier dedup fix), which introduced `build_passthrough_tag()`. That PR fixed the re-processing loop; this PR corrects the confidence value that function emits.

## Functional patterns used

Pure function (`build_passthrough_tag` has no side effects). The change is a single constant correction with no structural impact.

## Tests run

- [x] `git diff` verified: exactly one line changed, only in `build_passthrough_tag()`, `build_revised_tag()` untouched
- [ ] Runtime test against `memory.db` — skipped: no DB available in this environment; change is a single constant value, no logic altered
- [ ] Automated unit tests — none exist for classifiers yet (noted in PR #66)

**Blocked items needing attention before merge:** none. Depends on PR #66 merging first (this PR targets that branch).