### PR TITLE
docs: engineering-principles.md — PR review checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to Lobster
+
+## Engineering Principles
+
+Before opening a PR, read [`docs/engineering-principles.md`](docs/engineering-principles.md).
+It is a four-question checklist that every PR is evaluated against:
+
+1. Does each module have one contract?
+2. Are isolation boundaries enforced at the DB/view layer?
+3. Is audit-before-transition observed for every state change?
+4. Does the audit_log tell the full story on its own?
+
+These are structural constraints, not style preferences. PRs that violate them
+will be blocked at review.
+
+## Development Setup
+
+See [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) for environment setup and
+local testing instructions.
+
+## PR Sequence (WOS Phase 2)
+
+PRs in the WOS Phase 2 sequence (#302–#307) must be opened and merged in order.
+The integration test harness (issue #318) must pass for each PR before merge.


### PR DESCRIPTION
## Summary

- Adds `docs/engineering-principles.md`: a four-question PR review checklist (not a philosophy doc) covering the four structural constraints on Lobster architecture
- Adds `CONTRIBUTING.md` with a pointer to the checklist and WOS Phase 2 PR sequencing notes

## The four invariants

1. **Fractal unit coherence** — each module has one contract, statable in one sentence
2. **Isolation at the DB/view layer** — structural enforcement, not programmer discipline
3. **Audit-before-transition** — every state change is audited inside the same transaction, before the transition
4. **Cognitive clarity test** — audit_log alone reconstructs intent for a future reader

## Context

Requested as part of the implementation plan for WOS Phase 2 (#301). Reviewers apply this checklist to every PR in the #302–#307 sequence.

## Test plan

- [ ] Read `docs/engineering-principles.md` — each principle has a single actionable review question
- [ ] Read `CONTRIBUTING.md` — pointer to checklist is present and link resolves
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)