### PR TITLE
fix: update vision.md to vision.yaml in lobster-oracle and lobster-hygiene

### DIFF
--- a/.claude/agents/lobster-hygiene.md
+++ b/.claude/agents/lobster-hygiene.md
@@ -9,7 +9,7 @@ model: claude-sonnet-4-5
 
 You are running a quarterly artifact hygiene review. You do NOT call `wait_for_messages`. Write output to `~/lobster-workspace/meta/hygiene-review.md`, then exit.
 
-Read `~/lobster-workspace/vision.md` before beginning.
+Read `~/lobster-user-config/vision.yaml` before beginning.
 
 ---
 

--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -10,7 +10,7 @@ model: claude-opus-4-5
 
 You are a Lobster subagent. Do NOT call `wait_for_messages`. Call `send_reply` and `write_result` when complete.
 
-Read `~/lobster-workspace/vision.md` before beginning any review.
+Read `~/lobster-user-config/vision.yaml` before beginning any review.
 
 Read `~/lobster-workspace/oracle/learnings.md` and `~/lobster/oracle/golden-patterns.md` before beginning Stage 1. Use the named failure patterns in learnings.md as an active prior: check whether the work under review exhibits any of them. Use the named golden patterns in golden-patterns.md as positive design criteria: does this work extend or apply a golden pattern? If a pattern matches (either file), cite it in Stage 1 findings and state specifically how it constrained what you wrote — what you did not say, what you looked for differently, what you weighted differently because of it. Naming a pattern without stating its effect on your analysis is not a citation; it is a label. The bar is behavioral change, not labeling.
 
@@ -32,11 +32,11 @@ Do not let the quality of the implementation resolve your Stage 1 question. Good
 
 Your task prompt specifies one of:
 
-**Standard (post-PR):** You receive issue description + vision.md. You do NOT yet read the implementation. Complete Stage 1, write findings. Then receive PR diff for Stage 2.
+**Standard (post-PR):** You receive issue description + vision.yaml. You do NOT yet read the implementation. Complete Stage 1, write findings. Then receive PR diff for Stage 2.
 
-**Non-PR (explicit request):** You receive the output or decision to review + vision.md + the question it was meant to serve. Same two-stage structure.
+**Non-PR (explicit request):** You receive the output or decision to review + vision.yaml + the question it was meant to serve. Same two-stage structure.
 
-**Premise-review:** You receive a pattern of observations accumulated by lobster-meta + vision.md. Evaluate whether a founding premise is generating systematic tension. Output goes to `meta/premise-review.md` only.
+**Premise-review:** You receive a pattern of observations accumulated by lobster-meta + vision.yaml. Evaluate whether a founding premise is generating systematic tension. Output goes to `meta/premise-review.md` only.
 
 ---
 
@@ -44,7 +44,7 @@ Your task prompt specifies one of:
 
 Before seeing any implementation, ask:
 
-- What is the implicit theory of change in vision.md? Does this task serve that theory?
+- What is the implicit theory of change in vision.yaml? Does this task serve that theory?
 - What would have to be true about the world for this work to be the right path?
 - Is there a cheaper test of the underlying assumption that hasn't been run?
 - What does this work foreclose? What directions become harder if this ships?


### PR DESCRIPTION
Oracle reviews and hygiene sessions were running without a live vision anchor. Both agents read `~/lobster-workspace/vision.md`, which is a stub file that emits a redirect message rather than the actual Vision Object. The real content lives at `~/lobster-user-config/vision.yaml` (established in PR #219 for lobster-meta.md, but the fix wasn't applied to the other two files).

## What changed

Updated `lobster-oracle.md` and `lobster-hygiene.md` to read `~/lobster-user-config/vision.yaml` directly. This covers both the file-read instructions at the top of each agent file and all prose references in the invocation mode documentation within lobster-oracle.md.

The `quick_classifier.py` references to `"vision.md"` are literal strings used for pattern matching in the signal classifier — they are not file reads and are intentionally unchanged.

## Functional patterns

Pure substitution — no logic changes, no new behavior. The change is declarative: correct the path in the read instruction so agents load the actual Vision Object instead of a redirect stub.

## Tests run

- [x] `grep -r "vision\.md" .claude/agents/` — zero matches after fix
- [ ] Live oracle/hygiene agent invocation — skipped: requires production session restart; no behavior logic changed, only path corrected

Closes #240