### PR TITLE
fix: replace relative imports in memory_store/memory_search (fixes memory_store failures)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -6767,7 +6767,7 @@ async def handle_memory_store(arguments: dict[str, Any]) -> list[TextContent]:
     if not content:
         return [TextContent(type="text", text="Error: content is required.")]
 
-    from .memory.provider import VALENCE_VALUES
+    from memory.provider import VALENCE_VALUES
     raw_valence = arguments.get("valence", "neutral")
     valence = raw_valence if raw_valence in VALENCE_VALUES else "neutral"
 
@@ -6820,7 +6820,7 @@ async def handle_memory_search(arguments: dict[str, Any]) -> list[TextContent]:
     limit = arguments.get("limit", 10)
     project = arguments.get("project")
 
-    from .memory.provider import VALENCE_VALUES
+    from memory.provider import VALENCE_VALUES
     raw_valence = arguments.get("valence")
     valence = raw_valence if raw_valence in VALENCE_VALUES else None
 


### PR DESCRIPTION
## Summary

- `handle_memory_store` and `handle_memory_search` in `inbox_server.py` used relative imports (`from .memory.provider import VALENCE_VALUES`) inside lazy `from` statements
- `inbox_server.py` is launched as a script (`python inbox_server.py`), not as a module (`python -m`), so Python never sets `__package__`
- This causes `ImportError: attempted relative import with no known parent package` every time either function is called — 3 consecutive failures triggered the CAPABILITY ALERT

## Root cause vs. PR #86

This is a **different root cause** from #86 (which fixed a `sys.path` collision between `src/memory/` and `src/mcp/memory/`). That fix is correct and unaffected. The relative imports were introduced alongside or after #86.

## Fix

Replace both `from .memory.provider import VALENCE_VALUES` with `from memory.provider import VALENCE_VALUES`. This resolves correctly because `src/mcp/` is inserted at the front of `sys.path` at startup, so `memory.provider` resolves to `src/mcp/memory/provider.py` as intended.

## Test plan

- [ ] Verify `memory_store` succeeds after MCP server restart
- [ ] Verify `memory_search` with a valence filter succeeds
- [ ] Confirm no regression in `from memory import create_memory_provider` at module load (unaffected — that import uses the absolute path already)

🤖 Generated with [Claude Code](https://claude.com/claude-code)