### PR TITLE
feat(wos): numbered DB migration layer + _migrations table (item 4)

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2697,6 +2697,21 @@ conn.close()
         fi
     fi
 
+    # Migration 56: Run numbered DB migrations (WOS orchestration layer)
+    # src/orchestration/migrate.py applies all unapplied numbered .sql files
+    # from src/orchestration/migrations/ to the registry DB. It is idempotent:
+    # already-applied migrations are skipped. This call handles all future
+    # schema changes to the WOS registry without requiring new upgrade.sh entries.
+    local registry_db="$WORKSPACE_DIR/orchestration/registry.db"
+    if [ -f "$registry_db" ]; then
+        if uv run "$LOBSTER_DIR/src/orchestration/migrate.py" "$registry_db" 2>/dev/null; then
+            substep "WOS DB migrations applied (or already up to date)"
+            migrated=$((migrated + 1))
+        else
+            warn "WOS DB migration runner failed — run manually: uv run src/orchestration/migrate.py $registry_db"
+        fi
+    fi
+
     # Migration 55: Add transcription-monitor cron entry
     # transcription-monitor.py pings the user every 5 minutes while whisper-cli
     # is running, providing progress feedback during long transcriptions (e.g. a

--- a/src/orchestration/migrate.py
+++ b/src/orchestration/migrate.py
@@ -1,0 +1,171 @@
+"""
+DB migration runner for the WOS orchestration layer.
+
+Design:
+- Migrations live in src/orchestration/migrations/ as numbered .sql files:
+    0001_initial_schema.sql, 0002_add_notes_column.sql, ...
+- The _migrations table tracks which versions have been applied.
+- run_migrations(db_path) is idempotent: already-applied versions are skipped.
+- Any SQL error raises immediately — no silent swallowing.
+- Uses busy_timeout=5000 and WAL mode, consistent with Registry._connect().
+
+Entry point:
+    uv run src/orchestration/migrate.py [DB_PATH]
+
+    DB_PATH defaults to $REGISTRY_DB_PATH if not supplied as an argument.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+_CREATE_MIGRATIONS_TABLE = """
+CREATE TABLE IF NOT EXISTS _migrations (
+    id          INTEGER PRIMARY KEY,
+    version     INTEGER UNIQUE NOT NULL,
+    applied_at  TEXT    NOT NULL,
+    filename    TEXT    NOT NULL
+);
+"""
+
+_MIGRATION_FILENAME_RE = re.compile(r"^(\d{4})_[a-z0-9_]+\.sql$")
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def _discover_migrations(migrations_dir: Path) -> list[tuple[int, Path]]:
+    """
+    Return all migration files in ascending version order.
+
+    Each file must match the pattern NNNN_description.sql.
+    Files that do not match are silently ignored (e.g. README, __init__).
+
+    Returns: sorted list of (version, path) tuples.
+    """
+    results: list[tuple[int, Path]] = []
+    for path in migrations_dir.iterdir():
+        m = _MIGRATION_FILENAME_RE.match(path.name)
+        if m:
+            version = int(m.group(1))
+            results.append((version, path))
+    results.sort(key=lambda pair: pair[0])
+    return results
+
+
+def _applied_versions(conn: sqlite3.Connection) -> frozenset[int]:
+    """Return the set of migration versions already recorded in _migrations."""
+    rows = conn.execute("SELECT version FROM _migrations").fetchall()
+    return frozenset(row["version"] for row in rows)
+
+
+def _record_migration(
+    conn: sqlite3.Connection,
+    version: int,
+    filename: str,
+    applied_at: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO _migrations (version, applied_at, filename) VALUES (?, ?, ?)",
+        (version, applied_at, filename),
+    )
+
+
+def run_migrations(db_path: Path) -> list[int]:
+    """
+    Apply all unapplied migrations in order.
+
+    Creates the database and its parent directory if they do not exist.
+    Creates the _migrations table if it does not exist.
+    Skips any migration whose version is already recorded.
+    Each migration is applied and recorded in its own transaction.
+    Raises sqlite3.OperationalError (or any subclass) on SQL failure.
+
+    Returns: list of version numbers that were applied (empty if nothing to do).
+    """
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    migrations = _discover_migrations(_MIGRATIONS_DIR)
+    if not migrations:
+        return []
+
+    conn = _connect(db_path)
+    try:
+        conn.execute(_CREATE_MIGRATIONS_TABLE)
+        conn.commit()
+
+        applied = _applied_versions(conn)
+        newly_applied: list[int] = []
+
+        for version, path in migrations:
+            if version in applied:
+                continue
+
+            sql = path.read_text()
+            now = datetime.now(timezone.utc).isoformat()
+
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.executescript(sql)
+                # executescript issues an implicit COMMIT, so we open a new
+                # transaction to atomically record the migration version.
+                conn.execute("BEGIN IMMEDIATE")
+                _record_migration(conn, version, path.name, now)
+                conn.commit()
+            except Exception:
+                # executescript commits implicitly, so a partial DDL run may
+                # have succeeded. We do not attempt a rollback of DDL (SQLite
+                # does not support transactional DDL for schema changes like
+                # ALTER TABLE). The version is NOT recorded, so the next run
+                # will retry. The caller is responsible for diagnosing.
+                conn.rollback()
+                raise
+
+            newly_applied.append(version)
+
+        return newly_applied
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        db_path = Path(sys.argv[1])
+    else:
+        import os
+        env_path = os.environ.get("REGISTRY_DB_PATH")
+        if not env_path:
+            print(
+                "Usage: uv run src/orchestration/migrate.py <db_path>\n"
+                "       or set REGISTRY_DB_PATH environment variable",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        db_path = Path(env_path)
+
+    try:
+        applied = run_migrations(db_path)
+    except Exception as exc:
+        print(f"Migration failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if applied:
+        print(f"Applied {len(applied)} migration(s): {applied}")
+    else:
+        print("No migrations needed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestration/migrations/0001_initial_schema.sql
+++ b/src/orchestration/migrations/0001_initial_schema.sql
@@ -1,0 +1,69 @@
+-- Migration 0001: Initial WOS schema
+--
+-- Establishes the baseline schema for the Unit-of-Work registry.
+-- This migration captures the full schema as it existed at the point
+-- the migration system was introduced. New installs run all migrations
+-- sequentially; existing installs with CREATE TABLE IF NOT EXISTS will
+-- skip DDL that already exists but still record this migration as applied.
+--
+-- Tables created:
+--   uow_registry — core UoW store with all Phase 2 fields
+--   executor_uow_view — view exposing only executor-accessible columns
+--   audit_log — append-only event log for status transitions
+
+CREATE TABLE IF NOT EXISTS uow_registry (
+    id                  TEXT    PRIMARY KEY,
+    type                TEXT    NOT NULL DEFAULT 'executable',
+    source              TEXT    NOT NULL,
+    source_issue_number INTEGER,
+    sweep_date          TEXT,
+    status              TEXT    NOT NULL DEFAULT 'proposed',
+    posture             TEXT    NOT NULL DEFAULT 'solo',
+    agent               TEXT,
+    children            TEXT    DEFAULT '[]',
+    parent              TEXT,
+    created_at          TEXT    NOT NULL,
+    updated_at          TEXT    NOT NULL,
+    started_at          TEXT,
+    completed_at        TEXT,
+    summary             TEXT    NOT NULL,
+    output_ref          TEXT,
+    hooks_applied       TEXT    DEFAULT '[]',
+    route_reason        TEXT,
+    route_evidence      TEXT    DEFAULT '{}',
+    trigger             TEXT    DEFAULT '{"type": "immediate"}',
+    vision_ref          TEXT    DEFAULT NULL,
+
+    -- Phase 2 fields — Executor-accessible (included in executor_uow_view)
+    workflow_artifact   TEXT    NULL,
+    success_criteria    TEXT    NOT NULL DEFAULT '',
+    prescribed_skills   TEXT    NULL,
+    steward_cycles      INTEGER NOT NULL DEFAULT 0,
+    timeout_at          TEXT    NULL,
+    estimated_runtime   INTEGER NULL,
+
+    -- Phase 2 fields — Steward-private (excluded from executor_uow_view)
+    steward_agenda      TEXT    NULL,
+    steward_log         TEXT    NULL,
+
+    UNIQUE(source_issue_number, sweep_date)
+);
+
+CREATE VIEW IF NOT EXISTS executor_uow_view AS
+SELECT
+    id, status, output_ref, started_at, completed_at,
+    source_issue_number, summary,
+    workflow_artifact, success_criteria, prescribed_skills,
+    steward_cycles, timeout_at, estimated_runtime
+FROM uow_registry;
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          TEXT    NOT NULL,
+    uow_id      TEXT    NOT NULL,
+    event       TEXT    NOT NULL,
+    from_status TEXT,
+    to_status   TEXT,
+    agent       TEXT,
+    note        TEXT
+);

--- a/src/orchestration/migrations/0002_add_notes_column.sql
+++ b/src/orchestration/migrations/0002_add_notes_column.sql
@@ -1,0 +1,17 @@
+-- Migration 0002: Add notes column to uow_registry
+--
+-- Adds the `notes` column for free-form annotation on UoW records.
+-- This column was added to schema.sql for new installs (item 18) but
+-- existing installs need this ALTER TABLE to gain the column.
+--
+-- The column is intentionally permissive:
+--   - NOT NULL DEFAULT '{}' — empty JSON object, consistent with other
+--     JSON-typed fields (route_evidence, trigger) that default to empty
+--     structures rather than NULL.
+--   - TEXT type — contents are JSON but SQLite has no native JSON type.
+--
+-- Idempotency: SQLite does not support IF NOT EXISTS on ALTER TABLE.
+-- The migration runner skips this file if version 2 is already recorded
+-- in _migrations, so double-application is not possible.
+
+ALTER TABLE uow_registry ADD COLUMN notes TEXT NOT NULL DEFAULT '{}';

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -189,7 +189,21 @@ class Registry:
     def __init__(self, db_path: Path) -> None:
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._init_schema()
+        self._run_migrations()
+
+    # -----------------------------------------------------------------------
+    # Migration bootstrap — called once at Registry init
+    # -----------------------------------------------------------------------
+
+    def _run_migrations(self) -> None:
+        """Apply all pending numbered migrations via migrate.run_migrations().
+
+        This replaces the old _init_schema() / executescript(schema.sql) path.
+        The initial schema is now migration 0001, so new and existing DBs are
+        both handled by the migration runner.
+        """
+        from src.orchestration.migrate import run_migrations  # local import avoids circular
+        run_migrations(self.db_path)
 
     # -----------------------------------------------------------------------
     # Internal helpers
@@ -201,13 +215,6 @@ class Registry:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=5000")
         return conn
-
-    def _init_schema(self) -> None:
-        conn = self._connect()
-        try:
-            conn.executescript(_SCHEMA_SQL)
-        finally:
-            conn.close()
 
     def _row_to_dict(self, row: sqlite3.Row) -> dict[str, Any]:
         d = dict(row)

--- a/tests/unit/test_orchestration/test_migrations.py
+++ b/tests/unit/test_orchestration/test_migrations.py
@@ -1,0 +1,320 @@
+"""
+Tests for the numbered DB migration layer (issue #334).
+
+Covers:
+- Fresh DB runs all migrations in order and records them in _migrations
+- Already-migrated DB is idempotent (run_migrations twice == same result)
+- _migrations table is created automatically
+- Migration versions are recorded with filename and applied_at
+- Missing migration file raises clearly (FileNotFoundError or similar)
+- 0001_initial_schema: all expected tables and view are created
+- 0002_add_notes_column: notes column present with correct default
+- Registry.__init__ calls run_migrations (integration smoke test)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.orchestration.migrate import run_migrations, _discover_migrations, _MIGRATIONS_DIR
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _open(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _table_names(db_path: Path) -> set[str]:
+    conn = _open(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        return {r["name"] for r in rows}
+    finally:
+        conn.close()
+
+
+def _column_names(db_path: Path, table: str) -> set[str]:
+    conn = _open(db_path)
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        return {r["name"] for r in rows}
+    finally:
+        conn.close()
+
+
+def _applied_versions(db_path: Path) -> list[int]:
+    conn = _open(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT version FROM _migrations ORDER BY version"
+        ).fetchall()
+        return [r["version"] for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Fresh DB: all migrations applied
+# ---------------------------------------------------------------------------
+
+class TestFreshDB:
+    def test_all_migrations_applied_on_fresh_db(self, tmp_path: Path) -> None:
+        """run_migrations on a new file applies every migration."""
+        db_path = tmp_path / "fresh.db"
+        applied = run_migrations(db_path)
+        expected_versions = [v for v, _ in _discover_migrations(_MIGRATIONS_DIR)]
+        assert applied == expected_versions
+
+    def test_migrations_table_created(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        assert "_migrations" in _table_names(db_path)
+
+    def test_migrations_records_versions(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        expected = sorted(v for v, _ in _discover_migrations(_MIGRATIONS_DIR))
+        assert _applied_versions(db_path) == expected
+
+    def test_migrations_record_filenames(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        conn = _open(db_path)
+        try:
+            rows = conn.execute(
+                "SELECT version, filename FROM _migrations ORDER BY version"
+            ).fetchall()
+            for row in rows:
+                assert row["filename"].endswith(".sql")
+                assert row["filename"].startswith(f"{row['version']:04d}_")
+        finally:
+            conn.close()
+
+    def test_migrations_record_applied_at(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        conn = _open(db_path)
+        try:
+            rows = conn.execute("SELECT applied_at FROM _migrations").fetchall()
+            for row in rows:
+                # applied_at must be a non-empty ISO timestamp string
+                assert row["applied_at"]
+                assert "T" in row["applied_at"]  # ISO format
+        finally:
+            conn.close()
+
+    def test_initial_schema_tables_created(self, tmp_path: Path) -> None:
+        """Migration 0001 must create uow_registry and audit_log."""
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        tables = _table_names(db_path)
+        assert "uow_registry" in tables
+        assert "audit_log" in tables
+
+    def test_executor_uow_view_created(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        conn = _open(db_path)
+        try:
+            views = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='view' AND name='executor_uow_view'"
+            ).fetchone()
+            assert views is not None
+        finally:
+            conn.close()
+
+    def test_notes_column_present_after_migration(self, tmp_path: Path) -> None:
+        """Migration 0002 must add the notes column to uow_registry."""
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        cols = _column_names(db_path, "uow_registry")
+        assert "notes" in cols
+
+    def test_notes_column_default_empty_json_object(self, tmp_path: Path) -> None:
+        """notes column defaults to '{}' (empty JSON object)."""
+        db_path = tmp_path / "fresh.db"
+        run_migrations(db_path)
+        conn = _open(db_path)
+        try:
+            import uuid
+            from datetime import datetime, timezone
+            uow_id = f"uow_{uuid.uuid4().hex[:6]}"
+            now = datetime.now(timezone.utc).isoformat()
+            conn.execute(
+                """
+                INSERT INTO uow_registry
+                    (id, type, source, sweep_date, status, posture, created_at, updated_at, summary)
+                VALUES (?, 'executable', 'test', '2026-01-01', 'proposed', 'solo', ?, ?, 'Test')
+                """,
+                (uow_id, now, now),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT notes FROM uow_registry WHERE id = ?", (uow_id,)
+            ).fetchone()
+            assert row["notes"] == "{}"
+        finally:
+            conn.close()
+
+    def test_creates_parent_dirs_if_needed(self, tmp_path: Path) -> None:
+        """run_migrations creates intermediate directories."""
+        db_path = tmp_path / "deep" / "nested" / "registry.db"
+        run_migrations(db_path)
+        assert db_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: second run is a no-op
+# ---------------------------------------------------------------------------
+
+class TestIdempotency:
+    def test_second_run_applies_nothing(self, tmp_path: Path) -> None:
+        """Running run_migrations twice returns empty list on the second call."""
+        db_path = tmp_path / "idem.db"
+        run_migrations(db_path)
+        applied_second = run_migrations(db_path)
+        assert applied_second == []
+
+    def test_second_run_does_not_duplicate_records(self, tmp_path: Path) -> None:
+        """_migrations table has exactly one row per version after two runs."""
+        db_path = tmp_path / "idem.db"
+        run_migrations(db_path)
+        run_migrations(db_path)
+        conn = _open(db_path)
+        try:
+            rows = conn.execute("SELECT version, COUNT(*) as cnt FROM _migrations GROUP BY version").fetchall()
+            for row in rows:
+                assert row["cnt"] == 1, f"Version {row['version']} recorded {row['cnt']} times"
+        finally:
+            conn.close()
+
+    def test_schema_unchanged_after_second_run(self, tmp_path: Path) -> None:
+        """Column set is identical after first and second run."""
+        db_path = tmp_path / "idem.db"
+        run_migrations(db_path)
+        cols_first = _column_names(db_path, "uow_registry")
+        run_migrations(db_path)
+        cols_second = _column_names(db_path, "uow_registry")
+        assert cols_first == cols_second
+
+
+# ---------------------------------------------------------------------------
+# Missing file raises clearly
+# ---------------------------------------------------------------------------
+
+class TestMissingFile:
+    def test_missing_migration_file_raises(self, tmp_path: Path) -> None:
+        """
+        If a migration file is discovered but cannot be read (e.g. deleted
+        between discovery and execution), a clear exception propagates.
+
+        We simulate this by patching _discover_migrations to return a path
+        that does not exist.
+        """
+        db_path = tmp_path / "missing.db"
+        ghost_path = tmp_path / "migrations" / "0099_ghost.sql"
+        # ghost_path is intentionally NOT created
+
+        fake_migrations = [(99, ghost_path)]
+        with patch(
+            "src.orchestration.migrate._discover_migrations",
+            return_value=fake_migrations,
+        ):
+            with pytest.raises((FileNotFoundError, OSError)):
+                run_migrations(db_path)
+
+    def test_error_message_contains_path(self, tmp_path: Path) -> None:
+        """The exception message or type should indicate which file failed."""
+        db_path = tmp_path / "missing2.db"
+        ghost_path = tmp_path / "migrations" / "0088_gone.sql"
+
+        fake_migrations = [(88, ghost_path)]
+        with patch(
+            "src.orchestration.migrate._discover_migrations",
+            return_value=fake_migrations,
+        ):
+            with pytest.raises((FileNotFoundError, OSError)) as exc_info:
+                run_migrations(db_path)
+            assert "0088_gone.sql" in str(exc_info.value) or "0088" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Registry integration: __init__ calls run_migrations
+# ---------------------------------------------------------------------------
+
+class TestRegistryIntegration:
+    def test_registry_init_creates_tables(self, tmp_path: Path) -> None:
+        """Registry.__init__ must result in all migration tables existing."""
+        from src.orchestration.registry import Registry
+        db_path = tmp_path / "reg.db"
+        Registry(db_path)
+        tables = _table_names(db_path)
+        assert "uow_registry" in tables
+        assert "audit_log" in tables
+        assert "_migrations" in tables
+
+    def test_registry_init_is_idempotent(self, tmp_path: Path) -> None:
+        """Constructing Registry twice does not fail."""
+        from src.orchestration.registry import Registry
+        db_path = tmp_path / "reg.db"
+        Registry(db_path)
+        Registry(db_path)  # must not raise
+
+    def test_registry_can_upsert_after_migration(self, tmp_path: Path) -> None:
+        """After migration, Registry.upsert works normally."""
+        from src.orchestration.registry import Registry, UpsertInserted
+        db_path = tmp_path / "reg.db"
+        reg = Registry(db_path)
+        result = reg.upsert(issue_number=42, title="Post-migration UoW", sweep_date="2026-01-01")
+        assert isinstance(result, UpsertInserted)
+
+    def test_notes_column_accessible_after_registry_init(self, tmp_path: Path) -> None:
+        """The notes column exists and is accessible after Registry.__init__."""
+        from src.orchestration.registry import Registry
+        db_path = tmp_path / "reg.db"
+        Registry(db_path)
+        cols = _column_names(db_path, "uow_registry")
+        assert "notes" in cols
+
+
+# ---------------------------------------------------------------------------
+# _discover_migrations utility
+# ---------------------------------------------------------------------------
+
+class TestDiscoverMigrations:
+    def test_discovers_numbered_files_in_order(self, tmp_path: Path) -> None:
+        """_discover_migrations returns files sorted by version number."""
+        mdir = tmp_path / "migrations"
+        mdir.mkdir()
+        (mdir / "0003_third.sql").write_text("SELECT 1;")
+        (mdir / "0001_first.sql").write_text("SELECT 1;")
+        (mdir / "0002_second.sql").write_text("SELECT 1;")
+        (mdir / "not_a_migration.txt").write_text("ignore me")
+
+        from src.orchestration.migrate import _discover_migrations
+        result = _discover_migrations(mdir)
+        versions = [v for v, _ in result]
+        assert versions == [1, 2, 3]
+
+    def test_ignores_non_matching_files(self, tmp_path: Path) -> None:
+        mdir = tmp_path / "migrations"
+        mdir.mkdir()
+        (mdir / "README.md").write_text("docs")
+        (mdir / "__init__.py").write_text("")
+        (mdir / "0001_valid.sql").write_text("SELECT 1;")
+
+        from src.orchestration.migrate import _discover_migrations
+        result = _discover_migrations(mdir)
+        assert len(result) == 1
+        assert result[0][0] == 1


### PR DESCRIPTION
## Problem

`registry.py` used `conn.executescript(schema.sql)` at startup — a CREATE TABLE IF NOT EXISTS blunt instrument that cannot handle additive changes to existing databases. When a new column is needed on existing installs, it had to be shimmed into `upgrade.sh` as ad-hoc inline SQL with no tracking of what had been applied.

## What changed

A numbered migration layer now owns all WOS registry schema evolution:

- `src/orchestration/migrations/0001_initial_schema.sql` — the full current schema (uow_registry, executor_uow_view, audit_log), captured at migration-system introduction time
- `src/orchestration/migrations/0002_add_notes_column.sql` — `ALTER TABLE uow_registry ADD COLUMN notes TEXT NOT NULL DEFAULT '{}'` for existing installs
- `src/orchestration/migrate.py` — the runner: creates `_migrations` table if absent, discovers numbered `.sql` files, skips already-applied versions, records each applied migration (version, filename, applied_at), raises on any SQL error
- `Registry.__init__` now calls `run_migrations()` instead of `executescript(schema.sql)` — both new and existing DBs go through the same path
- `upgrade.sh` gains Migration 56 which calls `migrate.py` against the live registry DB

The `_SCHEMA_SQL` module constant and `_init_schema()` method are removed; schema authority moves to the numbered files.

## Functional patterns used

Pure functions (`_discover_migrations`, `_applied_versions`) with no side effects. Side-effecting operations (`run_migrations`) are isolated at the boundary. The runner is a pipeline: discover → filter unapplied → apply in order → record.

## What is out of scope

- `steward.py`, `executor.py`, and all non-orchestration code are untouched
- Pre-existing upgrade.sh migrations (48, 54) for older columns are left in place — they predate the numbered system and are safe to re-run
- The `test_startup_sweep.py` and `test_observation_loop.py` failures pre-exist on main (both fail with `NameError: _EXECUTOR_ORPHAN_THRESHOLD_SECONDS` in `steward-heartbeat.py`) and are unrelated to this PR

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_migrations.py -x -v` — 21 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/ --ignore=tests/unit/test_orchestration/test_startup_sweep.py --ignore=tests/unit/test_orchestration/test_observation_loop.py` — 193 passed, 0 failed (the two ignored tests fail on main with a pre-existing NameError in steward-heartbeat.py, not introduced here)

Closes #334