### PR TITLE
feat(vision-object): Vision Object Phase 1 — substrate, registry schema, staleness check

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2244,6 +2244,16 @@ The database lives at `~/lobster-workspace/orchestration/registry.db`.
 
 ## Instructions
 
+### 0. Load Vision Object
+
+Read `~/lobster-user-config/vision.yaml` at the start of each sweep. Extract:
+- `current_focus.this_week.primary` — the primary focus for this week
+- `current_focus.what_not_to_touch` — list of domains to exclude from UoW proposals
+- `active_project.phase_intent` — the current phase intent (one paragraph)
+
+Use these to populate `vision_ref` when upserting UoWs (see step 4). If the file
+does not exist, log a warning in sweep output and continue without vision anchoring.
+
 ### 1. Expire stale proposals
 
 First, expire any proposals older than 14 days that have not been confirmed:
@@ -2284,6 +2294,8 @@ For each issue, apply the following criteria:
 - Has `needs-design` label (not ready for execution)
 - Has `stale` label already
 - Has an open linked PR (work in progress)
+- Issue title/domain matches an entry in `vision.current_focus.what_not_to_touch`
+  (note as "excluded by vision.what_not_to_touch" in sweep output)
 
 ### 4. Create UoWs for qualifying issues
 
@@ -2296,7 +2308,20 @@ uv run ~/lobster/src/orchestration/registry_cli.py upsert \
   --sweep-date "$(date +%Y-%m-%d)"
 ```
 
-Record the result (inserted vs skipped with reason) in your sweep output.
+After upserting, write the `vision_ref` field using the Registry CLI or direct
+SQLite update. Determine the vision anchor by checking:
+
+1. If the issue title or content matches `current_focus.this_week.primary`:
+   vision_ref = {"layer": "current_focus", "field": "this_week.primary",
+                 "statement": "<verbatim primary text>", "anchored_at": "<now ISO>"}
+
+2. If the issue is structural/registry/substrate work (relates to WOS, routing,
+   or Vision Object itself): vision_ref references `active_project.phase_intent`.
+
+3. Otherwise: vision_ref = null (issue has no explicit vision anchor yet).
+
+Record the result (inserted vs skipped with reason, and vision_ref assigned) in
+your sweep output.
 
 ### 5. Compute gate readiness
 
@@ -2328,16 +2353,19 @@ Flag any `proposed` records approaching 14-day expiry (>= 12 days old) with:
 
 Call `write_task_output` with a structured report containing:
 
-1. **Expired proposals**: count and ids
-2. **Stale-active UoWs**: list (id, issue, summary) — if any
-3. **Issues scanned**: count
-4. **UoWs created**: list (id, issue number, title, action: inserted/skipped)
-5. **Ready queue** (proposed — awaiting /confirm):
+1. **Vision Object loaded**: yes/no (if no, reason)
+2. **Current focus**: one-line summary from vision.current_focus.this_week.primary
+3. **Expired proposals**: count and ids
+4. **Stale-active UoWs**: list (id, issue, summary) — if any
+5. **Issues scanned**: count
+6. **UoWs created**: list (id, issue number, title, action: inserted/skipped, vision_ref: layer or null)
+7. **Vision-excluded issues**: issues skipped due to what_not_to_touch
+8. **Ready queue** (proposed — awaiting /confirm):
    - One line per UoW: `<id> | #<issue> | <title> | created: <date> [EXPIRING SOON]`
-6. **Confirmed queue** (pending — awaiting execution):
+9. **Confirmed queue** (pending — awaiting execution):
    - One line per UoW: `<id> | #<issue> | <title>`
-7. **Dan-blocked items**: issues with `on-hold` label
-8. **Gate readiness**: gate_met, days_running, ratio
+10. **Dan-blocked items**: issues with `on-hold` label
+11. **Gate readiness**: gate_met, days_running, ratio
 
 Keep it concise — Dan reads this on mobile.
 
@@ -2371,6 +2399,25 @@ ISSUE_SWEEPER_TASK
                 substep "Crontab synchronized (issue-sweeper added)"
             fi
 
+            migrated=$((migrated + 1))
+        fi
+    fi
+
+    # Migration 48: Add vision_ref column to uow_registry (Vision Object Phase 1)
+    # Adds the intent-anchor field that connects each UoW back to a specific
+    # Vision Object layer. NULL is correct for pre-existing rows.
+    local registry_db="$WORKSPACE_DIR/orchestration/registry.db"
+    if [ -f "$registry_db" ]; then
+        if ! python3 -c "
+import sqlite3, sys
+conn = sqlite3.connect('$registry_db')
+cols = [row[1] for row in conn.execute('PRAGMA table_info(uow_registry)').fetchall()]
+conn.close()
+sys.exit(0 if 'vision_ref' in cols else 1)
+" 2>/dev/null; then
+            sqlite3 "$registry_db" "ALTER TABLE uow_registry ADD COLUMN vision_ref TEXT DEFAULT NULL;" 2>/dev/null && \
+                substep "Added vision_ref column to uow_registry" || \
+                warn "Could not add vision_ref column to uow_registry (non-fatal: column added at schema init for new installs)"
             migrated=$((migrated + 1))
         fi
     fi

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -83,7 +83,7 @@ class Registry:
     def _row_to_dict(self, row: sqlite3.Row) -> dict[str, Any]:
         d = dict(row)
         # Deserialize JSON-stored fields
-        for field in ("children", "hooks_applied", "route_evidence", "trigger"):
+        for field in ("children", "hooks_applied", "route_evidence", "trigger", "vision_ref"):
             if d.get(field) and isinstance(d[field], str):
                 try:
                     d[field] = json.loads(d[field])

--- a/src/orchestration/schema.sql
+++ b/src/orchestration/schema.sql
@@ -42,8 +42,14 @@ CREATE TABLE IF NOT EXISTS uow_registry (
     route_reason        TEXT,
     route_evidence      TEXT    DEFAULT '{}',
     trigger             TEXT    DEFAULT '{"type": "immediate"}',
+    vision_ref          TEXT    DEFAULT NULL,
     UNIQUE(source_issue_number, sweep_date)
 );
+-- vision_ref: JSON {layer, field, statement, anchored_at}
+-- NULL = created before Vision Object existed or no vision anchor found.
+-- Example: {"layer": "current_focus", "field": "primary",
+--           "statement": "Design and commit Vision Object...",
+--           "anchored_at": "2026-03-27T00:00:00+00:00"}
 
 CREATE TABLE IF NOT EXISTS audit_log (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## What this solves

Without a queryable intent substrate, every agent routing decision requires reading prose handoff docs and inferring Dan's priorities from conversational texture. The result is contextually fluent outputs that are structurally unanchored — the agent sounds aligned without being derivably so.

This PR implements Vision Object Phase 1 (three MVI steps from the design doc at docs/vision-object.md), giving every agent a structural reference for why work exists and which work matters right now.

## What changed

**Step 1: vision.yaml created** (private, not in this repo)

`~/lobster-user-config/vision.yaml` is now live, seeded from the epistemic framework and handoff doc:
- `core` layer: vision statement, fundamental intent, 3 inviolable constraints (screen-dependency, traceability, Orient-first), 5 operating principles
- `active_project` layer: WOS Phase 1 + Vision Object, phase_intent, success criteria, 2 open decisions (authority model, vision_ref schema), known risks
- `current_focus` layer: primary focus on Vision Object Phase 1, what_not_to_touch list (inference engine, multiplayer bot, cron Phase 2+3), horizon pointing to classifier routing integration

**Step 2: vision_ref column added to uow_registry**

`schema.sql` adds `vision_ref TEXT DEFAULT NULL` to `uow_registry`. The field carries:
```json
{"layer": "current_focus", "field": "this_week.primary",
 "statement": "<verbatim quoted text from vision.yaml>",
 "anchored_at": "<ISO8601>"}
```
NULL means the UoW was created before the Vision Object existed or no anchor was found — itself informative (orphaned from intent).

`registry.py` includes `vision_ref` in the JSON-deserialized field set, so callers get a parsed dict rather than a raw string.

**Migration 48** in `upgrade.sh`: `ALTER TABLE uow_registry ADD COLUMN vision_ref TEXT DEFAULT NULL` for existing registry.db installs. Idempotent (checks if column already exists before running).

**Issue sweeper heredoc updated** (migration 47 in upgrade.sh): The sweeper now reads `vision.yaml` at startup (Step 0), uses `what_not_to_touch` to exclude issues before proposing them as UoWs, and writes a `vision_ref` to each UoW it creates. Sweep output now includes Vision Object loaded status, current_focus summary, and vision-excluded issues.

**Step 3: Morning briefing staleness check wired**

`~/lobster-workspace/scheduled-jobs/tasks/async-deep-work.md` (the live task file, runtime state — not in this repo) now includes a Step 0 that:
- Reads vision.yaml, checks each layer's `updated_at` against staleness thresholds (core: 90d, active_project: 30d, current_focus: 7d)
- Checks if `current_focus.week_of` is more than 14 days past
- Surfaces a staleness notice and one-line vision summary at the top of every morning briefing artifact
- Does not send a separate ping — surfaces in the artifact only

## Functional patterns used

Pure functions and immutability throughout registry.py (each method opens a fresh connection, operates in a transaction, closes — no shared mutable state). The `vision_ref` field follows the same JSON-in-TEXT pattern as `route_evidence` — composable with the existing audit chain without schema complexity.

## Before/after: sweeper flow

```
Before:
  expire-proposals → check-stale → scan backlog → upsert UoWs
  (no intent anchor; every UoW orphaned from Dan's current focus)

After:
  load vision.yaml → expire-proposals → check-stale → scan backlog
  → [exclude what_not_to_touch issues] → upsert UoWs with vision_ref
  (UoWs carry traceable anchor; orphaned UoWs explicitly marked null)
```

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/ -x -q` — 54 passed, 0 failed
- [ ] Live sweeper run against registry.db — skipped: issue-sweeper migration hasn't run on live install yet; vision_ref column will be added by migration 48 on next upgrade

**Blocked items needing attention before merge:** none

Relates to #171 (WOS umbrella), #167 (WOS Phase 1)

vision.yaml content (redacted open decisions, retained structure):
```yaml
core:
  vision_statement: |
    Strong attunement to me and my principals — few poiesis-driven vision prompts,
    back-and-forth clarity, finished MVP, finished product.
  inviolable_constraints:
    - No system change that increases screen dependency or atrophies first-principles thinking
    - Every agent decision traceable to a specific vision.yaml field, not inferred from prose
    - Orient before Act — fix routing before adding detection

active_project:
  current_phase: "WOS Phase 1 + Vision Object substrate"
  phase_intent: |
    Build the substrate that lets every agent make intent-anchored decisions.

current_focus:
  this_week.primary: "Design, commit, and wire Vision Object Phase 1"
  what_not_to_touch:
    - "User model v2 Phase 3 inference engine — not until WOS substrate is stable"
    - "Multiplayer Telegram bot — not this quarter"
```