### PR TITLE
fix: UoWStatus.is_in_flight() missing READY_FOR_EXECUTOR and DIAGNOSING (#347)

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -45,7 +45,9 @@ class UoWStatus(StrEnum):
     PROPOSED = "proposed"
     PENDING = "pending"
     READY_FOR_STEWARD = "ready-for-steward"
+    READY_FOR_EXECUTOR = "ready-for-executor"
     ACTIVE = "active"
+    DIAGNOSING = "diagnosing"
     BLOCKED = "blocked"
     DONE = "done"
     FAILED = "failed"
@@ -56,8 +58,14 @@ class UoWStatus(StrEnum):
         return self in {UoWStatus.DONE, UoWStatus.FAILED, UoWStatus.EXPIRED}
 
     def is_in_flight(self) -> bool:
-        """True for statuses that block re-proposal (active, pending, ready-for-steward)."""
-        return self in {UoWStatus.ACTIVE, UoWStatus.PENDING, UoWStatus.READY_FOR_STEWARD}
+        """True for statuses that block re-proposal (active, pending, ready-for-steward, ready-for-executor, diagnosing)."""
+        return self in {
+            UoWStatus.ACTIVE,
+            UoWStatus.PENDING,
+            UoWStatus.READY_FOR_STEWARD,
+            UoWStatus.READY_FOR_EXECUTOR,
+            UoWStatus.DIAGNOSING,
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #347.

\`is_in_flight()\` was returning \`False\` for two statuses that are actively used in the system: \`READY_FOR_EXECUTOR\` (Executor dispatch path in steward.py) and \`DIAGNOSING\` (startup sweep per issue #339). Any UoW in these states would be misclassified as not in flight, causing the upcoming Observation Loop (#306) to incorrectly treat live UoWs as stalled.

The fix adds both statuses to \`UoWStatus\` and includes them in the \`is_in_flight()\` set. \`is_terminal()\` is unchanged — it still returns \`True\` only for \`done\`, \`failed\`, and \`expired\`.

**Functional pattern:** pure enum method, no side effects. The \`is_in_flight()\` and \`is_terminal()\` predicates remain mutually exclusive by construction.

## Tests run
- [x] \`uv run pytest tests/unit/test_orchestration/ -q\` — 149 passed, 0 failed

**Blocked items needing attention before merge:** none