### PR TITLE
fix: remove blue-lobster private dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "websockets>=13.0",
     "cryptography>=42.0.0",
     "pyyaml>=6.0.0",
-    "blue-lobster @ git+https://github.com/sayhar/blue-lobster.git",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -188,14 +188,6 @@ wheels = [
 ]
 
 [[package]]
-name = "blue-lobster"
-version = "0.1.0"
-source = { git = "https://github.com/sayhar/blue-lobster.git#461cdea04620fe2b659180970e00f1e6945406d3" }
-dependencies = [
-    { name = "httpx" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -881,7 +873,6 @@ name = "lobster"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "blue-lobster" },
     { name = "cryptography" },
     { name = "fastembed" },
     { name = "httpx" },
@@ -921,7 +912,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blue-lobster", git = "https://github.com/sayhar/blue-lobster.git" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastembed", specifier = ">=0.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary

- Removes `sayhar/blue-lobster` from `pyproject.toml` dependencies — it is a private repo inaccessible to fork CI, causing `uv sync` to fail on every cron run
- Neither `quick_classifier.py` nor `slow_reclassifier.py` ever imported it, so no fallback logic is needed — the dep was declared but completely unused
- `uv.lock` regenerated cleanly with 90 packages; 48 classifier tests pass

## Test plan

- [ ] `uv sync` resolves without error (no private git dep)
- [ ] `pytest -k classif` — 48 tests pass
- [ ] quick-classifier-loop and slow-reclassifier-loop cron jobs should pass on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)