### PR TITLE
fix: exclude internal event types from classifier inputs (E1+E2)

### DIFF
--- a/src/classifiers/quick_classifier.py
+++ b/src/classifiers/quick_classifier.py
@@ -252,6 +252,8 @@ def read_unclassified_events(
                 ON ct.entry_id = CAST(e.id AS TEXT)
                 AND ct.classifier = ?
             WHERE ct.entry_id IS NULL
+              AND e.type NOT IN ('health_check', 'pattern_observation', 'proprioceptive', 'health_check_response')
+              AND (e.source IS NULL OR e.source NOT LIKE 'health-check%')
             ORDER BY e.created_at DESC
             LIMIT ?
         """, (CLASSIFIER_VERSION, limit))

--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -565,8 +565,15 @@ def detect_complex_request(
     """
     Detect complex requests: 2+ short events (content len < 50) from same source
     within 5 minutes.
+
+    Health-check events are excluded from the clustering window — their short,
+    frequent payloads would otherwise trigger spurious complex_request detections.
     """
-    short_events = [ev for ev in cluster if len(ev.content.strip()) < COMPLEX_REQUEST_CHAR_LIMIT]
+    short_events = [
+        ev for ev in cluster
+        if len(ev.content.strip()) < COMPLEX_REQUEST_CHAR_LIMIT
+        and not ev.source.startswith("health-check")
+    ]
     short_events.sort(key=lambda e: e.timestamp)
 
     observations: list[PatternObservation] = []


### PR DESCRIPTION
The quick-classifier and slow-reclassifier were processing internal system events — health checks, proprioceptive events, and pattern observations — as if they were user-intent signals. These event types have no intent to classify; feeding them in was a category error producing ~95% spurious classification tags.

## What changed

**E1 — quick_classifier: `read_unclassified_events` SQL filter**

Added two WHERE conditions to exclude events before they reach the classifier:

```sql
AND e.type NOT IN ('health_check', 'pattern_observation', 'proprioceptive', 'health_check_response')
AND (e.source IS NULL OR e.source NOT LIKE 'health-check%')
```

The `pattern_observation` exclusion was already present in the slow-reclassifier's `read_recent_events` (with a documented rationale about feedback loops), but was absent from the quick-classifier's read path. The other types (`health_check`, `proprioceptive`, `health_check_response`) are high-frequency internal noise with no user-intent content.

**E2 — slow_reclassifier: `detect_complex_request` source filter**

The complex_request detector triggers on 2+ short events (content < 50 chars) from the same source within 5 minutes. Health check payloads are short, frequent, and all share the same source — they meet this threshold structurally, generating spurious `complex_request` pattern observations on every cycle.

Added a pre-filter before the length check:

```python
and not ev.source.startswith("health-check")
```

This keeps the detector semantics intact for real user events while excluding the noise source.

## What was not changed

No routing logic, WOS registry, event schema, or other classifier files were modified. The `read_recent_events` function in the slow-reclassifier already excluded `pattern_observation` events and was not touched.

## Functional patterns

Both changes are pure SQL/list-comprehension filters — no state mutation, no new branches in classification logic. The quick-classifier change is in the DB read layer; the slow-reclassifier change is in a pure function operating on in-memory `EventRow` lists.

## Tests run

- [x] `uv run pytest tests/unit/test_slow_reclassifier_valence.py -v` — 18 passed, 0 failed
- [x] `uv run pytest tests/unit/ --tb=short` — 1747 passed, 24 skipped, 6 errors (pre-existing `FileExistsError` in unrelated path-guard fixtures — confirmed not caused by this change), 0 new failures

**Blocked items needing attention before merge:** none