### PR TITLE
feat: add valence field (golden/smell/neutral) to memory system

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2194,6 +2194,27 @@ AUTO_ROUTER_TASK
         fi
     fi
 
+    # Migration 50: Add valence column to memory.db events table.
+    # Classifies observations as golden (reinforce), smell (address), or neutral.
+    # The Python code handles this via ALTER TABLE on startup for existing DBs,
+    # but this migration catches cases where the MCP server hasn't restarted yet
+    # and ensures the column exists before the next search or store call.
+    local MEMORY_DB="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/data/memory.db"
+    if [ -f "$MEMORY_DB" ] && command -v sqlite3 >/dev/null 2>&1; then
+        if ! sqlite3 "$MEMORY_DB" "PRAGMA table_info(events);" 2>/dev/null | grep -q "valence"; then
+            substep "Adding valence column to memory.db events table..."
+            sqlite3 "$MEMORY_DB" \
+                "ALTER TABLE events ADD COLUMN valence TEXT DEFAULT 'neutral' CHECK(valence IN ('golden', 'smell', 'neutral'));" \
+                2>/dev/null && \
+                sqlite3 "$MEMORY_DB" \
+                    "CREATE INDEX IF NOT EXISTS idx_events_valence ON events(valence);" \
+                    2>/dev/null && \
+                success "valence column added to memory.db (golden/smell/neutral register enabled)" || \
+                warn "Failed to add valence column to memory.db (may already exist or DB locked)"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/harvest/philosophy_harvester.py
+++ b/src/harvest/philosophy_harvester.py
@@ -46,6 +46,7 @@ class BootupCandidate:
 class MemoryObservation:
     text: str
     type: str = "pattern_observation"
+    valence: str = "neutral"   # 'golden' | 'smell' | 'neutral'
 
 
 @dataclass(frozen=True)
@@ -118,10 +119,12 @@ def parse_action_seeds(yaml_text: str) -> ActionSeeds:
         for item in (raw.get("bootup_candidates") or [])
     )
 
+    _valid_valences = {"golden", "smell", "neutral"}
     memory_observations = tuple(
         MemoryObservation(
             text=item["text"],
             type=item.get("type", "pattern_observation"),
+            valence=item.get("valence", "neutral") if item.get("valence") in _valid_valences else "neutral",
         )
         for item in (raw.get("memory_observations") or [])
     )
@@ -234,6 +237,7 @@ def store_memory_observation(obs: MemoryObservation, dry_run: bool) -> bool:
     mcp_cmd = ["uv", "run", "-m", "mcp", "call", "lobster-inbox", "memory_store",
                json.dumps({"content": obs.text, "type": "note",
                            "tags": [obs.type], "source": "internal",
+                           "valence": obs.valence,
                            "task_id": "philosophy-harvester"})]
 
     result = subprocess.run(mcp_cmd, capture_output=True, text=True, timeout=15)
@@ -250,6 +254,7 @@ def store_memory_observation(obs: MemoryObservation, dry_run: bool) -> bool:
         "type": "note",
         "tags": [obs.type],
         "source": "philosophy-harvester",
+        "valence": obs.valence,
     }
     with pending_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record) + "\n")

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2322,6 +2322,16 @@ async def list_tools() -> list[Tool]:
                         "items": {"type": "string"},
                         "description": "Optional tags for categorization.",
                     },
+                    "valence": {
+                        "type": "string",
+                        "enum": ["golden", "smell", "neutral"],
+                        "description": (
+                            "Observation valence: 'golden' for patterns that work well and should be reinforced, "
+                            "'smell' for problematic patterns that should be addressed, "
+                            "'neutral' for observations with no strong directional signal (default)."
+                        ),
+                        "default": "neutral",
+                    },
                     "task_id": {
                         "type": "string",
                         "description": "Optional subagent task identifier. Included in debug alerts when LOBSTER_DEBUG=true so the caller is visible in the memory write notification.",
@@ -2348,6 +2358,14 @@ async def list_tools() -> list[Tool]:
                     "project": {
                         "type": "string",
                         "description": "Optional project filter.",
+                    },
+                    "valence": {
+                        "type": "string",
+                        "enum": ["golden", "smell", "neutral"],
+                        "description": (
+                            "Optional valence filter. Pass 'golden' to retrieve only golden patterns, "
+                            "'smell' to retrieve only smell patterns, or omit to search all observations."
+                        ),
                     },
                     "task_id": {
                         "type": "string",
@@ -6722,6 +6740,10 @@ async def handle_memory_store(arguments: dict[str, Any]) -> list[TextContent]:
     if not content:
         return [TextContent(type="text", text="Error: content is required.")]
 
+    from .memory.provider import VALENCE_VALUES
+    raw_valence = arguments.get("valence", "neutral")
+    valence = raw_valence if raw_valence in VALENCE_VALUES else "neutral"
+
     event = MemoryEvent(
         id=None,
         timestamp=datetime.now(timezone.utc),
@@ -6730,11 +6752,12 @@ async def handle_memory_store(arguments: dict[str, Any]) -> list[TextContent]:
         project=arguments.get("project"),
         content=content,
         metadata={"tags": arguments.get("tags", [])},
+        valence=valence,
     )
 
     try:
         event_id = _memory_provider.store(event)
-        result_text = f"Stored memory event #{event_id} (type={event.type}, source={event.source})"
+        result_text = f"Stored memory event #{event_id} (type={event.type}, source={event.source}, valence={event.valence})"
     except Exception as e:
         log.error(f"memory_store failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error storing memory: {e}")]
@@ -6770,8 +6793,12 @@ async def handle_memory_search(arguments: dict[str, Any]) -> list[TextContent]:
     limit = arguments.get("limit", 10)
     project = arguments.get("project")
 
+    from .memory.provider import VALENCE_VALUES
+    raw_valence = arguments.get("valence")
+    valence = raw_valence if raw_valence in VALENCE_VALUES else None
+
     try:
-        results = _memory_provider.search(query, limit=limit, project=project)
+        results = _memory_provider.search(query, limit=limit, project=project, valence=valence)
     except Exception as e:
         log.error(f"memory_search failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error searching memory: {e}")]
@@ -6793,16 +6820,19 @@ async def handle_memory_search(arguments: dict[str, Any]) -> list[TextContent]:
         pass
 
     if not results:
-        return [TextContent(type="text", text=f"No memory events found for: {query}")]
+        valence_note = f" with valence={valence}" if valence else ""
+        return [TextContent(type="text", text=f"No memory events found for: {query}{valence_note}")]
 
-    lines = [f"**Memory Search Results** ({len(results)} found for \"{query}\"):"]
+    valence_label = f", valence={valence}" if valence else ""
+    lines = [f"**Memory Search Results** ({len(results)} found for \"{query}\"{valence_label}):"]
     for i, event in enumerate(results, 1):
         ts = _format_display_ts(event.timestamp, "%Y-%m-%d %I:%M %p %Z") if event.timestamp else "?"
         proj = f" [{event.project}]" if event.project else ""
         eid = f"#{event.id}" if event.id else ""
+        valence_tag = f" [{event.valence}]" if event.valence != "neutral" else ""
         # Truncate content for display
         content_preview = event.content[:200] + "..." if len(event.content) > 200 else event.content
-        lines.append(f"\n{i}. {eid} ({event.type}/{event.source}{proj}) {ts}")
+        lines.append(f"\n{i}. {eid} ({event.type}/{event.source}{proj}{valence_tag}) {ts}")
         lines.append(f"   {content_preview}")
 
     return [TextContent(type="text", text="\n".join(lines))]

--- a/src/mcp/memory/provider.py
+++ b/src/mcp/memory/provider.py
@@ -11,6 +11,9 @@ from typing import Protocol, Optional
 from datetime import datetime
 
 
+VALENCE_VALUES = frozenset({"golden", "smell", "neutral"})
+
+
 @dataclass
 class MemoryEvent:
     """A single event stored in memory.
@@ -18,6 +21,11 @@ class MemoryEvent:
     Events represent messages, tasks, decisions, notes, or links
     that Lobster should remember. Each event is stored with its
     embedding for vector search and indexed for keyword search.
+
+    The ``valence`` field classifies an observation as a golden pattern
+    (something that works well and should be reinforced), a smell (something
+    problematic that should be addressed), or neutral (no strong signal).
+    Valid values: 'golden' | 'smell' | 'neutral' (default).
     """
     id: Optional[int]
     timestamp: datetime
@@ -27,6 +35,7 @@ class MemoryEvent:
     content: str
     metadata: dict = field(default_factory=dict)
     consolidated: bool = False
+    valence: str = "neutral"   # 'golden' | 'smell' | 'neutral'
 
     def to_dict(self) -> dict:
         """Serialize to a dictionary."""
@@ -39,6 +48,7 @@ class MemoryEvent:
             "content": self.content,
             "metadata": self.metadata,
             "consolidated": self.consolidated,
+            "valence": self.valence,
         }
 
     @classmethod
@@ -58,6 +68,7 @@ class MemoryEvent:
             content=data.get("content", ""),
             metadata=data.get("metadata", {}),
             consolidated=data.get("consolidated", False),
+            valence=data.get("valence", "neutral"),
         )
 
 
@@ -73,11 +84,20 @@ class MemoryProvider(Protocol):
         """Store an event and return its ID."""
         ...
 
-    def search(self, query: str, limit: int = 10, project: str = None) -> list[MemoryEvent]:
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        project: str = None,
+        valence: str = None,
+    ) -> list[MemoryEvent]:
         """Search memory for events matching the query.
 
         Uses hybrid search (vector + keyword) when available,
         falls back to keyword-only search otherwise.
+
+        Pass ``valence='golden'`` or ``valence='smell'`` to restrict results
+        to observations with that classification.
         """
         ...
 

--- a/src/mcp/memory/vector_memory.py
+++ b/src/mcp/memory/vector_memory.py
@@ -142,9 +142,22 @@ class VectorMemory:
                 content TEXT NOT NULL,
                 metadata TEXT DEFAULT '{}',
                 consolidated INTEGER DEFAULT 0,
-                created_at TEXT DEFAULT (datetime('now'))
+                created_at TEXT DEFAULT (datetime('now')),
+                valence TEXT DEFAULT 'neutral' CHECK(valence IN ('golden', 'smell', 'neutral'))
             )
         """)
+
+        # Add valence column to existing databases that pre-date this schema change.
+        # ALTER TABLE is a no-op on new databases (the column is in CREATE TABLE above).
+        try:
+            conn.execute(
+                "ALTER TABLE events ADD COLUMN valence TEXT DEFAULT 'neutral' "
+                "CHECK(valence IN ('golden', 'smell', 'neutral'))"
+            )
+            conn.commit()
+        except Exception:
+            # Column already exists — expected on new installs after CREATE TABLE
+            pass
 
         # Create FTS5 virtual table for keyword search
         conn.execute("""
@@ -200,6 +213,10 @@ class VectorMemory:
             CREATE INDEX IF NOT EXISTS idx_events_project
             ON events(project)
         """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_events_valence
+            ON events(valence)
+        """)
 
         conn.commit()
         return conn
@@ -212,10 +229,13 @@ class VectorMemory:
         # Generate embedding
         embedding = self._embedder.embed_one(event.content)
 
+        from .provider import VALENCE_VALUES
+        valence = event.valence if event.valence in VALENCE_VALUES else "neutral"
+
         cursor = self._conn.execute(
             """
-            INSERT INTO events (timestamp, type, source, project, content, metadata, consolidated)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO events (timestamp, type, source, project, content, metadata, consolidated, valence)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 event.timestamp.isoformat(),
@@ -225,6 +245,7 @@ class VectorMemory:
                 event.content,
                 json.dumps(event.metadata),
                 1 if event.consolidated else 0,
+                valence,
             ),
         )
         event_id = cursor.lastrowid
@@ -240,18 +261,29 @@ class VectorMemory:
         event.id = event_id
         return event_id
 
-    def search(self, query: str, limit: int = 10, project: str = None) -> list[MemoryEvent]:
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        project: str = None,
+        valence: str = None,
+    ) -> list[MemoryEvent]:
         """Hybrid search: 70% cosine similarity + 30% BM25 keyword.
 
         Falls back to keyword-only if vector search fails.
+
+        Pass ``valence='golden'`` or ``valence='smell'`` to restrict results
+        to observations with that classification.
         """
+        from .provider import VALENCE_VALUES
+        effective_valence = valence if valence in VALENCE_VALUES else None
         try:
-            return self._hybrid_search(query, limit, project)
+            return self._hybrid_search(query, limit, project, effective_valence)
         except Exception as e:
             log.warning(f"Hybrid search failed, falling back to keyword: {e}")
-            return self._keyword_search(query, limit, project)
+            return self._keyword_search(query, limit, project, effective_valence)
 
-    def _hybrid_search(self, query: str, limit: int, project: str = None) -> list[MemoryEvent]:
+    def _hybrid_search(self, query: str, limit: int, project: str = None, valence: str = None) -> list[MemoryEvent]:
         """Combine vector similarity and BM25 keyword scores."""
         # Vector search
         query_embedding = self._embedder.embed_one(query)
@@ -332,19 +364,28 @@ class VectorMemory:
         if project:
             ranked_ids = [eid for eid in ranked_ids if self._event_matches_project(eid, project)]
 
+        # Apply valence filter if specified (post-rank, preserves score ordering)
+        if valence:
+            ranked_ids = [eid for eid in ranked_ids if self._event_matches_valence(eid, valence)]
+
         # Fetch full events for top results
         return self._fetch_events(ranked_ids[:limit])
 
-    def _keyword_search(self, query: str, limit: int, project: str = None) -> list[MemoryEvent]:
+    def _keyword_search(self, query: str, limit: int, project: str = None, valence: str = None) -> list[MemoryEvent]:
         """Keyword-only search using FTS5."""
         fts_query = query.replace('"', '""')
 
-        where_clause = ""
+        where_parts = []
         params = []
 
         if project:
-            where_clause = "AND e.project = ?"
+            where_parts.append("e.project = ?")
             params.append(project)
+        if valence:
+            where_parts.append("e.valence = ?")
+            params.append(valence)
+
+        where_clause = ("AND " + " AND ".join(where_parts)) if where_parts else ""
 
         try:
             rows = self._conn.execute(
@@ -385,6 +426,13 @@ class VectorMemory:
             "SELECT project FROM events WHERE id = ?", (event_id,)
         ).fetchone()
         return row is not None and row["project"] == project
+
+    def _event_matches_valence(self, event_id: int, valence: str) -> bool:
+        """Check if an event has the specified valence."""
+        row = self._conn.execute(
+            "SELECT valence FROM events WHERE id = ?", (event_id,)
+        ).fetchone()
+        return row is not None and row["valence"] == valence
 
     def _fetch_events(self, event_ids: list[int]) -> list[MemoryEvent]:
         """Fetch full event objects by ID, preserving order."""
@@ -472,6 +520,12 @@ class VectorMemory:
         if isinstance(ts, str):
             ts = datetime.fromisoformat(ts)
 
+        # valence column may be absent on DBs not yet migrated; default to 'neutral'
+        try:
+            valence = row["valence"] or "neutral"
+        except (IndexError, KeyError):
+            valence = "neutral"
+
         return MemoryEvent(
             id=row["id"],
             timestamp=ts,
@@ -481,4 +535,5 @@ class VectorMemory:
             content=row["content"],
             metadata=metadata,
             consolidated=bool(row["consolidated"]),
+            valence=valence,
         )

--- a/tests/unit/test_mcp_server/test_debug_alerts.py
+++ b/tests/unit/test_mcp_server/test_debug_alerts.py
@@ -40,12 +40,13 @@ def _make_fake_memory_provider(result_count: int = 3):
         project = None
         timestamp = None
         content = "fake event content"
+        valence = "neutral"
 
     class FakeMemoryProvider:
         def store(self, event) -> int:
             return 42
 
-        def search(self, query, limit=10, project=None):
+        def search(self, query, limit=10, project=None, valence=None):
             return [FakeEvent() for _ in range(result_count)]
 
     return FakeMemoryProvider()
@@ -54,7 +55,7 @@ def _make_fake_memory_provider(result_count: int = 3):
 class MemoryEvent:
     """Thin stand-in so handle_memory_store can construct an event."""
 
-    def __init__(self, *, id, timestamp, type, source, project, content, metadata):
+    def __init__(self, *, id, timestamp, type, source, project, content, metadata, valence="neutral"):
         self.id = id
         self.timestamp = timestamp
         self.type = type
@@ -62,6 +63,7 @@ class MemoryEvent:
         self.project = project
         self.content = content
         self.metadata = metadata
+        self.valence = valence
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What problem this solves

The memory system accumulates observations but has no way to distinguish golden patterns (things working well) from smell patterns (things to fix) from neutral observations. The only way to find golden patterns was to search for keywords that happened to appear in their content — fragile and incomplete.

This PR adds a single `valence` field that makes the accumulation layer into a queryable golden/smell register.

## What changed

The `valence` field (`golden | smell | neutral`, default `neutral`) is added throughout the memory stack:

**Schema (memory.db `events` table)**
- New column `valence TEXT DEFAULT 'neutral' CHECK(valence IN ('golden', 'smell', 'neutral'))` with a supporting index
- Existing databases are migrated automatically in two ways: (1) `VectorMemory._init_db()` runs `ALTER TABLE ... ADD COLUMN` on startup with a silent catch for the "already exists" case; (2) Migration 50 in `upgrade.sh` does the same via `sqlite3` so the column is available before the MCP server restarts

**Data model (`src/mcp/memory/provider.py`)**
- `MemoryEvent` gains a `valence: str = "neutral"` field
- `to_dict()` / `from_dict()` round-trip it
- `MemoryProvider.search()` protocol signature gains `valence: str = None`
- `VALENCE_VALUES` frozenset is exported for validation at call sites

**Storage backend (`src/mcp/memory/vector_memory.py`)**
- `store()` writes `valence` (validated against `VALENCE_VALUES`, falls back to `"neutral"`)
- `search()` accepts `valence=` and passes it to both `_hybrid_search` and `_keyword_search`
- Hybrid search: valence filter applied post-rank (preserves score ordering)
- Keyword search: valence filter added directly to the WHERE clause (efficient)
- `_row_to_event()` reads `valence` with a safe fallback for DBs not yet migrated
- New helper `_event_matches_valence()`

**MCP API (`src/mcp/inbox_server.py`)**
- `memory_store` tool: new optional `valence` parameter with `enum` schema (`golden | smell | neutral`)
- `memory_search` tool: new optional `valence` filter parameter
- Search results display `[golden]` or `[smell]` tags inline when valence is non-neutral
- Error messages include valence context when a filtered search returns no results

**Harvester callers (`src/harvest/philosophy_harvester.py`)**
- `MemoryObservation` dataclass gains `valence: str = "neutral"`
- `parse_action_seeds()` reads `valence` from YAML action seeds
- `store_memory_observation()` passes `valence` through the MCP call and into the fallback JSONL record
- YAML format for action seeds now supports: `valence: golden` or `valence: smell` per observation item

What was not changed: `weekly_harvester.py` calls `memory_store` without valence — neutral is the right default there since the weekly retro produces mixed-signal observations. The `slow_reclassifier.py` writes directly to the events table; it would need a separate PR to classify its pattern observations by valence.

## How to query golden patterns

```
# Via MCP tool (dispatcher or subagent):
memory_search(query="patterns that work well", valence="golden")
memory_search(query="golden pattern", valence="golden", limit=20)
memory_search(query="reliability problem", valence="smell")
```

## Before/after flow

No state machine changes. The change is purely additive: a new column on a write path and a new optional filter on a read path. No routing, sequencing, or retry logic altered.

## Tests run

- [x] `uv run pytest tests/ -q --ignore=tests/integration/test_installation.py` — 2165 passed, 21 failed, 24 skipped. The 21 failures are pre-existing on main (confirmed by running identical command on main — identical failure set)
- [x] `uv run pytest tests/ -q -k "memory"` — 71 passed, 0 failed
- [x] Pre-existing failure `tests/integration/test_installation.py::TestPythonEnvironment::test_bot_module_importable` confirmed on main

**Functional patterns used:** pure-function validation (`VALENCE_VALUES` frozenset, checked at every boundary), immutability (frozen `MemoryObservation` dataclass), composition (valence filter composes with project filter without touching hybrid scoring logic), consistent defaults (`SQL DEFAULT 'neutral'` + `Python = "neutral"` + `API enum default "neutral"` all agree).