### PR TITLE
feat(wos): add dispatcher routing for wos_execute messages

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -359,8 +359,8 @@ REMINDER_ROUTING = {
 1. mark_processing(message_id)
 2. uow_id = msg["uow_id"]
 3. instructions = msg["instructions"]
-4. output_ref = f"~/lobster-workspace/orchestration/outputs/{uow_id}.json"
-   result_path = f"~/lobster-workspace/orchestration/outputs/{uow_id}.result.json"
+4. result_path = f"~/lobster-workspace/orchestration/outputs/{uow_id}.result.json"
+   # output_ref ({uow_id}.json) is pre-written by the Python Executor before dispatch — do not write it here
 5. task_id = f"wos-{uow_id}"
 6. Spawn lobster-generalist (run_in_background=True) with prompt:
    ---
@@ -385,6 +385,10 @@ REMINDER_ROUTING = {
      {"uow_id": "{uow_id}", "outcome": "complete", "success": true}
    or on failure:
      {"uow_id": "{uow_id}", "outcome": "failed", "success": false, "reason": "<why>"}
+   or on partial completion:
+     {"uow_id": "{uow_id}", "outcome": "partial", "success": false, "reason": "<what was done and what was not>"}
+   or when blocked by an external dependency:
+     {"uow_id": "{uow_id}", "outcome": "blocked", "success": false, "reason": "<what is blocking and why>"}
 
    Outcome values: "complete" | "partial" | "failed" | "blocked"
    "success" must be true if and only if outcome == "complete".
@@ -405,7 +409,7 @@ REMINDER_ROUTING = {
 
 **Rules:**
 - The subagent writes `{uow_id}.result.json`. The Steward reads it on its next heartbeat cycle.
-- Do NOT relay the result to the user: task_id starts with `wos-`, chat_id=0 — both silent-drop conditions apply.
+- Do NOT relay the result to the user: chat_id=0 is the silent-drop sentinel — the subagent_result handler drops it without relaying.
 - If the subagent fails to write the result file, the Observation Loop detects the stall at `timeout_at` and surfaces it to Dan.
 
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)


### PR DESCRIPTION
## What this solves

After PR #355, the Executor writes `wos_execute` messages to `~/messages/inbox/` when it dispatches a UoW. The dispatcher had no handler for this type — messages would arrive, find no matching routing section, and be processed but never acted on. No subagent would be spawned, no result file written, and the Steward's heartbeat would eventually hit the stall cap and surface to Dan.

## How it works

A new `## Handling WOS Execute Messages` section is added to `sys.dispatcher.bootup.md`, following the existing per-type handler pattern (one section per `type: "..."` the dispatcher must route).

**When the dispatcher reads a `wos_execute` message:**

1. `mark_processing(message_id)`
2. Extracts `uow_id` and `instructions` from the message
3. Derives `output_ref` and `result_path` deterministically — `~/lobster-workspace/orchestration/outputs/{uow_id}.result.json` — matching the formula in `executor.py:_output_ref_path()`. No DB query needed.
4. Spawns a `lobster-generalist` background subagent with:
   - The raw `instructions` from the workflow artifact (verbatim, not summarized)
   - An appended result-contract mandate specifying the path, JSON schema, and atomic write steps
   - `task_id: wos-{uow_id}`, `chat_id: 0`, `source: system`
5. `mark_processed(message_id)`

The subagent calls `write_result(chat_id=0, ...)` on completion. The existing chat_id=0 silent-drop logic in the `subagent_result` handler then discards the result message without relaying it to the user — closing the loop silently.

**Before/after message flow:**

```
Before this PR:
  Executor writes wos_execute → inbox
  Dispatcher reads wos_execute → no handler → message processed, no subagent spawned
  Steward heartbeat → result.json absent → stall cycle → surfaces to Dan

After this PR:
  Executor writes wos_execute → inbox
  Dispatcher reads wos_execute → spawns lobster-generalist with instructions
  Subagent executes, writes {uow_id}.result.json → write_result(chat_id=0)
  Dispatcher reads subagent_result → chat_id=0 → silent drop
  Steward heartbeat → result.json present → evaluates outcome → closes or re-prescribes
```

## What is not changed

- `executor.py` — the Executor side (PR #355) is unchanged
- `executor-contract.md` — the result file schema is unchanged; the subagent prompt references it
- The `subagent_result` silent-drop logic — no change needed; `chat_id=0` already drops silently
- Any Python source files in `src/orchestration/`

## Functional patterns used

Pure derivation of `output_ref` from `uow_id` (same formula as `_output_ref_path()`), no hidden state. Declarative routing: the section is a table-encodable handler, consistent with the existing per-type pattern in the bootup file.

## Tests run

- [ ] Live end-to-end test — blocked: requires a running Lobster instance with a UoW at `ready-for-executor` state. The handler is behavioral (dispatcher-side instructions), not a Python module, so there are no unit tests to run.
- [ ] Manual message routing test — blocked: same reason; requires live dispatcher and inbox.

**Blocked items needing attention before merge:** The handler adds routing instructions to the dispatcher bootup doc, which is behavioral configuration read by the running Claude Code instance. Correctness can be verified by inspection against the executor contract and the existing per-type handler pattern. Live verification requires a UoW to be dispatched through the full pipeline.

Relates to PR #355.