### PR TITLE
fix: generate embeddings for pattern_observation events in slow_reclassifier

### DIFF
--- a/scripts/backfill_pattern_embeddings.py
+++ b/scripts/backfill_pattern_embeddings.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+scripts/backfill_pattern_embeddings.py
+
+One-time backfill: generate and store embeddings for pattern_observation events
+that were written before the fix in write_pattern_event() was applied.
+
+Root cause: slow_reclassifier.write_pattern_event() inserted directly into the
+events table without also inserting into events_vec. This left all
+pattern_observation events invisible to vector search.
+
+Usage:
+    uv run scripts/backfill_pattern_embeddings.py [--dry-run] [--db PATH]
+
+Options:
+    --dry-run   Report how many events need backfilling without writing.
+    --db PATH   Override memory.db path (default: ~/lobster-workspace/data/memory.db).
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+
+def _serialize_vector(floats: list[float]) -> bytes:
+    return struct.pack(f"{len(floats)}f", *floats)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Backfill embeddings for pattern_observation events")
+    parser.add_argument("--dry-run", action="store_true", help="Report without writing")
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / "lobster-workspace" / "data" / "memory.db"),
+        help="Path to memory.db",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        print(f"memory.db not found at {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    import sqlite3
+    try:
+        import sqlite_vec
+    except ImportError:
+        print("sqlite_vec not installed — cannot run backfill", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+
+    # Find pattern_observation events missing a vec entry.
+    rows = conn.execute("""
+        SELECT e.id, e.content
+        FROM events e
+        LEFT JOIN events_vec v ON e.id = v.rowid
+        WHERE e.type = 'pattern_observation'
+          AND v.rowid IS NULL
+        ORDER BY e.id
+    """).fetchall()
+
+    if not rows:
+        print("No pattern_observation events missing embeddings — nothing to do.")
+        conn.close()
+        return
+
+    print(f"Found {len(rows)} pattern_observation events missing embeddings.")
+    if args.dry_run:
+        print("--dry-run: no changes written.")
+        conn.close()
+        return
+
+    # Load embedding model.
+    print("Loading embedding model (all-MiniLM-L6-v2)...")
+    from fastembed import TextEmbedding
+    model = TextEmbedding("sentence-transformers/all-MiniLM-L6-v2")
+
+    # Batch embed.
+    contents = [r["content"] for r in rows]
+    ids = [r["id"] for r in rows]
+    embeddings = list(model.embed(contents))
+    print(f"Embedded {len(embeddings)} events. Writing to events_vec...")
+
+    inserted = 0
+    failed = 0
+    for event_id, emb in zip(ids, embeddings):
+        floats = emb.tolist() if hasattr(emb, "tolist") else list(emb)
+        blob = _serialize_vector(floats)
+        try:
+            conn.execute(
+                "INSERT INTO events_vec(rowid, embedding) VALUES (?, ?)",
+                (event_id, blob),
+            )
+            inserted += 1
+        except Exception as exc:
+            print(f"  Failed for event {event_id}: {exc}", file=sys.stderr)
+            failed += 1
+
+    conn.commit()
+    conn.close()
+    print(f"Done: {inserted} embeddings written, {failed} failed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -62,6 +62,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterator
 
+import struct
+
 from src.classifiers.checkpoint import max_event_id, save_checkpoint, should_run
 
 # ---------------------------------------------------------------------------
@@ -158,7 +160,43 @@ class PatternObservation:
 def open_db(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
+    # Load sqlite-vec so events_vec INSERT works in write_pattern_event().
+    conn.enable_load_extension(True)
+    try:
+        import sqlite_vec
+        sqlite_vec.load(conn)
+    except Exception as exc:
+        log.warning("sqlite_vec unavailable — pattern_observation embeddings will be skipped: %s", exc)
+    conn.enable_load_extension(False)
     return conn
+
+
+# ---------------------------------------------------------------------------
+# Embedding helpers (same model as VectorMemory — all-MiniLM-L6-v2)
+# ---------------------------------------------------------------------------
+
+_EMBEDDING_DIM = 384
+_embed_model = None
+
+
+def _get_embed_model():
+    global _embed_model
+    if _embed_model is None:
+        from fastembed import TextEmbedding
+        _embed_model = TextEmbedding("sentence-transformers/all-MiniLM-L6-v2")
+    return _embed_model
+
+
+def _embed_content(text: str) -> bytes | None:
+    """Return a 384-dim float32 blob for *text*, or None if embedding is unavailable."""
+    try:
+        model = _get_embed_model()
+        vec = list(model.embed([text]))[0]
+        floats = vec.tolist() if hasattr(vec, "tolist") else list(vec)
+        return struct.pack(f"{len(floats)}f", *floats)
+    except Exception as exc:
+        log.warning("Embedding failed for pattern_observation content: %s", exc)
+        return None
 
 
 def ensure_classification_table(conn: sqlite3.Connection) -> None:
@@ -294,7 +332,7 @@ def write_tag(conn: sqlite3.Connection, tag: ClassificationTag) -> None:
 
 def write_pattern_event(conn: sqlite3.Connection, obs: PatternObservation) -> int:
     """
-    Write a pattern_observation event to the events table.
+    Write a pattern_observation event to the events table and events_vec.
     Returns the new event id.
     """
     metadata = json.dumps({
@@ -313,8 +351,21 @@ def write_pattern_event(conn: sqlite3.Connection, obs: PatternObservation) -> in
         INSERT INTO events (timestamp, type, source, content, metadata)
         VALUES (?, 'pattern_observation', ?, ?, ?)
     """, (obs.detected_at.isoformat(), obs.source, content, metadata))
+    event_id = cursor.lastrowid
+
+    # Store embedding so this event is reachable via vector search.
+    vec_blob = _embed_content(content)
+    if vec_blob is not None:
+        try:
+            conn.execute(
+                "INSERT INTO events_vec(rowid, embedding) VALUES (?, ?)",
+                (event_id, vec_blob),
+            )
+        except Exception as exc:
+            log.warning("Could not insert embedding for event %d: %s", event_id, exc)
+
     conn.commit()
-    return cursor.lastrowid
+    return event_id
 
 
 def write_run_log(


### PR DESCRIPTION
## Summary

`pattern_observation` events — produced by `slow_reclassifier` when it detects cross-event patterns like design sessions, brainstorm bursts, and meta-thread activity — have never been reachable via vector search. The `write_pattern_event()` function inserted rows into the `events` table but never into `events_vec`, silently bypassing the embedding pipeline that all other event types go through. This left 1617 events (every `pattern_observation` since the slow_reclassifier was introduced) with no embedding and therefore invisible to `VectorMemory.search()`.

## What changed

**Forward fix (`slow_reclassifier.py`):**
- `open_db()` now loads the `sqlite_vec` extension on connection init, which is required for `events_vec` writes.
- `write_pattern_event()` embeds the event content using the same model as `VectorMemory` (`all-MiniLM-L6-v2` via fastembed) and inserts the vector into `events_vec` alongside the `events` row. If the embedding model is unavailable, the event is still stored and the failure is logged as a warning — matching the graceful-degradation behavior in `VectorMemory`.

**Backfill script (`scripts/backfill_pattern_embeddings.py`):**
- One-time script to generate and insert embeddings for existing `pattern_observation` events that lack a `events_vec` entry.
- Run on live `memory.db` before this PR: all 1617 missing embeddings were written. 2064/2064 events now have vec entries.

**Patterns used:** pure functions for serialization (`_serialize_vector`, `_embed_content`), defensive error isolation (embedding failure does not break event storage), lazy model loading.

**Out of scope:** this PR does not change how `pattern_observation` events are classified, surfaced, or consumed. It only ensures they are findable via vector search, which is the prerequisite for memory consolidation and meta-thread matching.

## Tests run
- [x] `scripts/backfill_pattern_embeddings.py --dry-run` — reported 1617 events needing backfill
- [x] `scripts/backfill_pattern_embeddings.py` (live) — 1617 embeddings written, 0 failed
- [x] Verification query against `memory.db` — `events_with_no_vec_entry = 0` (was 1617)
- [x] `uv run pytest tests/ -q --ignore=tests/integration/test_installation.py` — 21 failed, 2127 passed, same 21 failures as on `main` (pre-existing, unrelated to this change)
- [ ] Unit test for `write_pattern_event()` embedding behavior — no dedicated slow_reclassifier test file exists; gap noted for future PR

**Blocked items needing attention before merge:** none