### PR TITLE
fix(wos): four quick fixes for orchestration layer (fixes 6-9)

### DIFF
--- a/scheduled-tasks/startup-sweep.py
+++ b/scheduled-tasks/startup-sweep.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Startup Sweep — WOS Phase 2 crash recovery for orphaned UoWs.
+
+Scans `active`, `ready-for-executor`, and `diagnosing` UoWs and surfaces
+orphans back to the Steward via 'ready-for-steward' transitions with
+'startup_sweep' audit entries.
+
+Runs as Phase 1 of the steward-heartbeat.py cron script (every 3 minutes).
+Can also be invoked standalone for testing:
+
+    uv run ~/lobster/scheduled-tasks/startup-sweep.py [--dry-run]
+
+Full implementation spec: #307.
+
+Phase 2 dependency: requires schema migration to have been applied:
+    uv run ~/lobster/scripts/migrate_add_steward_fields.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+log = logging.getLogger("startup-sweep")
+
+
+# ---------------------------------------------------------------------------
+# Named constants
+# ---------------------------------------------------------------------------
+
+_STATUS_ACTIVE = "active"
+_STATUS_READY_FOR_EXECUTOR = "ready-for-executor"
+_STATUS_DIAGNOSING = "diagnosing"
+_STARTUP_SWEEP_ACTOR = "steward_startup"
+_EXECUTOR_ORPHAN_THRESHOLD_SECONDS = 3600  # 1 hour: ready-for-executor age threshold
+
+
+# ---------------------------------------------------------------------------
+# Startup sweep result type
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class StartupSweepResult:
+    """Pure result value returned by run_startup_sweep."""
+    active_swept: int
+    executor_orphans_swept: int
+    diagnosing_swept: int
+    skipped_dry_run: int
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Startup sweep — crash recovery (#307)
+# ---------------------------------------------------------------------------
+
+def _classify_active_uow(output_ref: str | None) -> tuple[str, dict]:
+    """
+    Classify an active UoW by examining output_ref.
+
+    Returns (classification, extra_fields) where extra_fields contains
+    file mtime info for possibly_complete, or is empty for other cases.
+
+    Classification values:
+    - possibly_complete: output_ref exists and is non-empty
+    - crashed_zero_bytes: output_ref exists but is 0 bytes
+    - crashed_output_ref_missing: output_ref path written but file missing
+    - crashed_no_output_ref: output_ref IS NULL
+    """
+    if output_ref is None:
+        return "crashed_no_output_ref", {}
+
+    if not os.path.isabs(output_ref):
+        log.warning(
+            "Startup sweep: output_ref %r is not an absolute path — "
+            "classifying as crashed_no_output_ref",
+            output_ref,
+        )
+        return "crashed_no_output_ref", {}
+
+    try:
+        exists = os.path.exists(output_ref)
+    except (OSError, ValueError):
+        exists = False
+
+    if not exists:
+        return "crashed_output_ref_missing", {}
+
+    try:
+        size = os.path.getsize(output_ref)
+    except OSError:
+        return "crashed_output_ref_missing", {}
+
+    if size == 0:
+        return "crashed_zero_bytes", {}
+
+    # Non-empty file — possibly_complete; include mtime signal for Steward.
+    try:
+        mtime = os.path.getmtime(output_ref)
+        mtime_dt = datetime.fromtimestamp(mtime, tz=timezone.utc)
+        mtime_iso = mtime_dt.isoformat()
+        age_seconds = int((datetime.now(timezone.utc) - mtime_dt).total_seconds())
+    except OSError:
+        mtime_iso = None
+        age_seconds = None
+
+    return "possibly_complete", {
+        "output_ref_mtime": mtime_iso,
+        "output_ref_age_seconds": age_seconds,
+    }
+
+
+def run_startup_sweep(
+    registry,
+    dry_run: bool = False,
+    orphan_threshold_seconds: int = _EXECUTOR_ORPHAN_THRESHOLD_SECONDS,
+) -> StartupSweepResult:
+    """
+    Startup sweep — crash recovery for orphaned UoWs (#307).
+
+    Runs on every heartbeat invocation (step 1 of 3, before Observation Loop
+    and Steward main loop). Scans three populations:
+
+    1. `active` UoWs: Executors that may have crashed mid-execution.
+       Classified by output_ref state and surfaced to ready-for-steward.
+
+    2. `ready-for-executor` UoWs older than orphan_threshold_seconds:
+       Executors that crashed before step 1 of the claim sequence.
+       Classified as executor_orphan. Steward treats as clean first execution.
+
+    3. `diagnosing` UoWs: Steward crashed mid-diagnosis.
+       Reset to ready-for-steward for re-diagnosis on the next heartbeat.
+
+    Each transition uses the optimistic-lock + audit pattern (Principle 1):
+    - Audit entry written in same transaction as status UPDATE.
+    - If rows_affected == 0: another process won the race — skip silently.
+    - In dry_run mode: classify but do not write or transition.
+
+    Periodic 15-minute sweep (design doc pattern) is deferred to Phase 3.
+    The 3-minute heartbeat cadence achieves finer coverage.
+
+    Returns StartupSweepResult with counts for each population swept.
+    """
+    try:
+        active_uows = registry.list(status=_STATUS_ACTIVE)
+    except Exception as e:
+        log.warning("Startup sweep: failed to query active UoWs — %s", e)
+        active_uows = []
+
+    try:
+        rfe_uows = registry.list(status=_STATUS_READY_FOR_EXECUTOR)
+    except Exception as e:
+        log.warning("Startup sweep: failed to query ready-for-executor UoWs — %s", e)
+        rfe_uows = []
+
+    try:
+        diagnosing_uows = registry.list(status=_STATUS_DIAGNOSING)
+    except Exception as e:
+        log.warning("Startup sweep: failed to query diagnosing UoWs — %s", e)
+        diagnosing_uows = []
+
+    now = datetime.now(timezone.utc)
+    active_swept = 0
+    executor_orphans_swept = 0
+    diagnosing_swept = 0
+    skipped_dry_run = 0
+
+    # --- Population 1: active UoWs (Executor crash during execution) ---
+    for uow in active_uows:
+        uow_id = uow.id
+        output_ref = uow.output_ref
+        classification, extra = _classify_active_uow(output_ref)
+
+        if dry_run:
+            log.info(
+                "Startup sweep (DRY RUN): active UoW %s would be classified as %s "
+                "and transitioned to ready-for-steward",
+                uow_id, classification,
+            )
+            skipped_dry_run += 1
+            continue
+
+        rows = registry.record_startup_sweep_active(
+            uow_id=uow_id,
+            classification=classification,
+            output_ref=output_ref,
+            extra=extra if extra else None,
+        )
+
+        if rows == 1:
+            active_swept += 1
+            log.info(
+                "Startup sweep: active UoW %s → ready-for-steward (classification=%s)",
+                uow_id, classification,
+            )
+        else:
+            log.debug(
+                "Startup sweep: race on active UoW %s — another component already "
+                "advanced it (rows_affected=0)",
+                uow_id,
+            )
+
+    # --- Population 2: ready-for-executor UoWs older than threshold ---
+    for uow in rfe_uows:
+        uow_id = uow.id
+        proposed_at = uow.created_at  # proposed_at proxy: conservative lower bound
+
+        try:
+            proposed_dt = datetime.fromisoformat(
+                proposed_at.replace("Z", "+00:00")
+            )
+            if proposed_dt.tzinfo is None:
+                proposed_dt = proposed_dt.replace(tzinfo=timezone.utc)
+            age_seconds = (now - proposed_dt).total_seconds()
+        except (ValueError, TypeError, AttributeError):
+            log.warning(
+                "Startup sweep: UoW %s has unparseable created_at=%r — skipping",
+                uow_id, proposed_at,
+            )
+            continue
+
+        if age_seconds <= orphan_threshold_seconds:
+            # Not old enough — leave it alone.
+            continue
+
+        if dry_run:
+            log.info(
+                "Startup sweep (DRY RUN): ready-for-executor UoW %s (age=%.0fs) "
+                "would be classified as executor_orphan and transitioned to ready-for-steward",
+                uow_id, age_seconds,
+            )
+            skipped_dry_run += 1
+            continue
+
+        rows = registry.record_startup_sweep_executor_orphan(
+            uow_id=uow_id,
+            proposed_at=proposed_at,
+            age_seconds=age_seconds,
+            threshold_seconds=orphan_threshold_seconds,
+        )
+
+        if rows == 1:
+            executor_orphans_swept += 1
+            log.info(
+                "Startup sweep: executor_orphan UoW %s → ready-for-steward "
+                "(age=%.0fs, threshold=%ds)",
+                uow_id, age_seconds, orphan_threshold_seconds,
+            )
+        else:
+            log.debug(
+                "Startup sweep: race on ready-for-executor UoW %s — another component "
+                "already advanced it (rows_affected=0)",
+                uow_id,
+            )
+
+    # --- Population 3: diagnosing UoWs (Steward crash mid-diagnosis) ---
+    for uow in diagnosing_uows:
+        uow_id = uow.id
+
+        if dry_run:
+            log.info(
+                "Startup sweep (DRY RUN): diagnosing UoW %s would be reset to "
+                "ready-for-steward",
+                uow_id,
+            )
+            skipped_dry_run += 1
+            continue
+
+        rows = registry.record_startup_sweep_diagnosing(uow_id=uow_id)
+
+        if rows == 1:
+            diagnosing_swept += 1
+            log.info(
+                "Startup sweep: diagnosing UoW %s → ready-for-steward "
+                "(Steward crash recovery)",
+                uow_id,
+            )
+        else:
+            log.debug(
+                "Startup sweep: race on diagnosing UoW %s — another component "
+                "already advanced it (rows_affected=0)",
+                uow_id,
+            )
+
+    total = active_swept + executor_orphans_swept + diagnosing_swept + skipped_dry_run
+    if total > 0:
+        log.info(
+            "Startup sweep complete: %d active swept, %d executor_orphans swept, "
+            "%d diagnosing swept, %d skipped (dry-run)",
+            active_swept, executor_orphans_swept, diagnosing_swept, skipped_dry_run,
+        )
+
+    return StartupSweepResult(
+        active_swept=active_swept,
+        executor_orphans_swept=executor_orphans_swept,
+        diagnosing_swept=diagnosing_swept,
+        skipped_dry_run=skipped_dry_run,
+    )

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -7,7 +7,7 @@ Runs every 3 minutes. On each invocation executes three functions in order:
 1. Startup sweep — crash recovery. Scans `active`, `ready-for-executor`, and
    `diagnosing` UoWs and surfaces orphans back to the Steward via
    'ready-for-steward' transitions with 'startup_sweep' audit entries.
-   Full implementation is here (#307).
+   Implementation lives in startup-sweep.py. Full spec: #307.
 
 2. Observation Loop — detect stalled `active` UoWs by checking `timeout_at`.
    Surfaces stalled UoWs back to the Steward via the 'ready-for-steward'
@@ -33,7 +33,6 @@ Phase 2 dependency: requires schema migration to have been applied:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import os
 import sys
@@ -54,6 +53,25 @@ if str(_REPO_ROOT) not in sys.path:
 from src.orchestration.steward import BOOTUP_CANDIDATE_GATE, run_steward_cycle
 
 # ---------------------------------------------------------------------------
+# Startup sweep — imported from startup-sweep.py (Phase 1 concern)
+# Re-exported here so tests that load this module via importlib can still
+# access run_startup_sweep, StartupSweepResult, and _classify_active_uow
+# by name without change.
+# ---------------------------------------------------------------------------
+
+import importlib.util as _ilu
+
+_SWEEP_PATH = Path(__file__).parent / "startup-sweep.py"
+_sweep_spec = _ilu.spec_from_file_location("startup_sweep", _SWEEP_PATH)
+_sweep_mod = _ilu.module_from_spec(_sweep_spec)
+sys.modules["startup_sweep"] = _sweep_mod
+_sweep_spec.loader.exec_module(_sweep_mod)
+
+run_startup_sweep = _sweep_mod.run_startup_sweep
+StartupSweepResult = _sweep_mod.StartupSweepResult
+_classify_active_uow = _sweep_mod._classify_active_uow
+
+# ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
 
@@ -69,12 +87,7 @@ log = logging.getLogger("steward-heartbeat")
 # Named constants
 # ---------------------------------------------------------------------------
 
-_STATUS_ACTIVE = "active"
-_STATUS_READY_FOR_EXECUTOR = "ready-for-executor"
-_STATUS_DIAGNOSING = "diagnosing"
-_STARTUP_SWEEP_ACTOR = "steward_startup"
 _DEFAULT_STALL_SECONDS = 1800  # 30 minutes fallback when timeout_at is NULL
-_EXECUTOR_ORPHAN_THRESHOLD_SECONDS = 3600  # 1 hour: ready-for-executor age threshold
 
 
 # ---------------------------------------------------------------------------
@@ -124,267 +137,6 @@ def _default_db_path() -> Path:
         "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
     ))
     return workspace / "data" / "registry.db"
-
-
-# ---------------------------------------------------------------------------
-# Startup sweep result type
-# ---------------------------------------------------------------------------
-
-@dataclass(frozen=True, slots=True)
-class StartupSweepResult:
-    """Pure result value returned by run_startup_sweep."""
-    active_swept: int
-    executor_orphans_swept: int
-    diagnosing_swept: int
-    skipped_dry_run: int
-
-
-# ---------------------------------------------------------------------------
-# Phase 1: Startup sweep — crash recovery (#307)
-# ---------------------------------------------------------------------------
-
-def _classify_active_uow(output_ref: str | None) -> tuple[str, dict]:
-    """
-    Classify an active UoW by examining output_ref.
-
-    Returns (classification, extra_fields) where extra_fields contains
-    file mtime info for possibly_complete, or is empty for other cases.
-
-    Classification values:
-    - possibly_complete: output_ref exists and is non-empty
-    - crashed_zero_bytes: output_ref exists but is 0 bytes
-    - crashed_output_ref_missing: output_ref path written but file missing
-    - crashed_no_output_ref: output_ref IS NULL
-    """
-    if output_ref is None:
-        return "crashed_no_output_ref", {}
-
-    if not os.path.isabs(output_ref):
-        log.warning(
-            "Startup sweep: output_ref %r is not an absolute path — "
-            "classifying as crashed_no_output_ref",
-            output_ref,
-        )
-        return "crashed_no_output_ref", {}
-
-    try:
-        exists = os.path.exists(output_ref)
-    except (OSError, ValueError):
-        exists = False
-
-    if not exists:
-        return "crashed_output_ref_missing", {}
-
-    try:
-        size = os.path.getsize(output_ref)
-    except OSError:
-        return "crashed_output_ref_missing", {}
-
-    if size == 0:
-        return "crashed_zero_bytes", {}
-
-    # Non-empty file — possibly_complete; include mtime signal for Steward.
-    try:
-        mtime = os.path.getmtime(output_ref)
-        mtime_dt = datetime.fromtimestamp(mtime, tz=timezone.utc)
-        mtime_iso = mtime_dt.isoformat()
-        age_seconds = int((datetime.now(timezone.utc) - mtime_dt).total_seconds())
-    except OSError:
-        mtime_iso = None
-        age_seconds = None
-
-    return "possibly_complete", {
-        "output_ref_mtime": mtime_iso,
-        "output_ref_age_seconds": age_seconds,
-    }
-
-
-def run_startup_sweep(
-    registry,
-    dry_run: bool = False,
-    orphan_threshold_seconds: int = _EXECUTOR_ORPHAN_THRESHOLD_SECONDS,
-) -> StartupSweepResult:
-    """
-    Startup sweep — crash recovery for orphaned UoWs (#307).
-
-    Runs on every heartbeat invocation (step 1 of 3, before Observation Loop
-    and Steward main loop). Scans three populations:
-
-    1. `active` UoWs: Executors that may have crashed mid-execution.
-       Classified by output_ref state and surfaced to ready-for-steward.
-
-    2. `ready-for-executor` UoWs older than orphan_threshold_seconds:
-       Executors that crashed before step 1 of the claim sequence.
-       Classified as executor_orphan. Steward treats as clean first execution.
-
-    3. `diagnosing` UoWs: Steward crashed mid-diagnosis.
-       Reset to ready-for-steward for re-diagnosis on the next heartbeat.
-
-    Each transition uses the optimistic-lock + audit pattern (Principle 1):
-    - Audit entry written in same transaction as status UPDATE.
-    - If rows_affected == 0: another process won the race — skip silently.
-    - In dry_run mode: classify but do not write or transition.
-
-    Periodic 15-minute sweep (design doc pattern) is deferred to Phase 3.
-    The 3-minute heartbeat cadence achieves finer coverage.
-
-    Returns StartupSweepResult with counts for each population swept.
-    """
-    try:
-        active_uows = registry.list(status=_STATUS_ACTIVE)
-    except Exception as e:
-        log.warning("Startup sweep: failed to query active UoWs — %s", e)
-        active_uows = []
-
-    try:
-        rfe_uows = registry.list(status=_STATUS_READY_FOR_EXECUTOR)
-    except Exception as e:
-        log.warning("Startup sweep: failed to query ready-for-executor UoWs — %s", e)
-        rfe_uows = []
-
-    try:
-        diagnosing_uows = registry.list(status=_STATUS_DIAGNOSING)
-    except Exception as e:
-        log.warning("Startup sweep: failed to query diagnosing UoWs — %s", e)
-        diagnosing_uows = []
-
-    now = datetime.now(timezone.utc)
-    active_swept = 0
-    executor_orphans_swept = 0
-    diagnosing_swept = 0
-    skipped_dry_run = 0
-
-    # --- Population 1: active UoWs (Executor crash during execution) ---
-    for uow in active_uows:
-        uow_id = uow.id
-        output_ref = uow.output_ref
-        classification, extra = _classify_active_uow(output_ref)
-
-        if dry_run:
-            log.info(
-                "Startup sweep (DRY RUN): active UoW %s would be classified as %s "
-                "and transitioned to ready-for-steward",
-                uow_id, classification,
-            )
-            skipped_dry_run += 1
-            continue
-
-        rows = registry.record_startup_sweep_active(
-            uow_id=uow_id,
-            classification=classification,
-            output_ref=output_ref,
-            extra=extra if extra else None,
-        )
-
-        if rows == 1:
-            active_swept += 1
-            log.info(
-                "Startup sweep: active UoW %s → ready-for-steward (classification=%s)",
-                uow_id, classification,
-            )
-        else:
-            log.debug(
-                "Startup sweep: race on active UoW %s — another component already "
-                "advanced it (rows_affected=0)",
-                uow_id,
-            )
-
-    # --- Population 2: ready-for-executor UoWs older than threshold ---
-    for uow in rfe_uows:
-        uow_id = uow.id
-        proposed_at = uow.created_at  # proposed_at proxy: conservative lower bound
-
-        try:
-            proposed_dt = datetime.fromisoformat(
-                proposed_at.replace("Z", "+00:00")
-            )
-            if proposed_dt.tzinfo is None:
-                proposed_dt = proposed_dt.replace(tzinfo=timezone.utc)
-            age_seconds = (now - proposed_dt).total_seconds()
-        except (ValueError, TypeError, AttributeError):
-            log.warning(
-                "Startup sweep: UoW %s has unparseable created_at=%r — skipping",
-                uow_id, proposed_at,
-            )
-            continue
-
-        if age_seconds <= orphan_threshold_seconds:
-            # Not old enough — leave it alone.
-            continue
-
-        if dry_run:
-            log.info(
-                "Startup sweep (DRY RUN): ready-for-executor UoW %s (age=%.0fs) "
-                "would be classified as executor_orphan and transitioned to ready-for-steward",
-                uow_id, age_seconds,
-            )
-            skipped_dry_run += 1
-            continue
-
-        rows = registry.record_startup_sweep_executor_orphan(
-            uow_id=uow_id,
-            proposed_at=proposed_at,
-            age_seconds=age_seconds,
-            threshold_seconds=orphan_threshold_seconds,
-        )
-
-        if rows == 1:
-            executor_orphans_swept += 1
-            log.info(
-                "Startup sweep: executor_orphan UoW %s → ready-for-steward "
-                "(age=%.0fs, threshold=%ds)",
-                uow_id, age_seconds, orphan_threshold_seconds,
-            )
-        else:
-            log.debug(
-                "Startup sweep: race on ready-for-executor UoW %s — another component "
-                "already advanced it (rows_affected=0)",
-                uow_id,
-            )
-
-    # --- Population 3: diagnosing UoWs (Steward crash mid-diagnosis) ---
-    for uow in diagnosing_uows:
-        uow_id = uow.id
-
-        if dry_run:
-            log.info(
-                "Startup sweep (DRY RUN): diagnosing UoW %s would be reset to "
-                "ready-for-steward",
-                uow_id,
-            )
-            skipped_dry_run += 1
-            continue
-
-        rows = registry.record_startup_sweep_diagnosing(uow_id=uow_id)
-
-        if rows == 1:
-            diagnosing_swept += 1
-            log.info(
-                "Startup sweep: diagnosing UoW %s → ready-for-steward "
-                "(Steward crash recovery)",
-                uow_id,
-            )
-        else:
-            log.debug(
-                "Startup sweep: race on diagnosing UoW %s — another component "
-                "already advanced it (rows_affected=0)",
-                uow_id,
-            )
-
-    total = active_swept + executor_orphans_swept + diagnosing_swept + skipped_dry_run
-    if total > 0:
-        log.info(
-            "Startup sweep complete: %d active swept, %d executor_orphans swept, "
-            "%d diagnosing swept, %d skipped (dry-run)",
-            active_swept, executor_orphans_swept, diagnosing_swept, skipped_dry_run,
-        )
-
-    return StartupSweepResult(
-        active_swept=active_swept,
-        executor_orphans_swept=executor_orphans_swept,
-        diagnosing_swept=diagnosing_swept,
-        skipped_dry_run=skipped_dry_run,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -450,10 +202,8 @@ def run_observation_loop(
         uow_id = uow.id
         timeout_at: str | None = uow.timeout_at
         started_at: str | None = None
-        # started_at is not on the UoW dataclass — access raw via registry if needed.
-        # The UoW dataclass doesn't expose started_at; we derive deadline from
-        # timeout_at (preferred) or the fallback window from started_at (via DB query).
-        # For the fallback path we need started_at — fetch it from DB directly.
+        # started_at is not on the UoW dataclass — access it via the public
+        # registry.get_started_at() method when needed for the fallback path.
         stall_reason: _StallReason | None = None
         deadline: datetime | None = None
 
@@ -471,10 +221,8 @@ def run_observation_loop(
             if now >= deadline:
                 stall_reason = _StallReason.TIMEOUT_EXCEEDED
         else:
-            # Fallback: fetch started_at from DB for the 1800s window.
-            # We fetch via registry to avoid opening a raw connection here.
-            raw = _fetch_started_at(registry, uow_id)
-            started_at = raw
+            # Fallback: fetch started_at via the public Registry API.
+            started_at = registry.get_started_at(uow_id)
 
             if started_at is None:
                 # Both timeout_at and started_at are NULL — immediate stall.
@@ -531,27 +279,6 @@ def run_observation_loop(
             )
 
     return ObservationResult(checked=len(active_uows), stalled=stalled, skipped_dry_run=skipped_dry_run)
-
-
-def _fetch_started_at(registry, uow_id: str) -> str | None:
-    """
-    Fetch started_at for a UoW by id. Returns None if the UoW is not found
-    or started_at is NULL.
-
-    started_at is not exposed on the UoW dataclass (it is an Executor-set
-    field not needed by most callers). We read it directly from the Registry's
-    connection here to avoid widening the UoW dataclass surface area.
-    """
-    conn = registry._connect()
-    try:
-        row = conn.execute(
-            "SELECT started_at FROM uow_registry WHERE id = ?", (uow_id,)
-        ).fetchone()
-        if row is None:
-            return None
-        return row["started_at"]
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -819,6 +819,27 @@ class Registry:
         """
         return self.list(status=UoWStatus.ACTIVE)
 
+    def get_started_at(self, uow_id: str) -> str | None:
+        """
+        Return the started_at timestamp string for a UoW, or None if the UoW
+        is not found or started_at is NULL.
+
+        started_at is set by the Executor at claim time and is not exposed on
+        the UoW dataclass (it is not needed by most callers). This method
+        provides public access without requiring callers to open a raw
+        connection via registry._connect().
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT started_at FROM uow_registry WHERE id = ?", (uow_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            return row["started_at"]
+        finally:
+            conn.close()
+
     def record_startup_sweep_active(
         self,
         uow_id: str,

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -849,7 +849,7 @@ def _write_workflow_artifact(
 # Dan notification
 # ---------------------------------------------------------------------------
 
-_DAN_CHAT_ID = "8075091586"
+_DAN_CHAT_ID = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
 
 
 def _default_notify_dan(


### PR DESCRIPTION
## What this solves

Four small cleanup items that were accumulating technical debt in the WOS orchestration layer. None change observable behavior — they harden the code against operational variance and enforce separation of concerns.

## Changes

**Fix 6 — _DAN_CHAT_ID centralized (steward.py)**

The steward's notification path had a hardcoded `_DAN_CHAT_ID = "8075091586"` that ignored the `LOBSTER_ADMIN_CHAT_ID` env var that every other notification path in the codebase already respects. Now reads from env with the same fallback.

**Fix 7 — steward-heartbeat.py split into two files**

The heartbeat script contained two distinct concerns: startup sweep (crash recovery, Phase 1) and the heartbeat orchestration itself. Startup sweep logic is now in `startup-sweep.py`. The heartbeat imports and re-exports the sweep symbols (`run_startup_sweep`, `StartupSweepResult`, `_classify_active_uow`) so tests that load the heartbeat via `importlib` by path continue to work without modification.

**Fix 8 — Registry.get_started_at() public method added (registry.py)**

The observation loop needed `started_at` for the stall-detection fallback path, but the field isn't on the UoW dataclass. Previously it called `registry._connect()` directly — bypassing the public API. A new `get_started_at(uow_id: str) -> str | None` method is added to Registry, and the observation loop uses it. The private `_fetch_started_at()` helper in the heartbeat is removed.

**Fix 9 — busy_timeout verified (no code change)**

Verified that all `sqlite3.connect()` calls in Phase 2 writers (`registry.py`, `executor.py`) already carry `timeout=10.0` and `PRAGMA busy_timeout=5000`. No changes required.

## Functional patterns

Pure functions throughout: `run_startup_sweep` and `run_observation_loop` are side-effect-free except at the explicit registry-call boundary. `get_started_at` is a pure read with no observable side effects. The split uses importlib to re-export sweep symbols from the heartbeat, keeping the public surface unchanged while separating the concerns into cohesive files.

## Areas to review closely

- The importlib bootstrap in `steward-heartbeat.py` (lines ~53–66): this is the mechanism that re-exports startup sweep symbols so existing tests don't need path changes. It uses `spec_from_file_location` the same way the tests themselves do.
- `Registry.get_started_at()` — confirm the SQL matches the pattern of the removed `_fetch_started_at()` helper exactly.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/` — 199 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_startup_sweep.py tests/unit/test_orchestration/test_observation_loop.py` — 50 passed, 0 failed (covers both split files and the public API change)

Pre-existing failures in `test_emit_event`, `test_hibernation`, `test_memory`, `test_write_observation` are unrelated to this PR and present on main.

**Blocked items needing attention before merge:** none