### PR TITLE
feat: wire proposals.md into active producer/consumer pipeline (issue #141)

### DIFF
--- a/scheduled-tasks/proposals-digest.py
+++ b/scheduled-tasks/proposals-digest.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Proposals Digest — Lobster Scheduled Job
+=========================================
+
+Reads meta/proposals.md, finds entries that have not yet been delivered,
+and surfaces them to the user via the Lobster inbox. Marks delivered entries
+so they are not re-sent on subsequent runs.
+
+A "delivered" entry is tracked by appending a `<!-- delivered: YYYY-MM-DD -->`
+HTML comment on the line immediately after its heading.
+
+Delivery state is purely file-based — no external database required. The file
+is the source of truth.
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/proposals-digest.py
+"""
+
+import json
+import os
+import re
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PROPOSALS_PATH = Path.home() / "lobster-workspace" / "meta" / "proposals.md"
+JOB_NAME = "proposals-digest"
+
+# Maximum number of entries to deliver per run. Keeps Telegram from flooding.
+MAX_DELIVER_PER_RUN = 2
+
+# Heading pattern that opens a meta-run entry: ### [YYYY-MM-DD] ...
+ENTRY_HEADING_RE = re.compile(r"^### \[(\d{4}-\d{2}-\d{2})\](.+)$", re.MULTILINE)
+
+# Marker we write into the file to record delivery.
+DELIVERED_MARKER_PREFIX = "<!-- proposals-digest-delivered:"
+DELIVERED_MARKER_RE = re.compile(
+    r"<!-- proposals-digest-delivered: (\d{4}-\d{2}-\d{2}) -->"
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure data helpers
+# ---------------------------------------------------------------------------
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def timestamp_iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def today_str(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# Proposals file parsing
+# ---------------------------------------------------------------------------
+
+def parse_entries(content: str) -> list[dict]:
+    """
+    Parse proposals.md into a list of entry dicts.
+
+    Each entry has:
+      - date: str  (YYYY-MM-DD from heading)
+      - title: str (rest of heading after date)
+      - heading_pos: int (character offset of the heading start)
+      - body_start: int (character offset of the line after heading)
+      - body_end: int (character offset where next entry begins, or end of file)
+      - delivered: bool (True if a delivered marker is present in the body)
+      - delivered_date: str | None
+    """
+    entries = []
+    matches = list(ENTRY_HEADING_RE.finditer(content))
+
+    for idx, m in enumerate(matches):
+        date_str = m.group(1)
+        title = m.group(2).strip()
+        heading_pos = m.start()
+
+        # Body starts at the character after the heading line's newline
+        body_start = m.end() + 1  # +1 to skip the \n after the heading
+
+        # Body ends at the start of the next entry heading, or end of file
+        body_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(content)
+
+        body = content[body_start:body_end]
+
+        delivered_match = DELIVERED_MARKER_RE.search(body)
+        delivered = delivered_match is not None
+        delivered_date = delivered_match.group(1) if delivered_match else None
+
+        entries.append({
+            "date": date_str,
+            "title": title,
+            "heading_pos": heading_pos,
+            "body_start": body_start,
+            "body_end": body_end,
+            "body": body,
+            "delivered": delivered,
+            "delivered_date": delivered_date,
+        })
+
+    return entries
+
+
+def undelivered_entries(entries: list[dict]) -> list[dict]:
+    """Return entries that have not yet been delivered, oldest first."""
+    return [e for e in entries if not e["delivered"]]
+
+
+def select_to_deliver(entries: list[dict]) -> list[dict]:
+    """Select up to MAX_DELIVER_PER_RUN oldest undelivered entries."""
+    # entries are already in file order (chronological, oldest first in typical append style)
+    return entries[:MAX_DELIVER_PER_RUN]
+
+
+# ---------------------------------------------------------------------------
+# File mutation
+# ---------------------------------------------------------------------------
+
+def insert_delivered_marker(content: str, entry: dict, date_str: str) -> str:
+    """
+    Return a new content string with a delivered marker inserted at the start
+    of the entry's body. Pure: does not mutate content.
+    """
+    marker = f"{DELIVERED_MARKER_PREFIX} {date_str} -->\n"
+    insert_pos = entry["body_start"]
+    return content[:insert_pos] + marker + content[insert_pos:]
+
+
+def mark_all_delivered(content: str, entries: list[dict], date_str: str) -> str:
+    """
+    Insert delivered markers for all given entries.
+
+    Processes entries in reverse body_start order so that earlier insertions
+    do not shift the character offsets of later ones.
+    Pure: returns a new string.
+    """
+    result = content
+    offset = 0  # cumulative character offset from prior insertions
+
+    # Sort by body_start ascending so we process in document order,
+    # then apply with a running offset to keep positions accurate.
+    sorted_entries = sorted(entries, key=lambda e: e["body_start"])
+    marker_len = len(f"{DELIVERED_MARKER_PREFIX} {date_str} -->\n")
+
+    for entry in sorted_entries:
+        adjusted_entry = {**entry, "body_start": entry["body_start"] + offset}
+        result = insert_delivered_marker(result, adjusted_entry, date_str)
+        offset += marker_len
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Message formatting
+# ---------------------------------------------------------------------------
+
+def format_entry(entry: dict, index: int, total: int) -> str:
+    """
+    Format a single proposals entry as a Telegram message.
+
+    Strips the delivered marker (if somehow present) from the body before
+    formatting. Uses plain text for Telegram compatibility.
+    """
+    body = entry["body"].strip()
+    # Remove any existing delivered markers (defensive)
+    body = DELIVERED_MARKER_RE.sub("", body).strip()
+
+    date_str = entry["date"]
+    title = entry["title"]
+
+    header = f"Proposals digest {index}/{total} — {date_str}: {title}"
+
+    return "\n".join([header, "", body])
+
+
+def format_task_summary(delivered: int, remaining: int) -> str:
+    parts = [f"Delivered: {delivered} proposal entry(ies)."]
+    if remaining:
+        parts.append(f"Remaining undelivered: {remaining}.")
+    else:
+        parts.append("All entries delivered.")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Inbox / task-output I/O helpers
+# ---------------------------------------------------------------------------
+
+def _inbox_dir() -> Path:
+    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
+    inbox = Path(messages_base) / "inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+    return inbox
+
+
+def _task_outputs_dir() -> Path:
+    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
+    task_outputs = Path(messages_base) / "task-outputs"
+    task_outputs.mkdir(parents=True, exist_ok=True)
+    return task_outputs
+
+
+def write_inbox_message(chat_id: int, text: str, ts: str) -> None:
+    """
+    Write a subagent_result message to the Lobster inbox.
+    The dispatcher picks it up and routes it via send_reply.
+    All I/O is isolated to this function.
+    """
+    inbox = _inbox_dir()
+    msg_id = f"proposals_digest_{uuid.uuid4().hex}"
+    msg = {
+        "id": msg_id,
+        "type": "subagent_result",
+        "task_id": msg_id,
+        "chat_id": chat_id,
+        "source": "telegram",
+        "text": text,
+        "status": "success",
+        "sent_reply_to_user": False,
+        "timestamp": ts,
+    }
+    out_path = inbox / f"{msg_id}.json"
+    tmp_path = Path(str(out_path) + ".tmp")
+    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp_path.replace(out_path)
+
+
+def write_task_output(output: str, status: str, ts: str) -> None:
+    task_outputs = _task_outputs_dir()
+    date_prefix = ts[:19].replace(":", "").replace("-", "").replace("T", "-")
+    filename = f"{date_prefix}-proposals-digest.json"
+    record = {
+        "job_name": JOB_NAME,
+        "timestamp": ts,
+        "status": status,
+        "output": output,
+    }
+    out_path = task_outputs / filename
+    tmp_path = Path(str(out_path) + ".tmp")
+    tmp_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp_path.replace(out_path)
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+def run() -> int:
+    """
+    Execute the proposals digest pipeline.
+
+    Reads proposals.md → finds undelivered entries → selects up to
+    MAX_DELIVER_PER_RUN → formats messages → writes inbox files for dispatcher
+    delivery → inserts delivered markers → saves proposals.md.
+
+    Returns exit code: 0 for success, 1 for failure.
+    """
+    now = now_utc()
+    ts = timestamp_iso(now)
+    date_today = today_str(now)
+
+    print(f"[{ts}] Starting proposals-digest")
+    print(f"  Proposals path: {PROPOSALS_PATH}")
+
+    if not PROPOSALS_PATH.exists():
+        msg = "proposals.md not found — nothing to deliver."
+        print(f"  {msg}")
+        write_task_output(msg, "success", ts)
+        return 0
+
+    content = PROPOSALS_PATH.read_text(encoding="utf-8")
+    entries = parse_entries(content)
+    print(f"  Total entries parsed: {len(entries)}")
+
+    pending = undelivered_entries(entries)
+    print(f"  Undelivered entries: {len(pending)}")
+
+    if not pending:
+        msg = "No undelivered proposals entries. Queue is clear."
+        print(f"  {msg}")
+        write_task_output(msg, "success", ts)
+        return 0
+
+    to_deliver = select_to_deliver(pending)
+    remaining_after = len(pending) - len(to_deliver)
+
+    print(f"  Delivering {len(to_deliver)} entry(ies)...")
+
+    chat_id = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
+
+    messages = [
+        format_entry(entry, i + 1, len(to_deliver))
+        for i, entry in enumerate(to_deliver)
+    ]
+
+    for msg_text in messages:
+        write_inbox_message(chat_id, msg_text, ts)
+
+    # Mark delivered entries in the file
+    updated_content = mark_all_delivered(content, to_deliver, date_today)
+    PROPOSALS_PATH.write_text(updated_content, encoding="utf-8")
+    print(f"  Marked {len(to_deliver)} entry(ies) as delivered in proposals.md")
+
+    summary = format_task_summary(len(to_deliver), remaining_after)
+    print(f"  {summary}")
+    write_task_output(summary, "success", ts)
+
+    print(f"[{ts}] proposals-digest complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1899,6 +1899,153 @@ SURFACE_QUEUE_TASK
         fi
     fi
 
+    # Migration 44: Register lobster-meta scheduled job (issue #141)
+    # Runs the lobster-meta drift-detection agent nightly. Reads phase-alignment
+    # signals, surfaces anomalies against vision.md, appends entries to
+    # meta/proposals.md, and queues items to reflective-surface-queue.json.
+    # Runs at 01:00 UTC — before proposals-digest (03:00) so proposals are
+    # written before the consumer reads them.
+    local lobster_meta_task="$WORKSPACE_DIR/scheduled-jobs/tasks/lobster-meta.md"
+    if [ ! -f "$lobster_meta_task" ]; then
+        mkdir -p "$WORKSPACE_DIR/scheduled-jobs/tasks"
+        cat > "$lobster_meta_task" << 'LOBSTER_META_TASK'
+# Lobster Meta — Nightly Drift Detection
+
+**Job**: lobster-meta
+**Schedule**: Daily at 1:00 AM UTC (`0 1 * * *`)
+**GitHub issue**: https://github.com/dcetlin/Lobster/issues/141
+
+## Context
+
+You are running as a scheduled task. The main Lobster instance created this job.
+
+## Instructions
+
+You are running as the lobster-meta drift-detection agent.
+
+**Start here:** Read `~/lobster/.claude/agents/lobster-meta.md` in full. That file
+contains your complete operating instructions including epistemic posture, processing
+sequence, and output format. Do not proceed until you have read it.
+
+Follow all steps in that file exactly:
+1. Read phase-alignment signals
+2. Find what doesn't fit (anomalies, silences, contradictions)
+3. Check premise-review.md
+4. Append findings to ~/lobster-workspace/meta/proposals.md
+5. Queue reflective surfaces to ~/lobster-workspace/meta/reflective-surface-queue.json
+6. Archive processed signals
+7. Exit
+
+## Output
+
+When you complete your task, call `write_task_output` with:
+- job_name: "lobster-meta"
+- output: One-line summary: signals processed, anomalies found, surfaces queued.
+- status: "success" or "failed"
+
+Keep output concise. The main Lobster instance will review this later.
+LOBSTER_META_TASK
+        substep "Created lobster-meta task file in scheduled-jobs/tasks/"
+        migrated=$((migrated + 1))
+    fi
+    if [ -f "$JOBS_FILE" ] && command -v jq >/dev/null 2>&1; then
+        if ! jq -e '.jobs["lobster-meta"]' "$JOBS_FILE" > /dev/null 2>&1; then
+            local now_iso
+            now_iso=$(date -u +"%Y-%m-%dT%H:%M:%S.%6N+00:00")
+            TMP_JOBS=$(mktemp)
+            jq --arg now "$now_iso" '.jobs["lobster-meta"] = {
+                "name": "lobster-meta",
+                "schedule": "0 1 * * *",
+                "schedule_human": "Daily at 1:00",
+                "task_file": "tasks/lobster-meta.md",
+                "created_at": $now,
+                "updated_at": $now,
+                "enabled": true
+            }' "$JOBS_FILE" > "$TMP_JOBS" && mv "$TMP_JOBS" "$JOBS_FILE"
+            substep "Registered lobster-meta job in jobs.json (daily at 01:00 UTC)"
+            if [ -x "$LOBSTER_DIR/scheduled-tasks/sync-crontab.sh" ]; then
+                bash "$LOBSTER_DIR/scheduled-tasks/sync-crontab.sh" 2>/dev/null || true
+                substep "Crontab synchronized (lobster-meta added)"
+            fi
+            migrated=$((migrated + 1))
+        fi
+    fi
+
+    # Migration 45: Register proposals-digest scheduled job (issue #141)
+    # Reads meta/proposals.md, finds undelivered entries, delivers them to Dan
+    # via the Lobster inbox (up to 2 per run), and marks them as delivered by
+    # inserting a <!-- proposals-digest-delivered: YYYY-MM-DD --> marker.
+    # Runs at 03:00 UTC — after lobster-meta (01:00) so fresh proposals are
+    # included in the same morning's digest.
+    local proposals_digest_task="$WORKSPACE_DIR/scheduled-jobs/tasks/proposals-digest.md"
+    if [ ! -f "$proposals_digest_task" ]; then
+        mkdir -p "$WORKSPACE_DIR/scheduled-jobs/tasks"
+        cat > "$proposals_digest_task" << 'PROPOSALS_DIGEST_TASK'
+# Proposals Digest
+
+**Job**: proposals-digest
+**Schedule**: Daily at 3:00 AM UTC (`0 3 * * *`)
+**GitHub issue**: https://github.com/dcetlin/Lobster/issues/141
+
+## Context
+
+You are running as a scheduled task. The main Lobster instance created this job.
+
+## Instructions
+
+Run the proposals digest script:
+
+```bash
+uv run ~/lobster/scheduled-tasks/proposals-digest.py
+```
+
+The script:
+- Reads `~/lobster-workspace/meta/proposals.md`
+- Finds entries that have not yet been delivered (no delivered marker)
+- Delivers up to 2 entries to Dan via the Lobster inbox (Telegram)
+- Marks delivered entries with `<!-- proposals-digest-delivered: YYYY-MM-DD -->` so
+  they are not re-sent on subsequent runs
+
+No further action is needed after running the script.
+
+If the script fails (non-zero exit), include the error output in write_task_output
+with status="failed".
+
+## Output
+
+When you complete your task, call `write_task_output` with:
+- job_name: "proposals-digest"
+- output: The script's stdout output (or summary if clean)
+- status: "success" or "failed"
+
+Keep output concise. The main Lobster instance will review this later.
+PROPOSALS_DIGEST_TASK
+        substep "Created proposals-digest task file in scheduled-jobs/tasks/"
+        migrated=$((migrated + 1))
+    fi
+    if [ -f "$JOBS_FILE" ] && command -v jq >/dev/null 2>&1; then
+        if ! jq -e '.jobs["proposals-digest"]' "$JOBS_FILE" > /dev/null 2>&1; then
+            local now_iso
+            now_iso=$(date -u +"%Y-%m-%dT%H:%M:%S.%6N+00:00")
+            TMP_JOBS=$(mktemp)
+            jq --arg now "$now_iso" '.jobs["proposals-digest"] = {
+                "name": "proposals-digest",
+                "schedule": "0 3 * * *",
+                "schedule_human": "Daily at 3:00",
+                "task_file": "tasks/proposals-digest.md",
+                "created_at": $now,
+                "updated_at": $now,
+                "enabled": true
+            }' "$JOBS_FILE" > "$TMP_JOBS" && mv "$TMP_JOBS" "$JOBS_FILE"
+            substep "Registered proposals-digest job in jobs.json (daily at 03:00 UTC)"
+            if [ -x "$LOBSTER_DIR/scheduled-tasks/sync-crontab.sh" ]; then
+                bash "$LOBSTER_DIR/scheduled-tasks/sync-crontab.sh" 2>/dev/null || true
+                substep "Crontab synchronized (proposals-digest added)"
+            fi
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## What this fixes

`meta/proposals.md` has been accumulating since initialization on 2026-03-22 with no producer writing to it on a schedule and no consumer routing its content to the user. One entry has sat unread for four days. This PR closes that loop.

## What changed

Two scheduled jobs, registered via migrations 44 and 45 in `scripts/upgrade.sh`:

**Producer — `lobster-meta` (01:00 UTC nightly)**
The lobster-meta agent already existed as an agent definition but had no cron schedule. Migration 44 creates the task file and registers it in `jobs.json`. It reads phase-alignment signals, surfaces anomalies/silences against `vision.md`, appends entries to `proposals.md`, and queues items to `reflective-surface-queue.json`.

**Consumer — `proposals-digest` (03:00 UTC nightly)**
Migration 45 registers a new scheduled job backed by `scheduled-tasks/proposals-digest.py`. It reads `proposals.md`, selects up to 2 undelivered entries (oldest first), delivers them to the user via the Lobster inbox (same inbox-write pattern as `surface-queue-delivery.py`), and marks each entry with a `<!-- proposals-digest-delivered: YYYY-MM-DD -->` HTML comment so subsequent runs do not re-deliver.

The 03:00 schedule means fresh lobster-meta output from the same night is already written before the digest runs.

## Flow (added behavior)

```
01:00 UTC  lobster-meta runs
           → reads signals/phase-alignment/
           → appends entry to meta/proposals.md
           → queues items to reflective-surface-queue.json

03:00 UTC  proposals-digest runs
           → reads meta/proposals.md
           → finds entries without delivered marker
           → writes ≤2 inbox messages for dispatcher delivery
           → inserts <!-- proposals-digest-delivered: YYYY-MM-DD --> into file
           → writes task output

dispatcher  picks up inbox messages → send_reply → user sees proposals digest
```

Before this PR: proposals.md entries accumulated indefinitely with no delivery path. After: entries surface within ~26 hours of being written (at worst, next morning's 03:00 run).

## Design notes

- Delivery state is in-file (HTML comment marker), not a separate database. The file is the source of truth.
- Marker format is a valid HTML comment — it does not render in Markdown viewers and does not corrupt the file's readability.
- Pure functions handle all data transformation in `proposals-digest.py` (parsing, selection, marker insertion). I/O is isolated to `write_inbox_message()` and the final file write.
- Cap of 2 entries per run prevents Telegram flooding if proposals accumulate over a multi-day gap.
- The issue raises the risk that proposals.md format may not be stable. The parser matches only the `### [YYYY-MM-DD]` heading pattern from the agent definition — it does not assume internal field structure, so body format changes do not break delivery.

## Areas to review closely

- `mark_all_delivered()` in proposals-digest.py: inserts markers at body_start positions while tracking a cumulative offset. The logic handles multiple-entry delivery correctly but is the most stateful part of the pure pipeline — worth verifying the offset arithmetic.
- Migration 44 schedule (01:00 UTC): lobster-meta may take significant turns depending on signal volume. If it runs long and bleeds into 03:00, the proposals-digest will catch output on the next night rather than the same night. This is acceptable.
- The existing undelivered entry (2026-03-22) will be the first item sent when the job runs.

## Tests run

- [x] Manual unit tests on pure functions (parse_entries, undelivered_entries, select_to_deliver, mark_all_delivered, format_entry) — 5 assertions passed, including idempotency, MAX_DELIVER_PER_RUN cap, and marker-stripping in format output
- [x] Parse test against real `~/lobster-workspace/meta/proposals.md` — 1 entry parsed, delivery preview correct
- [x] `uv run pytest tests/ -q --ignore=tests/integration/test_installation.py` — 21 failed, 2164 passed (identical failure count to main before this change — pre-existing failures unrelated to this pipeline)

Closes #141