### PR TITLE
feat(wos): go-live prerequisites — decide handler, audit fixes #339-342, startup gate

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -412,6 +412,49 @@ REMINDER_ROUTING = {
 - Do NOT relay the result to the user: chat_id=0 is the silent-drop sentinel — the subagent_result handler drops it without relaying.
 - If the subagent fails to write the result file, the Observation Loop detects the stall at `timeout_at` and surfaces it to Dan.
 
+## Handling WOS Surface Messages (`type: "wos_surface"`) and Decide Callbacks
+
+`wos_surface` messages are written by the Steward when a UoW hits a stuck condition (hard_cap, crash_repeated, executor_blocked). The Steward writes the message to the inbox; the dispatcher delivers it to Dan with inline Retry/Close buttons.
+
+**When `wait_for_messages` returns a message with metadata `type: "wos_surface"`:**
+
+```
+1. mark_processing(message_id)
+2. Extract text and buttons from the message (msg["text"], msg.get("buttons"))
+3. send_reply(chat_id, text, buttons=msg.get("buttons"))
+4. mark_processed(message_id)
+```
+
+The message already has `buttons` set by the Steward:
+```
+[
+  [
+    {"text": "Retry", "callback_data": "decide_retry:<uow_id>"},
+    {"text": "Close", "callback_data": "decide_close:<uow_id>"}
+  ]
+]
+```
+
+**When `wait_for_messages` returns a callback (`type: "callback"`) with `callback_data` matching `decide_retry:<uow_id>` or `decide_close:<uow_id>`:**
+
+Inline button presses. Handle directly on the dispatcher thread (fast CLI call, <1 second -- no subagent):
+
+```
+1. mark_processing(message_id)
+2. Parse: action, uow_id = callback_data.split(":", 1)
+3. Run the appropriate CLI command:
+   - decide_retry: uv run ~/lobster/src/orchestration/registry_cli.py decide-retry --id <uow_id>
+   - decide_close: uv run ~/lobster/src/orchestration/registry_cli.py decide-close --id <uow_id>
+4. Parse JSON output; send_reply(chat_id, result_message)
+5. mark_processed(message_id)
+```
+
+The CLI commands return structured JSON:
+- Success: `{"status": "ok", "message": "UoW <id> reset for retry -- blocked to ready-for-steward"}`
+- Not blocked: `{"status": "not_blocked", "message": "UoW <id> could not be retried -- not in blocked status"}`
+
+No subagent needed -- these are fast synchronous DB writes.
+
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)
 
 **When `wait_for_messages` returns a message with `type: "subagent_result"`:**
@@ -875,6 +918,8 @@ Status: `proposed → pending`"
   If no records: reply "(none)".
 
   Valid status values: `proposed`, `pending`, `active`, `blocked`, `done`, `failed`, `expired`
+
+**Note:** Decide actions (Retry / Close on stuck UoWs) are handled via inline button callbacks — see "Handling WOS Surface Messages" section above.
 
 These commands are handled directly in the dispatcher (no subagent — they are fast CLI calls).
 Reply immediately after running the CLI command.

--- a/scheduled-tasks/issue-sweeper.py
+++ b/scheduled-tasks/issue-sweeper.py
@@ -64,7 +64,10 @@ def _now_iso() -> str:
 
 def _default_db_path() -> Path:
     workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
-    return workspace / "data" / "registry.db"
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    return workspace / "orchestration" / "registry.db"
 
 
 # ---------------------------------------------------------------------------

--- a/scheduled-tasks/startup-sweep.py
+++ b/scheduled-tasks/startup-sweep.py
@@ -25,6 +25,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Callable
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +132,8 @@ def run_startup_sweep(
     registry,
     dry_run: bool = False,
     orphan_threshold_seconds: int = _EXECUTOR_ORPHAN_THRESHOLD_SECONDS,
+    bootup_candidate_gate: bool | None = None,
+    github_client: Callable[[int], dict[str, Any]] | None = None,
 ) -> StartupSweepResult:
     """
     Startup sweep — crash recovery for orphaned UoWs (#307).
@@ -153,11 +156,35 @@ def run_startup_sweep(
     - If rows_affected == 0: another process won the race — skip silently.
     - In dry_run mode: classify but do not write or transition.
 
+    BOOTUP_CANDIDATE_GATE (#342): when True, UoWs whose GitHub issue carries
+    the `bootup-candidate` label are skipped in all three populations,
+    consistent with the gate applied in run_steward_cycle.
+
+    bootup_candidate_gate: override for BOOTUP_CANDIDATE_GATE module constant.
+    github_client: callable(issue_number) → {labels, ...}. Defaults to the
+        production gh CLI client from steward.py.
+
     Periodic 15-minute sweep (design doc pattern) is deferred to Phase 3.
     The 3-minute heartbeat cadence achieves finer coverage.
 
     Returns StartupSweepResult with counts for each population swept.
     """
+    from src.orchestration.steward import BOOTUP_CANDIDATE_GATE, _default_github_client
+
+    _gate = bootup_candidate_gate if bootup_candidate_gate is not None else BOOTUP_CANDIDATE_GATE
+    _github = github_client or _default_github_client
+
+    def _is_bootup_candidate_gated(uow) -> bool:
+        """Return True if this UoW should be skipped due to BOOTUP_CANDIDATE_GATE."""
+        if not _gate:
+            return False
+        source_issue_number = getattr(uow, "source_issue_number", None)
+        if not source_issue_number:
+            return False
+        issue_info = _github(source_issue_number)
+        labels = issue_info.get("labels", [])
+        return "bootup-candidate" in labels
+
     try:
         active_uows = registry.list(status=_STATUS_ACTIVE)
     except Exception as e:
@@ -185,6 +212,14 @@ def run_startup_sweep(
     # --- Population 1: active UoWs (Executor crash during execution) ---
     for uow in active_uows:
         uow_id = uow.id
+
+        if _is_bootup_candidate_gated(uow):
+            log.debug(
+                "Startup sweep: skipping bootup-candidate UoW %s (gate=True)",
+                uow_id,
+            )
+            continue
+
         output_ref = uow.output_ref
         classification, extra = _classify_active_uow(output_ref)
 
@@ -220,6 +255,14 @@ def run_startup_sweep(
     # --- Population 2: ready-for-executor UoWs older than threshold ---
     for uow in rfe_uows:
         uow_id = uow.id
+
+        if _is_bootup_candidate_gated(uow):
+            log.debug(
+                "Startup sweep: skipping bootup-candidate UoW %s (gate=True)",
+                uow_id,
+            )
+            continue
+
         proposed_at = uow.created_at  # proposed_at proxy: conservative lower bound
 
         try:
@@ -273,6 +316,13 @@ def run_startup_sweep(
     # --- Population 3: diagnosing UoWs (Steward crash mid-diagnosis) ---
     for uow in diagnosing_uows:
         uow_id = uow.id
+
+        if _is_bootup_candidate_gated(uow):
+            log.debug(
+                "Startup sweep: skipping bootup-candidate UoW %s (gate=True)",
+                uow_id,
+            )
+            continue
 
         if dry_run:
             log.info(

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -136,7 +136,12 @@ def _default_db_path() -> Path:
     workspace = Path(os.environ.get(
         "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
     ))
-    return workspace / "data" / "registry.db"
+    # Primary: orchestration/registry.db (used by registry_cli.py and the Executor)
+    # Fallback: REGISTRY_DB_PATH env override (used in tests and alternate installs)
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    return workspace / "orchestration" / "registry.db"
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +324,7 @@ def main() -> int:
     # Phase 1: Startup sweep
     log.info("--- Phase 1: Startup sweep ---")
     try:
-        sweep_result = run_startup_sweep(registry, dry_run=dry_run)
+        sweep_result = run_startup_sweep(registry, dry_run=dry_run, bootup_candidate_gate=BOOTUP_CANDIDATE_GATE)
         log.info(
             "Startup sweep complete: active_swept=%d executor_orphans=%d "
             "diagnosing=%d skipped_dry_run=%d",

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -8,6 +8,8 @@ Telegram. No MCP tools, no network calls — those belong in the dispatcher.
 The dispatcher calls these handlers when it recognizes:
   /approve <uow-id>        → handle_approve(uow_id, registry)
   /wos status [status]     → handle_wos_status(status, registry)
+  decide retry <uow-id>    → handle_decide_retry(uow_id, registry)
+  decide close <uow-id>    → handle_decide_close(uow_id, registry)
 """
 
 from __future__ import annotations
@@ -57,6 +59,49 @@ def handle_confirm(uow_id: str, *, registry: "Registry") -> str:
     compatibility while delegating to the renamed approve() method.
     """
     return handle_approve(uow_id, registry=registry)
+
+
+def handle_decide_retry(uow_id: str, *, registry: "Registry") -> str:
+    """
+    Handle a decide_retry action for a UoW.
+
+    Called when Dan selects "Retry" after the Steward surfaces a stuck UoW,
+    or sends a message matching "decide retry <uow-id>".
+
+    Resets steward_cycles to 0 and transitions blocked → ready-for-steward so
+    the Steward re-diagnoses the UoW on its next heartbeat cycle.
+    """
+    rows = registry.decide_retry(uow_id)
+    if rows == 1:
+        return (
+            f"UoW `{uow_id}` reset for retry.\n"
+            f"Status: `blocked \u2192 ready-for-steward` (steward_cycles reset to 0)"
+        )
+    return (
+        f"UoW `{uow_id}` could not be retried \u2014 it is not currently in `blocked` status.\n"
+        f"Run `/wos status blocked` to see blocked UoWs."
+    )
+
+
+def handle_decide_close(uow_id: str, *, registry: "Registry") -> str:
+    """
+    Handle a decide_close action for a UoW.
+
+    Called when Dan selects "Close" after the Steward surfaces a stuck UoW,
+    or sends a message matching "decide close <uow-id>".
+
+    Transitions blocked → failed with reason=user_closed.
+    """
+    rows = registry.decide_close(uow_id)
+    if rows == 1:
+        return (
+            f"UoW `{uow_id}` closed.\n"
+            f"Status: `blocked \u2192 failed` (reason: user_closed)"
+        )
+    return (
+        f"UoW `{uow_id}` could not be closed \u2014 it is not currently in `blocked` status.\n"
+        f"Run `/wos status blocked` to see blocked UoWs."
+    )
 
 
 def handle_wos_status(status: str | None, *, registry: "Registry") -> str:

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -871,7 +871,7 @@ class Registry:
         now = _now_iso()
         note: dict[str, Any] = {
             "event": "startup_sweep",
-            "actor": "steward_startup",
+            "actor": "steward",
             "classification": classification,
             "output_ref": output_ref,
             "uow_id": uow_id,
@@ -899,7 +899,7 @@ class Registry:
                 conn.execute(
                     """
                     INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
-                    VALUES (?, ?, 'startup_sweep', 'active', 'ready-for-steward', 'steward_startup', ?)
+                    VALUES (?, ?, 'startup_sweep', 'active', 'ready-for-steward', 'steward', ?)
                     """,
                     (now, uow_id, note_json),
                 )
@@ -935,7 +935,7 @@ class Registry:
         now = _now_iso()
         note_json = json.dumps({
             "event": "startup_sweep",
-            "actor": "steward_startup",
+            "actor": "steward",
             "classification": "executor_orphan",
             "output_ref": None,
             "uow_id": uow_id,
@@ -965,7 +965,7 @@ class Registry:
                     """
                     INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
                     VALUES (?, ?, 'startup_sweep', 'ready-for-executor', 'ready-for-steward',
-                            'steward_startup', ?)
+                            'steward', ?)
                     """,
                     (now, uow_id, note_json),
                 )
@@ -995,7 +995,7 @@ class Registry:
         now = _now_iso()
         note_json = json.dumps({
             "event": "startup_sweep",
-            "actor": "steward_startup",
+            "actor": "steward",
             "classification": "diagnosing_orphan",
             "output_ref": None,
             "uow_id": uow_id,
@@ -1022,7 +1022,7 @@ class Registry:
                     """
                     INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
                     VALUES (?, ?, 'startup_sweep', 'diagnosing', 'ready-for-steward',
-                            'steward_startup', ?)
+                            'steward', ?)
                     """,
                     (now, uow_id, note_json),
                 )
@@ -1090,6 +1090,116 @@ class Registry:
                 (now, uow_id),
             )
             conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def decide_retry(self, uow_id: str) -> int:
+        """
+        Reset a stuck UoW so it re-enters the Steward queue.
+
+        Intended for use when Dan selects "Retry" after the Steward surfaces a
+        UoW that has hit the 5-cycle hard cap or another stuck condition.
+
+        Transitions: blocked → ready-for-steward (optimistic lock on blocked).
+        Also resets steward_cycles to 0 so the Steward treats it as a fresh start.
+
+        Returns rows_affected (1 on success, 0 if UoW is not in blocked status).
+        Writes audit entry atomically in the same transaction as the UPDATE.
+        """
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+
+            note_json = json.dumps({
+                "event": "decide_retry",
+                "actor": "user",
+                "uow_id": uow_id,
+                "timestamp": now,
+                "note": "user requested retry — steward_cycles reset to 0",
+            })
+
+            conn.execute(
+                """
+                INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+                VALUES (?, ?, 'decide_retry', 'blocked', 'ready-for-steward', 'user', ?)
+                """,
+                (now, uow_id, note_json),
+            )
+
+            cursor = conn.execute(
+                """
+                UPDATE uow_registry
+                SET status = 'ready-for-steward',
+                    steward_cycles = 0,
+                    updated_at = ?
+                WHERE id = ? AND status = 'blocked'
+                """,
+                (now, uow_id),
+            )
+            rows_affected = cursor.rowcount
+
+            conn.commit()
+            return rows_affected
+
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def decide_close(self, uow_id: str) -> int:
+        """
+        Close a stuck UoW as user-requested failure.
+
+        Intended for use when Dan selects "Close" after the Steward surfaces a
+        UoW that has hit the 5-cycle hard cap or another stuck condition.
+
+        Transitions: blocked → failed (optimistic lock on blocked).
+        Sets route_reason to record the user closure decision.
+
+        Returns rows_affected (1 on success, 0 if UoW is not in blocked status).
+        Writes audit entry atomically in the same transaction as the UPDATE.
+        """
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+
+            note_json = json.dumps({
+                "event": "decide_close",
+                "actor": "user",
+                "uow_id": uow_id,
+                "timestamp": now,
+                "reason": "user_closed",
+            })
+
+            conn.execute(
+                """
+                INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+                VALUES (?, ?, 'decide_close', 'blocked', 'failed', 'user', ?)
+                """,
+                (now, uow_id, note_json),
+            )
+
+            cursor = conn.execute(
+                """
+                UPDATE uow_registry
+                SET status = 'failed',
+                    route_reason = 'user_closed',
+                    updated_at = ?
+                WHERE id = ? AND status = 'blocked'
+                """,
+                (now, uow_id),
+            )
+            rows_affected = cursor.rowcount
+
+            conn.commit()
+            return rows_affected
+
         except Exception:
             conn.rollback()
             raise

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -140,6 +140,42 @@ def cmd_gate_readiness(registry: Registry, args: argparse.Namespace) -> None:
     })
 
 
+def cmd_decide_retry(registry: Registry, args: argparse.Namespace) -> None:
+    """Handle decide-retry: reset a stuck UoW for a new Steward cycle."""
+    uow_id = args.id
+    rows = registry.decide_retry(uow_id)
+    if rows == 1:
+        _output({
+            "status": "ok",
+            "id": uow_id,
+            "message": f"UoW `{uow_id}` reset for retry — blocked \u2192 ready-for-steward (steward_cycles reset to 0)",
+        })
+    else:
+        _output({
+            "status": "not_blocked",
+            "id": uow_id,
+            "message": f"UoW `{uow_id}` could not be retried — it is not currently in `blocked` status",
+        })
+
+
+def cmd_decide_close(registry: Registry, args: argparse.Namespace) -> None:
+    """Handle decide-close: close a stuck UoW as user-requested failure."""
+    uow_id = args.id
+    rows = registry.decide_close(uow_id)
+    if rows == 1:
+        _output({
+            "status": "ok",
+            "id": uow_id,
+            "message": f"UoW `{uow_id}` closed — blocked \u2192 failed (reason: user_closed)",
+        })
+    else:
+        _output({
+            "status": "not_blocked",
+            "id": uow_id,
+            "message": f"UoW `{uow_id}` could not be closed — it is not currently in `blocked` status",
+        })
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -181,6 +217,20 @@ def _build_parser() -> argparse.ArgumentParser:
     # gate-readiness
     subparsers.add_parser("gate-readiness", help="Check Phase 1 → Phase 2 autonomy gate metric")
 
+    # decide-retry
+    p_decide_retry = subparsers.add_parser(
+        "decide-retry",
+        help="Reset a stuck UoW for a new Steward cycle (blocked → ready-for-steward)",
+    )
+    p_decide_retry.add_argument("--id", required=True, help="UoW id")
+
+    # decide-close
+    p_decide_close = subparsers.add_parser(
+        "decide-close",
+        help="Close a stuck UoW as user-requested failure (blocked → failed)",
+    )
+    p_decide_close.add_argument("--id", required=True, help="UoW id")
+
     return parser
 
 
@@ -192,6 +242,8 @@ _COMMAND_MAP = {
     "check-stale": cmd_check_stale,
     "expire-proposals": cmd_expire_proposals,
     "gate-readiness": cmd_gate_readiness,
+    "decide-retry": cmd_decide_retry,
+    "decide-close": cmd_decide_close,
 }
 
 

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -887,11 +887,21 @@ def _default_notify_dan(
         ]
     if surface_log:
         body_lines.append(f"\nSteward log:\n{surface_log}")
+    # Inline buttons let Dan resolve the stuck UoW without typing commands.
+    # The dispatcher routes callback_data="decide_retry:<uow_id>" and
+    # callback_data="decide_close:<uow_id>" to handle_decide_retry/close.
+    buttons = [
+        [
+            {"text": "Retry", "callback_data": f"decide_retry:{uow_id}"},
+            {"text": "Close", "callback_data": f"decide_close:{uow_id}"},
+        ]
+    ]
     msg = {
         "id": msg_id,
         "source": "system",
         "chat_id": _DAN_CHAT_ID,
         "text": "\n".join(body_lines),
+        "buttons": buttons,
         "timestamp": time.time(),
         "metadata": {
             "type": "wos_surface",
@@ -1116,6 +1126,7 @@ def _process_uow(
                 "uow_id": uow_id,
                 "steward_cycles": cycles,
                 "surface_condition": stuck_condition,
+                "return_reason": return_reason,
                 "timestamp": _now_iso(),
             })
 
@@ -1227,6 +1238,19 @@ def _process_uow(
             prescribed_skills=prescribed_skills,
             artifact_dir=artifact_dir,
         )
+
+        # Audit-before-transition: write agenda_update audit entry BEFORE updating
+        # steward_agenda in the DB. Only on re-entry (cycles > 0) — the initial
+        # agenda_update is written in the cycles == 0 initialization block above.
+        if cycles > 0:
+            registry.append_audit_log(uow_id, {
+                "event": "agenda_update",
+                "actor": _ACTOR_STEWARD,
+                "uow_id": uow_id,
+                "steward_cycles": cycles,
+                "agenda_snapshot": updated_agenda,
+                "timestamp": _now_iso(),
+            })
 
         # Write all steward fields BEFORE status transition
         _write_steward_fields(

--- a/tests/unit/test_orchestration/test_startup_sweep.py
+++ b/tests/unit/test_orchestration/test_startup_sweep.py
@@ -311,7 +311,7 @@ class TestActiveUowClassifications:
         assert entries[0]["event"] == "startup_sweep"
         assert entries[0]["from_status"] == "active"
         assert entries[0]["to_status"] == "ready-for-steward"
-        assert entries[0]["agent"] == "steward_startup"
+        assert entries[0]["agent"] == "steward"
 
         note = json.loads(entries[0]["note"])
         assert note["classification"] == "possibly_complete"
@@ -451,7 +451,7 @@ class TestDiagnosingUow:
         note = json.loads(entries[0]["note"])
         assert note["classification"] == "diagnosing_orphan"
         assert note["prior_status"] == "diagnosing"
-        assert note["actor"] == "steward_startup"
+        assert note["actor"] == "steward"
 
 
 class TestConcurrency:
@@ -616,7 +616,7 @@ class TestAuditEntryStructure:
         for field in ("event", "actor", "classification", "output_ref", "uow_id", "timestamp"):
             assert field in note, f"Missing field: {field}"
         assert note["event"] == "startup_sweep"
-        assert note["actor"] == "steward_startup"
+        assert note["actor"] == "steward"
         assert note["uow_id"] == uow_id
 
     def test_all_required_fields_present_in_executor_orphan_audit_entry(


### PR DESCRIPTION
## What this solves

Four audit/observability gaps and one missing operator escape hatch were blocking WOS from running safely in production. This PR closes all of them.

The central gap: when the Steward surfaces a stuck UoW to Dan after hitting the 5-cycle hard cap, Dan had no way to resolve it. The UoW was stuck in `blocked` forever. This PR adds Retry and Close buttons to surface notifications.

The secondary gaps: three audit log entries were missing information that made it impossible to answer "why was this surfaced?", "what did the agenda look like at each cycle?", and "did the startup sweep apply the same safety gate as the main Steward loop?"

## Changes

### Decide handler — Retry / Close for stuck UoWs

When the Steward surfaces a UoW (`hard_cap`, `crash_repeated`, `executor_blocked`), the notification message now includes inline Telegram buttons: **Retry** and **Close**.

- **Retry** (`decide_retry`): resets `steward_cycles` to 0 and transitions `blocked → ready-for-steward`. Steward re-diagnoses fresh on the next heartbeat.
- **Close** (`decide_close`): transitions `blocked → failed` with `reason=user_closed`.

Both use audit-before-transition (audit INSERT in same transaction as status UPDATE). Exposed via `registry_cli.py` subcommands `decide-retry` and `decide-close`. Dispatcher routing protocol documented in `sys.dispatcher.bootup.md`.

### Audit trail — issues #339–342

| Issue | Fix |
|-------|-----|
| #340 | `steward_surface` entries now include `return_reason` |
| #341 | `agenda_update` audit entries written on re-entry (cycles > 0) before agenda field update |
| #339 | `actor` in startup sweep entries changed from `"steward_startup"` to `"steward"` per design doc |
| #342 | `run_startup_sweep` now checks BOOTUP_CANDIDATE_GATE on all three populations |

### DB path fix

`steward-heartbeat.py` and `issue-sweeper.py` corrected to use `orchestration/registry.db` (was `data/registry.db` which did not exist). `REGISTRY_DB_PATH` env override retained for tests.

### Steward-heartbeat cron

Registered as scheduled job `steward-heartbeat` via Lobster inbox scheduler, schedule `*/3 * * * *`.

## Migration state confirmed

Both migrations applied to `orchestration/registry.db`, all Phase 2 fields present.

## What was not changed

No changes to Steward diagnosis logic, cycle thresholds, Executor, or result contract. No schema migrations required.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/ -q` — 287 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/ tests/unit/test_cli/ tests/unit/test_path_guard.py tests/unit/test_skill_manager.py -q` — 354 passed, 0 failed
- [x] Syntax check (`py_compile`) on all 6 changed Python files — clean
- [ ] Live end-to-end (heartbeat with real blocked UoW) — skipped: no UoW currently in blocked status. Safe to merge: heartbeat exits cleanly when no UoWs match.

Closes #339
Closes #340
Closes #341
Closes #342