### PR TITLE
feat: sweep-based issue lifecycle system

### DIFF
--- a/.github/ISSUE_TEMPLATE/design-seed.md
+++ b/.github/ISSUE_TEMPLATE/design-seed.md
@@ -1,0 +1,50 @@
+---
+name: Design seed
+about: A high-value design seed surfaced from philosophy explorations or voice notes
+title: "Design: "
+labels: design-seed, needs-design, action:iterate-design
+assignees: ""
+---
+
+<!-- REQUIRED: Link back to the source artifact (philosophy-explore file, voice note, or explore session date).
+     Without this, the issue is detached from its context and cannot be re-evaluated against its origin. -->
+**Source:** <!-- e.g., philosophy/2026-03-25-explore.md lines 42–78, or "Dan's voice note 2026-03-25" -->
+
+---
+
+## What the seed surfaces
+
+<!-- Describe the raw insight, tension, or question as it appeared in the source material.
+     Keep this close to the original — do not pre-resolve it. -->
+
+---
+
+## Design question
+
+<!-- Formulate the actionable design question this seed raises.
+     What would have to be true, designed, or built for this to be resolved? -->
+
+---
+
+## Required agent posture
+
+<!-- If this issue needs a specific posture to advance (adversarial reviewer, meta/drift-detection,
+     phenomenological interviewer), name it here. Leave blank if not yet determined. -->
+Required posture: <!-- e.g., lobster-oracle adversarial, meta/drift-detection, phenomenological interviewer -->
+
+---
+
+## Resolution condition
+
+<!-- REQUIRED before moving to ready-to-execute: what would have to be true for this issue to be closed?
+     A closed issue that lacks this field cannot be audited for genuine completion vs. declared-complete. -->
+Resolution condition: <!-- e.g., "A working design doc with named before/after conditions accepted by Dan" -->
+
+---
+
+## Dependency metadata
+
+<!-- Optional. Use issue numbers. -->
+depends-on: <!-- [#X, #Y] — must be complete before this can advance -->
+benefits-from: <!-- [#X, #Y] — completion raises quality here but is non-blocking -->
+enables: <!-- [#X, #Y] — issues that become more executable when this completes -->

--- a/.github/LIFECYCLE.md
+++ b/.github/LIFECYCLE.md
@@ -1,0 +1,118 @@
+# Lobster Issue Lifecycle
+
+Issues in this repo follow a sweep-based lifecycle. The system prevents single-perspective
+lock-in: the posture that advances an issue cannot also audit its own advancement.
+
+## States
+
+| Label | Meaning |
+|-------|---------|
+| `design-seed` | Surfaced from philosophy explorations; raw seed not yet shaped as a design question |
+| `needs-design` | Design question formulated; not ready for implementation |
+| `needs-agent-posture` | Requires a specific posture (named in issue body) before advancing |
+| `ready-to-execute` | Design fully specified; can enter implementation |
+| `auditing` | Implementation complete or in progress; under adversarial or meta audit |
+| (closed) | Resolved, deferred, or out of scope |
+
+## Action Types
+
+Each issue carries exactly one `action:*` label describing what kind of work advances it now.
+
+| Label | What it means | Typical posture |
+|-------|--------------|-----------------|
+| `action:iterate-design` | Produce the next design iteration | oracle |
+| `action:challenge-design` | Adversarial challenge of an existing design | lobster-oracle adversarial |
+| `action:implement` | Build it | functional-engineer |
+| `action:experiment` | Time-bounded experiment with named before/after conditions | functional-engineer + lobster-oracle |
+| `action:design-conversation` | Requires dialogue with Dan before advancing | dispatcher (not a subagent) |
+| `blocked-on-dan` | Waiting for Dan's input or action | — |
+
+Action type is mutable — it changes as an issue advances through states.
+
+## State Transitions
+
+```
+design-seed
+    │
+    ▼ (oracle reads seed, formulates design question)
+needs-design  ──────────────────────────────────────┐
+    │                                                │
+    │ (design reaches limit of current posture)      │ (design fully specified,
+    ▼                                                │  resolution condition named)
+needs-agent-posture                                  │
+    │                                                │
+    │ (required posture applied)                     │
+    └──────────────────────► ready-to-execute ◄──────┘
+                                    │
+                                    ▼ (implementation begins/completes)
+                                auditing
+                                    │
+                     ┌──────────────┴──────────────┐
+                     │                             │
+                     ▼ (audit passes)              ▼ (new design req surfaced)
+                   closed                      needs-design
+```
+
+## Ergonomic Preconditions
+
+An issue **cannot** move to `ready-to-execute` unless its body contains:
+
+1. **Source traceability** — link to the philosophy-explore file/voice note where the seed was surfaced
+2. **Posture specification** — if `needs-agent-posture`, the required posture is explicitly named
+3. **Resolution condition** — what would have to be true for this issue to be closed
+
+An issue **cannot** move from `auditing` to `closed` if the same posture that produced the
+implementation is the only posture that has audited it.
+
+## Dependency Metadata
+
+Each issue body may contain these structured fields:
+
+```
+depends-on: [#X, #Y]      # hard block — must be complete before this advances
+benefits-from: [#X, #Y]   # soft signal — completion raises quality ceiling here
+enables: [#X, #Y]          # issues that become more executable when this completes
+```
+
+## Batch Readout
+
+Run `scripts/issue-batch.sh` to see the current queue at a glance:
+
+```
+./scripts/issue-batch.sh
+./scripts/issue-batch.sh --repo dcetlin/Lobster
+./scripts/issue-batch.sh --json   # machine-readable output
+```
+
+Output format:
+```
+Executable now (ready-to-execute, unblocked)     N issues
+In design iteration (can run now, no blocker)    N issues
+Needs design conversation with Dan               N issues
+Needs agent posture (specified in issue)         N issues
+Blocked by dependency                            N issues
+Blocked on Dan                                   N issues
+Under audit                                      N issues
+Design seed (not yet shaped)                     N issues
+High upstream leverage (enables >= 3):  [list]
+```
+
+The **high upstream leverage** list is the key planning signal. Issues that `enables` three or more
+downstream issues should be scheduled before leaf-node issues, independent of surface-level priority.
+
+## Creating a New Design Seed
+
+Use the "Design seed" issue template. Required fields before the issue can advance:
+- Source traceability (philosophy-explore file, voice note, or session date)
+- Resolution condition (what would make this closeable)
+
+Optional but recommended at creation time: `depends-on`, `benefits-from`, `enables` metadata.
+
+## Execution Ordering Heuristic
+
+When multiple issues are executable, prefer highest `enables` count first.
+Tie-break: Dan's explicit priority signal, then estimated impact on the absorption-ceiling /
+transparency arc, then FIFO.
+
+This is advisory, not algorithmic. The batch readout surfaces upstream-leverage candidates
+so the ordering decision is cheap.

--- a/scripts/issue-batch.sh
+++ b/scripts/issue-batch.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# issue-batch.sh — Sweep-based lifecycle batch readout for dcetlin/Lobster
+#
+# Produces a structured view of the current issue queue across lifecycle states.
+# Use this to answer: what can be acted on right now, and what requires a human
+# decision before anything moves?
+#
+# Usage:
+#   ./scripts/issue-batch.sh [--repo OWNER/REPO] [--json]
+#
+# Output modes:
+#   (default)  Human-readable batch readout
+#   --json     Machine-readable JSON (useful for downstream tooling or weekly synthesis)
+#
+# Requires: gh CLI authenticated, jq
+
+set -euo pipefail
+
+REPO="${LOBSTER_ISSUE_REPO:-dcetlin/Lobster}"
+OUTPUT_JSON=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --json) OUTPUT_JSON=true; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Fetch all open issues with full label data in one call
+ALL_ISSUES=$(gh issue list \
+  --repo "$REPO" \
+  --state open \
+  --limit 200 \
+  --json number,title,labels,body,createdAt \
+)
+
+# Pure label-predicate functions (return 0 if issue has label, 1 otherwise)
+has_label() {
+  local issue="$1" label="$2"
+  echo "$issue" | jq -e --arg l "$label" \
+    '.labels | map(.name) | contains([$l])' > /dev/null 2>&1
+}
+
+# Extract the 'enables' list from issue body metadata field
+# Parses: "enables: [#X, #Y]" or "enables: <!-- ... -->" (treats comment as empty)
+extract_enables_count() {
+  local body="$1"
+  echo "$body" \
+    | grep -Eo '^enables:[[:space:]]*\[.*\]' 2>/dev/null \
+    | grep -Eo '#[0-9]+' \
+    | wc -l \
+    | tr -d ' '
+}
+
+# Classify each issue into one of the batch buckets.
+# Returns a JSON object with bucket membership and metadata.
+classify_issue() {
+  local issue="$1"
+  local number title body enables_count
+  number=$(echo "$issue" | jq -r '.number')
+  title=$(echo "$issue" | jq -r '.title')
+  body=$(echo "$issue" | jq -r '.body // ""')
+  enables_count=$(extract_enables_count "$body")
+
+  # Dependency check: extract depends-on references and check if any are still open
+  local depends_on_open=false
+  local depends_raw
+  depends_raw=$(echo "$body" | grep -Eo '^depends-on:[[:space:]]*\[.*\]' 2>/dev/null | grep -Eo '#[0-9]+' || true)
+  if [[ -n "$depends_raw" ]]; then
+    for dep_ref in $depends_raw; do
+      dep_num="${dep_ref#\#}"
+      dep_state=$(echo "$ALL_ISSUES" | jq -r --argjson n "$dep_num" \
+        '.[] | select(.number == $n) | "open"' 2>/dev/null || echo "")
+      # If the dep appears in open issues list, it's unresolved
+      dep_in_open=$(echo "$ALL_ISSUES" | jq -r --argjson n "$dep_num" \
+        'map(select(.number == $n)) | length' 2>/dev/null || echo "0")
+      if [[ "$dep_in_open" -gt 0 ]]; then
+        depends_on_open=true
+        break
+      fi
+    done
+  fi
+
+  # Determine primary bucket
+  local bucket=""
+
+  if has_label "$issue" "blocked-on-dan"; then
+    bucket="blocked-on-dan"
+  elif has_label "$issue" "ready-to-execute" && [[ "$depends_on_open" == "false" ]]; then
+    bucket="executable-now"
+  elif has_label "$issue" "ready-to-execute" && [[ "$depends_on_open" == "true" ]]; then
+    bucket="blocked-by-dep"
+  elif has_label "$issue" "needs-further-design" || has_label "$issue" "needs-design"; then
+    if has_label "$issue" "action:iterate-design" || \
+       has_label "$issue" "action:challenge-design" || \
+       ! has_label "$issue" "action:design-conversation"; then
+      bucket="in-design"
+    else
+      bucket="design-conversation"
+    fi
+  elif has_label "$issue" "action:design-conversation"; then
+    bucket="design-conversation"
+  elif has_label "$issue" "needs-agent-posture"; then
+    bucket="needs-posture"
+  elif has_label "$issue" "auditing"; then
+    bucket="auditing"
+  elif has_label "$issue" "design-seed"; then
+    bucket="design-seed"
+  else
+    bucket="unclassified"
+  fi
+
+  # Collect action type
+  local action_type=""
+  for at in "action:iterate-design" "action:challenge-design" "action:implement" \
+            "action:experiment" "action:design-conversation"; do
+    if has_label "$issue" "$at"; then
+      action_type="${at#action:}"
+      break
+    fi
+  done
+
+  jq -n \
+    --argjson num "$number" \
+    --arg title "$title" \
+    --arg bucket "$bucket" \
+    --arg action_type "$action_type" \
+    --argjson enables "$enables_count" \
+    --argjson depends_blocked "$([ "$depends_on_open" = true ] && echo 'true' || echo 'false')" \
+    '{number: $num, title: $title, bucket: $bucket, action_type: $action_type,
+      enables: $enables, depends_blocked: $depends_blocked}'
+}
+
+# Build classified list
+CLASSIFIED=$(echo "$ALL_ISSUES" | jq -c '.[]' | while IFS= read -r issue; do
+  classify_issue "$issue"
+done | jq -s '.')
+
+if [[ "$OUTPUT_JSON" == "true" ]]; then
+  echo "$CLASSIFIED"
+  exit 0
+fi
+
+# ── Human-readable readout ────────────────────────────────────────────────────
+
+print_bucket() {
+  local label="$1" bucket="$2"
+  local items
+  items=$(echo "$CLASSIFIED" | jq -r \
+    --arg b "$bucket" \
+    '.[] | select(.bucket == $b) | "  #\(.number)  \(.title)"')
+  local count
+  count=$(echo "$CLASSIFIED" | jq --arg b "$bucket" '[.[] | select(.bucket == $b)] | length')
+  echo ""
+  echo "$label ($count)"
+  if [[ -n "$items" ]]; then
+    echo "$items"
+  else
+    echo "  (none)"
+  fi
+}
+
+HIGH_LEVERAGE=$(echo "$CLASSIFIED" | jq -r \
+  '[.[] | select(.enables >= 3)] | sort_by(-.enables)[] |
+   "  #\(.number) [enables \(.enables)]  \(.title)"')
+HIGH_LEVERAGE_COUNT=$(echo "$CLASSIFIED" | jq '[.[] | select(.enables >= 3)] | length')
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Lobster Issue Batch Readout  —  $(date '+%Y-%m-%d')"
+echo " Repo: $REPO"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+print_bucket "Executable now (ready-to-execute, unblocked)" "executable-now"
+print_bucket "In design iteration (can run now, no blocker)" "in-design"
+print_bucket "Needs design conversation with Dan" "design-conversation"
+print_bucket "Needs agent posture (specified in issue)" "needs-posture"
+print_bucket "Blocked by dependency" "blocked-by-dep"
+print_bucket "Blocked on Dan" "blocked-on-dan"
+print_bucket "Under audit" "auditing"
+print_bucket "Design seed (not yet shaped)" "design-seed"
+print_bucket "Unclassified (no lifecycle labels)" "unclassified"
+
+echo ""
+echo "High upstream leverage (enables >= 3 downstream issues): $HIGH_LEVERAGE_COUNT"
+if [[ -n "$HIGH_LEVERAGE" ]]; then
+  echo "$HIGH_LEVERAGE"
+else
+  echo "  (none tagged yet)"
+fi
+
+echo ""
+TOTAL=$(echo "$CLASSIFIED" | jq 'length')
+echo "Total open issues scanned: $TOTAL"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## What this solves

The design backlog had no shared grammar for what state an issue was in or what kind of work could advance it. Issues could spin indefinitely in a single posture without a forcing function to bring in a different perspective. This PR establishes that grammar as GitHub-native infrastructure.

## What changed

Three artifacts, each addressing a different gap:

**`scripts/issue-batch.sh`** — the operational view. Run this at any time to see what is executable now, what is in design, what is blocked on Dan, and which issues have the highest upstream leverage (enables >= 3 downstream issues). Outputs human-readable text by default; `--json` flag for downstream tooling. Uses pure label and body-field queries against `gh issue list` — no external state, no database.

**`.github/ISSUE_TEMPLATE/design-seed.md`** — enforces the ergonomic preconditions at creation time. The template requires: source traceability (philosophy-explore file or voice note), resolution condition (what would make this closeable), and dependency metadata fields (`depends-on`, `benefits-from`, `enables`). Issues that skip these fields will be underdetermined at audit time.

**`.github/LIFECYCLE.md`** — documents the state machine, action types, transition rules, ergonomic preconditions, and how to use the batch script. Single authoritative reference.

**GitHub labels** — 8 new labels created directly on dcetlin/Lobster covering the full state and action-type space: `ready-to-execute`, `auditing`, `blocked-on-dan`, `action:iterate-design`, `action:challenge-design`, `action:implement`, `action:experiment`, `action:design-conversation`.

**Issues #98-#117 updated** — all issues in the recent design series now carry lifecycle labels. Issues with `needs-design` got `action:iterate-design`. Issues with `needs-agent-posture` got `action:challenge-design`. Issue #112 (this one) moved to `ready-to-execute` + `action:implement`.

## Batch readout output shape

```
Executable now (ready-to-execute, unblocked)     N issues
In design iteration (can run now, no blocker)    N issues
Needs design conversation with Dan               N issues
Needs agent posture (specified in issue)         N issues
Blocked by dependency                            N issues
Blocked on Dan                                   N issues
High upstream leverage (enables >= 3):  [list]
```

The high-leverage list is the key planning signal: issues that unblock three or more downstream issues get surfaced for priority ordering.

## What is out of scope

The older backlog (#14-#96) is intentionally left unclassified for now — 44 issues appear in the "unclassified" bucket. These can be triaged in a separate pass once the framework is established. Forcing labels onto issues without understanding their current state would produce noise, not signal.

No automation beyond the batch script. The value is in the framework being used consistently, not in elaborate tooling.

## Functional patterns

The batch script is written as a set of pure classification functions over immutable issue data fetched once per run. `classify_issue` maps an issue to a bucket without side effects; the final readout is a fold over the classified list. This makes the logic easy to verify and extend without hidden state.

## Tests run

- [x] `bash scripts/issue-batch.sh` — ran successfully, correct output with 1 executable-now, 13 in-design, 4 needs-posture, 44 unclassified
- [x] `bash scripts/issue-batch.sh --json` — produces valid JSON array
- [ ] Template rendering in GitHub UI — not testable from CLI; template YAML front matter follows GitHub documented format

Closes #112