### PR TITLE
fix: stop slow_reclassifier from re-processing events every cycle

### DIFF
--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -195,7 +195,14 @@ def ensure_classification_table(conn: sqlite3.Connection) -> None:
 
 def read_recent_events(conn: sqlite3.Connection, hours: int = LOOK_BACK_HOURS) -> list[EventRow]:
     """
-    Read events from the last `hours` hours that have a quick-v1 classification tag.
+    Read events from the last `hours` hours that have a quick-v1 classification tag
+    but do NOT yet have a slow-v1 tag (i.e. not yet reclassified this cycle).
+
+    Excludes pattern_observation events — those are synthetic outputs written by this
+    classifier itself and must never be re-classified, or they create a feedback loop
+    where pattern_observation events get tagged meta_reflection by the quick classifier,
+    which then triggers more meta_thread detections and more pattern_observation writes.
+
     Returns them sorted by timestamp ascending (oldest first).
     """
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
@@ -204,7 +211,11 @@ def read_recent_events(conn: sqlite3.Connection, hours: int = LOOK_BACK_HOURS) -
         FROM events e
         INNER JOIN classification_tags ct ON ct.entry_id = CAST(e.id AS TEXT)
             AND ct.classifier = 'quick-v1'
+        LEFT JOIN classification_tags slow ON slow.entry_id = CAST(e.id AS TEXT)
+            AND slow.classifier = 'slow-v1'
         WHERE e.timestamp >= ?
+          AND e.type != 'pattern_observation'
+          AND slow.entry_id IS NULL
         ORDER BY e.timestamp ASC
     """, (cutoff,))
     rows = []


### PR DESCRIPTION
## What this fixes

The slow reclassifier was generating unbounded `pattern_observation` spam — approximately 12 new DB rows per 15-minute cycle with no upper bound. Two compounding bugs in `read_recent_events()` were responsible.

**Bug 1: Feedback loop via pattern_observation events**

`write_pattern_event()` inserts rows with `type='pattern_observation'` and content containing the word "pattern". The quick classifier picks these up and tags them `signal_type='meta_reflection'`. On the next slow reclassifier run, those tagged synthetic events appear in `read_recent_events()` results, satisfy the `meta_thread` threshold (2+ meta_reflection events within 2 hours), and trigger another `pattern_observation` write — which starts the loop again.

**Bug 2: Already-classified events re-processed every cycle**

`read_recent_events()` returned all events with a `quick-v1` tag in the 6-hour window, including events already tagged by `slow-v1` in a prior run. The pattern detectors would re-find the same patterns, and `write_tag()` would overwrite the existing `slow-v1` rows with identical data on every cycle.

## How it's fixed

Both bugs are fixed in a single SQL query change to `read_recent_events()`:

```sql
-- Added:
LEFT JOIN classification_tags slow ON slow.entry_id = CAST(e.id AS TEXT)
    AND slow.classifier = 'slow-v1'
WHERE ...
  AND e.type != 'pattern_observation'   -- Bug 1: exclude synthetic events
  AND slow.entry_id IS NULL             -- Bug 2: skip already-reclassified events
```

The `pattern_observation` filter breaks the feedback loop at the source: synthetic events are never fed back into the classifier. The `slow.entry_id IS NULL` guard mirrors the pattern `quick_classifier.py` already uses — only process events that haven't been through this stage yet.

No changes to pattern detection logic, output format, or any other function.

## Before / after

```
Before (every 15-min cycle):
  read_recent_events() -> [real events] + [pattern_observation events]
  -> detect patterns -> write more pattern_observation events
  -> repeat indefinitely

After (every 15-min cycle):
  read_recent_events() -> [real events without slow-v1 tag only]
  -> detect patterns -> write pattern_observation events + slow-v1 tags
  -> next cycle: those events are excluded (have slow-v1), pattern_observation excluded (type filter)
  -> converges to 0 new rows once all real events are classified
```

## Tests run

- [x] `git diff` reviewed — change is confined to `read_recent_events()` SQL query and its docstring; no logic outside the query is altered
- [ ] Unit tests — no test suite exists for this file; `tests/` directory is empty
- [ ] Live DB verification — requires access to the production `memory.db` to confirm row growth stops; not available in this environment

**Blocked items needing attention before merge:** Live DB spot-check recommended before deploying — confirm `pattern_observation` count stabilizes after next slow reclassifier run.

Closes #65