### PR TITLE
docs: name and document the three scheduled-job execution modes

### DIFF
--- a/scheduled-tasks/README.md
+++ b/scheduled-tasks/README.md
@@ -33,15 +33,84 @@ For full architecture documentation, see issue #1059.
 
 ---
 
+## Layer 2 Execution Modes
+
+When the dispatcher spawns a Layer 2 subagent, the subagent can execute in one
+of two modes. Both are triggered identically (via `dispatch-job.sh` → inbox →
+`scheduled_reminder` message). The difference is in how the `.md` task brief is
+written.
+
+### Mode A: Pure-dispatch (agent-only)
+
+The `.md` task brief in `scheduled-jobs/tasks/<job-name>.md` contains all
+instructions in natural language. The subagent reasons over them and calls MCP
+tools directly — no Python script is involved.
+
+```
+dispatch-job.sh → inbox → dispatcher → subagent reads task brief → MCP tools
+```
+
+**Examples:** `morning-briefing`, `issue-sweeper`, `negentropic-sweep`,
+`uow-reflection`, `async-deep-work`, `lobster-hygiene`.
+
+Use this mode when the job logic is best expressed as agent reasoning: fetching
+data via MCP, writing summaries, updating GitHub issues, sending Telegram
+messages.
+
+### Mode B: Script-assisted (agent calls Python)
+
+The `.md` task brief instructs the subagent to run a Python script in
+`scheduled-tasks/` via `uv run`. The script does the heavy data work; the
+subagent wraps it with delivery and logging.
+
+```
+dispatch-job.sh → inbox → dispatcher → subagent reads task brief
+  → uv run scheduled-tasks/<job>.py → subagent delivers result via MCP
+```
+
+**Examples:** `pattern-candidate-sweep` (runs `pattern-candidate-sweep.py`),
+`weekly-epistemic-retro` (runs `weekly-epistemic-retro.py`).
+
+Use this mode when the job requires deterministic data processing that is easier
+to test and version as Python code, but the delivery and logging still benefit
+from agent judgment.
+
+> **Note:** The Python scripts under `scheduled-tasks/` that share a name with a
+> job (e.g., `pattern-candidate-sweep.py`) are **task executors**, not Layer 1
+> scripts. They are invoked by the subagent at Layer 2, not by cron. Do not add
+> a direct cron entry for them — wire them through `dispatch-job.sh` instead.
+
+### Mode C: Local-code (no LLM)
+
+Some scripts bypass the dispatch path entirely. Cron calls them directly and
+they perform self-contained maintenance work with no LLM involvement. These use
+the `local-code` template.
+
+```
+Cron → script → done  (no inbox write, no subagent)
+```
+
+**Examples:** `export-logs.py`, `sync-crontab.sh`, `transcription-monitor.py`.
+
+> **Delivery note for `transcription-monitor.py`:** This script writes directly
+> to `~/messages/outbox/` rather than routing through the inbox. See
+> [Delivery Convention Exception](#delivery-convention-exception) below.
+
+---
+
 ## Scripts in This Directory
 
-| Script | Pattern | Description |
+| Script | Mode | Description |
 |---|---|---|
-| `dispatch-job.sh` | Non-polling dispatcher | Writes a `scheduled_reminder` to the inbox; called by all Layer 1 scripts and directly by cron for reminder jobs |
-| `bot-talk-check-dispatch.sh` | Poll with state | Polls bot-talk API; skips dispatch if no new messages since last cursor |
-| `lobstertalk-incoming-check.sh` | API poll | Polls bot-talk API for messages addressed to SaharLobster; skips dispatch if none |
-| `sync-crontab.sh` | Local code | Syncs the crontab from a config file; no LLM |
-| `export-logs.py` | Local code | Exports log data; no LLM |
+| `dispatch-job.sh` | — | Core dispatcher: writes `scheduled_reminder` to inbox; used by Layer 1 scripts and called directly by cron for non-polling jobs |
+| `bot-talk-check-dispatch.sh` | Layer 1 poll-with-state | Polls bot-talk API; skips dispatch if no new messages since last cursor |
+| `lobstertalk-incoming-check.sh` | Layer 1 API poll | Polls bot-talk API for messages addressed to SaharLobster; skips dispatch if none |
+| `sync-crontab.sh` | Mode C (local-code) | Syncs crontab from config; no LLM, no inbox write |
+| `export-logs.py` | Mode C (local-code) | Exports log data; no LLM, no inbox write |
+| `transcription-monitor.py` | Mode C (local-code) | Progress pings during transcription; writes to outbox directly (see Delivery Convention Exception) |
+| `pattern-candidate-sweep.py` | Mode B task executor | Called by the `pattern-candidate-sweep` subagent; not a cron script |
+| `weekly-epistemic-retro.py` | Mode B task executor | Called by the `weekly-epistemic-retro` subagent; not a cron script |
+| `daily-metrics.py` | Mode B task executor | Called by a subagent task brief; not a cron script |
 
 ### `dispatch-job.sh`
 
@@ -61,6 +130,25 @@ Purpose-built for **self-reminders** created by the dispatcher itself (e.g.,
 "remind me in 30 minutes"). Has built-in dedup: checks `inbox/` and
 `processing/` for an existing unprocessed message of the same type before
 writing. Safe to call from cron or from `at`.
+
+---
+
+## Delivery Convention Exception
+
+All scheduled jobs that produce user-facing messages follow the standard delivery
+path: write to inbox → dispatcher picks up → subagent sends via `send_reply`.
+
+**`transcription-monitor.py` is the one documented exception.** It writes
+progress pings directly to `~/messages/outbox/`, bypassing the inbox. This is
+intentional: transcription runs synchronously on the machine and the user needs
+real-time progress feedback. The inbox polling interval (up to several seconds)
+would introduce noticeable lag in pings that are already time-sensitive. The
+connector picks up outbox files immediately, so direct outbox writes give
+near-instant delivery.
+
+If you encounter another script that writes to outbox directly without this
+justification, treat it as unintentional drift and route it through the inbox
+instead.
 
 ---
 

--- a/scheduled-tasks/transcription-monitor.py
+++ b/scheduled-tasks/transcription-monitor.py
@@ -10,6 +10,18 @@ feedback during long transcriptions.
 Self-silencing: exits immediately (no outbox write) when whisper-cli is
 not running. Safe to call from cron every 5 minutes.
 
+Delivery convention note
+------------------------
+This script is a documented exception to the standard Lobster delivery path.
+Most jobs route output through the inbox (dispatch-job.sh → dispatcher →
+subagent → send_reply). This script writes directly to outbox/ instead,
+bypassing the inbox entirely.
+
+The deviation is intentional: inbox polling can add several seconds of latency,
+which is noticeable when the user is actively waiting on a long transcription.
+Direct outbox writes are delivered by the connector on its next cycle with no
+queuing delay. See scheduled-tasks/README.md § Delivery Convention Exception.
+
 Usage:
     uv run scheduled-tasks/transcription-monitor.py
 
@@ -273,6 +285,19 @@ def main() -> int:
     reply_to_message_id = msg_data.get("telegram_message_id")
     reply = build_outbox_reply(int(chat_id), text, reply_to_message_id)
 
+    # Intentional exception to the standard delivery convention:
+    # Most jobs route output through the inbox (dispatch-job.sh → dispatcher →
+    # subagent → send_reply). This script bypasses the inbox and writes directly
+    # to outbox/ so the connector delivers the ping immediately.
+    #
+    # Reason: transcription is time-sensitive. The inbox polling interval can
+    # introduce several seconds of lag, which is noticeable when the user is
+    # waiting on a long transcription. Direct outbox writes are picked up by the
+    # connector on its next cycle (sub-second on this hardware) with no queuing.
+    #
+    # This is the only local-code script that writes to outbox/. All other
+    # outbox-direct writes come from worker.py (the transcription worker itself),
+    # which has the same real-time delivery requirement.
     OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
     dest = OUTBOX_DIR / f"{reply['id']}.json"
     atomic_write_json(dest, reply)


### PR DESCRIPTION
A developer reading this codebase could not determine from inspection alone which execution path any given scheduled job uses, or why transcription-monitor.py writes to outbox directly when everything else routes through the inbox. Both gaps left architectural drift indistinguishable from intentional design.

## What changed

**Issue #267 — Two execution paths named and documented**

scheduled-tasks/README.md gains a new "Layer 2 Execution Modes" section naming three execution paths that coexist in the codebase:

- Mode A (pure-dispatch): dispatch-job.sh -> inbox -> dispatcher spawns subagent -> subagent uses MCP tools directly. The .md task brief is the full instruction set. Examples: morning-briefing, issue-sweeper, negentropic-sweep.
- Mode B (script-assisted): Same dispatch path, but the task brief tells the subagent to run a Python script in scheduled-tasks/ via uv run. The script does deterministic data work; the subagent handles delivery and logging. Examples: pattern-candidate-sweep, weekly-epistemic-retro.
- Mode C (local-code): Cron calls the script directly. No inbox write, no subagent, no LLM. Examples: export-logs.py, sync-crontab.sh, transcription-monitor.py.

The Scripts table is updated to show the mode for each file. A note under Mode B clarifies that Python files sharing a job name (e.g., pattern-candidate-sweep.py) are task executors invoked by the subagent, not Layer 1 cron scripts.

**Issue #268 — Outbox-direct delivery exception documented**

transcription-monitor.py is a Mode C script with one further distinction: it writes to outbox/ directly rather than through the inbox. This is intentional — inbox polling latency is perceptible when the user is waiting on a long transcription, and direct outbox writes are delivered by the connector with no queuing delay.

The justification is stated in three places:
1. The module docstring
2. An inline comment at the outbox write site in main()
3. A "Delivery Convention Exception" section in the README, which also draws the anti-drift line: any other script found writing to outbox directly should be treated as unintentional drift

No code behavior changed.

## Functional patterns

Pure documentation — no production logic modified.

## Tests run

- [x] git diff --stat — 2 files changed, 119 insertions, 6 deletions; no unintended changes
- [ ] Full test suite — no automated tests cover README content or inline comments

Closes #267
Closes #268