### PR TITLE
fix: stop SessionStart hook stubs cluttering active-sessions view (#56)

### DIFF
--- a/hooks/write-dispatcher-session-id.py
+++ b/hooks/write-dispatcher-session-id.py
@@ -169,6 +169,16 @@ def _auto_register_subagent(session_id: str) -> None:
     row first is left untouched. init_db() ensures the schema exists; the
     INSERT then uses the module's connection pool without duplicating DDL.
     Failures are logged and silently swallowed.
+
+    ## agent_type='hook'
+
+    Stubs written here use agent_type='hook' (not 'subagent') so the
+    reconciler and active-sessions query can filter them out. The session_id
+    at SessionStart (UUID format) never matches the real agent hex ID from the
+    PostToolUse auto-register-agent.py hook, so these stubs are always orphans
+    — the PostToolUse hook writes the canonical entry with the correct ID and
+    output_file path. Tagging them 'hook' keeps them out of the dispatcher's
+    active-sessions view and prevents 30-minute "dead agent" churn (issue #56).
     """
     from datetime import datetime, timezone
 
@@ -181,7 +191,7 @@ def _auto_register_subagent(session_id: str) -> None:
             INSERT OR IGNORE INTO agent_sessions
                 (id, description, chat_id, status, agent_type, spawned_at)
             VALUES
-                (?, 'auto-registered by SessionStart hook', '0', 'running', 'subagent', ?)
+                (?, 'auto-registered by SessionStart hook', '0', 'running', 'hook', ?)
             """,
             (session_id, now),
         )

--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -683,6 +683,7 @@ def get_active_sessions(path: Path | None = None) -> list[dict]:
         """
         SELECT * FROM agent_sessions
         WHERE status IN ('running', 'starting')
+          AND (agent_type IS NULL OR agent_type NOT IN ('dispatcher', 'hook'))
         ORDER BY spawned_at ASC
         """
     )

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -8197,10 +8197,18 @@ async def reconcile_agent_sessions() -> None:
                 # agent_sessions.db with agent_type='dispatcher' (on crash-restart
                 # before the marker file is cleared).  The dispatcher is never a
                 # "dead agent" — never emit agent_failed for it.
-                if (session.get("agent_type") or "") == "dispatcher":
+                #
+                # Issue #56: Also skip agent_type='hook' sessions. These are stub
+                # entries written by write-dispatcher-session-id.py at SessionStart
+                # for every subagent/scheduled-job session. The session UUID used at
+                # SessionStart never matches the real agent hex ID from PostToolUse,
+                # so these stubs are always orphans with no output_file. They are
+                # never user-facing agents and should never generate reconciler noise.
+                agent_type = (session.get("agent_type") or "")
+                if agent_type in ("dispatcher", "hook"):
                     log.debug(
-                        f"[reconciler] Skipping dispatcher session {agent_id!r} "
-                        "(agent_type='dispatcher' — not a subagent)"
+                        f"[reconciler] Skipping {agent_type!r} session {agent_id!r} "
+                        f"(agent_type={agent_type!r} — infrastructure, not a subagent)"
                     )
                     continue
 


### PR DESCRIPTION
## Root cause

The `write-dispatcher-session-id.py` SessionStart hook registers a DB stub for every non-dispatcher session (subagents and cron-launched scheduled jobs). These stubs have `agent_type='subagent'` and no `output_file`.

The session UUID used at SessionStart is a different format than the real agent hex ID written by the PostToolUse `auto-register-agent.py` hook — so `INSERT OR IGNORE` never deduplicates them. Every stub is an orphan.

Result: with the `*/5` quick-classifier cron job running, 8+ stubs accumulate as `running` in the active-sessions view at any time. Each sits there for 30 minutes before the reconciler marks it dead (516 dead stubs confirmed in DB).

## Fix (three files)

**`hooks/write-dispatcher-session-id.py`** — tag stubs as `agent_type='hook'` instead of `'subagent'`. These are infrastructure housekeeping entries, not user-facing agents.

**`src/agents/session_store.py`** — filter `agent_type IN ('dispatcher', 'hook')` from `get_active_sessions()`. The `dispatcher` exclusion was already present in the reconciler but not in the query; this closes both gaps together.

**`src/mcp/inbox_server.py`** — reconciler skips `agent_type='hook'` sessions (same logic as the existing `agent_type='dispatcher'` skip), preventing dead-agent processing for stub entries.

## Verification

- 74 existing tests pass unchanged
- Live DB: 8 running stubs migrated to `agent_type='hook'`; active-sessions view drops from 9 entries to 1 (the real running subagent)
- No changes to PostToolUse hook or real subagent registration path

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)