### PR TITLE
fix(sweeper): remove 14-day gate framing from sweeper output

### DIFF
--- a/scheduled-tasks/issue-sweeper.py
+++ b/scheduled-tasks/issue-sweeper.py
@@ -178,7 +178,8 @@ def main() -> int:
     print(
         f"Issue sweeper done: evaluated={result['evaluated']} "
         f"advanced={result['advanced']} skipped={result['skipped']} "
-        f"race_skipped={result['race_skipped']}"
+        f"race_skipped={result['race_skipped']} "
+        f"gate=Phase1Complete/Phase2Active"
     )
     return 0
 

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -133,6 +133,7 @@ def cmd_gate_readiness(registry: Registry, args: argparse.Namespace) -> None:
     gs = registry.registry_health()
     _output({
         "gate_met": gs.gate_met,
+        "phase": "phase_1_complete_phase_2_active",
         "days_running": gs.days_running,
         "proposed_to_confirmed_ratio_7d": gs.approval_rate,
         "reason": gs.reason,

--- a/tests/unit/test_orchestration/test_registry_cli.py
+++ b/tests/unit/test_orchestration/test_registry_cli.py
@@ -205,6 +205,7 @@ class TestGateReadinessCommand:
         result = run_cli(db_path, "gate-readiness")
         assert "gate_met" in result
         assert result["gate_met"] is True
+        assert result["phase"] == "phase_1_complete_phase_2_active"
         assert "days_running" in result
         assert "proposed_to_confirmed_ratio_7d" in result
         assert "reason" in result


### PR DESCRIPTION
## What changed and why

Phase 1 was declared complete on 2026-03-30 (commit 2900900), but the sweeper subagent kept reporting **"Gate: not met (2 days running, need 14)"** in every sweep output and morning briefing. This happened because `gate-readiness` CLI output only emitted `days_running` and `reason`, giving LLM subagents no machine-readable signal that the 14-day threshold was gone — so they reconstructed the old logic from the numeric field.

This PR adds an explicit `"phase": "phase_1_complete_phase_2_active"` field to the `gate-readiness` JSON output and updates the sweeper's own printed line to use `gate=Phase1Complete/Phase2Active`. Subagents now receive an unambiguous signal without needing to interpret `days_running` against a threshold that no longer exists.

The `gate_met` field already returned `True` unconditionally (committed in 2900900). This PR surfaces that fact in the output rather than leaving it implicit.

## What was not changed

- `registry_health()` in `registry.py` — logic unchanged, still always returns `gate_met=True`
- `days_running` and `approval_rate` fields — retained for observability, still present in output
- Sweeper sweep logic (`run_sweep`) — no change to UoW evaluation or transition logic
- The task definition in `~/lobster-workspace/scheduled-jobs/tasks/issue-sweeper.md` is runtime state (not committed); the CLI output change causes the next sweep to report correctly without a task file edit

## Functional patterns

Pure function — `cmd_gate_readiness` composes `registry.registry_health()` into a dict and passes it to `_output()`. The added `phase` key is a static string derived from the already-computed `gate_met: True` invariant.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry_cli.py -v` — 16 passed, 0 failed (includes new assertion on `phase` field)
- [x] `uv run pytest tests/unit/test_orchestration/ -v` — 199 passed, 0 failed

Closes #308