### PR TITLE
feat: route cron jobs through dispatcher inbox (Phase 2, #138)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -383,6 +383,72 @@ REMINDER_ROUTING = {
 - Do not ack these — they are background system tasks, not user requests
 - When in doubt about a new job name, add it to REMINDER_ROUTING as `None` (fast-exit)
 
+## Handling Scheduled Job Triggers (`scheduled_job_trigger`)
+
+Cron calls `post-job-trigger.sh <job-name>` instead of running `claude -p` directly.
+That script drops a JSON file in `~/messages/inbox/` with `type: "scheduled_job_trigger"`.
+The dispatcher picks it up here and spawns a background subagent to run the job.
+
+**Message shape:**
+```json
+{
+  "type": "scheduled_job_trigger",
+  "job_name": "daily-metrics",
+  "timestamp": "2026-01-01T07:00:00+00:00",
+  "source": "cron",
+  "chat_id": 8075091586
+}
+```
+
+**When `wait_for_messages` returns a message with `type: "scheduled_job_trigger"`:**
+
+```
+1. mark_processing(message_id)
+
+2. job_name = msg["job_name"]
+   chat_id  = msg.get("chat_id") or ADMIN_CHAT_ID
+
+3. task_file = f"~/lobster-workspace/scheduled-jobs/tasks/{job_name}.md"
+   # Do NOT read the file inline — delegate to the subagent. The subagent
+   # receives the path and reads it as its first action.
+
+4. task_id = f"scheduled-job-{job_name}"
+
+5. Spawn subagent (run_in_background=True):
+   subagent_type: "lobster-generalist"
+   prompt:
+     ---
+     task_id: scheduled-job-{job_name}
+     chat_id: {chat_id}
+     source: telegram
+     ---
+
+     You are running as a scheduled job. Your task definition is in:
+       ~/lobster-workspace/scheduled-jobs/tasks/{job_name}.md
+
+     Steps:
+     1. Read that file to get the full job instructions.
+     2. Execute the job as instructed.
+     3. When done, call send_reply(chat_id={chat_id}, text=<your digest>, source="telegram")
+        to deliver results to the user.
+     4. Call write_result(task_id="scheduled-job-{job_name}", chat_id={chat_id},
+        text=<same text>, source="telegram", sent_reply_to_user=True) to signal completion.
+
+     Both calls are required. send_reply delivers immediately; write_result(sent_reply_to_user=True)
+     tells the dispatcher the job is done without double-sending.
+
+6. mark_processed(message_id)
+   # THE VERY NEXT ACTION MUST BE wait_for_messages()
+```
+
+**Rules:**
+- Do NOT read the task file on the main thread — that is a file I/O violation of the 7-second rule.
+- Do NOT send an ack to the user — this is a background system event, not a user request.
+- The subagent delivers results via `send_reply` + `write_result` (same contract as the old `run-job.sh`).
+- If the task file is missing, the subagent will fail; its `write_result` will arrive as `subagent_error` and be relayed to the user as an error.
+
+---
+
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)
 
 Background subagents call `write_result(task_id, chat_id, text, ...)`, which drops a message of type `subagent_result` (or `subagent_error`) into the inbox. The main thread picks it up.

--- a/scheduled-tasks/post-job-trigger.sh
+++ b/scheduled-tasks/post-job-trigger.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Lobster Scheduled Job Trigger Writer
+# Called by cron instead of run-job.sh. Writes a trigger message to the
+# dispatcher inbox so the dispatcher spawns the job subagent — avoiding the
+# competing claude -p session problem (issue #138).
+#
+# Usage: post-job-trigger.sh <job-name>
+
+set -e
+
+JOB_NAME="$1"
+
+if [ -z "$JOB_NAME" ]; then
+    echo "Usage: $0 <job-name>"
+    exit 1
+fi
+
+# Load env files so LOBSTER_ADMIN_CHAT_ID and other vars are available
+# when running from cron (which does not inherit systemd EnvironmentFile entries).
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+INBOX_DIR="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
+mkdir -p "$INBOX_DIR"
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
+FILENAME="$INBOX_DIR/trigger-${JOB_NAME}-$(date +%Y%m%d%H%M%S)-$$.json"
+
+# Write trigger message. The dispatcher reads this and spawns the job subagent.
+cat > "$FILENAME" << EOF
+{
+  "type": "scheduled_job_trigger",
+  "job_name": "$JOB_NAME",
+  "timestamp": "$TIMESTAMP",
+  "source": "cron",
+  "chat_id": ${LOBSTER_ADMIN_CHAT_ID:-0}
+}
+EOF
+
+echo "[$TIMESTAMP] Trigger written for job: $JOB_NAME -> $FILENAME"

--- a/scheduled-tasks/sync-crontab.sh
+++ b/scheduled-tasks/sync-crontab.sh
@@ -7,7 +7,7 @@ set -e
 WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 REPO_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 JOBS_FILE="$WORKSPACE/scheduled-jobs/jobs.json"
-RUNNER="$REPO_DIR/scheduled-tasks/run-job.sh"
+RUNNER="$REPO_DIR/scheduled-tasks/post-job-trigger.sh"
 
 # Check if crontab is available
 if ! command -v crontab &> /dev/null; then
@@ -26,7 +26,8 @@ fi
 MARKER="# LOBSTER-SCHEDULED"
 
 # Get existing crontab entries (excluding lobster ones)
-EXISTING=$(crontab -l 2>/dev/null | grep -v "$MARKER" | grep -v "$RUNNER" || true)
+OLD_RUNNER="$REPO_DIR/scheduled-tasks/run-job.sh"
+EXISTING=$(crontab -l 2>/dev/null | grep -v "$MARKER" | grep -v "$RUNNER" | grep -v "$OLD_RUNNER" || true)
 
 # Generate new crontab entries from jobs.json
 if command -v jq &> /dev/null; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1725,6 +1725,20 @@ DAILY_METRICS_TASK
         fi
     fi
 
+
+    # Migration 38: Update existing crontab entries to call post-job-trigger.sh instead of run-job.sh
+    # Phase 2 of issue #138: cron now writes a trigger message to the dispatcher inbox
+    # instead of spawning claude -p directly. This avoids competing MCP stdio connections.
+    # The old run-job.sh entries must be replaced with post-job-trigger.sh entries.
+    local OLD_RUNNER="$LOBSTER_DIR/scheduled-tasks/run-job.sh"
+    local NEW_RUNNER="$LOBSTER_DIR/scheduled-tasks/post-job-trigger.sh"
+    if crontab -l 2>/dev/null | grep -q "$OLD_RUNNER"; then
+        chmod +x "$NEW_RUNNER" 2>/dev/null || true
+        { crontab -l 2>/dev/null | sed "s|$OLD_RUNNER|$NEW_RUNNER|g" || true; } | crontab -
+        substep "Updated crontab entries: run-job.sh → post-job-trigger.sh (issue #138 Phase 2)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

- **`scheduled-tasks/post-job-trigger.sh`** (new): Cron calls this instead of `run-job.sh`. Writes a `scheduled_job_trigger` JSON file to `~/messages/inbox/` with `type`, `job_name`, `timestamp`, `source: "cron"`, and `chat_id` from `LOBSTER_ADMIN_CHAT_ID`. Never invokes `claude -p`.

- **`.claude/sys.dispatcher.bootup.md`**: New handler section for `scheduled_job_trigger` messages. Dispatcher reads `job_name` and `chat_id` from the trigger, spawns a `lobster-generalist` subagent (`run_in_background=True`) with the task file path, and marks the message processed. The subagent delivers results via `send_reply` + `write_result` — same contract as the old `run-job.sh` path.

- **`scheduled-tasks/sync-crontab.sh`**: `RUNNER` now points to `post-job-trigger.sh`. Also filters legacy `run-job.sh` entries from the `EXISTING` baseline so old entries don't survive a re-sync.

- **`scripts/upgrade.sh` (Migration 38)**: Rewrites any existing `run-job.sh` crontab entries to `post-job-trigger.sh` on existing installs.

`run-job.sh` is kept as a manual/fallback path. Phase 3 (remove it + flip the block-claude-p hook to block mode) requires 7 days of clean production first.

## Root cause addressed

`run-job.sh` spawned independent `claude -p` sessions that competed with the dispatcher's active MCP stdio connection, causing connection drops. Phase 2 routes all scheduled job execution through the dispatcher's existing inbox mechanism instead.

## Test plan

- [ ] Verify `post-job-trigger.sh <job-name>` writes a valid JSON file to `~/messages/inbox/`
- [ ] Verify the dispatcher picks up `scheduled_job_trigger` messages and spawns a subagent
- [ ] Verify `sync-crontab.sh` generates entries pointing to `post-job-trigger.sh`
- [ ] Run `upgrade.sh` on an install with existing `run-job.sh` crontab entries and confirm Migration 38 rewrites them
- [ ] Confirm `run-job.sh` still works manually as a fallback

Closes #138 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)