### PR TITLE
feat(wos-p2-pr3): evaluate_condition(uow) with polling backend + Registrar sweep wiring

### DIFF
--- a/scheduled-tasks/issue-sweeper.py
+++ b/scheduled-tasks/issue-sweeper.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Issue Sweeper — UoW Registrar sweep script.
+
+Scans the UoW registry for `pending` records and advances those whose trigger
+condition is met to `ready-for-steward`.
+
+Phase 2 dependency: this script requires the Phase 2 schema migration to have
+been applied (scripts/migrate_add_steward_fields.py). The sweep calls
+registry.transition() and registry.append_audit_log() which write Phase 2
+fields. Do not run against a Phase 1-only database.
+
+Design constraints:
+- Only evaluates `pending` UoWs. UoWs in any other status are not touched.
+- evaluate_condition(False) path: no state change, no audit entry, no log output.
+- Optimistic lock on transition: if rows == 0 (another sweep won the race),
+  skip silently — do not write audit entry, DEBUG log only.
+- Does not crash the sweep when evaluate_condition raises (belt-and-suspenders:
+  conditions.py is designed to not raise, but the sweep is defensive).
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/issue-sweeper.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.orchestration.registry import Registry
+from src.orchestration.conditions import evaluate_condition
+
+log = logging.getLogger("issue-sweeper")
+
+
+# ---------------------------------------------------------------------------
+# Named constants
+# ---------------------------------------------------------------------------
+
+_STATUS_PENDING = "pending"
+_STATUS_READY_FOR_STEWARD = "ready-for-steward"
+_ACTOR_REGISTRAR = "registrar"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _default_db_path() -> Path:
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    return workspace / "data" / "registry.db"
+
+
+# ---------------------------------------------------------------------------
+# Core sweep function — testable, injectable
+# ---------------------------------------------------------------------------
+
+def run_sweep(
+    registry: Registry | None = None,
+    github_client: Callable[[int], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """
+    Sweep all `pending` UoWs and advance those whose trigger condition is met.
+
+    Parameters
+    ----------
+    registry:
+        Registry instance to use. If None, opens the production database at
+        the path returned by _default_db_path().
+    github_client:
+        Optional callable(issue_number) → {"status_code": int, "state": str|None}.
+        Passed through to evaluate_condition for issue_closed triggers.
+        Defaults to the production gh CLI client inside evaluate_condition.
+
+    Returns
+    -------
+    dict with keys:
+        evaluated: int — number of pending UoWs evaluated
+        advanced: int — number of UoWs transitioned to ready-for-steward
+        skipped: int — number of UoWs where condition was False (no change)
+        race_skipped: int — number of UoWs where transition returned 0 rows
+    """
+    if registry is None:
+        registry = Registry(_default_db_path())
+
+    pending_uows = registry.query(status=_STATUS_PENDING)
+    log.debug("Sweep: %d pending UoWs found", len(pending_uows))
+
+    evaluated = 0
+    advanced = 0
+    skipped = 0
+    race_skipped = 0
+
+    eval_kwargs: dict[str, Any] = {"registry": registry}
+    if github_client is not None:
+        eval_kwargs["github_client"] = github_client
+
+    for uow in pending_uows:
+        uow_id = uow["id"]
+
+        try:
+            condition_met = evaluate_condition(uow, **eval_kwargs)
+        except Exception:
+            log.exception("evaluate_condition raised unexpectedly for UoW %s — skipping", uow_id)
+            skipped += 1
+            evaluated += 1
+            continue
+
+        evaluated += 1
+
+        if not condition_met:
+            # Normal non-firing path — no state change, no audit entry, no log output.
+            skipped += 1
+            continue
+
+        # Condition met — attempt optimistic-lock transition.
+        rows = registry.transition(
+            uow_id,
+            to_status=_STATUS_READY_FOR_STEWARD,
+            where_status=_STATUS_PENDING,
+        )
+
+        if rows == 1:
+            # Transition succeeded — write trigger_fired audit entry.
+            registry.append_audit_log(uow_id, {
+                "event": "trigger_fired",
+                "actor": _ACTOR_REGISTRAR,
+                "uow_id": uow_id,
+                "trigger": uow.get("trigger"),
+                "timestamp": _now_iso(),
+            })
+            advanced += 1
+            log.info("UoW %s advanced to %s (trigger fired)", uow_id, _STATUS_READY_FOR_STEWARD)
+
+        else:
+            # rows == 0: another sweep already advanced this UoW — skip silently.
+            race_skipped += 1
+            log.debug("UoW %s: transition returned 0 rows (already advanced by another sweep)", uow_id)
+
+    log.info(
+        "Sweep complete: evaluated=%d advanced=%d skipped=%d race_skipped=%d",
+        evaluated, advanced, skipped, race_skipped,
+    )
+    return {
+        "evaluated": evaluated,
+        "advanced": advanced,
+        "skipped": skipped,
+        "race_skipped": race_skipped,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    result = run_sweep()
+    print(
+        f"Issue sweeper done: evaluated={result['evaluated']} "
+        f"advanced={result['advanced']} skipped={result['skipped']} "
+        f"race_skipped={result['race_skipped']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/orchestration/conditions.py
+++ b/src/orchestration/conditions.py
@@ -1,0 +1,236 @@
+"""
+UoW trigger condition evaluator — Phase 2 polling implementation.
+
+evaluate_condition(uow) is called by the Registrar sweep for each `pending`
+UoW to determine whether the UoW's trigger condition has been met.
+
+Design constraints:
+- Does not raise: all error paths return True or False with audit_log entries.
+- GitHub API call is isolated behind the `github_client` callable parameter,
+  making the function testable without monkeypatching.
+- NULL trigger returns True (backward compat with pre-trigger UoWs).
+- Malformed/unknown triggers return True + write condition_eval_error audit entry.
+- GitHub API failures return False + write condition_eval_failed audit entry.
+- registry_state with non-existent UoW returns False + condition_eval_error audit.
+- Normal False conditions (issue open, state not matched) write no audit entry.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any, Callable
+
+
+# ---------------------------------------------------------------------------
+# Type alias for the GitHub API client callable.
+# Callable[[int], dict] — takes an issue number, returns {"status_code": int, "state": str|None}
+# ---------------------------------------------------------------------------
+
+GithubClient = Callable[[int], dict[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# Production GitHub client (uses gh CLI — no network library needed)
+# ---------------------------------------------------------------------------
+
+def _default_github_client(issue_number: int) -> dict[str, Any]:
+    """
+    Query GitHub issue state via the gh CLI.
+
+    Returns {"status_code": 200, "state": "open"|"closed"} on success.
+    Returns {"status_code": <N>, "state": None} on non-200 or subprocess error.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "view", str(issue_number),
+                "--repo", "dcetlin/Lobster",
+                "--json", "state",
+                "--jq", ".state",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            state = result.stdout.strip().lower()
+            return {"status_code": 200, "state": state}
+        # gh CLI exits non-zero for 404 and other API errors.
+        # Parse the stderr to extract a status code if available.
+        stderr = result.stderr.lower()
+        if "not found" in stderr or "404" in stderr:
+            return {"status_code": 404, "state": None}
+        if "forbidden" in stderr or "403" in stderr:
+            return {"status_code": 403, "state": None}
+        return {"status_code": 500, "state": None}
+    except subprocess.TimeoutExpired:
+        return {"status_code": 408, "state": None}
+    except Exception:
+        return {"status_code": 500, "state": None}
+
+
+# ---------------------------------------------------------------------------
+# Trigger handlers — pure functions mapping (trigger_dict, uow, registry,
+# github_client) → bool. Each handler is responsible only for its trigger type.
+# ---------------------------------------------------------------------------
+
+def _eval_immediate(_trigger: dict, _uow: dict, **_kwargs) -> bool:
+    """Immediate trigger always fires."""
+    return True
+
+
+def _eval_issue_closed(
+    trigger: dict,
+    uow: dict,
+    registry: Any | None,
+    github_client: GithubClient,
+) -> bool:
+    """
+    Returns True when the specified GitHub issue is in 'closed' state.
+    Returns False on API failure (defer, not advance).
+    Writes condition_eval_failed audit entry on non-200 response.
+    """
+    issue_number = trigger.get("number")
+    response = github_client(issue_number)
+    status_code = response.get("status_code", 500)
+
+    if status_code == 200:
+        return response.get("state", "").lower() == "closed"
+
+    # Non-200: cannot confirm condition — defer (return False) and log.
+    if registry is not None:
+        registry.append_audit_log(uow["id"], {
+            "event": "condition_eval_failed",
+            "error_code": status_code,
+            "trigger_type": "issue_closed",
+            "uow_id": uow["id"],
+        })
+    return False
+
+
+def _eval_registry_state(
+    trigger: dict,
+    uow: dict,
+    registry: Any | None,
+) -> bool:
+    """
+    Returns True when the specified UoW is in the specified state.
+    Returns False if the UoW does not exist or registry is unreadable.
+    Writes condition_eval_error audit entry for non-existent UoW ID.
+    """
+    target_uow_id = trigger.get("uow_id")
+    target_state = trigger.get("state")
+
+    if registry is None:
+        # No registry provided — cannot evaluate; return False (safe default).
+        return False
+
+    try:
+        target = registry.get(target_uow_id)
+    except Exception:
+        # Unreadable registry — return False without crashing.
+        return False
+
+    if target.get("error") == "not found":
+        registry.append_audit_log(uow["id"], {
+            "event": "condition_eval_error",
+            "note": f"referenced uow_id not found: {target_uow_id}",
+            "uow_id": uow["id"],
+        })
+        return False
+
+    return target.get("status") == target_state
+
+
+# ---------------------------------------------------------------------------
+# Named constants for trigger types
+# ---------------------------------------------------------------------------
+
+_TRIGGER_IMMEDIATE = "immediate"
+_TRIGGER_ISSUE_CLOSED = "issue_closed"
+_TRIGGER_REGISTRY_STATE = "registry_state"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def evaluate_condition(
+    uow: dict[str, Any],
+    *,
+    registry: Any | None = None,
+    github_client: GithubClient | None = None,
+) -> bool:
+    """
+    Returns True if the UoW's trigger condition is met.
+
+    uow: a dict from registry._row_to_dict — reads uow['trigger'], uow['source_issue_number'],
+         uow['id']
+    registry: optional Registry instance for registry_state lookups and audit_log writes.
+              In production the sweep loop passes the registry instance. In isolated unit
+              tests it can be None (disables audit writes and registry_state lookups).
+    github_client: optional callable(issue_number) → {"status_code": int, "state": str|None}.
+                   Defaults to _default_github_client (uses gh CLI). Override in tests.
+
+    Returns True:  condition met — sweep should advance UoW to ready-for-steward.
+    Returns False: condition not yet met — remain pending, no state change.
+    Does not raise: all error paths return True or False, with optional audit_log entries.
+
+    Error return semantics:
+    - Malformed/unknown trigger → True (fail-open: do not silently block a UoW forever)
+    - GitHub API failure → False (fail-safe: do not advance without confirmation)
+    - registry_state with missing UoW → False (cannot confirm; log error)
+    """
+    if github_client is None:
+        github_client = _default_github_client
+
+    uow_id = uow.get("id", "unknown")
+    trigger = uow.get("trigger")
+
+    # NULL trigger: backward compat with pre-trigger UoWs — always fire.
+    if trigger is None:
+        return True
+
+    # If trigger is still a raw string (not yet deserialized), attempt parse.
+    if isinstance(trigger, str):
+        try:
+            trigger = json.loads(trigger)
+        except (json.JSONDecodeError, ValueError):
+            if registry is not None:
+                registry.append_audit_log(uow_id, {
+                    "event": "condition_eval_error",
+                    "note": "trigger not valid JSON",
+                    "uow_id": uow_id,
+                })
+            return True
+
+    # Unexpected type (not dict, not str, not None).
+    if not isinstance(trigger, dict):
+        if registry is not None:
+            registry.append_audit_log(uow_id, {
+                "event": "condition_eval_error",
+                "note": f"trigger not valid JSON (unexpected type: {type(trigger).__name__})",
+                "uow_id": uow_id,
+            })
+        return True
+
+    trigger_type = trigger.get("type")
+
+    if trigger_type == _TRIGGER_IMMEDIATE:
+        return _eval_immediate(trigger, uow)
+
+    if trigger_type == _TRIGGER_ISSUE_CLOSED:
+        return _eval_issue_closed(trigger, uow, registry=registry, github_client=github_client)
+
+    if trigger_type == _TRIGGER_REGISTRY_STATE:
+        return _eval_registry_state(trigger, uow, registry=registry)
+
+    # Unknown trigger type — fail-open with audit entry.
+    if registry is not None:
+        registry.append_audit_log(uow_id, {
+            "event": "condition_eval_error",
+            "note": f"unknown trigger type: {trigger_type}",
+            "uow_id": uow_id,
+        })
+    return True

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -454,6 +454,90 @@ class Registry:
         finally:
             conn.close()
 
+    def query(self, status: str) -> list[dict[str, Any]]:
+        """
+        Return all UoW records with the given status.
+
+        This is a named alias for `list(status=...)` with an explicit status
+        parameter — used by the Registrar sweep to fetch only `pending` UoWs.
+        """
+        return self.list(status=status)
+
+    def transition(
+        self,
+        uow_id: str,
+        to_status: str,
+        where_status: str,
+    ) -> int:
+        """
+        Conditional status transition — optimistic lock pattern.
+
+        Atomically updates status to `to_status` only if the current status
+        equals `where_status`. Returns the number of rows affected (0 or 1).
+
+        Callers must check the return value:
+        - 1: transition succeeded — write audit entry, proceed.
+        - 0: another sweep already advanced this UoW — skip silently.
+
+        Does NOT write an audit entry (the caller is responsible for that,
+        conditioned on rows == 1). This keeps audit responsibility at the
+        sweep layer where the business context is available.
+        """
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            now = _now_iso()
+            cursor = conn.execute(
+                """
+                UPDATE uow_registry
+                SET status = ?, updated_at = ?
+                WHERE id = ? AND status = ?
+                """,
+                (to_status, now, uow_id, where_status),
+            )
+            rows_affected = cursor.rowcount
+            conn.commit()
+            return rows_affected
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def append_audit_log(self, uow_id: str, entry: dict[str, Any]) -> None:
+        """
+        Append an unstructured audit log entry for a UoW.
+
+        The `entry` dict is serialized as JSON into the `note` column.
+        The `entry['event']` key is used as the audit event name.
+
+        This method is used by callers (e.g., the sweep loop, conditions.py)
+        that need to write rich structured events beyond the structured fields
+        in `_write_audit`. The entry dict may contain any keys the caller
+        finds useful for diagnostics.
+
+        Writes atomically in a BEGIN IMMEDIATE transaction. Does not write
+        a from_status or to_status — this is an annotation, not a transition.
+        """
+        event = entry.get("event", "unknown")
+        note_json = json.dumps(entry)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO audit_log (ts, uow_id, event, note)
+                VALUES (?, ?, ?, ?)
+                """,
+                (_now_iso(), uow_id, event, note_json),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
     def gate_readiness(self) -> dict[str, Any]:
         """
         Compute Phase 1 → Phase 2 autonomy gate metric.

--- a/tests/unit/test_orchestration/test_conditions.py
+++ b/tests/unit/test_orchestration/test_conditions.py
@@ -1,0 +1,354 @@
+"""
+Tests for evaluate_condition(uow) — conditions.py
+
+TDD: tests written first, implementation follows.
+
+Coverage:
+- NULL trigger field → True (backward compat)
+- immediate trigger → True
+- issue_closed: issue open → False
+- issue_closed: issue closed → True
+- issue_closed: GitHub API returns 403 → False + audit entry
+- issue_closed: GitHub API returns 404 → False + audit entry
+- issue_closed: GitHub API non-200 (500) → False + audit entry
+- registry_state: target UoW in specified state → True
+- registry_state: target UoW NOT in specified state → False
+- registry_state: non-existent UoW ID → False + audit entry
+- registry_state: unreadable registry → False (no crash)
+- Malformed JSON trigger → True + audit entry
+- Unknown trigger type → True + audit entry
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path):
+    from src.orchestration.registry import Registry
+    return Registry(db_path)
+
+
+def _make_uow(
+    uow_id: str = "uow_test_abc",
+    trigger_json: str | None = '{"type": "immediate"}',
+    source_issue_number: int = 42,
+    status: str = "pending",
+) -> dict[str, Any]:
+    """Build a minimal UoW dict as returned by _row_to_dict."""
+    return {
+        "id": uow_id,
+        "status": status,
+        "source_issue_number": source_issue_number,
+        "trigger": json.loads(trigger_json) if trigger_json is not None else None,
+    }
+
+
+def _audit_entries(db_path: Path, uow_id: str) -> list[dict]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id",
+        (uow_id,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# NULL trigger (backward compat)
+# ---------------------------------------------------------------------------
+
+class TestNullTrigger:
+    def test_null_trigger_returns_true(self, db_path):
+        from src.orchestration.conditions import evaluate_condition
+        uow = _make_uow(uow_id="uow_null_1", trigger_json=None)
+        result = evaluate_condition(uow)
+        assert result is True
+
+    def test_null_trigger_writes_no_audit(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+        uow = _make_uow(uow_id="uow_null_2", trigger_json=None)
+        # Insert UoW so audit_log writes work
+        from src.orchestration.registry import Registry
+        reg = Registry(db_path)
+        # Just evaluate — no audit entry expected
+        evaluate_condition(uow)
+        # No audit entries should exist for this UoW
+        entries = _audit_entries(db_path, "uow_null_2")
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# immediate trigger
+# ---------------------------------------------------------------------------
+
+class TestImmediateTrigger:
+    def test_immediate_returns_true(self):
+        from src.orchestration.conditions import evaluate_condition
+        uow = _make_uow(trigger_json='{"type": "immediate"}')
+        assert evaluate_condition(uow) is True
+
+    def test_immediate_already_dict(self):
+        """_row_to_dict deserializes trigger JSON — ensure dict is handled."""
+        from src.orchestration.conditions import evaluate_condition
+        uow = {
+            "id": "uow_imm_2",
+            "trigger": {"type": "immediate"},
+            "source_issue_number": 1,
+        }
+        assert evaluate_condition(uow) is True
+
+
+# ---------------------------------------------------------------------------
+# issue_closed trigger
+# ---------------------------------------------------------------------------
+
+class TestIssueClosedTrigger:
+    def _make_closed_trigger(self, number: int = 42) -> dict:
+        return _make_uow(
+            uow_id=f"uow_ic_{number}",
+            trigger_json=json.dumps({"type": "issue_closed", "number": number}),
+            source_issue_number=number,
+        )
+
+    def test_issue_open_returns_false(self):
+        from src.orchestration.conditions import evaluate_condition
+        uow = self._make_closed_trigger(100)
+
+        def mock_github_client(issue_number: int) -> dict:
+            return {"status_code": 200, "state": "open"}
+
+        result = evaluate_condition(uow, github_client=mock_github_client)
+        assert result is False
+
+    def test_issue_closed_returns_true(self):
+        from src.orchestration.conditions import evaluate_condition
+        uow = self._make_closed_trigger(101)
+
+        def mock_github_client(issue_number: int) -> dict:
+            return {"status_code": 200, "state": "closed"}
+
+        result = evaluate_condition(uow, github_client=mock_github_client)
+        assert result is True
+
+    def test_github_api_403_returns_false_with_audit(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_ic_403"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json='{"type": "issue_closed", "number": 200}',
+        )
+
+        def mock_github_client(issue_number: int) -> dict:
+            return {"status_code": 403, "state": None}
+
+        result = evaluate_condition(uow, github_client=mock_github_client, registry=registry)
+        assert result is False
+
+        entries = _audit_entries(db_path, uow_id)
+        assert len(entries) == 1
+        assert entries[0]["event"] == "condition_eval_failed"
+        note = json.loads(entries[0]["note"])
+        assert note["error_code"] == 403
+        assert note["trigger_type"] == "issue_closed"
+
+    def test_github_api_404_returns_false_with_audit(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_ic_404"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json='{"type": "issue_closed", "number": 201}',
+        )
+
+        def mock_github_client(issue_number: int) -> dict:
+            return {"status_code": 404, "state": None}
+
+        result = evaluate_condition(uow, github_client=mock_github_client, registry=registry)
+        assert result is False
+
+        entries = _audit_entries(db_path, uow_id)
+        assert len(entries) == 1
+        assert entries[0]["event"] == "condition_eval_failed"
+        note = json.loads(entries[0]["note"])
+        assert note["error_code"] == 404
+
+    def test_github_api_500_returns_false_with_audit(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_ic_500"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json='{"type": "issue_closed", "number": 202}',
+        )
+
+        def mock_github_client(issue_number: int) -> dict:
+            return {"status_code": 500, "state": None}
+
+        result = evaluate_condition(uow, github_client=mock_github_client, registry=registry)
+        assert result is False
+
+        entries = _audit_entries(db_path, uow_id)
+        assert len(entries) == 1
+        assert entries[0]["event"] == "condition_eval_failed"
+        note = json.loads(entries[0]["note"])
+        assert note["error_code"] == 500
+
+    def test_no_audit_when_issue_open(self, registry, db_path):
+        """False condition (issue open) must not write audit entry."""
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_ic_noaudit"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json='{"type": "issue_closed", "number": 300}',
+        )
+
+        def mock_github_client(issue_number: int) -> dict:
+            return {"status_code": 200, "state": "open"}
+
+        evaluate_condition(uow, github_client=mock_github_client, registry=registry)
+        entries = _audit_entries(db_path, uow_id)
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# registry_state trigger
+# ---------------------------------------------------------------------------
+
+class TestRegistryStateTrigger:
+    def test_target_uow_in_specified_state_returns_true(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+
+        # Insert a target UoW into the registry and advance it to "done"
+        result = registry.upsert(issue_number=99, title="target UoW")
+        target_id = result["id"]
+        registry.confirm(target_id)
+        registry.set_status_direct(target_id, "done")
+
+        uow_id = "uow_rs_match"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json=json.dumps({"type": "registry_state", "uow_id": target_id, "state": "done"}),
+        )
+        result = evaluate_condition(uow, registry=registry)
+        assert result is True
+
+    def test_target_uow_not_in_specified_state_returns_false(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+
+        result = registry.upsert(issue_number=100, title="pending target")
+        target_id = result["id"]
+        # UoW stays in "proposed" state
+
+        uow_id = "uow_rs_nomatch"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json=json.dumps({"type": "registry_state", "uow_id": target_id, "state": "done"}),
+        )
+        result = evaluate_condition(uow, registry=registry)
+        assert result is False
+
+    def test_nonexistent_uow_id_returns_false_with_audit(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_rs_notfound"
+        nonexistent_id = "uow_does_not_exist_xyz"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json=json.dumps({"type": "registry_state", "uow_id": nonexistent_id, "state": "done"}),
+        )
+        result = evaluate_condition(uow, registry=registry)
+        assert result is False
+
+        entries = _audit_entries(db_path, uow_id)
+        assert len(entries) == 1
+        assert entries[0]["event"] == "condition_eval_error"
+        note = json.loads(entries[0]["note"])
+        assert "not found" in note["note"]
+
+    def test_no_audit_when_state_not_matched(self, registry, db_path):
+        """False condition (state not matched) must not write audit entry."""
+        from src.orchestration.conditions import evaluate_condition
+        result = registry.upsert(issue_number=101, title="still proposed")
+        target_id = result["id"]
+
+        uow_id = "uow_rs_silent"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json=json.dumps({"type": "registry_state", "uow_id": target_id, "state": "done"}),
+        )
+        evaluate_condition(uow, registry=registry)
+        entries = _audit_entries(db_path, uow_id)
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON trigger
+# ---------------------------------------------------------------------------
+
+class TestMalformedTrigger:
+    def test_malformed_json_string_returns_true_with_audit(self, registry, db_path):
+        """When trigger is stored as a malformed JSON string, return True + audit."""
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_malformed"
+        # Simulate a UoW that arrived with trigger as a raw string (pre-deserialized)
+        uow = {
+            "id": uow_id,
+            "trigger": "not-valid-json{{{",  # raw string, not dict
+            "source_issue_number": 1,
+        }
+        result = evaluate_condition(uow, registry=registry)
+        assert result is True
+
+        entries = _audit_entries(db_path, uow_id)
+        assert len(entries) == 1
+        assert entries[0]["event"] == "condition_eval_error"
+        note = json.loads(entries[0]["note"])
+        assert "not valid JSON" in note["note"]
+
+    def test_trigger_as_non_dict_non_string_returns_true_with_audit(self, registry, db_path):
+        """When trigger is some unexpected type (e.g., list), treat as error → True + audit."""
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_badtype"
+        uow = {
+            "id": uow_id,
+            "trigger": [1, 2, 3],  # unexpected type
+            "source_issue_number": 1,
+        }
+        result = evaluate_condition(uow, registry=registry)
+        assert result is True
+        entries = _audit_entries(db_path, uow_id)
+        assert len(entries) == 1
+        assert entries[0]["event"] == "condition_eval_error"
+
+
+# ---------------------------------------------------------------------------
+# Unknown trigger type
+# ---------------------------------------------------------------------------
+
+class TestUnknownTriggerType:
+    def test_unknown_type_returns_true_with_audit(self, registry, db_path):
+        from src.orchestration.conditions import evaluate_condition
+        uow_id = "uow_unknown"
+        uow = _make_uow(
+            uow_id=uow_id,
+            trigger_json='{"type": "webhook"}',
+        )
+        result = evaluate_condition(uow, registry=registry)
+        assert result is True
+
+        entries = _audit_entries(db_path, uow_id)
+        assert len(entries) == 1
+        assert entries[0]["event"] == "condition_eval_error"
+        note = json.loads(entries[0]["note"])
+        assert "unknown trigger type" in note["note"]
+        assert "webhook" in note["note"]

--- a/tests/unit/test_orchestration/test_issue_sweeper.py
+++ b/tests/unit/test_orchestration/test_issue_sweeper.py
@@ -1,0 +1,237 @@
+"""
+Integration tests for the issue-sweeper.py Registrar sweep loop.
+
+Coverage per acceptance criteria:
+- Sweep with one pending UoW whose trigger is immediate → transitions to ready-for-steward,
+  audit_log contains trigger_fired
+- Sweep with issue_closed trigger where issue is NOT closed → UoW stays pending, no audit entry
+- Two consecutive sweep runs on same UoW that advanced on first run — second run does not
+  call evaluate_condition for this UoW (it is no longer pending)
+- Optimistic lock: transition returns 0 rows → no audit entry written
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+SWEEPER_PATH = REPO_ROOT / "scheduled-tasks" / "issue-sweeper.py"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path):
+    from src.orchestration.registry import Registry
+    return Registry(db_path)
+
+
+def _audit_entries(db_path: Path, uow_id: str | None = None) -> list[dict]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    if uow_id:
+        rows = conn.execute(
+            "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id",
+            (uow_id,),
+        ).fetchall()
+    else:
+        rows = conn.execute("SELECT * FROM audit_log ORDER BY id").fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def _run_sweep(registry, github_client=None) -> dict[str, Any]:
+    """Import and run the sweep function directly."""
+    # Dynamically import the sweeper module
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("issue_sweeper", SWEEPER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    kwargs = {"registry": registry}
+    if github_client is not None:
+        kwargs["github_client"] = github_client
+    return module.run_sweep(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Immediate trigger: pending → ready-for-steward
+# ---------------------------------------------------------------------------
+
+class TestImmediateTriggerSweep:
+    def test_pending_immediate_advances_to_ready_for_steward(self, registry, db_path):
+        # Insert and confirm a UoW (proposed → pending)
+        result = registry.upsert(issue_number=10, title="test UoW")
+        uow_id = result["id"]
+        registry.confirm(uow_id)
+
+        # Verify it's pending with immediate trigger
+        uow = registry.get(uow_id)
+        assert uow["status"] == "pending"
+
+        _run_sweep(registry)
+
+        uow_after = registry.get(uow_id)
+        assert uow_after["status"] == "ready-for-steward"
+
+    def test_trigger_fired_audit_entry_written(self, registry, db_path):
+        result = registry.upsert(issue_number=11, title="audit test")
+        uow_id = result["id"]
+        registry.confirm(uow_id)
+
+        _run_sweep(registry)
+
+        entries = _audit_entries(db_path, uow_id)
+        trigger_fired = [e for e in entries if e["event"] == "trigger_fired"]
+        assert len(trigger_fired) == 1
+
+        note = json.loads(trigger_fired[0]["note"])
+        assert note["actor"] == "registrar"
+        assert note["uow_id"] == uow_id
+        assert "trigger" in note
+        assert "timestamp" in note
+
+    def test_proposed_uow_not_swept(self, registry, db_path):
+        """Proposed UoWs must not be passed to evaluate_condition."""
+        result = registry.upsert(issue_number=12, title="proposed only")
+        uow_id = result["id"]
+        # Do NOT confirm — stays at "proposed"
+
+        _run_sweep(registry)
+
+        uow_after = registry.get(uow_id)
+        assert uow_after["status"] == "proposed"
+
+    def test_ready_for_steward_uow_not_swept(self, registry, db_path):
+        """UoWs already at ready-for-steward must not be swept again."""
+        result = registry.upsert(issue_number=13, title="already advanced")
+        uow_id = result["id"]
+        registry.confirm(uow_id)
+        registry.set_status_direct(uow_id, "ready-for-steward")
+
+        eval_call_count = {"n": 0}
+        original_import = None
+
+        # Patch evaluate_condition to count calls
+        import src.orchestration.conditions as cond_module
+        original_eval = cond_module.evaluate_condition
+
+        def counting_eval(uow, **kwargs):
+            eval_call_count["n"] += 1
+            return original_eval(uow, **kwargs)
+
+        cond_module.evaluate_condition = counting_eval
+        try:
+            _run_sweep(registry)
+        finally:
+            cond_module.evaluate_condition = original_eval
+
+        assert eval_call_count["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# issue_closed trigger: issue not closed → stays pending, no audit
+# ---------------------------------------------------------------------------
+
+class TestIssueClosedTriggerSweep:
+    def test_issue_not_closed_stays_pending_no_audit(self, registry, db_path):
+        result = registry.upsert(issue_number=50, title="awaiting issue close")
+        uow_id = result["id"]
+        registry.confirm(uow_id)
+
+        # Override trigger to issue_closed
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE uow_registry SET trigger = ? WHERE id = ?",
+            (json.dumps({"type": "issue_closed", "number": 50}), uow_id),
+        )
+        conn.commit()
+        conn.close()
+
+        def mock_github_client(issue_number: int) -> dict:
+            return {"status_code": 200, "state": "open"}
+
+        _run_sweep(registry, github_client=mock_github_client)
+
+        uow_after = registry.get(uow_id)
+        assert uow_after["status"] == "pending"
+
+        # No trigger_fired audit entry
+        entries = _audit_entries(db_path, uow_id)
+        trigger_fired = [e for e in entries if e["event"] == "trigger_fired"]
+        assert trigger_fired == []
+
+
+# ---------------------------------------------------------------------------
+# Two consecutive sweeps — second sweep skips already-advanced UoW
+# ---------------------------------------------------------------------------
+
+class TestConsecutiveSweeps:
+    def test_second_sweep_skips_advanced_uow(self, registry, db_path):
+        """After first sweep advances a UoW, second sweep must not evaluate it."""
+        result = registry.upsert(issue_number=60, title="two-sweep test")
+        uow_id = result["id"]
+        registry.confirm(uow_id)
+
+        eval_calls = []
+        import src.orchestration.conditions as cond_module
+        original_eval = cond_module.evaluate_condition
+
+        def recording_eval(uow, **kwargs):
+            eval_calls.append(uow["id"])
+            return original_eval(uow, **kwargs)
+
+        cond_module.evaluate_condition = recording_eval
+        try:
+            _run_sweep(registry)  # first sweep — advances to ready-for-steward
+            first_count = len(eval_calls)
+            assert first_count == 1  # was evaluated once
+
+            _run_sweep(registry)  # second sweep — UoW is now ready-for-steward, not pending
+            second_count = len(eval_calls)
+            assert second_count == 1  # NOT called again
+        finally:
+            cond_module.evaluate_condition = original_eval
+
+        uow_after = registry.get(uow_id)
+        assert uow_after["status"] == "ready-for-steward"
+
+
+# ---------------------------------------------------------------------------
+# Optimistic lock: transition returns 0 rows → no audit entry
+# ---------------------------------------------------------------------------
+
+class TestOptimisticLock:
+    def test_zero_rows_transition_writes_no_trigger_fired(self, registry, db_path):
+        """
+        Simulate a race: another process advances the UoW between evaluate_condition
+        and transition. When transition returns 0, no trigger_fired entry should be written.
+        """
+        result = registry.upsert(issue_number=70, title="race condition test")
+        uow_id = result["id"]
+        registry.confirm(uow_id)
+
+        # Patch transition to return 0 (simulate another sweep winning the race)
+        original_transition = registry.transition
+
+        def zero_transition(tid, to_status, where_status):
+            # Advance the UoW externally, then call original which finds 0 rows
+            registry.set_status_direct(tid, "ready-for-steward")
+            return original_transition(tid, to_status=to_status, where_status=where_status)
+
+        registry.transition = zero_transition
+        try:
+            _run_sweep(registry)
+        finally:
+            registry.transition = original_transition
+
+        entries = _audit_entries(db_path, uow_id)
+        trigger_fired = [e for e in entries if e["event"] == "trigger_fired"]
+        assert trigger_fired == []


### PR DESCRIPTION
## What this solves

Phase 2 UoWs in `pending` status have no mechanism to advance to `ready-for-steward`. A UoW waiting on a GitHub issue to close, another UoW to reach `done`, or no condition at all (immediate) sits in `pending` with nothing to act on it. This PR delivers the callable that checks those conditions and the sweep loop that drives the transitions.

## What changed

**`src/orchestration/conditions.py` — `evaluate_condition(uow)`**

Three trigger types, all error-tolerant:

| Trigger type | Fires when | Error behavior |
|---|---|---|
| `{"type": "immediate"}` | Always | N/A |
| `{"type": "issue_closed", "number": N}` | GitHub issue N is `closed` | API failure → False + `condition_eval_failed` audit; no crash |
| `{"type": "registry_state", "uow_id": "...", "state": "..."}` | Target UoW is in specified state | Missing UoW → False + `condition_eval_error` audit |

Backward compat: NULL trigger returns True.

Malformed JSON and unknown trigger types return True + write `condition_eval_error` — fail-open so a bad trigger value never silently blocks a UoW forever.

The GitHub API call is isolated behind a `github_client` callable parameter (default: `_default_github_client` using the `gh` CLI). Tests pass a mock instead of hitting the network.

**`scheduled-tasks/issue-sweeper.py` — Registrar sweep loop**

```
for uow in registry.query(status='pending'):
    if evaluate_condition(uow):
        rows = registry.transition(uow_id, to_status='ready-for-steward', where_status='pending')
        if rows == 1: write trigger_fired audit entry
        # rows == 0: another sweep won the race — skip silently (DEBUG log only)
    # False: no state change, no audit entry, no log output
```

Optimistic lock on `transition()` prevents double-advance in concurrent sweep runs.

**`src/orchestration/registry.py` — three new methods**

- `query(status)`: filters by status — used by the sweep to fetch only `pending` UoWs
- `transition(uow_id, to_status, where_status)`: conditional UPDATE returning rows affected; audit responsibility stays at the caller (the sweep knows the business context)
- `append_audit_log(uow_id, entry_dict)`: writes structured dict as JSON to `note` column; used by conditions.py and the sweep for rich events (`trigger_fired`, `condition_eval_failed`, etc.)

## State transition

```
Before this PR:
  pending → [nothing — no mechanism to advance]

After this PR:
  pending → evaluate_condition() → True + rows=1 → ready-for-steward (trigger_fired audit)
                                 → True + rows=0 → skip (another sweep won — DEBUG only)
                                 → False          → stay pending (no noise)
```

## Functional patterns

- Pure functions: `evaluate_condition` is a pure transformation of (uow, callable) → bool. The trigger handlers (`_eval_immediate`, `_eval_issue_closed`, `_eval_registry_state`) are each single-responsibility.
- Dependency injection: `github_client` and `registry` are injected callable/object parameters — testable without monkeypatching.
- Named constants: `_TRIGGER_IMMEDIATE`, `_TRIGGER_ISSUE_CLOSED`, `_TRIGGER_REGISTRY_STATE`, `_STATUS_PENDING`, `_STATUS_READY_FOR_STEWARD`.
- Optimistic locking: `transition()` returns rows affected; the caller branches on 0/1 rather than re-reading state.

## What is out of scope

- No Steward or Executor code — those are #303 and #305.
- No schema changes — this PR writes to existing columns only.
- `registry.query()` is a thin alias over `registry.list(status=...)` — no new SQL.
- The sweep does not change `_write_audit` or any existing audit behavior.

## Dependency note

The sweep integration (`issue-sweeper.py`) requires the Phase 2 schema migration from #309 (`scripts/migrate_add_steward_fields.py`) to be applied. `evaluate_condition` itself and the three new registry methods have no schema dependency beyond the base `uow_registry` and `audit_log` tables.

## Tests run

- [x] `uv run --no-sync -m pytest tests/unit/test_orchestration/test_conditions.py -q` — 17 passed, 0 failed
- [x] `uv run --no-sync -m pytest tests/unit/test_orchestration/test_issue_sweeper.py -q` — 7 passed, 0 failed
- [x] `uv run --no-sync -m pytest tests/unit/test_orchestration/ -q` — 78 passed, 0 failed (24 new + 54 pre-existing)
- [ ] Live sweep against production registry — blocked: requires Phase 2 schema migration (#309) to be merged and applied first

**Blocked items needing attention before merge:** none — all live testing blocked only by #309 not yet merged, not by any issue in this PR.

Closes #304