### PR TITLE
fix: stop triage agents firing on every cron completion (#79)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -297,13 +297,18 @@ REMINDER_ROUTING = {
 
 ```
 1. mark_processing(message_id)
-2. reminder_type = msg["reminder_type"]
-3. route = REMINDER_ROUTING.get(reminder_type, fallback_lobster_generalist)
-4. Spawn subagent (run_in_background=True):
+2. reminder_type = msg.get("reminder_type")
+3. If reminder_type is None or empty:
+   # Defensive drop — cron job completions use type "cron_reminder" (not "scheduled_reminder").
+   # A "scheduled_reminder" without a reminder_type field is malformed; drop it silently.
+   mark_processed(message_id)
+   continue  # Return to wait_for_messages()
+4. route = REMINDER_ROUTING.get(reminder_type, fallback_lobster_generalist)
+5. Spawn subagent (run_in_background=True):
    - subagent_type: route["subagent_type"]
    - prompt: route["prompt"]
-5. mark_processed(message_id)
-6. Return to wait_for_messages() immediately — no ack, no send_reply
+6. mark_processed(message_id)
+7. Return to wait_for_messages() immediately — no ack, no send_reply
 ```
 
 **Rules:**
@@ -325,6 +330,14 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
        # Subagent already called send_reply — nothing to deliver
        mark_processed(message_id)
    else:
+       # --- SILENT DROP: chat_id=0 sentinel ---
+       # A subagent_result with chat_id=0 is the no-op sentinel used by cron triage subagents
+       # and other system subagents to signal "nothing actionable happened — drop silently."
+       # Never relay these; they have no valid Telegram/Slack destination.
+       if str(msg.get("chat_id", "")).strip() in ("0", "", "None"):
+           mark_processed(message_id)
+           continue  # Return to wait_for_messages()
+       # --- END SILENT DROP: chat_id=0 ---
        # --- SILENT DROP: scheduled job no-op results ---
        # If task_id starts with "scheduled-job-" AND text signals nothing happened,
        # drop immediately without relaying. Do not deliberate — if in doubt, drop it.

--- a/scheduled-tasks/post-reminder.sh
+++ b/scheduled-tasks/post-reminder.sh
@@ -58,7 +58,7 @@ status = sys.argv[7]
 msg = {
     "id": msg_id,
     "source": "system",
-    "type": "scheduled_reminder",
+    "type": "cron_reminder",
     "chat_id": 0,
     "user_id": 0,
     "username": "lobster-cron",

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -678,7 +678,7 @@ TYPE_ALIASES: dict[str, str] = {
     "message": "text",
     "audio": "voice",
     "image": "photo",
-    "cron_reminder": "scheduled_reminder",
+    # "cron_reminder" is no longer aliased — it is its own canonical type handled separately from "scheduled_reminder"
     "task-output": "health_check",
     "system": "health_check",  # when type="system" from health check scripts
 }

--- a/src/mcp/message_types.py
+++ b/src/mcp/message_types.py
@@ -45,8 +45,8 @@ INBOX_SYSTEM_TYPES: frozenset[str] = frozenset({
     "agent_failed",           # reconciler/agent-monitor detected dead agent (chat_id=0; dispatcher decides re-queue vs escalate vs drop)
     "compact_group",          # grouped compact messages (internal, produced by check_inbox)
     "compact_reminder",       # on-compact hook reminder (hooks/on-compact.py)
-    "cron_reminder",          # DEPRECATED alias — normalizes to "scheduled_reminder" on ingest
-    "scheduled_reminder",     # scheduled reminder (scripts/post-reminder.sh, scheduled-tasks/post-reminder.sh)
+    "cron_reminder",          # cron job completion (scheduled-tasks/post-reminder.sh; fields: job_name, status, duration_seconds)
+    "scheduled_reminder",     # system-level scheduled reminder (scripts/post-reminder.sh; fields: reminder_type)
     "update_notification",    # system update available (scripts/check-updates.sh)
     "consolidation",          # nightly consolidation result
     "observation",            # OOM-monitor or similar system observation


### PR DESCRIPTION
## Summary

- `cron_reminder` was aliased to `scheduled_reminder` in `TYPE_ALIASES`, so every classifier loop completion fell through to the `scheduled_reminder` fallback handler, which spawned a generic `lobster-generalist` agent with no context. These agents registered with `chat_id=0` and burned ~13K tokens per run with no useful output (~12×/hour).
- Three-layer fix: restore `cron_reminder` as a distinct type, add a defensive drop for malformed `scheduled_reminder` messages (no `reminder_type`), and add a `chat_id=0` silent-drop guard in the `subagent_result` handler.

## Root Cause

`post-reminder.sh` (in `scheduled-tasks/`) was writing `type: "scheduled_reminder"` with no `reminder_type` field and `job_name` instead. The `TYPE_ALIASES` map folded `cron_reminder` into `scheduled_reminder`, so the documented `cron_reminder` handler was never reachable. The `scheduled_reminder` handler tried `msg["reminder_type"]`, got `None`, fell through to `fallback_lobster_generalist`, and spawned a context-free agent.

## Changes

| File | Change |
|------|--------|
| `scheduled-tasks/post-reminder.sh` | Write `type: "cron_reminder"` (was `"scheduled_reminder"`) |
| `src/mcp/inbox_server.py` | Remove `"cron_reminder": "scheduled_reminder"` alias |
| `src/mcp/message_types.py` | Update comments: `cron_reminder` is canonical (not deprecated) |
| `.claude/sys.dispatcher.bootup.md` | (1) Add `reminder_type` absent → silent drop guard in `scheduled_reminder` handler; (2) Add `chat_id=0` silent-drop guard in `subagent_result` handler |

## Test plan

- [ ] Confirm classifier loop completions no longer spawn triage agents (watch `~/messages/processed/` — `cron_reminder` messages should appear without corresponding `subagent_result` entries)
- [ ] Confirm ghost_detector and oom_check scheduled reminders still work (they have `reminder_type` and use `type: "scheduled_reminder"` from `scripts/post-reminder.sh`)
- [ ] Confirm subagent no-op results with `chat_id=0` are silently dropped without `send_reply` attempts

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)