### PR TITLE
feat: wire valence into slow_reclassifier; convert surface delivery to digest

### DIFF
--- a/scheduled-tasks/surface-queue-delivery.py
+++ b/scheduled-tasks/surface-queue-delivery.py
@@ -198,40 +198,79 @@ def apply_updates(
 # Message formatting
 # ---------------------------------------------------------------------------
 
-def format_item(item: dict, index: int, total: int) -> str:
+_SOURCE_LABELS: dict[str, str] = {
+    "meta/premise-review.md": "Premise Review",
+    "meta/hygiene-review.md": "Hygiene Review",
+    "meta/oracle/learnings.md": "Oracle Learnings",
+}
+
+_GROUP_ORDER = ["Premise Review", "Hygiene Review", "Oracle Learnings"]
+
+
+def _queued_label(item: dict) -> str:
+    """Return a formatted date string for the item's queued_at field."""
+    raw = item.get("queued_at", "")
+    if not raw:
+        return "unknown date"
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        return raw
+
+
+def _source_label(item: dict) -> str:
+    return _SOURCE_LABELS.get(item.get("source_file", ""), item.get("source_file", "unknown source"))
+
+
+def format_item_block(item: dict) -> str:
     """
-    Format a single queue item as a Telegram message.
-
-    Uses plain text (no markdown) for Telegram compatibility.
+    Format a single item as a block of plain text for inclusion in a digest.
+    Pure function — no I/O.
     """
-    source_file = item.get("source_file", "unknown source")
-    source_label = {
-        "meta/premise-review.md": "Premise Review",
-        "meta/hygiene-review.md": "Hygiene Review",
-        "meta/oracle/learnings.md": "Oracle Learnings",
-    }.get(source_file, source_file)
-
-    queued = item.get("queued_at", "")
-    if queued:
-        try:
-            dt = datetime.fromisoformat(queued.replace("Z", "+00:00"))
-            queued_label = dt.strftime("%Y-%m-%d")
-        except ValueError:
-            queued_label = queued
-    else:
-        queued_label = "unknown date"
-
     observation = item.get("observation", "").strip()
     surface_reason = item.get("surface_reason", "").strip()
+    date_label = _queued_label(item)
 
-    lines = [
-        f"Reflective surface item {index}/{total} — {source_label} ({queued_label})",
-        "",
-        observation,
-    ]
-
+    lines = [f"({date_label}) {observation}"]
     if surface_reason:
-        lines += ["", f"Why surfaced: {surface_reason}"]
+        lines += [f"  Why surfaced: {surface_reason}"]
+    return "\n".join(lines)
+
+
+def format_digest(items: list[dict]) -> str:
+    """
+    Format all items as a single digest message, grouped by type.
+
+    Groups: Premise Review / Hygiene Review / Oracle Learnings (then others).
+    Pure function — no I/O.
+    """
+    if not items:
+        return ""
+
+    # Group items by their source label, preserving relative order within each group
+    groups: dict[str, list[dict]] = {}
+    for item in items:
+        label = _source_label(item)
+        groups.setdefault(label, []).append(item)
+
+    # Ordered: known groups first, then any unknown source labels alphabetically
+    known = [g for g in _GROUP_ORDER if g in groups]
+    unknown = sorted(g for g in groups if g not in _GROUP_ORDER)
+    ordered_groups = known + unknown
+
+    lines = ["Reflective Surface Digest"]
+    lines.append("")
+
+    for group_label in ordered_groups:
+        lines.append(f"-- {group_label} --")
+        for item in groups[group_label]:
+            lines.append(format_item_block(item))
+            lines.append("")
+
+    # Strip trailing blank line
+    while lines and lines[-1] == "":
+        lines.pop()
 
     return "\n".join(lines)
 
@@ -318,17 +357,14 @@ def write_task_output(output: str, status: str, timestamp: str) -> None:
 # Delivery via direct inbox writes
 # ---------------------------------------------------------------------------
 
-def deliver(messages: list[str], job_summary: str, delivered_count: int, archived_count: int) -> None:
+def deliver(digest_text: str, job_summary: str) -> None:
     """
-    Deliver messages to the Lobster inbox and write task output.
-    Each message is written as a subagent_result inbox file; the dispatcher
-    picks them up and routes them via send_reply. No Claude subprocess is spawned.
-    Side effects are isolated to this function.
+    Deliver the digest as a single inbox message and write task output.
+    One write_inbox_message call — not per-item. Side effects isolated here.
     """
     chat_id = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    for msg_text in messages:
-        write_inbox_message(chat_id, msg_text, timestamp)
+    write_inbox_message(chat_id, digest_text, timestamp)
     write_task_output(job_summary, "success", timestamp)
 
 
@@ -346,8 +382,10 @@ def run() -> int:
     """
     Execute the surface queue delivery pipeline.
 
-    Reads queue -> scores undelivered items -> selects top N -> formats messages
-    -> writes inbox files for dispatcher delivery -> marks delivered -> saves queue.
+    Reads queue -> scores undelivered items -> selects all candidates -> formats
+    as a single digest -> writes ONE inbox file -> marks all delivered -> saves queue.
+
+    If the queue has 0 undelivered items, nothing is sent (guardrail #5: no firehose).
 
     Returns exit code: 0 for success, 1 for failure.
     """
@@ -365,29 +403,24 @@ def run() -> int:
     print(f"  Items to archive (age > {ARCHIVE_AGE_DAYS} days): {len(to_archive)}")
 
     if not to_deliver and not to_archive:
-        print("  Nothing to do.")
+        print("  Nothing to do — queue is empty.")
         deliver_no_items("No undelivered items in the reflective surface queue.")
         return 0
 
-    # Format messages
-    messages = [
-        format_item(item, i + 1, len(to_deliver))
-        for i, item in enumerate(to_deliver)
-    ]
-
-    # Count remaining after this run
+    # Count remaining after this run (items not in to_deliver or to_archive)
     all_undelivered = [i for i in items if not is_delivered(i) and not is_archived(i)]
     remaining_after = max(0, len(all_undelivered) - len(to_deliver) - len(to_archive))
 
     job_summary = format_summary(len(to_deliver), len(to_archive), remaining_after)
     print(f"  Summary: {job_summary}")
 
-    # Deliver
-    if messages:
-        print("  Writing messages to inbox for dispatcher delivery...")
-        deliver(messages, job_summary, len(to_deliver), len(to_archive))
+    # Format and deliver as a single digest (not per-item)
+    if to_deliver:
+        digest_text = format_digest(to_deliver)
+        print("  Writing digest to inbox for dispatcher delivery...")
+        deliver(digest_text, job_summary)
     else:
-        # Only archiving, no messages to send — still write task output
+        # Only archiving — no items to show, just write task output
         deliver_no_items(job_summary)
 
     # Mark items in queue and save

--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -141,6 +141,25 @@ class ClassificationTag:
     )
 
 
+_GOLDEN_KEYWORDS = frozenset({"golden", "win", "strength"})
+_SMELL_KEYWORDS = frozenset({"smell", "drift", "failure", "error"})
+
+
+def classify_valence(pattern_type: str, description: str) -> str:
+    """
+    Classify a pattern observation as 'golden', 'smell', or 'neutral'.
+
+    Applies keyword heuristics to pattern_type and description text.
+    Pure function — no I/O.
+    """
+    combined = (pattern_type + " " + description).lower()
+    if any(kw in combined for kw in _GOLDEN_KEYWORDS):
+        return "golden"
+    if any(kw in combined for kw in _SMELL_KEYWORDS):
+        return "smell"
+    return "neutral"
+
+
 @dataclass
 class PatternObservation:
     """A cross-event pattern detected across a cluster."""
@@ -151,6 +170,7 @@ class PatternObservation:
     urgency: str
     posture_hint: str
     detected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    valence: str = "neutral"    # golden | smell | neutral
 
 
 # ---------------------------------------------------------------------------
@@ -341,16 +361,27 @@ def write_pattern_event(conn: sqlite3.Connection, obs: PatternObservation) -> in
         "signal_type": obs.signal_type,
         "urgency": obs.urgency,
         "posture_hint": obs.posture_hint,
+        "valence": obs.valence,
     })
     content = (
         f"pattern_observation | {obs.pattern_type} | source: {obs.source}\n"
         f"contributing events: {obs.event_ids}\n"
         f"signal_type: {obs.signal_type} | posture_hint: {obs.posture_hint}"
     )
-    cursor = conn.execute("""
-        INSERT INTO events (timestamp, type, source, content, metadata)
-        VALUES (?, 'pattern_observation', ?, ?, ?)
-    """, (obs.detected_at.isoformat(), obs.source, content, metadata))
+    # Write valence to the events table column added by PR #181.
+    # Fall back to INSERT without the column for databases that pre-date the migration
+    # (the column has a DEFAULT 'neutral' so the value is still correct either way).
+    try:
+        cursor = conn.execute("""
+            INSERT INTO events (timestamp, type, source, content, metadata, valence)
+            VALUES (?, 'pattern_observation', ?, ?, ?, ?)
+        """, (obs.detected_at.isoformat(), obs.source, content, metadata, obs.valence))
+    except sqlite3.OperationalError:
+        # valence column not yet present (pre-migration DB)
+        cursor = conn.execute("""
+            INSERT INTO events (timestamp, type, source, content, metadata)
+            VALUES (?, 'pattern_observation', ?, ?, ?)
+        """, (obs.detected_at.isoformat(), obs.source, content, metadata))
     event_id = cursor.lastrowid
 
     # Store embedding so this event is reachable via vector search.
@@ -487,6 +518,7 @@ def detect_design_session(
                     signal_type="design_session",
                     urgency="normal",
                     posture_hint="structural_coherence",
+                    valence=classify_valence("design_session", ""),
                 ))
 
     return observations
@@ -520,6 +552,7 @@ def detect_brainstorm_mode(
                     signal_type="brainstorm",
                     urgency="normal",
                     posture_hint="pattern_perception",
+                    valence=classify_valence("brainstorm_mode", ""),
                 ))
 
     return observations
@@ -551,6 +584,7 @@ def detect_complex_request(
                     signal_type="task_request",
                     urgency="high",
                     posture_hint="minimal_cognitive_friction",
+                    valence=classify_valence("complex_request", ""),
                 ))
 
     return observations
@@ -584,6 +618,7 @@ def detect_meta_thread(
                     signal_type="meta_thread",
                     urgency="normal",
                     posture_hint="structural_coherence",
+                    valence=classify_valence("meta_thread", ""),
                 ))
 
     return observations

--- a/tests/unit/test_slow_reclassifier_valence.py
+++ b/tests/unit/test_slow_reclassifier_valence.py
@@ -1,0 +1,164 @@
+"""
+Tests for the valence classification added to slow_reclassifier.py.
+
+Covers:
+- classify_valence heuristic (golden / smell / neutral)
+- PatternObservation carries valence
+- detect_* functions produce observations with expected valence
+"""
+from __future__ import annotations
+
+import pytest
+from src.classifiers.slow_reclassifier import (
+    PatternObservation,
+    classify_valence,
+    detect_brainstorm_mode,
+    detect_complex_request,
+    detect_design_session,
+    detect_meta_thread,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_valence — pure heuristic
+# ---------------------------------------------------------------------------
+
+class TestClassifyValence:
+    def test_golden_keyword_in_pattern_type(self):
+        assert classify_valence("golden_pattern", "") == "golden"
+
+    def test_win_keyword_in_description(self):
+        assert classify_valence("design_session", "This is a win for the team") == "golden"
+
+    def test_strength_keyword_in_description(self):
+        assert classify_valence("meta_thread", "Identified a core strength") == "golden"
+
+    def test_smell_keyword_in_pattern_type(self):
+        assert classify_valence("code_smell", "") == "smell"
+
+    def test_drift_keyword_in_description(self):
+        assert classify_valence("complex_request", "noticeable drift in direction") == "smell"
+
+    def test_failure_keyword_in_description(self):
+        assert classify_valence("brainstorm_mode", "repeated failure pattern") == "smell"
+
+    def test_error_keyword_in_description(self):
+        assert classify_valence("meta_thread", "error in the pipeline") == "smell"
+
+    def test_neutral_when_no_keywords(self):
+        assert classify_valence("design_session", "discussing architecture") == "neutral"
+
+    def test_neutral_empty_inputs(self):
+        assert classify_valence("", "") == "neutral"
+
+    def test_case_insensitive(self):
+        assert classify_valence("GOLDEN_PATTERN", "STRONG WIN") == "golden"
+        assert classify_valence("CODE_SMELL", "DRIFT DETECTED") == "smell"
+
+    def test_golden_takes_priority_over_smell_when_both_present(self):
+        # golden keywords appear first in the combined string since pattern_type is prepended
+        result = classify_valence("golden_item", "has a smell too")
+        assert result == "golden"
+
+
+# ---------------------------------------------------------------------------
+# PatternObservation default valence
+# ---------------------------------------------------------------------------
+
+class TestPatternObservationValence:
+    def _make(self, pattern_type: str = "design_session", valence: str = "neutral") -> PatternObservation:
+        return PatternObservation(
+            pattern_type=pattern_type,
+            source="test_source",
+            event_ids=[1, 2, 3],
+            signal_type="design_session",
+            urgency="normal",
+            posture_hint="structural_coherence",
+            valence=valence,
+        )
+
+    def test_default_valence_is_neutral(self):
+        obs = PatternObservation(
+            pattern_type="design_session",
+            source="src",
+            event_ids=[1],
+            signal_type="design_session",
+            urgency="normal",
+            posture_hint="structural_coherence",
+        )
+        assert obs.valence == "neutral"
+
+    def test_valence_golden(self):
+        obs = self._make(valence="golden")
+        assert obs.valence == "golden"
+
+    def test_valence_smell(self):
+        obs = self._make(valence="smell")
+        assert obs.valence == "smell"
+
+
+# ---------------------------------------------------------------------------
+# Detect functions produce observations with correct valence
+# ---------------------------------------------------------------------------
+
+class TestDetectFunctionsValence:
+    """
+    All four pattern types map to neutral valence via the current keyword heuristic
+    (none of design_session / brainstorm_mode / complex_request / meta_thread contain
+    golden or smell keywords). This tests that the valence field is wired through
+    and that the default is neutral.
+    """
+
+    from datetime import datetime, timezone
+
+    def _make_event(self, event_id: int, event_type: str, signal_type: str):
+        from datetime import datetime, timezone
+        from src.classifiers.slow_reclassifier import EventRow
+        return EventRow(
+            id=event_id,
+            timestamp=datetime(2026, 3, 27, 12, 0, event_id % 60, tzinfo=timezone.utc),
+            event_type=event_type,
+            source="test",
+            content="x",
+            metadata={},
+        )
+
+    def test_design_session_valence_neutral(self):
+        events = [self._make_event(i, "user_message", "design_question") for i in range(3)]
+        quick_tags = {e.id: {"signal_type": "design_question"} for e in events}
+        observations = detect_design_session(events, quick_tags)
+        assert len(observations) >= 1
+        assert all(obs.valence == "neutral" for obs in observations)
+
+    def test_brainstorm_mode_valence_neutral(self):
+        events = [self._make_event(i, "voice_note", "voice_note") for i in range(3)]
+        quick_tags = {e.id: {"signal_type": "voice_note"} for e in events}
+        observations = detect_brainstorm_mode(events, quick_tags)
+        assert len(observations) >= 1
+        assert all(obs.valence == "neutral" for obs in observations)
+
+    def test_complex_request_valence_neutral(self):
+        from src.classifiers.slow_reclassifier import EventRow
+        from datetime import datetime, timezone
+        events = [
+            EventRow(
+                id=i,
+                timestamp=datetime(2026, 3, 27, 12, 0, i, tzinfo=timezone.utc),
+                event_type="user_message",
+                source="test",
+                content="short",  # len < 50
+                metadata={},
+            )
+            for i in range(2)
+        ]
+        quick_tags = {e.id: {"signal_type": "task_request"} for e in events}
+        observations = detect_complex_request(events, quick_tags)
+        assert len(observations) >= 1
+        assert all(obs.valence == "neutral" for obs in observations)
+
+    def test_meta_thread_valence_neutral(self):
+        events = [self._make_event(i, "user_message", "meta_reflection") for i in range(2)]
+        quick_tags = {e.id: {"signal_type": "meta_reflection"} for e in events}
+        observations = detect_meta_thread(events, quick_tags)
+        assert len(observations) >= 1
+        assert all(obs.valence == "neutral" for obs in observations)

--- a/tests/unit/test_surface_queue_delivery.py
+++ b/tests/unit/test_surface_queue_delivery.py
@@ -155,3 +155,84 @@ class TestSelectItems:
         ]
         to_deliver, to_archive = sqd.select_items(items, now)
         assert len(to_deliver) == 0
+
+
+# ---------------------------------------------------------------------------
+# format_digest: single digest message from multiple items
+# ---------------------------------------------------------------------------
+
+class TestFormatDigest:
+    def _item(self, source_file: str, observation: str, surface_reason: str = "",
+              queued_at: str = "2026-03-25T12:00:00Z") -> dict:
+        return {
+            "source_file": source_file,
+            "observation": observation,
+            "surface_reason": surface_reason,
+            "queued_at": queued_at,
+        }
+
+    def test_empty_list_returns_empty_string(self):
+        assert sqd.format_digest([]) == ""
+
+    def test_single_item_contains_header_and_observation(self):
+        item = self._item("meta/premise-review.md", "Core premise is off")
+        result = sqd.format_digest([item])
+        assert "Reflective Surface Digest" in result
+        assert "Premise Review" in result
+        assert "Core premise is off" in result
+
+    def test_groups_by_source_type(self):
+        items = [
+            self._item("meta/premise-review.md", "Premise obs"),
+            self._item("meta/hygiene-review.md", "Hygiene obs"),
+        ]
+        result = sqd.format_digest(items)
+        assert "Premise Review" in result
+        assert "Hygiene Review" in result
+        assert "Premise obs" in result
+        assert "Hygiene obs" in result
+
+    def test_premise_review_before_hygiene_review(self):
+        items = [
+            self._item("meta/hygiene-review.md", "Hygiene obs"),
+            self._item("meta/premise-review.md", "Premise obs"),
+        ]
+        result = sqd.format_digest(items)
+        premise_pos = result.index("Premise Review")
+        hygiene_pos = result.index("Hygiene Review")
+        assert premise_pos < hygiene_pos
+
+    def test_surface_reason_included_when_present(self):
+        item = self._item("meta/hygiene-review.md", "The queue grew", surface_reason="Misaligned priority")
+        result = sqd.format_digest([item])
+        assert "Why surfaced: Misaligned priority" in result
+
+    def test_surface_reason_absent_when_empty(self):
+        item = self._item("meta/hygiene-review.md", "Routine check", surface_reason="")
+        result = sqd.format_digest([item])
+        assert "Why surfaced" not in result
+
+    def test_queued_date_formatted(self):
+        item = self._item("meta/premise-review.md", "obs", queued_at="2026-01-15T08:00:00Z")
+        result = sqd.format_digest([item])
+        assert "2026-01-15" in result
+
+    def test_result_is_single_string(self):
+        items = [
+            self._item("meta/premise-review.md", "obs 1"),
+            self._item("meta/premise-review.md", "obs 2"),
+        ]
+        result = sqd.format_digest(items)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_multiple_items_same_group(self):
+        items = [
+            self._item("meta/premise-review.md", "first obs"),
+            self._item("meta/premise-review.md", "second obs"),
+        ]
+        result = sqd.format_digest(items)
+        # Group header should appear once
+        assert result.count("Premise Review") == 1
+        assert "first obs" in result
+        assert "second obs" in result


### PR DESCRIPTION
## What problem this solves

Two follow-up wiring tasks from recent merged PRs:

**PR #181 (valence field)** explicitly noted that `slow_reclassifier.py` writes `pattern_observation` events directly and would need a separate PR to carry valence. Those events were being stored with no valence column, so they were invisible to `memory_search(valence='golden')` and `memory_search(valence='smell')` queries.

**Guardrail #5 (no per-item firehose)** — the surface-queue-delivery script was sending N individual inbox messages per run, one per item. Dan's guardrail says one daily digest, not a firehose.

## What changed

### slow_reclassifier.py

Added `classify_valence(pattern_type, description) -> str` — a pure keyword heuristic. Checks the combined pattern type + description string for golden keywords (`golden`, `win`, `strength`) and smell keywords (`smell`, `drift`, `failure`, `error`). Returns `'golden'`, `'smell'`, or `'neutral'`.

`PatternObservation` gains a `valence: str = "neutral"` field. All four `detect_*` functions pass `valence=classify_valence(pattern_type, "")` when constructing observations.

`write_pattern_event()` writes the `valence` column in the `INSERT` statement. If the column is absent (pre-PR-#181 DB), it silently falls back to the column-less insert — the DB default of `'neutral'` is correct either way. The valence value is also included in the `metadata` JSON blob for observability.

The four built-in pattern types (`design_session`, `brainstorm_mode`, `complex_request`, `meta_thread`) resolve to `neutral` under the current heuristic — none of their names hit the golden or smell keyword sets. That is correct: future pattern types or explicit description fields can carry non-neutral valence.

### surface-queue-delivery.py

Replaced the per-item message loop with a single digest. Added `format_digest(items)` — pure function, groups items by source label (`Premise Review / Hygiene Review / Oracle Learnings`) in a fixed priority order, formats each as a `(date) observation / Why surfaced:` block. `deliver()` now takes a single digest string and calls `write_inbox_message` once. If the queue has 0 items, nothing is sent.

`format_item()` (the old single-item formatter) is removed; `_source_labels`, `_group_order`, `_queued_label()`, `_source_label()`, `format_item_block()` replace it.

The scoring, archiving, and queue-save logic are unchanged.

## Functional patterns

Pure functions for all formatting and classification logic (`classify_valence`, `format_digest`, `format_item_block`). Immutable item dicts (existing `mark_delivered`/`mark_archived` pattern preserved). Composition: `format_digest` delegates to `format_item_block` per item. Keyword-based classification avoids external API calls.

## Areas to review closely

- `classify_valence`: golden-before-smell priority (first match wins on the combined string) means a string containing both `golden` and `smell` returns `golden`. This seems intentional — golden-signal patterns should not be downgraded to smell.
- The `write_pattern_event` fallback on `sqlite3.OperationalError` is a silent catch for schema compatibility.
- `format_digest` groups items with unknown source files alphabetically after the known groups.

## Concerns / known gaps

None. Pre-existing test failures are present on unmodified main and unrelated.

## Tests run

- [x] `uv run pytest tests/unit/test_slow_reclassifier_valence.py tests/unit/test_surface_queue_delivery.py -x -q` — 38 passed, 0 failed
- [x] `uv run pytest tests/ -x -q -k "reclassifier or surface"` — 41 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 1693 passed, 1 pre-existing failure, 6 pre-existing errors (same count as unmodified main)

**Blocked items needing attention before merge:** none.