### PR TITLE
fix: read workflow_artifact from file path; add src/ to executor-heartbeat sys.path

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -40,6 +40,10 @@ _REPO_ROOT = Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+_SRC_ROOT = _REPO_ROOT / "src"
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------

--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -362,8 +362,33 @@ class Executor:
                     reason="workflow_artifact field is NULL or empty",
                 )
 
+            # The Steward writes the artifact JSON to a file and stores the
+            # absolute path in the workflow_artifact column. Detect a path
+            # value (starts with '/') and read the file; otherwise treat the
+            # field value as inline JSON (legacy / test path).
+            artifact_json_str = workflow_artifact_raw
+            if workflow_artifact_raw.startswith("/"):
+                artifact_file = Path(workflow_artifact_raw)
+                if not artifact_file.exists():
+                    missing_reason = (
+                        f"workflow_artifact file not found: {workflow_artifact_raw}"
+                    )
+                    missing_result = ExecutorResult(
+                        uow_id=uow_id,
+                        outcome=ExecutorOutcome.FAILED,
+                        success=False,
+                        reason=missing_reason,
+                    )
+                    _write_result_json(output_ref, missing_result)
+                    self.registry.fail_uow(uow_id, missing_reason)
+                    return ClaimRejected(
+                        uow_id=uow_id,
+                        reason=missing_reason,
+                    )
+                artifact_json_str = artifact_file.read_text(encoding="utf-8")
+
             try:
-                artifact = from_json(workflow_artifact_raw)
+                artifact = from_json(artifact_json_str)
             except ValueError as e:
                 deser_reason = f"workflow_artifact deserialization failed: {e}"
                 deser_result = ExecutorResult(


### PR DESCRIPTION
## Summary

- **Bug 1 (PYTHONPATH):** `executor-heartbeat.py` added the repo root to `sys.path` but not `src/`. `executor.py` uses bare `from orchestration.xxx` imports, which resolve against `src/` — so the heartbeat would fail with `ModuleNotFoundError: No module named 'orchestration'` when run as a cron script. Fixed by also inserting `_REPO_ROOT / "src"` into `sys.path`, matching steward-heartbeat's pattern.

- **Bug 2 (workflow_artifact file path):** The Steward writes the WorkflowArtifact JSON to a file (`~/lobster-workspace/orchestration/artifacts/{uow_id}.json`) and stores the absolute file path in the `registry.workflow_artifact` column. The Executor was reading this column and passing the path string directly to `from_json()`, which calls `json.loads()` on a file path — always failing with "Expecting value: line 1 column 1 (char 0)". All 8 recently-failed UoWs have valid artifact files on disk; they were failing solely due to this path-vs-content mismatch. Fixed by detecting path values (starts with `/`), reading the file, then deserializing. Inline JSON values (used in tests and any legacy path) continue to work unchanged.

## Test plan

- [x] `uv run pytest tests/unit/test_executor.py` — 48 passed
- [ ] After merge: reset the 8 failed UoWs to `ready-for-steward` and verify next executor heartbeat dispatches them successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)