### PR TITLE
feat(wos-p2-pr1): WorkflowArtifact struct and serialization

### DIFF
--- a/src/orchestration/workflow_artifact.py
+++ b/src/orchestration/workflow_artifact.py
@@ -1,0 +1,133 @@
+"""
+WorkflowArtifact — Steward→Executor contract envelope.
+
+This module defines the typed structure for the workflow artifact: the
+document a Steward writes and an Executor reads. It is the boundary
+between planning (Steward) and execution (Executor).
+
+All downstream Phase 2 modules (#303 Steward, #305 Executor) import from
+this canonical path:
+
+    from orchestration.workflow_artifact import WorkflowArtifact, to_json, from_json
+
+The module is intentionally self-contained: no imports from other
+orchestration modules, so it can be imported in isolation without
+initializing the registry.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import TypedDict
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Canonical directory for artifact files written by the Steward.
+# Tilde is expanded to an absolute path at access time via artifact_path().
+_ARTIFACT_DIR_TEMPLATE = "~/lobster-workspace/orchestration/artifacts"
+
+# The only valid executor_type in Phase 2.
+# Phase 3 may add: 'code-runner', 'file-writer', etc.
+EXECUTOR_TYPE_GENERAL = "general"
+
+# All fields that must be present in a valid WorkflowArtifact.
+_REQUIRED_FIELDS = frozenset({"uow_id", "executor_type", "constraints", "prescribed_skills", "instructions"})
+
+
+# ---------------------------------------------------------------------------
+# Struct
+# ---------------------------------------------------------------------------
+
+class WorkflowArtifact(TypedDict):
+    """
+    The Steward→Executor contract.
+
+    Fields
+    ------
+    uow_id : str
+        Links to the UoWRegistry entry this artifact was produced for.
+    executor_type : str
+        Which Executor handles this UoW. Phase 2 valid value: 'general'.
+        Reserved for Phase 3 specialised dispatch paths.
+    constraints : list[str]
+        Hard constraints on execution (e.g. 'no-network-access').
+        Use [] for no constraints.
+    prescribed_skills : list[str]
+        Skill IDs to activate at task start.
+        None (NULL in registry) = Steward did not prescribe; use active skills.
+        [] = Steward explicitly prescribes no skills; deactivate contextual skills.
+        Phase 2: both None and [] are treated as "no skill activation required".
+        The semantic distinction is preserved for Phase 3.
+    instructions : str
+        Natural language guidance for the Executor's LLM dispatch.
+    """
+
+    uow_id: str
+    executor_type: str
+    constraints: list[str]
+    prescribed_skills: list[str]
+    instructions: str
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+def to_json(artifact: WorkflowArtifact) -> str:
+    """Serialize to JSON string for storage in registry.workflow_artifact field."""
+    return json.dumps(artifact)
+
+
+def from_json(json_str: str) -> WorkflowArtifact:
+    """
+    Deserialize from JSON string.
+
+    Raises ValueError on any parse or validation failure. Unknown extra
+    fields are silently ignored for forward compatibility (Phase 3 may add
+    optional fields without breaking Phase 2 readers).
+
+    Raises
+    ------
+    ValueError
+        If the input is not valid JSON, or if any required field is absent.
+    """
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"WorkflowArtifact: invalid JSON — possible partial write. Original error: {e}"
+        ) from e
+
+    missing = _REQUIRED_FIELDS - set(data.keys())
+    if missing:
+        raise ValueError(f"WorkflowArtifact missing required fields: {missing}")
+
+    # Reconstruct using only the known fields — ignores unknown keys.
+    return WorkflowArtifact(**{k: v for k, v in data.items() if k in _REQUIRED_FIELDS})
+
+
+# ---------------------------------------------------------------------------
+# Artifact file path utility
+# ---------------------------------------------------------------------------
+
+def artifact_path(uow_id: str) -> Path:
+    """
+    Return the absolute path for an artifact file.
+
+    Convention: ~/lobster-workspace/orchestration/artifacts/{uow_id}.json
+
+    The tilde is expanded to an absolute path at call time via
+    os.path.expanduser. The caller (Steward) must create the directory
+    before writing; artifact_path() does not create it.
+
+    The returned path must be stored in the registry as an absolute string
+    (str(artifact_path(uow_id))). The Executor reads the path from the
+    registry field and opens it without re-expansion.
+    """
+    expanded = os.path.expanduser(_ARTIFACT_DIR_TEMPLATE)
+    return Path(expanded) / f"{uow_id}.json"

--- a/tests/unit/test_orchestration/test_workflow_artifact.py
+++ b/tests/unit/test_orchestration/test_workflow_artifact.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for WorkflowArtifact — workflow_artifact.py
+
+Tests are written before implementation (TDD). They cover:
+- Import path stability
+- Round-trip serialization (all 5 required fields)
+- from_json() raises ValueError on missing fields (all 5 missing, single missing)
+- from_json() ignores unknown extra fields (forward compatibility)
+- from_json() raises ValueError (not json.JSONDecodeError) on malformed JSON
+- prescribed_skills=[] round-trips as [] (not None)
+- Artifact path utility: tilde expansion, absolute path
+- Audit log storability: to_json() → note → from_json() round-trip
+"""
+
+import json
+import os
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import path stability — must never break even if file is moved
+# ---------------------------------------------------------------------------
+
+def test_import_path_stable():
+    """The canonical import path must work. Catches accidental file renames."""
+    from orchestration.workflow_artifact import WorkflowArtifact, to_json, from_json
+    assert WorkflowArtifact is not None
+    assert callable(to_json)
+    assert callable(from_json)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+def test_round_trip_all_fields():
+    """Create WorkflowArtifact with all 5 fields set to non-default values, verify round-trip."""
+    from orchestration.workflow_artifact import WorkflowArtifact, to_json, from_json
+
+    artifact: WorkflowArtifact = {
+        "uow_id": "uow_20260330_abc123",
+        "executor_type": "general",
+        "constraints": ["no-network-access", "max-5-minutes"],
+        "prescribed_skills": ["systematic-debugging"],
+        "instructions": "Implement the feature described in the UoW summary.",
+    }
+
+    serialized = to_json(artifact)
+    recovered = from_json(serialized)
+
+    assert recovered["uow_id"] == "uow_20260330_abc123"
+    assert recovered["executor_type"] == "general"
+    assert recovered["constraints"] == ["no-network-access", "max-5-minutes"]
+    assert recovered["prescribed_skills"] == ["systematic-debugging"]
+    assert recovered["instructions"] == "Implement the feature described in the UoW summary."
+
+
+def test_round_trip_prescribed_skills_empty_list():
+    """prescribed_skills=[] must round-trip as [] (not None)."""
+    from orchestration.workflow_artifact import WorkflowArtifact, to_json, from_json
+
+    artifact: WorkflowArtifact = {
+        "uow_id": "uow_20260330_def456",
+        "executor_type": "general",
+        "constraints": [],
+        "prescribed_skills": [],
+        "instructions": "No skills required.",
+    }
+
+    serialized = to_json(artifact)
+    recovered = from_json(serialized)
+
+    assert recovered["prescribed_skills"] == []
+    assert recovered["prescribed_skills"] is not None
+
+
+# ---------------------------------------------------------------------------
+# from_json() validation — missing fields
+# ---------------------------------------------------------------------------
+
+def test_from_json_empty_object_raises_value_error():
+    """from_json('{}') raises ValueError naming all 5 missing fields."""
+    from orchestration.workflow_artifact import from_json
+
+    with pytest.raises(ValueError) as exc_info:
+        from_json("{}")
+
+    error_message = str(exc_info.value)
+    for field in ["uow_id", "executor_type", "constraints", "prescribed_skills", "instructions"]:
+        assert field in error_message, f"Missing field '{field}' not mentioned in error: {error_message}"
+
+
+def test_from_json_four_of_five_fields_raises_value_error():
+    """from_json() with 4 of 5 fields raises ValueError naming the single missing field."""
+    from orchestration.workflow_artifact import from_json
+
+    # All fields except 'instructions'
+    data = json.dumps({
+        "uow_id": "uow_20260330_abc123",
+        "executor_type": "general",
+        "constraints": [],
+        "prescribed_skills": [],
+    })
+
+    with pytest.raises(ValueError) as exc_info:
+        from_json(data)
+
+    assert "instructions" in str(exc_info.value)
+
+
+def test_from_json_missing_uow_id_raises_value_error():
+    """from_json() with missing uow_id raises ValueError naming uow_id."""
+    from orchestration.workflow_artifact import from_json
+
+    data = json.dumps({
+        "executor_type": "general",
+        "constraints": [],
+        "prescribed_skills": [],
+        "instructions": "Do something.",
+    })
+
+    with pytest.raises(ValueError) as exc_info:
+        from_json(data)
+
+    assert "uow_id" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# from_json() forward compatibility — unknown extra fields
+# ---------------------------------------------------------------------------
+
+def test_from_json_ignores_unknown_fields():
+    """from_json() with all 5 required fields plus unknown extras must succeed."""
+    from orchestration.workflow_artifact import from_json
+
+    data = json.dumps({
+        "uow_id": "uow_20260330_abc123",
+        "executor_type": "general",
+        "constraints": [],
+        "prescribed_skills": [],
+        "instructions": "Do something.",
+        # Phase 3 might add these — must be ignored in Phase 2
+        "priority": "high",
+        "deadline_at": "2026-04-01T00:00:00Z",
+    })
+
+    result = from_json(data)
+    assert result["uow_id"] == "uow_20260330_abc123"
+    assert "priority" not in result
+    assert "deadline_at" not in result
+
+
+# ---------------------------------------------------------------------------
+# from_json() error handling — malformed JSON
+# ---------------------------------------------------------------------------
+
+def test_from_json_malformed_json_raises_value_error_not_json_error():
+    """from_json() on malformed JSON must raise ValueError (not json.JSONDecodeError)."""
+    from orchestration.workflow_artifact import from_json
+
+    with pytest.raises(ValueError) as exc_info:
+        from_json("{this is not valid json}")
+
+    # Must NOT be a json.JSONDecodeError
+    assert type(exc_info.value) is ValueError
+    # Error message must reference partial write context
+    error_message = str(exc_info.value)
+    assert "WorkflowArtifact" in error_message
+    assert "partial write" in error_message
+
+
+def test_from_json_malformed_json_includes_original_error():
+    """from_json() on malformed JSON error message includes the original parse error."""
+    from orchestration.workflow_artifact import from_json
+
+    with pytest.raises(ValueError) as exc_info:
+        from_json("not json at all")
+
+    # The original error message must be chained/included
+    error_message = str(exc_info.value)
+    assert "Original error" in error_message
+
+
+# ---------------------------------------------------------------------------
+# Artifact path utilities
+# ---------------------------------------------------------------------------
+
+def test_artifact_path_expands_tilde():
+    """artifact_path(uow_id) must return an absolute path (no tilde prefix)."""
+    from orchestration.workflow_artifact import artifact_path
+
+    path = artifact_path("uow_20260330_abc123")
+    assert not str(path).startswith("~"), f"Path must not start with ~: {path}"
+    assert os.path.isabs(str(path)), f"Path must be absolute: {path}"
+
+
+def test_artifact_path_uses_uow_id_as_filename():
+    """artifact_path(uow_id) must end with {uow_id}.json."""
+    from orchestration.workflow_artifact import artifact_path
+
+    uow_id = "uow_20260330_abc123"
+    path = artifact_path(uow_id)
+    assert str(path).endswith(f"{uow_id}.json"), f"Path must end with {uow_id}.json: {path}"
+
+
+def test_artifact_path_uses_canonical_directory():
+    """artifact_path must point into the orchestration/artifacts/ directory."""
+    from orchestration.workflow_artifact import artifact_path
+
+    path = artifact_path("uow_20260330_abc123")
+    assert "orchestration/artifacts" in str(path), f"Path must contain orchestration/artifacts: {path}"
+
+
+# ---------------------------------------------------------------------------
+# Audit log storability
+# ---------------------------------------------------------------------------
+
+def test_audit_log_round_trip():
+    """
+    WorkflowArtifact serialized via to_json(), stored as a note string,
+    then from_json() on retrieval must produce an equal struct.
+    """
+    from orchestration.workflow_artifact import WorkflowArtifact, to_json, from_json
+
+    original: WorkflowArtifact = {
+        "uow_id": "uow_20260330_audit99",
+        "executor_type": "general",
+        "constraints": ["constraint-a"],
+        "prescribed_skills": ["systematic-debugging", "verification-before-completion"],
+        "instructions": "Validate the pipeline end-to-end.",
+    }
+
+    # Simulate storing in audit_log.note
+    note_value = to_json(original)
+    assert isinstance(note_value, str)
+
+    # Simulate reading back from audit_log.note
+    recovered = from_json(note_value)
+
+    assert recovered["uow_id"] == original["uow_id"]
+    assert recovered["executor_type"] == original["executor_type"]
+    assert recovered["constraints"] == original["constraints"]
+    assert recovered["prescribed_skills"] == original["prescribed_skills"]
+    assert recovered["instructions"] == original["instructions"]


### PR DESCRIPTION
## What this solves

Downstream Phase 2 PRs (#303 Steward, #305 Executor) need a shared, stable contract for the artifact a Steward writes and an Executor reads. Without a canonical module at a fixed import path, both modules would have to define their own struct or use plain dicts — creating divergence risk at the seam between planning and execution.

This PR establishes that contract.

## What changed

**New file: `src/orchestration/workflow_artifact.py`**

Defines `WorkflowArtifact` (a `TypedDict` with 5 required fields), `to_json()`, `from_json()`, and `artifact_path()`.

The import path `from orchestration.workflow_artifact import WorkflowArtifact, to_json, from_json` is now stable and can be safely referenced by #303 and #305.

Key behaviors:
- `from_json()` raises `ValueError` (not `json.JSONDecodeError`) on malformed input, with a message that flags partial-write as the likely cause — this is the diagnostic signal that matters at 2am.
- `from_json()` ignores unknown extra fields, so Phase 3 can add optional fields without breaking Phase 2 readers (tolerant interface principle).
- `artifact_path(uow_id)` expands `~` at call time and always returns an absolute `Path`. The registry must store `str(artifact_path(...))` — never a tilde-prefix string. The Executor reads the path from the registry field and opens it without re-expansion.
- `prescribed_skills=[]` round-trips as `[]`, not `None` — the semantic distinction between "not prescribed" and "explicitly empty" is preserved for Phase 3.

**Functional patterns used:** pure functions (`to_json`, `from_json`, `artifact_path` have no side effects), named constants (`EXECUTOR_TYPE_GENERAL`, `_REQUIRED_FIELDS`, `_ARTIFACT_DIR_TEMPLATE`) over inline magic values, `TypedDict` for the struct.

No changes to the registry, schema, or any other module.

## Tests run

- [x] `~/lobster/.venv/bin/python -m pytest tests/unit/test_orchestration/test_workflow_artifact.py -q` — 13 passed, 0 failed
- [x] `~/lobster/.venv/bin/python -m pytest tests/unit/test_orchestration/ -q` — 67 passed, 0 failed (all existing orchestration tests still pass)
- [ ] `uv run -m pytest` (full suite via uv) — blocked: `blue-lobster` git dep is unreachable in this environment (`remote: Repository not found`). The existing venv at `~/lobster/.venv` was used directly as the workaround. No behavior change to any existing module.

**Blocked items needing attention before merge:** none — the blocked test runner is an environment constraint, not a code issue.

Closes #302
Part of #301