### PR TITLE
feat(wos): add audit_queries.py — read-only query layer over audit_log

### DIFF
--- a/src/orchestration/audit_queries.py
+++ b/src/orchestration/audit_queries.py
@@ -109,10 +109,13 @@ def stall_events(
 def cycles_histogram(
     registry_path: Path | None = None,
 ) -> dict[str, int]:
-    """Return {uow_id: steward_cycle_count} for all UoWs with audit records.
+    """Return {uow_id: steward_activity_count} for all UoWs with audit records.
 
-    steward_cycle_count is the number of audit_log entries whose event is
-    'steward_cycle' for each UoW. UoWs with no such entries are omitted.
+    steward_activity_count is the number of audit_log entries written by the
+    steward for each UoW. The steward writes these event strings on each cycle:
+    'steward_prescription', 'steward_diagnosis', 'steward_surface',
+    'steward_closure', 'agenda_update', 'reentry_prescription', 'prescription'.
+    UoWs with no such entries are omitted.
     """
     path = registry_path if registry_path is not None else _default_registry_path()
     conn = _connect(path)
@@ -121,7 +124,15 @@ def cycles_histogram(
             """
             SELECT uow_id, COUNT(*) AS cycle_count
             FROM audit_log
-            WHERE event = 'steward_cycle'
+            WHERE event IN (
+                'steward_prescription',
+                'steward_diagnosis',
+                'steward_surface',
+                'steward_closure',
+                'agenda_update',
+                'reentry_prescription',
+                'prescription'
+            )
             GROUP BY uow_id
             ORDER BY uow_id ASC
             """,
@@ -137,9 +148,12 @@ def execution_outcomes(
 ) -> dict[str, int]:
     """Return {outcome: count} for all executor outcomes since the given datetime.
 
-    Executor outcomes are audit entries whose event is 'executor_outcome'.
-    The outcome value is stored in the audit_log.note column.
-    Entries with a NULL note are counted under the key 'unknown'.
+    Executor outcomes are audit entries whose event is 'execution_complete' or
+    'execution_failed' (written by executor._complete_uow and ._fail_uow).
+    The outcome key is the event value itself — 'execution_complete' or
+    'execution_failed'. The note column contains a JSON dict with actor,
+    output_ref or reason, and timestamp; the event string is the authoritative
+    outcome signal.
     """
     path = registry_path if registry_path is not None else _default_registry_path()
     since_iso = since.isoformat() if since.tzinfo is not None else since.replace(tzinfo=timezone.utc).isoformat()
@@ -147,11 +161,11 @@ def execution_outcomes(
     try:
         rows = conn.execute(
             """
-            SELECT COALESCE(note, 'unknown') AS outcome, COUNT(*) AS cnt
+            SELECT event AS outcome, COUNT(*) AS cnt
             FROM audit_log
-            WHERE event = 'executor_outcome'
+            WHERE event IN ('execution_complete', 'execution_failed')
               AND ts >= ?
-            GROUP BY COALESCE(note, 'unknown')
+            GROUP BY event
             """,
             (since_iso,),
         ).fetchall()

--- a/tests/unit/test_orchestration/test_audit_queries.py
+++ b/tests/unit/test_orchestration/test_audit_queries.py
@@ -169,29 +169,51 @@ class TestStallEvents:
 # ---------------------------------------------------------------------------
 
 class TestCyclesHistogram:
-    def test_counts_steward_cycle_events_per_uow(self, db_path):
+    def test_counts_steward_activity_events_per_uow(self, db_path):
         from src.orchestration.audit_queries import cycles_histogram
 
-        _seed_audit(db_path, uow_id="uow-1", event="steward_cycle", ts="2026-01-01T10:00:00+00:00")
-        _seed_audit(db_path, uow_id="uow-1", event="steward_cycle", ts="2026-01-01T11:00:00+00:00")
-        _seed_audit(db_path, uow_id="uow-1", event="steward_cycle", ts="2026-01-01T12:00:00+00:00")
-        _seed_audit(db_path, uow_id="uow-2", event="steward_cycle", ts="2026-01-01T10:00:00+00:00")
+        # Seed with the actual event strings the steward writes
+        _seed_audit(db_path, uow_id="uow-1", event="steward_prescription", ts="2026-01-01T10:00:00+00:00")
+        _seed_audit(db_path, uow_id="uow-1", event="steward_diagnosis", ts="2026-01-01T11:00:00+00:00")
+        _seed_audit(db_path, uow_id="uow-1", event="agenda_update", ts="2026-01-01T12:00:00+00:00")
+        _seed_audit(db_path, uow_id="uow-2", event="steward_prescription", ts="2026-01-01T10:00:00+00:00")
 
         result = cycles_histogram(registry_path=db_path)
 
         assert result == {"uow-1": 3, "uow-2": 1}
 
-    def test_excludes_non_steward_cycle_events(self, db_path):
+    def test_counts_all_steward_event_types(self, db_path):
+        from src.orchestration.audit_queries import cycles_histogram
+
+        # Each of the seven steward event strings must be counted
+        steward_events = [
+            "steward_prescription",
+            "steward_diagnosis",
+            "steward_surface",
+            "steward_closure",
+            "agenda_update",
+            "reentry_prescription",
+            "prescription",
+        ]
+        for event in steward_events:
+            _seed_audit(db_path, uow_id="uow-1", event=event, ts="2026-01-01T10:00:00+00:00")
+
+        result = cycles_histogram(registry_path=db_path)
+
+        assert result == {"uow-1": len(steward_events)}
+
+    def test_excludes_non_steward_events(self, db_path):
         from src.orchestration.audit_queries import cycles_histogram
 
         _seed_audit(db_path, uow_id="uow-1", event="status_change", ts="2026-01-01T10:00:00+00:00")
-        _seed_audit(db_path, uow_id="uow-1", event="steward_cycle", ts="2026-01-01T11:00:00+00:00")
+        _seed_audit(db_path, uow_id="uow-1", event="execution_complete", ts="2026-01-01T10:00:00+00:00")
+        _seed_audit(db_path, uow_id="uow-1", event="steward_prescription", ts="2026-01-01T11:00:00+00:00")
 
         result = cycles_histogram(registry_path=db_path)
 
         assert result == {"uow-1": 1}
 
-    def test_empty_dict_when_no_steward_cycles(self, db_path):
+    def test_empty_dict_when_no_steward_events(self, db_path):
         from src.orchestration.audit_queries import cycles_histogram
 
         result = cycles_histogram(registry_path=db_path)
@@ -200,7 +222,7 @@ class TestCyclesHistogram:
     def test_returns_plain_dict(self, db_path):
         from src.orchestration.audit_queries import cycles_histogram
 
-        _seed_audit(db_path, uow_id="uow-1", event="steward_cycle", ts="2026-01-01T10:00:00+00:00")
+        _seed_audit(db_path, uow_id="uow-1", event="steward_prescription", ts="2026-01-01T10:00:00+00:00")
 
         result = cycles_histogram(registry_path=db_path)
         assert isinstance(result, dict)
@@ -212,53 +234,50 @@ class TestCyclesHistogram:
 # ---------------------------------------------------------------------------
 
 class TestExecutionOutcomes:
-    def test_counts_outcomes_by_note_value(self, db_path):
+    def test_counts_execution_complete_and_failed_events(self, db_path):
         from src.orchestration.audit_queries import execution_outcomes
+        import json
 
         cutoff = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        # execution_complete — note is a JSON dict matching executor._complete_uow
         for _ in range(3):
-            _seed_audit(db_path, uow_id="uow-1", event="executor_outcome",
-                        ts="2026-01-02T10:00:00+00:00", note="complete")
+            _seed_audit(db_path, uow_id="uow-1", event="execution_complete",
+                        ts="2026-01-02T10:00:00+00:00",
+                        note=json.dumps({"actor": "executor", "output_ref": "/tmp/out", "timestamp": "2026-01-02T10:00:00+00:00"}))
+        # execution_failed — note is a JSON dict matching executor._fail_uow
         for _ in range(2):
-            _seed_audit(db_path, uow_id="uow-2", event="executor_outcome",
-                        ts="2026-01-02T10:00:00+00:00", note="failed")
-        _seed_audit(db_path, uow_id="uow-3", event="executor_outcome",
-                    ts="2026-01-02T10:00:00+00:00", note="blocked")
+            _seed_audit(db_path, uow_id="uow-2", event="execution_failed",
+                        ts="2026-01-02T10:00:00+00:00",
+                        note=json.dumps({"actor": "executor", "reason": "timeout", "timestamp": "2026-01-02T10:00:00+00:00"}))
 
         result = execution_outcomes(cutoff, registry_path=db_path)
 
-        assert result == {"complete": 3, "failed": 2, "blocked": 1}
-
-    def test_null_note_counted_as_unknown(self, db_path):
-        from src.orchestration.audit_queries import execution_outcomes
-
-        cutoff = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-        _seed_audit(db_path, uow_id="uow-1", event="executor_outcome",
-                    ts="2026-01-02T10:00:00+00:00", note=None)
-
-        result = execution_outcomes(cutoff, registry_path=db_path)
-
-        assert result == {"unknown": 1}
+        assert result == {"execution_complete": 3, "execution_failed": 2}
 
     def test_excludes_events_before_since(self, db_path):
         from src.orchestration.audit_queries import execution_outcomes
+        import json
 
         cutoff = datetime(2026, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
-        _seed_audit(db_path, uow_id="uow-1", event="executor_outcome",
-                    ts="2026-01-01T10:00:00+00:00", note="complete")  # before cutoff
-        _seed_audit(db_path, uow_id="uow-2", event="executor_outcome",
-                    ts="2026-07-01T10:00:00+00:00", note="failed")    # after cutoff
+        _seed_audit(db_path, uow_id="uow-1", event="execution_complete",
+                    ts="2026-01-01T10:00:00+00:00",  # before cutoff
+                    note=json.dumps({"actor": "executor", "output_ref": "/tmp/out", "timestamp": "2026-01-01T10:00:00+00:00"}))
+        _seed_audit(db_path, uow_id="uow-2", event="execution_failed",
+                    ts="2026-07-01T10:00:00+00:00",  # after cutoff
+                    note=json.dumps({"actor": "executor", "reason": "timeout", "timestamp": "2026-07-01T10:00:00+00:00"}))
 
         result = execution_outcomes(cutoff, registry_path=db_path)
 
-        assert result == {"failed": 1}
+        assert result == {"execution_failed": 1}
 
-    def test_excludes_non_executor_outcome_events(self, db_path):
+    def test_excludes_non_executor_events(self, db_path):
         from src.orchestration.audit_queries import execution_outcomes
 
         cutoff = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         _seed_audit(db_path, uow_id="uow-1", event="status_change",
-                    ts="2026-01-02T10:00:00+00:00", note="complete")
+                    ts="2026-01-02T10:00:00+00:00")
+        _seed_audit(db_path, uow_id="uow-1", event="steward_prescription",
+                    ts="2026-01-02T10:00:00+00:00")
 
         result = execution_outcomes(cutoff, registry_path=db_path)
         assert result == {}


### PR DESCRIPTION
## Problem

The audit_log table in the WOS registry DB is populated on every UoW transition, but nothing can read it. Steward cycle patterns, executor outcome distributions, and stall history are invisible — the data exists but has no query API.

## What this adds

A new module, `src/orchestration/audit_queries.py`, with four pure read-only functions:

| Function | Returns |
|---|---|
| `recent_transitions(uow_id, limit)` | Per-UoW audit history, newest first |
| `stall_events(since)` | All `stall_detected` entries in a time window |
| `cycles_histogram()` | `{uow_id: steward_cycle_count}` across all UoWs |
| `execution_outcomes(since)` | `{outcome: count}` breakdown for a time window |

All four follow the same `_connect()` / `registry_path` / `REGISTRY_DB_PATH` pattern used in `registry_cli.py`. Connections are opened read-only (`mode=ro` URI) and closed after each query. Return type is plain `dict` throughout — no dataclasses.

## Functional patterns

Pure functions with no side effects, immutable return values (new dicts on each call), composition avoided in favor of simple single-responsibility functions, side effects (DB I/O) isolated to each function's boundary.

## What is not changed

`registry.py`, `schema.sql`, and all existing modules are untouched. This is additive only.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_audit_queries.py -v` — 18 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/ -q` — 217 passed, 0 failed (full orchestration suite, no regressions)
- [ ] Full `tests/unit/` suite — 1645 passed, 5 failed, 578 errors — all failures and errors are pre-existing in `test_mcp_server` (unrelated `_DEBUG_RESOLVED` attribute patching issue), none in orchestration

**Blocked items needing attention before merge:** none