### PR TITLE
fix(steward): break executor loop — execution_complete is authoritative in _most_recent_return_reason

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -182,28 +182,43 @@ def _most_recent_return_reason(audit_entries: list[dict]) -> str | None:
     """
     Extract the most recent return_reason from audit entries.
     Looks for the last audit_log entry with a `return_reason` key in its note.
+
+    For `execution_complete` events: return `"execution_complete"` as the
+    authoritative signal even when the note does not carry an explicit
+    `return_reason` or `classification`.  Formerly, the absence of those fields
+    caused the function to fall through and pick up the nearest prior
+    `startup_sweep executor_orphan` entry — making the Steward treat a
+    successful Executor dispatch as an orphan and re-prescribe indefinitely.
     """
     for entry in reversed(audit_entries):
+        event = entry.get("event", "")
         note = entry.get("note")
+
+        note_data: dict = {}
         if note:
             try:
-                data = json.loads(note)
-                if "return_reason" in data:
-                    return data["return_reason"]
+                note_data = json.loads(note)
             except (json.JSONDecodeError, TypeError):
                 pass
-        # Also check event name for startup_sweep classifications
-        event = entry.get("event", "")
-        if event in ("startup_sweep", "execution_complete", "execution_failed"):
-            note_data = {}
-            if note:
-                try:
-                    note_data = json.loads(note)
-                except (json.JSONDecodeError, TypeError):
-                    pass
-            rr = note_data.get("return_reason") or note_data.get("classification")
-            if rr:
-                return rr
+
+        # Explicit return_reason in note always wins regardless of event type.
+        if "return_reason" in note_data:
+            return note_data["return_reason"]
+
+        # Event-type defaults: return the canonical reason for each terminal event.
+        if event == "execution_complete":
+            # Authoritative: Executor successfully dispatched.  Return immediately
+            # so older startup_sweep entries cannot mask this completion.
+            return "execution_complete"
+        elif event == "startup_sweep":
+            clf = note_data.get("classification")
+            if clf:
+                return clf
+        elif event == "execution_failed":
+            clf = note_data.get("return_reason") or note_data.get("classification")
+            if clf:
+                return clf
+
     return None
 
 


### PR DESCRIPTION
## Root Cause

`_most_recent_return_reason` iterated reversed audit entries looking for a `return_reason` or `classification` field. When an `execution_complete` entry lacked those fields (the normal Executor dispatch case — they're never written), the function fell through and returned the classification from the nearest prior `startup_sweep executor_orphan` entry.

This caused `_determine_reentry_posture` to compute `"executor_orphan"` even after a successful execution, which then blocked `_assess_completion` (which guards on `reentry_posture in ("execution_complete", "startup_sweep_possibly_complete")`), causing the Steward to re-prescribe instead of declaring done. The cycle repeated indefinitely:

```
executor dispatches → complete_uow → ready-for-steward
steward: _most_recent_return_reason → "executor_orphan" (wrong)
steward: _assess_completion → False (posture guard fails)
steward: prescribes again → ready-for-executor
executor dispatches again → ...
```

## Fix

Restructure `_most_recent_return_reason` to:
1. Parse `note_data` once per entry (not twice)
2. Check `return_reason` in note first (explicit always wins — preserves test case where execution_complete carries an explicit return_reason)
3. Treat `execution_complete` as an authoritative terminal event: return `"execution_complete"` immediately, preventing older `startup_sweep` entries from masking a valid completion

## Test coverage

- All 35 existing steward tests pass
- All 287 orchestration tests pass
- The fix is targeted to the one code path responsible for the loop; no behavioral change for other event types

## UoW state after fix

The looping UoWs (8 in ready-for-steward with steward_cycles=2) will be diagnosed correctly on next Steward cycle: with execution_complete result files present (outcome=complete, success=true), _assess_completion will return True and they will transition to done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)