### PR TITLE
fix: remove 14-day calendar gate from gate_readiness

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -456,13 +456,14 @@ class Registry:
 
     def gate_readiness(self) -> dict[str, Any]:
         """
-        Compute Phase 1 → Phase 2 autonomy gate metric.
+        Report Phase 1 → Phase 2 autonomy gate status.
 
-        Gate is met when:
-        1. Phase 1 has run for >= 14 days (oldest record is >= 14 days old)
-        2. proposed-to-confirmed ratio >= 80% over the last 7 days
+        The 14-day calendar gate has been removed. Phase 1 was declared complete
+        on 2026-03-30 (commit 2900900). gate_met is always True.
 
         Returns a dict with: gate_met, days_running, proposed_to_confirmed_ratio_7d, reason
+        The days_running and proposed_to_confirmed_ratio_7d fields are retained for
+        observability; they no longer gate Phase 2 entry.
         """
         conn = self._connect()
         try:
@@ -472,17 +473,17 @@ class Registry:
 
             if oldest is None:
                 return {
-                    "gate_met": False,
+                    "gate_met": True,
                     "days_running": 0,
                     "proposed_to_confirmed_ratio_7d": 0.0,
-                    "reason": "no records in registry",
+                    "reason": "phase 1 complete (2026-03-30)",
                 }
 
             oldest_dt = datetime.fromisoformat(oldest.replace("Z", "+00:00"))
             now = datetime.now(timezone.utc)
             days_running = (now - oldest_dt).days
 
-            # Ratio over last 7 days
+            # Ratio over last 7 days — retained for observability only
             seven_days_ago = (now - timedelta(days=7)).isoformat()
             proposed_last_7d = conn.execute(
                 """
@@ -504,21 +505,11 @@ class Registry:
 
             ratio = (confirmed_last_7d / proposed_last_7d) if proposed_last_7d > 0 else 0.0
 
-            days_ok = days_running >= 14
-            ratio_ok = ratio >= 0.80
-
-            if days_ok and ratio_ok:
-                reason = "all conditions met"
-            elif not days_ok:
-                reason = f"phase 1 has only been running {days_running} days (need >=14)"
-            else:
-                reason = f"proposed-to-confirmed ratio {ratio:.0%} over last 7 days (need >=80%)"
-
             return {
-                "gate_met": days_ok and ratio_ok,
+                "gate_met": True,
                 "days_running": days_running,
                 "proposed_to_confirmed_ratio_7d": round(ratio, 4),
-                "reason": reason,
+                "reason": "phase 1 complete (2026-03-30)",
             }
         finally:
             conn.close()

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -411,13 +411,23 @@ class TestCheckStale:
 # ---------------------------------------------------------------------------
 
 class TestGateReadiness:
-    def test_gate_not_ready_when_too_few_days(self, registry):
-        # Fewer than 14 days of data → gate not ready
+    def test_gate_met_regardless_of_days_running(self, registry):
+        # Phase 1 declared complete — 14-day calendar gate removed.
+        # gate_met is True even with a fresh (0-day-old) registry.
         readiness = registry.gate_readiness()
-        assert readiness["gate_met"] is False
-        assert "days_running" in readiness
+        assert readiness["gate_met"] is True
+
+    def test_gate_readiness_reports_phase1_complete(self, registry):
+        readiness = registry.gate_readiness()
+        assert "phase 1 complete" in readiness["reason"].lower()
 
     def test_gate_readiness_fields_present(self, registry):
         readiness = registry.gate_readiness()
         required_fields = {"gate_met", "days_running", "proposed_to_confirmed_ratio_7d", "reason"}
         assert required_fields.issubset(set(readiness.keys()))
+
+    def test_gate_readiness_no_records(self, registry):
+        # Empty registry should still report gate_met True (phase 1 complete).
+        readiness = registry.gate_readiness()
+        assert readiness["gate_met"] is True
+        assert readiness["days_running"] == 0


### PR DESCRIPTION
## What this fixes

`gate_readiness()` in `registry.py` was returning `gate_met: False` for any registry that hadn't accumulated 14 days of records — blocking Phase 2 UoW creation via the normal sweeper path. Phase 1 was declared complete on 2026-03-30 (commit 2900900), making the calendar gate a stale heuristic with no decision basis.

## Change

The 14-day day-count check and the 80% proposed-to-confirmed ratio check are removed as gate conditions. `gate_met` is now always `True`. The `days_running` and `proposed_to_confirmed_ratio_7d` fields are retained in the return value for observability — they no longer block Phase 2 entry.

The `reason` field now reads `"phase 1 complete (2026-03-30)"` instead of the blocking message `"phase 1 has only been running N days (need >=14)"`.

## Functional pattern

Pure function transformation: the function's return value is now a pure projection of observability metrics with a fixed `gate_met: True`, rather than conditional logic that mixed metric computation with gate policy. Gate policy is removed entirely since the decision has been made externally.

## What is not changed

- The `gate-readiness` CLI subcommand in `registry_cli.py` is untouched — it still works and will now report `gate_met: true`.
- The `expire-proposals` behavior (14-day expiry on proposed records) is a separate concept and is not changed.
- No schema changes.

## Which issues this unblocks

Closes #308. Unblocks Phase 2 implementation (#301) — specifically, new UoWs can now be created via the sweeper path without the gate blocking them.

## Tests run

- [x] `uv run --no-sync -m pytest tests/unit/test_orchestration/test_registry.py -x -q` — 34 passed, 0 failed (32 pre-existing + 2 new tests asserting `gate_met: True` and `reason` contains "phase 1 complete")