### PR TITLE
docs: add lobster-outputs repo documentation and wire auto-push to sweep/deep-work jobs

### DIFF
--- a/docs/lobster-outputs-repo.md
+++ b/docs/lobster-outputs-repo.md
@@ -1,0 +1,63 @@
+# lobster-outputs: Human-Readable Job Output Repo
+
+## What it is
+
+`dcetlin/lobster-outputs` is a private GitHub repo that receives human-readable outputs from Lobster scheduled jobs. It exists so Dan can get real GitHub links to browse sweep docs, digests, and hygiene reports without exposing sensitive runtime data (memory.db, events.jsonl, logs).
+
+Repo: https://github.com/dcetlin/lobster-outputs
+
+## Why it exists
+
+The VPS runtime directory (`~/lobster-workspace/`) contains sensitive files that cannot be committed to any repo. But scheduled job outputs — sweep markdown files, morning briefings, weekly retros — are human-readable and useful to browse on GitHub. This repo is the bridge: structured, browsable, private.
+
+## Directory layout
+
+```
+lobster-outputs/
+  hygiene/      # Negentropic sweep outputs (YYYY-MM-DD-sweep.md)
+  digests/      # Daily deep-work morning briefings (YYYY-MM-DD-deep-work.md)
+  .gitignore    # Excludes *.db, *.jsonl, logs/
+```
+
+## Which jobs push here
+
+| Job | Output path in repo | When |
+|-----|---------------------|------|
+| `negentropic-sweep` | `hygiene/YYYY-MM-DD-sweep.md` | Nightly at 02:00 UTC |
+| `async-deep-work` | `digests/YYYY-MM-DD-deep-work.md` | Nightly at 05:00 UTC |
+
+Each job:
+1. Writes output to `~/lobster-workspace/` (primary location, unchanged)
+2. Copies it to `~/lobster-workspace/projects/lobster-outputs/<dir>/`
+3. Commits and pushes to `dcetlin/lobster-outputs`
+4. Includes the GitHub URL in its `write_task_output` call
+
+## Push pattern
+
+The repo is cloned to `~/lobster-workspace/projects/lobster-outputs/` and uses the `gh` CLI credential helper for auth:
+
+```
+git config credential.helper "/usr/bin/gh auth git-credential"
+```
+
+This means no hardcoded tokens — auth rotates automatically with the gh PAT.
+
+The push sequence in each task file looks like:
+
+```bash
+OUTPUTS_DIR=~/lobster-workspace/projects/lobster-outputs
+cp <output-file> ${OUTPUTS_DIR}/<subdir>/<filename>
+cd ${OUTPUTS_DIR}
+git add <subdir>/<filename>
+git commit -m "<subdir>: <filename>"
+git push origin main
+```
+
+## What never goes in this repo
+
+- `*.db` files (memory.db, etc.)
+- `*.jsonl` files (events.jsonl, etc.)
+- Log files
+- Any credential or config files
+
+The `.gitignore` enforces this, and these files are never written to `~/lobster-workspace/projects/lobster-outputs/` by any job.


### PR DESCRIPTION
## What this does

Two Lobster scheduled jobs now automatically push their human-readable outputs to a new private repo (`dcetlin/lobster-outputs`) after each run. This gives Dan real GitHub links to browse sweep docs and morning briefings without exposing VPS runtime data.

## Background

Sweep outputs and morning briefings are already written to `~/lobster-workspace/` on the VPS, but that directory can't be committed anywhere — it contains `memory.db`, `events.jsonl`, and logs. The lobster-outputs repo is the solution: a private repo that only receives clean markdown outputs, with a `.gitignore` that excludes all sensitive file types.

## Changes

**New repo** (`dcetlin/lobster-outputs`, private):
- `hygiene/` — nightly sweep files (`YYYY-MM-DD-sweep.md`)
- `digests/` — morning briefing files (`YYYY-MM-DD-deep-work.md`)
- `.gitignore` — excludes `*.db`, `*.jsonl`, `logs/`
- Seeded with all existing sweep outputs from the VPS

**Task file: `negentropic-sweep`** — after writing the sweep file to `~/lobster-workspace/hygiene/`, also copies it to the outputs repo, commits, and pushes. Includes the GitHub URL in `write_task_output`.

**Task file: `async-deep-work`** — same pattern for the nightly morning briefing. Both the main `dcetlin/Lobster/deep-work/` URL and the outputs repo URL are included in the Telegram notification.

**New doc: `docs/lobster-outputs-repo.md`** — explains the repo layout, which jobs push there, the push pattern (using `gh auth git-credential` for token-rotation-safe auth), and what is explicitly excluded.

## Auth pattern

The outputs repo uses the `gh` CLI as a git credential helper:
```
git config credential.helper "/usr/bin/gh auth git-credential"
```
No hardcoded tokens. Rotates automatically with the gh PAT.

## What is not changed

The primary output paths (`~/lobster-workspace/hygiene/`, `~/lobster-workspace/deep-work/`) are unchanged. The push to lobster-outputs is additive — a copy step after the main write. If the push fails, the primary output is already written and the job should note the failure in `write_task_output` but not treat it as fatal.

## Tests run

- [x] `git push origin main` from `~/lobster-workspace/projects/lobster-outputs` — succeeded, 25 files pushed to `dcetlin/lobster-outputs`
- [x] Push via gh credential helper verified working (up-to-date push confirmed)
- [ ] End-to-end job run with auto-push — not run: would require triggering the nightly jobs, which run on cron schedule. Pattern is identical to existing push logic in `async-deep-work` and `weekly-epistemic-retro` (already working in production).

**Blocked items needing attention before merge:** none