### PR TITLE
fix: block-claude-p PreToolUse hook — warn mode, Phase 1 of cron resource conflict fix

### DIFF
--- a/hooks/block-claude-p.py
+++ b/hooks/block-claude-p.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: detect and warn/block agents from spawning new `claude -p` sessions.
+
+## Purpose
+
+When an agent writes a Bash command containing `claude -p` or `claude --print`,
+it creates an independent Claude Code session that competes with the dispatcher's
+active MCP stdio connection. The root cause of the 2026-03-25 incident where the
+dispatcher's MCP connection dropped was exactly this: scheduled jobs calling
+`claude -p` while the dispatcher was running triggered session conflict errors.
+
+This hook prevents agents from generating new `claude -p` invocations by
+detecting them in Bash tool calls and either warning or blocking, depending on
+the mode configured by the `LOBSTER_BLOCK_CLAUDE_P_MODE` environment variable.
+
+## Scope
+
+Bash tool calls only. Write and Edit tool calls are intentionally ignored — blocking
+writes that reference `claude -p` in source code, comments, or docs is unnecessary
+and produces false positives that are hard to debug.
+
+## Mode
+
+Controlled by `LOBSTER_BLOCK_CLAUDE_P_MODE`:
+  - `warn` (default): log the match, print a warning to stderr, allow the tool call
+  - `block`: hard-block the tool call with exit 2
+
+Deploy in `warn` mode first to validate zero false positives, then switch to `block`.
+
+## Allowlist
+
+The hook does not fire for:
+  - Lines that start with `#` (shell comments) before the claude invocation
+  - Known-safe caller scripts: `run-job.sh`, `claude-persistent.sh`
+  - String literal contexts: patterns where `claude -p` appears inside quotes
+    as an argument to echo, printf, cat, etc. (heuristic — see _is_allowlisted)
+
+## Logging
+
+Match details are written to ~/lobster-workspace/logs/claude-p-blocks.jsonl
+as newline-delimited JSON objects for post-hoc analysis.
+
+## Exit codes
+  0 — no match, or match is allowlisted, or mode is `warn`
+  1 — warning mode: match detected (soft warning; agent sees it and can reconsider)
+  2 — block mode: match detected (hard block; Bash call is aborted)
+"""
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Pattern: detect `claude -p` / `claude --print` as an actual shell invocation.
+# Matches `claude` followed by optional whitespace and then `-p` or `--print`,
+# then a word boundary or whitespace (to avoid matching `-profile`, `--printfoo`).
+# ---------------------------------------------------------------------------
+_CLAUDE_P_PATTERN = re.compile(r"\bclaude\s+(-p|--print)(\s|$)", re.MULTILINE)
+
+# Known-safe scripts that are permitted to call `claude -p`.
+# These are committed infrastructure scripts, not agent-generated calls.
+_SAFE_CALLERS = frozenset({"run-job.sh", "claude-persistent.sh"})
+
+# ---------------------------------------------------------------------------
+# Allowlist helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _lines_with_match(command: str) -> list[str]:
+    """Return lines of `command` that match the claude -p pattern."""
+    return [
+        line for line in command.splitlines()
+        if _CLAUDE_P_PATTERN.search(line)
+    ]
+
+
+def _is_comment_line(line: str) -> bool:
+    """Return True if the match line is a shell comment (starts with #, ignoring whitespace)."""
+    return line.lstrip().startswith("#")
+
+
+def _is_safe_caller(line: str) -> bool:
+    """Return True if the line invokes a known-safe caller script."""
+    return any(caller in line for caller in _SAFE_CALLERS)
+
+
+def _is_string_literal_context(line: str) -> bool:
+    """Heuristic: return True if `claude -p` appears as an argument to a print command.
+
+    This covers common false-positive patterns like:
+      echo "run: claude -p"
+      printf "usage: claude -p <task>"
+
+    The heuristic is: if the line starts with echo, printf, cat, or a variable
+    assignment containing a quoted string, and the match is inside a quoted section.
+
+    This is intentionally conservative — only clearly safe patterns are excluded.
+    Ambiguous cases are left for the warn/block logic to handle.
+    """
+    stripped = line.lstrip()
+    print_prefixes = ("echo ", "echo\t", "printf ", "printf\t")
+    if any(stripped.startswith(p) for p in print_prefixes):
+        return True
+    # Variable assignment: VAR="...claude -p..."
+    if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\s*=\s*[\"']", stripped):
+        return True
+    return False
+
+
+def _is_allowlisted(line: str) -> bool:
+    """Return True if this line should NOT trigger the hook."""
+    return (
+        _is_comment_line(line)
+        or _is_safe_caller(line)
+        or _is_string_literal_context(line)
+    )
+
+
+def _find_triggering_lines(command: str) -> list[str]:
+    """Return lines that match the claude -p pattern and are NOT allowlisted."""
+    return [
+        line for line in _lines_with_match(command)
+        if not _is_allowlisted(line)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Logging (side effect, isolated at the boundary)
+# ---------------------------------------------------------------------------
+
+
+def _log_match(command: str, triggering_lines: list[str], mode: str, session_id: str) -> None:
+    """Append a JSONL entry to ~/lobster-workspace/logs/claude-p-blocks.jsonl.
+
+    Best-effort: any failure is silently swallowed so the hook never blocks
+    due to a logging problem.
+    """
+    try:
+        log_dir = Path(os.path.expanduser("~/lobster-workspace/logs"))
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / "claude-p-blocks.jsonl"
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "session_id": session_id,
+            "mode": mode,
+            "triggering_lines": triggering_lines,
+            "command_snippet": command[:500],  # Truncate for log hygiene
+        }
+        with log_file.open("a") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except Exception:
+        pass  # Never block on logging failure
+
+
+# ---------------------------------------------------------------------------
+# Main hook logic
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # Unparseable input — don't block
+
+    tool_name = data.get("tool_name", "")
+
+    # Only check Bash tool calls. Write/Edit are explicitly out of scope.
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    if not command:
+        sys.exit(0)
+
+    triggering_lines = _find_triggering_lines(command)
+
+    if not triggering_lines:
+        sys.exit(0)
+
+    session_id = data.get("session_id", "unknown")
+    mode = os.environ.get("LOBSTER_BLOCK_CLAUDE_P_MODE", "warn").lower().strip()
+
+    _log_match(command, triggering_lines, mode, session_id)
+
+    warning_message = (
+        "Warning: Bash command contains `claude -p` / `claude --print`.\n\n"
+        "Spawning an independent `claude -p` session competes with the dispatcher's "
+        "active MCP stdio connection and can cause session conflicts or dropped connections. "
+        "Only committed infrastructure scripts (run-job.sh, claude-persistent.sh) should "
+        "call `claude -p` directly.\n\n"
+        "If you need to run a scheduled task or background job, route it through the "
+        "dispatcher's Agent spawning mechanism instead.\n\n"
+        f"Detected in: {triggering_lines[0]!r}"
+    )
+
+    if mode == "block":
+        print(
+            f"BLOCKED: {warning_message}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    else:
+        # warn mode (default): soft warning, allow the call through
+        print(warning_message, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1677,6 +1677,29 @@ else
     info "Skipping dispatcher-inline-tool-guard hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PreToolUse hook to warn/block agents from spawning `claude -p` sessions
+# Deployed in warn mode (LOBSTER_BLOCK_CLAUDE_P_MODE=warn) to validate before hard-blocking.
+# See: https://github.com/SiderealPress/lobster/issues/889
+chmod +x "$INSTALL_DIR/hooks/block-claude-p.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("block-claude-p"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "Bash",
+            "hooks": [{
+                "type": "command",
+                "command": "LOBSTER_BLOCK_CLAUDE_P_MODE=warn python3 '"$INSTALL_DIR"'/hooks/block-claude-p.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "block-claude-p hook installed (warn mode)"
+    else
+        info "block-claude-p hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping block-claude-p hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code PreToolUse hook to block edits to system files unless LOBSTER_DEBUG=true
 chmod +x "$INSTALL_DIR/hooks/system-file-protect.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1706,6 +1706,25 @@ DAILY_METRICS_TASK
         fi
     fi
 
+    # Migration 37: Register block-claude-p PreToolUse hook (warn mode).
+    # Catches agents that write `claude -p` in Bash commands — the root cause of the
+    # 2026-03-25 dispatcher MCP connection drop. Deployed in soft warn mode first.
+    # See: https://github.com/SiderealPress/lobster/issues/889
+    local claude_settings="$HOME/.claude/settings.json"
+    if [ -f "$claude_settings" ] && command -v jq >/dev/null 2>&1; then
+        if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("block-claude-p"))' "$claude_settings" > /dev/null 2>&1; then
+            chmod +x "$LOBSTER_DIR/hooks/block-claude-p.py" 2>/dev/null || true
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "LOBSTER_BLOCK_CLAUDE_P_MODE=warn python3 $LOBSTER_DIR/hooks/block-claude-p.py" \
+                '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": $cmd, "timeout": 5}]
+            }]' "$claude_settings" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$claude_settings"
+            substep "Registered block-claude-p hook in Claude Code settings (warn mode)"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_hooks/test_block_claude_p.py
+++ b/tests/unit/test_hooks/test_block_claude_p.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for hooks/block-claude-p.py
+
+Tests cover:
+- Non-Bash tool calls pass through (exit 0)
+- Bash with no claude invocation passes through (exit 0)
+- Actual invocation `claude -p ...` triggers the hook
+- `claude --print` triggers the hook
+- Comment lines (`# claude -p`) do not trigger the hook
+- String literal context (echo "claude -p") does not trigger
+- Known-safe callers (run-job.sh, claude-persistent.sh) do not trigger
+- warn mode (default): exit 1 on match
+- block mode: exit 2 on match
+- Log file is written on match
+"""
+
+import json
+import os
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = _HOOKS_DIR / "block-claude-p.py"
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the hook with given input and env
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(
+    hook_input: dict,
+    env_overrides: dict | None = None,
+) -> tuple[int, str, str]:
+    """Run the hook script and return (exit_code, stdout, stderr)."""
+    stdout_capture = StringIO()
+    stderr_capture = StringIO()
+    stdin_data = json.dumps(hook_input)
+
+    exit_code = None
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_capture),
+        patch("sys.stderr", stderr_capture),
+        patch.dict(os.environ, env_overrides or {}, clear=False),
+    ):
+        try:
+            hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+            exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_capture.getvalue(), stderr_capture.getvalue()
+
+
+def _make_bash_input(command: str, session_id: str = "test-session-001") -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": session_id,
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+
+
+def _make_tool_input(tool_name: str, tool_input: dict) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": "test-session-001",
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Non-Bash tool passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestNonBashTools:
+    def test_write_tool_passes_through(self):
+        """Write tool calls must never be checked — out of scope for this hook."""
+        hook_input = _make_tool_input("Write", {"file_path": "/tmp/x.sh", "content": "claude -p foo"})
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+    def test_edit_tool_passes_through(self):
+        """Edit tool calls must never be checked."""
+        hook_input = _make_tool_input("Edit", {"file_path": "/tmp/x.sh", "old_string": "", "new_string": "claude -p"})
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+    def test_agent_tool_passes_through(self):
+        """Agent tool calls are not Bash — pass through."""
+        hook_input = _make_tool_input("Agent", {"prompt": "run claude -p foo", "run_in_background": True})
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Bash with no claude invocation
+# ---------------------------------------------------------------------------
+
+
+class TestBashNoMatch:
+    def test_ls_command_passes_through(self):
+        exit_code, _, _ = _run_hook(_make_bash_input("ls /tmp"))
+        assert exit_code == 0
+
+    def test_claude_without_p_flag_passes_through(self):
+        """Claude invoked without -p flag should not trigger."""
+        exit_code, _, _ = _run_hook(_make_bash_input("claude --version"))
+        assert exit_code == 0
+
+    def test_unrelated_p_flag_passes_through(self):
+        """Other commands with -p flag are not affected."""
+        exit_code, _, _ = _run_hook(_make_bash_input("ssh -p 22 host"))
+        assert exit_code == 0
+
+    def test_empty_command_passes_through(self):
+        exit_code, _, _ = _run_hook(_make_bash_input(""))
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Actual invocations that should trigger
+# ---------------------------------------------------------------------------
+
+
+class TestActualInvocations:
+    def test_claude_p_in_warn_mode_exits_1(self):
+        """claude -p in warn mode (default) exits 1."""
+        exit_code, _, stderr = _run_hook(
+            _make_bash_input('claude -p "do some task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "warn"},
+        )
+        assert exit_code == 1, f"Expected 1 (warn), got {exit_code}"
+
+    def test_claude_p_default_mode_exits_1(self):
+        """Default mode is warn — exits 1 when no env var is set."""
+        env = {"LOBSTER_BLOCK_CLAUDE_P_MODE": "warn"}
+        exit_code, _, _ = _run_hook(_make_bash_input('claude -p "task"'), env_overrides=env)
+        assert exit_code == 1
+
+    def test_claude_print_triggers_hook(self):
+        """claude --print should also trigger the hook."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input('claude --print "task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "warn"},
+        )
+        assert exit_code == 1
+
+    def test_claude_p_in_block_mode_exits_2(self):
+        """claude -p in block mode exits 2 (hard block)."""
+        exit_code, _, stderr = _run_hook(
+            _make_bash_input('claude -p "do some task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 2, f"Expected 2 (block), got {exit_code}"
+
+    def test_block_mode_message_contains_blocked(self):
+        """Block mode must emit BLOCKED in stderr."""
+        _, _, stderr = _run_hook(
+            _make_bash_input('claude -p "task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert "BLOCKED" in stderr, f"Expected BLOCKED in stderr, got: {stderr!r}"
+
+    def test_warn_message_explains_problem(self):
+        """Warning message should explain the MCP conflict risk."""
+        _, _, stderr = _run_hook(
+            _make_bash_input('claude -p "task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "warn"},
+        )
+        assert "MCP" in stderr or "dispatcher" in stderr.lower(), (
+            f"Expected guidance about dispatcher/MCP in stderr, got: {stderr!r}"
+        )
+
+    def test_warning_not_in_stdout(self):
+        """Warning/block message must only appear in stderr, not stdout."""
+        _, stdout, _ = _run_hook(
+            _make_bash_input('claude -p "task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "warn"},
+        )
+        assert "claude" not in stdout.lower() or stdout == "", (
+            f"Message leaked to stdout: {stdout!r}"
+        )
+
+    def test_multiline_command_with_claude_p_triggers(self):
+        """Multi-line scripts containing claude -p should trigger."""
+        command = "#!/bin/bash\nls /tmp\nclaude -p 'run task'\necho done"
+        exit_code, _, _ = _run_hook(
+            _make_bash_input(command),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "warn"},
+        )
+        assert exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Allowlisted patterns that must NOT trigger
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistedPatterns:
+    def test_comment_line_does_not_trigger(self):
+        """Shell comment lines (# claude -p) must not fire the hook."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input("# claude -p foo"),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 0, "Comment line should not trigger the hook"
+
+    def test_indented_comment_does_not_trigger(self):
+        """Indented comment (  # claude -p) must also be excluded."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input("  # claude -p foo"),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 0
+
+    def test_echo_string_literal_does_not_trigger(self):
+        """echo 'run: claude -p' is a string literal, not an invocation."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input('echo "run: claude -p"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 0, "String literal in echo should not trigger"
+
+    def test_printf_string_literal_does_not_trigger(self):
+        """printf referencing claude -p is a string literal."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input('printf "usage: claude -p <task>"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 0
+
+    def test_run_job_sh_safe_caller_does_not_trigger(self):
+        """run-job.sh is a known-safe caller and must not be blocked."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input("bash run-job.sh my-job"),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 0, "run-job.sh is allowlisted"
+
+    def test_claude_persistent_sh_safe_caller_does_not_trigger(self):
+        """claude-persistent.sh is a known-safe caller and must not be blocked."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input("/path/to/claude-persistent.sh start"),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 0, "claude-persistent.sh is allowlisted"
+
+    def test_variable_assignment_string_does_not_trigger(self):
+        """Variable assignment with quoted string containing claude -p is allowlisted."""
+        exit_code, _, _ = _run_hook(
+            _make_bash_input('USAGE="run: claude -p task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "block"},
+        )
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Log file is written on match
+# ---------------------------------------------------------------------------
+
+
+class TestLogging:
+    def test_log_file_written_on_match(self, tmp_path, monkeypatch):
+        """A match must be logged to ~/lobster-workspace/logs/claude-p-blocks.jsonl."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_BLOCK_CLAUDE_P_MODE", "warn")
+
+        exit_code, _, _ = _run_hook(
+            _make_bash_input('claude -p "task"'),
+            env_overrides={"LOBSTER_BLOCK_CLAUDE_P_MODE": "warn"},
+        )
+        assert exit_code == 1
+
+        log_file = tmp_path / "lobster-workspace" / "logs" / "claude-p-blocks.jsonl"
+        assert log_file.exists(), f"Log file not created at {log_file}"
+
+        entries = [json.loads(line) for line in log_file.read_text().strip().splitlines()]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["mode"] == "warn"
+        assert "session_id" in entry
+        assert "timestamp" in entry
+        assert "triggering_lines" in entry
+        assert any("claude -p" in line for line in entry["triggering_lines"])
+
+    def test_no_match_no_log(self, tmp_path, monkeypatch):
+        """No match → no log file created."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        _run_hook(_make_bash_input("ls /tmp"))
+
+        log_file = tmp_path / "lobster-workspace" / "logs" / "claude-p-blocks.jsonl"
+        assert not log_file.exists(), "Log file should not exist when no match"


### PR DESCRIPTION
## What problem does this solve

On 2026-03-25, the dispatcher's MCP stdio connection dropped mid-session. Root cause: `run-job.sh` calls `claude -p` to run scheduled jobs, spawning a second top-level Claude Code session that competes with the dispatcher's active session for the shared MCP connection. The existing env-var unset in `run-job.sh` prevents the launch error but not the underlying resource conflict. Jobs succeed at midnight only because the dispatcher is hibernating.

This PR adds a PreToolUse hook that catches agents writing `claude -p` / `claude --print` into Bash commands — the stopgap that prevents the conflict from recurring while the architectural fix (Phase 2, tracked in #138) is being built.

## What this changes

`hooks/block-claude-p.py` fires on every Bash tool call and inspects the command for `claude\s+(-p|--print)` patterns. When a match is found that is not allowlisted, it logs the match and either warns (exit 1) or hard-blocks (exit 2), depending on `LOBSTER_BLOCK_CLAUDE_P_MODE`.

**Deployed in warn mode** (the default). This lets the hook run in production for 24h+ to confirm zero false positives before switching to `block`. Mode is controlled by env var — no code change or deploy needed to flip.

**Allowlist** (do not fire on):
- Lines starting with `#` (shell comments)
- Lines in `echo`/`printf` print-command context (string literals, not invocations)
- Variable assignments with quoted strings containing `claude -p`
- Known-safe callers: `run-job.sh`, `claude-persistent.sh` — committed infrastructure scripts that legitimately call `claude -p` today and are exempt until Phase 2 replaces them

**Logging:** every match is appended to `~/lobster-workspace/logs/claude-p-blocks.jsonl` as JSONL for post-hoc analysis. No match → no file created.

`install.sh` registers the hook idempotently on new installs. `scripts/upgrade.sh` adds Migration 37 for existing installs.

## Functional patterns used

Pure functions throughout the detection logic (`_find_triggering_lines`, `_is_allowlisted`, `_is_comment_line`, etc.) — each predicate is testable in isolation. Side effects (logging, sys.exit) are isolated at the boundaries in `_log_match` and `main`.

## Flow

```
Before (unchanged — this PR adds only a hook layer):
  cron → run-job.sh → claude -p  [resource conflict when dispatcher awake]

After this PR:
  Agent Bash call containing "claude -p"
    → block-claude-p.py fires
    → warn mode: logs match, prints warning to stderr, exits 1 (agent sees warning)
    → block mode: logs match, prints BLOCKED to stderr, exits 2 (Bash call aborted)
  Agent Bash call NOT containing "claude -p" (or allowlisted)
    → block-claude-p.py exits 0 immediately (no effect)
```

This PR does NOT change `run-job.sh`, crontab, or dispatcher routing. Those are Phase 2 (#138).

## Areas to review closely

- **Allowlist completeness** — the string-literal heuristic covers `echo`/`printf`/variable assignments but not all possible quoting patterns. In warn mode, false negatives (missed matches) are not harmful; false positives (unwanted blocks) are. Any borderline pattern that makes it to the log can be reviewed before switching to block mode.
- **install.sh idempotency** — uses `jq -e ... | test("block-claude-p")` to check if already registered. The matcher is `"Bash"` (not a unique string), but the command test is specific enough to be safe.
- **Mode switch path** — to go from warn to block: set `LOBSTER_BLOCK_CLAUDE_P_MODE=block` in the hook command in `~/.claude/settings.json`, or re-run `install.sh`. Phase 3 (#138) will remove the hook entirely once Phase 2 is live.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_block_claude_p.py -v` — 24 passed, 0 failed
- [x] `uv run --with ruff ruff check hooks/block-claude-p.py tests/unit/test_hooks/test_block_claude_p.py` — clean, no errors
- [ ] Live 24h warn-mode observation — not yet run; needed before switching to block mode (safe to merge in warn mode without it)

## References

- Phase 2+3 tracking: #138
- Upstream spec: SiderealPress/lobster#882, SiderealPress/lobster#889