### PR TITLE
feat: add engineering-sensibilities skill

### DIFF
--- a/lobster-shop/INDEX.md
+++ b/lobster-shop/INDEX.md
@@ -12,6 +12,7 @@ Browse available skills for your Lobster assistant. Install any skill with one c
 | [GCal Links](./gcal-links/) | Google Calendar integration: read/create events via API when authenticated, or fall back to deep links — all via natural language | Behavioral | Available |
 | [Lobster Watcher](./lobster-watcher/) | Real-time observability dashboard — see all running and recent Lobster agent sessions as a live timeline and 3D view | Tool | Available |
 | [Brain Dumps](./brain-dumps/) | Voice note brain dump detection and routing — identifies stream-of-consciousness voice messages and dispatches them to the brain-dumps agent for staged processing | Behavioral | Available |
+| [Engineering Sensibilities](./engineering-sensibilities/) | PR-review checklist enforcing four engineering principles: fractal structure, golden patterns, maximal elegance, and cognitive clarity — activates on PR reviews and WOS implementation work | Behavioral | Available |
 | [Hibernation](./hibernation/) | Dispatcher hibernation — idle timeout behavior, state file semantics, and how to break the hibernation loop cleanly | Behavioral | Available |
 | [Obsidian KM](./obsidian-km/) | Sync and access your Obsidian vault via Telegram — create, read, search, and manage notes from anywhere | Tool | In Dev |
 

--- a/lobster-shop/engineering-sensibilities/behavior/system.md
+++ b/lobster-shop/engineering-sensibilities/behavior/system.md
@@ -1,0 +1,60 @@
+---
+name: engineering-sensibilities
+description: >
+  Engineering principles as a PR-review checklist. Use when reviewing PRs,
+  assessing implementation work, or discussing code structure — especially for
+  WOS pipeline work. Enforces four principles: fractal organizational structure,
+  gardens of golden patterns, maximal elegance, and cognitive clarity.
+---
+
+# Engineering Sensibilities
+
+When reviewing a PR or assessing implementation work, apply this checklist. Each item is a pass/fail gate. Raise blocking concerns for any unchecked item before approving.
+
+## The Four Principles
+
+### Fractal Organizational Structure
+
+Every level of the system mirrors the same discipline: one thing, one place, one path.
+
+- [ ] One responsibility per module — the module's purpose is stateable in one sentence
+- [ ] One exit path per function — no hidden early returns that bypass cleanup or logging
+- [ ] One merge point per PR — the PR addresses a single coherent change
+- [ ] Each module's contract is stateable in one sentence — if you can't state it, the boundary is wrong
+
+### Gardens of Golden Patterns
+
+Consistency compounds. Reuse patterns before inventing new ones; when you invent, make it reusable.
+
+- [ ] Named constants over magic values — `BOOTUP_CANDIDATE_GATE` not an inline `0.7`
+- [ ] `TypedDict` over plain `dict` for structured data — structure is documented at definition
+- [ ] Injectable callables over monkeypatching — dependencies flow in, not around
+- [ ] Reuse established patterns before inventing new ones — search the codebase before writing new abstractions
+
+### Maximal Elegance
+
+Complexity must earn its keep. Every abstraction that doesn't pay its way is a future maintenance burden.
+
+- [ ] Interfaces are tolerant — `from_json` ignores unknown fields rather than rejecting; callers are not broken by additive changes
+- [ ] Isolation enforced at the DB/view layer, not application layer — row-level security belongs in the database, not scattered across handlers
+- [ ] Complexity is load-bearing — every abstraction is justified by the problem it solves, not by pattern preference
+
+### Cognitive Clarity
+
+The code must be legible to a future reader with no prior context.
+
+- [ ] A future reader can reconstruct intent from `audit_log` alone — log entries are meaningful, not just present
+- [ ] Invariants are enforced structurally, not by convention — if something must always be true, the type system or DB constraint enforces it
+- [ ] The failure mode of the code is obvious from reading it — error paths are explicit; silent failures are absent
+
+## How to Use This Checklist
+
+For each unchecked item, state the specific location (file + line) and what change would resolve it. Do not approve a PR with unchecked items unless you explicitly call out the exception and the reason it is acceptable here.
+
+When raising concerns, be concrete:
+
+> "Fractal structure — `router.py` handles both auth and routing (two responsibilities). Extract auth to `middleware/auth.py`."
+
+not:
+
+> "This could be cleaner."

--- a/lobster-shop/engineering-sensibilities/skill.toml
+++ b/lobster-shop/engineering-sensibilities/skill.toml
@@ -1,0 +1,38 @@
+[skill]
+name = "engineering-sensibilities"
+version = "1.0.0"
+description = "Engineering principles as a PR-review checklist — fractal structure, golden patterns, maximal elegance, and cognitive clarity. Activates during PR reviews and WOS implementation work."
+author = "dcetlin"
+category = "behavioral"
+
+[activation]
+mode = "triggered"
+triggers = ["/eng-check", "pr review", "ready for review", "implementation", "wos"]
+context_patterns = [
+    "when user asks to review a PR",
+    "when user says something is ready for review",
+    "when user asks about implementation approach",
+    "when user is working on WOS pipeline",
+    "when user asks about code structure or organization",
+]
+
+[layering]
+priority = 60
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/eng-check"]
+
+[compatibility]
+enhances = ["desloppify"]
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"


### PR DESCRIPTION
## Summary

- Adds `lobster-shop/engineering-sensibilities/` skill with `skill.toml` and `behavior/system.md`
- Formalizes four engineering principles as a PR-review checklist: fractal organizational structure, gardens of golden patterns, maximal elegance, and cognitive clarity
- Activates on keywords: `pr review`, `ready for review`, `implementation`, `wos`; also available via `/eng-check` command
- Registered in `lobster-shop/INDEX.md`

## Test plan

- [ ] Install skill via `/shop install engineering-sensibilities` and confirm it loads
- [ ] Send a message containing "pr review" and confirm the checklist surfaces in the system context
- [ ] Send a message containing "wos" to confirm contextual activation
- [ ] Verify `/eng-check` bot command triggers the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)