### PR TITLE
fix: replace bare python3 with uv run in dispatch-job.sh and sync-crontab.sh

### DIFF
--- a/scheduled-tasks/dispatch-job.sh
+++ b/scheduled-tasks/dispatch-job.sh
@@ -47,16 +47,19 @@ LOG_FILE="$LOG_DIR/${JOB_NAME}-${TIMESTAMP}.log"
 # --- Check enabled flag ---
 # If the job is marked enabled=false in jobs.json, exit silently.
 if [ -f "$JOBS_FILE" ]; then
-    ENABLED=$(python3 -c "
+    ENABLED=$(uv run - "$JOBS_FILE" "$JOB_NAME" << 'PYEOF'
 import json, sys
+jobs_file = sys.argv[1]
+job_name  = sys.argv[2]
 try:
-    with open('$JOBS_FILE') as f:
+    with open(jobs_file) as f:
         data = json.load(f)
-    job = data.get('jobs', {}).get('$JOB_NAME', {})
+    job = data.get('jobs', {}).get(job_name, {})
     print(str(job.get('enabled', True)).lower())
 except Exception:
     print('true')
-" 2>/dev/null)
+PYEOF
+    2>/dev/null)
     if [ "$ENABLED" = "false" ]; then
         echo "[$START_ISO] Job '$JOB_NAME' is disabled — skipping" >> "$LOG_FILE" 2>&1 || true
         exit 0

--- a/scheduled-tasks/sync-crontab.sh
+++ b/scheduled-tasks/sync-crontab.sh
@@ -64,25 +64,26 @@ if command -v jq &> /dev/null; then
         "\(.value.schedule) \($resolved_runner) \(.key) \($marker)"
     ' "$JOBS_FILE" 2>/dev/null || echo "")
 else
-    CRON_ENTRIES=$(python3 -c "
-import json
-import sys
-import os
+    CRON_ENTRIES=$(uv run - "$JOBS_FILE" "$REPO_DIR" "$RUNNER" "$MARKER" << 'PYEOF'
+import json, sys
+jobs_file      = sys.argv[1]
+repo_dir       = sys.argv[2]
+default_runner = sys.argv[3]
+marker         = sys.argv[4]
 try:
-    with open('$JOBS_FILE', 'r') as f:
+    with open(jobs_file, 'r') as f:
         data = json.load(f)
-    repo_dir = '$REPO_DIR'
-    default_runner = '$RUNNER'
     for name, job in data.get('jobs', {}).items():
         if job.get('enabled', True):
             schedule = job.get('schedule', '')
             if schedule:
                 runner = job.get('runner', default_runner)
-                runner = runner.replace('\$REPO_DIR', repo_dir)
-                print(f\"{schedule} {runner} {name} $MARKER\")
+                runner = runner.replace('$REPO_DIR', repo_dir)
+                print(f"{schedule} {runner} {name} {marker}")
 except Exception as e:
     sys.stderr.write(f'Error: {e}\n')
-" 2>/dev/null || echo "")
+PYEOF
+    2>/dev/null || echo "")
 fi
 
 # Build the new crontab content


### PR DESCRIPTION
## Summary

Both `dispatch-job.sh` and `sync-crontab.sh` used bare `python3 -c "..."` with shell-variable interpolation in their JSON-parsing fallback paths. This violates the uv convention stated in CLAUDE.md: "Always use `uv` instead of bare `python`, `python3`, or `pip`."

The deviation was invisible in normal deployments where `jq` is available, but activates in any environment without `jq`.

## What changed

Both invocations are replaced with the `uv run - arg1 arg2 << 'PYEOF'...PYEOF` heredoc pattern that `dispatch-job.sh` already uses for its primary Python invocation (line 80+). Shell variables that were previously embedded via string interpolation are now passed as positional arguments (`sys.argv[1]`, `sys.argv[2]`, etc.), which is safer and avoids potential injection from values with special characters.

The logic is identical — no behavior change in the jq-present path (the common case). Only the Python execution method changes in the jq-absent fallback.

**Functional pattern used:** Pure functions with explicit argument passing; no side effects beyond the intended file reads and stdout output.

## Tests run

- [x] Manual: `dispatch-job.sh` `ENABLED` check — tested with `enabled: true` and `enabled: false` jobs.json fixtures. Both return the correct value (`true`/`false`).
- [x] Manual: `sync-crontab.sh` jq-fallback block — tested with a sample jobs.json. Output matches expected crontab line format `"0 * * * * /path/dispatch-job.sh job-name # LOBSTER-SCHEDULED"`.
- [ ] Integration (full crontab sync in a live environment without jq) — not run; requires a cron-capable environment with jq removed. The unit-level tests above cover the logic path directly.

Closes #261