### PR TITLE
Voice message feedback pings: estimated time at start, done ping at completion

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1179,7 +1179,22 @@ async def handle_audio_message(
         atomic_write_json(pending_file, msg_data)
 
         log.info(f"Wrote {msg_type} message to pending-transcription: {msg_id}")
-        ack = "🎤 Voice message received. Transcribing..." if is_voice else "🎵 Audio file received. Transcribing..."
+        if is_voice:
+            duration_s = audio_obj.duration or 0
+            if duration_s > 0:
+                # Whisper typically runs ~1.5–2x real-time on this hardware;
+                # add a few seconds for ffmpeg conversion and startup overhead.
+                estimated_s = max(10, int(duration_s * 2 + 5))
+                if estimated_s < 60:
+                    time_estimate = f"~{estimated_s}s"
+                else:
+                    estimated_m = round(estimated_s / 60)
+                    time_estimate = f"~{estimated_m}m"
+                ack = f"🎤 Transcribing... ({time_estimate})"
+            else:
+                ack = "🎤 Transcribing... (~30s)"
+        else:
+            ack = "🎵 Audio file received. Transcribing..."
         await message.reply_text(ack)
         log.info(f"Ack sent to chat_id={message.chat_id} for {msg_type} message: {msg_id}")
 

--- a/src/transcription/worker.py
+++ b/src/transcription/worker.py
@@ -49,6 +49,7 @@ PENDING_DIR = _MESSAGES / "pending-transcription"
 INBOX_DIR = _MESSAGES / "inbox"
 AUDIO_DIR = _MESSAGES / "audio"
 DEAD_LETTER_DIR = _MESSAGES / "dead-letter"
+OUTBOX_DIR = _MESSAGES / "outbox"
 
 FFMPEG_PATH = Path.home() / ".local" / "bin" / "ffmpeg"
 WHISPER_CPP_PATH = _WORKSPACE / "whisper.cpp" / "build" / "bin" / "whisper-cli"
@@ -315,6 +316,46 @@ def notify_dispatcher_dead_letter(msg_data: dict, reason: str) -> None:
         log.warning(f"notify_dispatcher_dead_letter failed (non-fatal): {e}")
 
 
+def notify_transcription_complete(msg_data: dict) -> None:
+    """Write an outbox reply signalling that transcription is done and processing is starting.
+
+    Drops a reply JSON into ~/messages/outbox/ so lobster_bot.py picks it up
+    and sends it to the user via Telegram. This gives the user a visible ping
+    between the "Transcribing..." ack and the actual substantive reply, which
+    may arrive seconds later after Claude processes the transcript.
+
+    Silent on any failure — this feedback ping must never block the main
+    transcription pipeline.
+    """
+    try:
+        chat_id = msg_data.get("chat_id")
+        if not chat_id:
+            log.warning("notify_transcription_complete: no chat_id in msg_data, skipping ping")
+            return
+
+        reply_to_message_id = msg_data.get("telegram_message_id")
+        now = datetime.now(timezone.utc)
+        ts_ms = int(now.timestamp() * 1000)
+        reply_id = f"{ts_ms}_transcription_done_{uuid.uuid4().hex[:8]}"
+
+        reply: dict = {
+            "id": reply_id,
+            "source": msg_data.get("source", "telegram"),
+            "chat_id": chat_id,
+            "text": "✅ Transcription done — processing your message",
+            "timestamp": now.isoformat(),
+        }
+        if reply_to_message_id:
+            reply["reply_to_message_id"] = reply_to_message_id
+
+        OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
+        dest = OUTBOX_DIR / f"{reply_id}.json"
+        atomic_write_json(dest, reply)
+        log.info(f"Transcription-complete ping queued for chat_id={chat_id}: {reply_id}")
+    except Exception as e:
+        log.warning(f"notify_transcription_complete failed (non-fatal): {e}")
+
+
 def move_to_dead_letter(pending_file: Path, msg_data: dict, reason: str) -> None:
     """Move a failed file to dead-letter, annotating with failure reason."""
     DEAD_LETTER_DIR.mkdir(parents=True, exist_ok=True)
@@ -420,6 +461,11 @@ async def transcribe_pending_file(pending_file: Path) -> None:
                 atomic_write_json(inbox_file, msg_data)
                 pending_file.unlink(missing_ok=True)
                 log.info(f"  Transcription done → inbox/{pending_file.name}")
+
+                # Ping the user so they know transcription finished and
+                # Claude is now processing — visible feedback before the
+                # substantive reply arrives.
+                notify_transcription_complete(msg_data)
                 return
 
             elif success and not result:


### PR DESCRIPTION
## Problem

Before this change, sending a voice message produces one ack ("🎤 Voice message received. Transcribing...") and then silence until Claude's full reply arrives — which could be 30–90+ seconds. Users have no signal that transcription is progressing or that Claude has received the transcript and started working on a response.

## What changed

**Two feedback touchpoints added:**

**1. Transcription-start ack with time estimate** (`src/bot/lobster_bot.py`)

The immediate ack sent by `handle_audio_message` now includes a rough estimate:
- If Telegram supplies an audio duration (it always does for voice recordings): `🎤 Transcribing... (~45s)` — computed as `max(10, duration × 2 + 5)` seconds, formatted as minutes for long recordings.
- If duration is unavailable: `🎤 Transcribing... (~30s)` (generic fallback).
- Non-voice audio uploads keep the unchanged `🎵 Audio file received. Transcribing...` message (duration estimate is less meaningful for uploaded files where the user already knows what they sent).

The multiplier (2× real-time + 5s overhead) is a conservative estimate for this hardware; the wall-clock time is shown, not CPU time.

**2. Transcription-complete ping** (`src/transcription/worker.py`)

On successful transcription, the worker calls a new `notify_transcription_complete(msg_data)` helper. It writes an outbox reply (`✅ Transcription done — processing your message`) to `~/messages/outbox/`. `lobster_bot.py`'s existing outbox watcher picks this up and delivers it via Telegram — replying to the original voice message via `reply_to_message_id`.

The helper is wrapped in a broad `try/except` and logs only a warning on failure, consistent with the `notify_dispatcher_dead_letter` pattern already in the worker. It must never block the transcription pipeline.

## Flow after this change

```
User sends voice note
      │
      ▼
lobster_bot.py downloads audio
      │
      ├─► Telegram: "🎤 Transcribing... (~45s)"    ← NEW: includes estimate
      │
      ▼
worker.py runs whisper.cpp
      │
      ├─► outbox/: "✅ Transcription done..."      ← NEW: completion ping
      │         │
      │         └─► lobster_bot.py sends it to Telegram
      │
      ▼
inbox/: enriched message with transcription
      │
      ▼
Claude processes, sends substantive reply
```

## Scope

Only `handle_audio_message` in `lobster_bot.py` and the success path of `transcribe_pending_file` in `worker.py` are changed. No changes to retry logic, dead-letter handling, the outbox watcher, or any other code paths.

## Tests run

- [x] `uv run pytest tests/ --ignore=tests/integration/test_installation.py -q` — 21 failed / 2079 passed, same as main. No regressions introduced. (`test_installation.py::test_bot_module_importable` was already failing on main before this PR.)