### PR TITLE
feat: add /wos pdf command -- WOS registry PDF report via Telegram

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -919,10 +919,18 @@ Status: `proposed → pending`"
 
   Valid status values: `proposed`, `pending`, `active`, `blocked`, `done`, `failed`, `expired`
 
+- `/wos pdf [status]` -- Generate a PDF snapshot of the WOS Registry and send it to Telegram.
+  This command requires a subagent (PDF generation + file send can take 5-15 seconds).
+  Dispatch to a subagent: run `uv run ~/lobster/src/wos_report.py [--status <status>] --chat-id <chat_id>`.
+  The script writes a PDF to /tmp/, then drops a JSON file in ~/messages/outbox/ with
+  `type: "document"` so lobster_bot picks it up and sends it as a Telegram document.
+  Reply immediately: "Generating WOS PDF..." then let the bot deliver the file.
+  If `[status]` is provided (e.g. `/wos pdf active`), pass `--status <status>` to the script.
+
 **Note:** Decide actions (Retry / Close on stuck UoWs) are handled via inline button callbacks — see "Handling WOS Surface Messages" section above.
 
-These commands are handled directly in the dispatcher (no subagent — they are fast CLI calls).
-Reply immediately after running the CLI command.
+`/wos status` and `/confirm` are handled directly in the dispatcher (no subagent — fast CLI calls).
+`/wos pdf` requires a subagent — dispatch it and reply "Generating WOS PDF..." immediately.
 
 
 ## Meta-Thread Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "websockets>=13.0",
     "cryptography>=42.0.0",
     "pyyaml>=6.0.0",
+    "fpdf2>=2.8.7",
 ]
 
 [project.optional-dependencies]

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1476,6 +1476,45 @@ class OutboxHandler(FileSystemEventHandler):
                         os.remove(filepath)
                         return
 
+            # Handle document/file messages (e.g. PDF reports from wos_report.py)
+            if reply_type == 'document' and chat_id and bot_app:
+                doc_path = reply.get('document_path', '')
+                filename = reply.get('filename', '')
+                mime_type = reply.get('mime_type', 'application/octet-stream')
+                doc_caption = reply.get('caption', '')
+                if doc_path and os.path.exists(doc_path):
+                    try:
+                        doc_reply_params = ReplyParameters(message_id=int(reply_to_id)) if reply_to_id else None
+                        with open(doc_path, 'rb') as f:
+                            await bot_app.bot.send_document(
+                                chat_id=chat_id,
+                                document=f,
+                                filename=filename or os.path.basename(doc_path),
+                                caption=doc_caption or None,
+                                read_timeout=60,
+                                write_timeout=60,
+                                connect_timeout=30,
+                                reply_parameters=doc_reply_params,
+                            )
+                        log.info(f"Sent document to {chat_id}: {doc_path}")
+                        os.remove(filepath)
+                        return
+                    except Exception as e:
+                        log.error(f"send_document failed for {chat_id} ({doc_path}): {e}", exc_info=True)
+                        try:
+                            await bot_app.bot.send_message(
+                                chat_id=chat_id,
+                                text=f"Failed to send document: {e}"
+                            )
+                        except Exception:
+                            pass
+                        os.remove(filepath)
+                        return
+                else:
+                    log.warning(f"Document outbox entry missing or file not found: {doc_path!r}")
+                    os.remove(filepath)
+                    return
+
             if chat_id and text and bot_app:
                 reply_markup = build_inline_keyboard(buttons) if buttons else None
                 reply_params = ReplyParameters(message_id=int(reply_to_id)) if reply_to_id else None

--- a/src/wos_report.py
+++ b/src/wos_report.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+wos_report.py — Generate a PDF of the WOS Registry and send it to Telegram.
+
+Usage:
+    uv run ~/lobster/src/wos_report.py [--chat-id CHAT_ID] [--output PATH] [--no-send]
+
+Options:
+    --chat-id   Telegram chat ID to send to (default: 8075091586)
+    --output    Output file path (default: /tmp/wos-report-<timestamp>.pdf)
+    --no-send   Generate PDF but do not queue for sending
+    --status    Filter by status (default: all)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unicodedata
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ── fpdf2 ──────────────────────────────────────────────────────────────────────
+try:
+    from fpdf import FPDF
+    from fpdf.enums import XPos, YPos
+except ImportError:
+    print("ERROR: fpdf2 not installed. Run: uv add fpdf2", file=sys.stderr)
+    sys.exit(1)
+
+# ── constants ─────────────────────────────────────────────────────────────────
+REGISTRY_DB = Path(os.environ.get(
+    "WOS_REGISTRY_DB",
+    Path.home() / "lobster-workspace" / "orchestration" / "registry.db"
+))
+OUTBOX_DIR = Path(os.environ.get(
+    "LOBSTER_OUTBOX",
+    Path.home() / "messages" / "outbox"
+))
+DEFAULT_CHAT_ID = 8075091586
+GITHUB_REPO = "dcetlin/Lobster"
+
+# Status badge colours (R, G, B)
+STATUS_COLORS: dict[str, tuple[int, int, int]] = {
+    "proposed":           (180, 140,  60),
+    "pending":            ( 70, 130, 180),
+    "ready-for-steward":  (100, 160, 100),
+    "ready-for-executor": ( 80, 180, 120),
+    "active":             ( 40, 140, 200),
+    "diagnosing":         (180, 100,  50),
+    "blocked":            (200,  60,  60),
+    "done":               (100, 170,  90),
+    "failed":             (200,  60,  60),
+    "expired":            (140, 120, 100),
+}
+DEFAULT_STATUS_COLOR = (120, 120, 120)
+
+PAGE_W = 210          # A4 mm
+MARGIN = 14           # mm left/right/top
+CONTENT_W = PAGE_W - MARGIN * 2
+CARD_PAD = 5          # mm inner padding
+LABEL_W = 32          # mm for field labels
+
+
+# ── text helpers ──────────────────────────────────────────────────────────────
+
+# Unicode replacements that keep text readable when forced through latin-1
+_UNICODE_MAP = str.maketrans({
+    "\u2014": "--",   # em dash
+    "\u2013": "-",    # en dash
+    "\u2019": "'",    # right single quote
+    "\u2018": "'",    # left single quote
+    "\u201c": '"',    # left double quote
+    "\u201d": '"',    # right double quote
+    "\u2022": "*",    # bullet
+    "\u2026": "...",  # ellipsis
+    "\u00e9": "e",    # e acute
+    "\u00e8": "e",    # e grave
+    "\u00e0": "a",    # a grave
+    "\u00fc": "u",    # u umlaut
+    "\u00f6": "o",    # o umlaut
+    "\u00e4": "a",    # a umlaut
+    "\u00df": "ss",   # sharp s
+})
+
+
+def _safe(text: str) -> str:
+    """Replace non-latin-1 characters with ASCII equivalents."""
+    text = text.translate(_UNICODE_MAP)
+    # For anything still outside latin-1, replace with ?
+    return "".join(
+        c if ord(c) < 256 else "?"
+        for c in unicodedata.normalize("NFKD", text)
+        if ord(c) < 256 or unicodedata.category(c) not in ("Mn",)
+    )
+
+
+# ── data layer ────────────────────────────────────────────────────────────────
+
+def _source_url(source: str | None, issue_number: int | None) -> str:
+    """Derive a GitHub URL from the source field."""
+    if issue_number:
+        return f"https://github.com/{GITHUB_REPO}/issues/{issue_number}"
+    if source and source.startswith("github:issue/"):
+        num = source.split("/")[-1]
+        return f"https://github.com/{GITHUB_REPO}/issues/{num}"
+    return source or ""
+
+
+def _fmt_ts(ts: str | None) -> str:
+    """Format a timestamp string to YYYY-MM-DD HH:MM UTC, or return empty string."""
+    if not ts:
+        return ""
+    try:
+        ts_clean = ts.replace(" ", "T")
+        if "+" in ts_clean:
+            dt = datetime.fromisoformat(ts_clean)
+        elif ts_clean.endswith("Z"):
+            dt = datetime.fromisoformat(ts_clean[:-1]).replace(tzinfo=timezone.utc)
+        else:
+            dt = datetime.fromisoformat(ts_clean).replace(tzinfo=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return ts[:16] if ts else ""
+
+
+def _fmt_audit_event(row: dict) -> str:
+    """Format a single audit row into a concise one-liner."""
+    ts = _fmt_ts(row.get("ts"))
+    event = row.get("event", "")
+    from_s = row.get("from_status") or ""
+    to_s = row.get("to_status") or ""
+    note = row.get("note") or ""
+
+    if note and note.startswith("{"):
+        try:
+            n = json.loads(note)
+            note = n.get("assessment") or n.get("return_reason") or n.get("reason") or ""
+        except Exception:
+            pass
+    note = note[:60] + "..." if len(note) > 60 else note
+
+    if from_s and to_s:
+        line = f"{ts}  {event}: {from_s} -> {to_s}"
+    else:
+        line = f"{ts}  {event}"
+    if note:
+        line += f"  ({note})"
+    return _safe(line)
+
+
+def fetch_uows(status_filter: str | None = None) -> list[dict]:
+    """Load UoWs from the registry DB, sorted by created_at descending."""
+    if not REGISTRY_DB.exists():
+        raise FileNotFoundError(f"Registry DB not found: {REGISTRY_DB}")
+    conn = sqlite3.connect(str(REGISTRY_DB))
+    conn.row_factory = sqlite3.Row
+    try:
+        if status_filter:
+            rows = conn.execute(
+                "SELECT * FROM uow_registry WHERE status=? ORDER BY created_at DESC",
+                (status_filter,)
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM uow_registry ORDER BY created_at DESC"
+            ).fetchall()
+
+        uows = []
+        for row in rows:
+            d = dict(row)
+            audits = conn.execute(
+                "SELECT ts, event, from_status, to_status, note "
+                "FROM audit_log WHERE uow_id=? ORDER BY ts DESC LIMIT 4",
+                (d["id"],)
+            ).fetchall()
+            d["_audit_events"] = [dict(a) for a in reversed(audits)]
+            uows.append(d)
+        return uows
+    finally:
+        conn.close()
+
+
+# ── PDF builder ───────────────────────────────────────────────────────────────
+
+class WoSReport(FPDF):
+    """A4 PDF report of WOS Registry UoWs."""
+
+    def __init__(self, total: int, generated_at: str):
+        super().__init__()
+        self._total = total
+        self._generated_at = generated_at
+
+    def header(self):
+        self.set_font("Helvetica", "B", 14)
+        self.set_text_color(30, 30, 30)
+        self.cell(0, 10, "WOS Registry",
+                  new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="L")
+        self.set_font("Helvetica", "", 9)
+        self.set_text_color(100, 100, 100)
+        self.cell(0, 5, f"Generated {self._generated_at}  |  {self._total} unit(s)",
+                  new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="L")
+        self.ln(3)
+        self.set_draw_color(200, 200, 200)
+        self.set_line_width(0.3)
+        self.line(MARGIN, self.get_y(), PAGE_W - MARGIN, self.get_y())
+        self.ln(4)
+
+    def footer(self):
+        self.set_y(-12)
+        self.set_font("Helvetica", "", 8)
+        self.set_text_color(160, 160, 160)
+        self.cell(0, 5, f"WOS Registry  |  {self._generated_at}  |  Page {self.page_no()}",
+                  align="C")
+
+    # ── field row ──────────────────────────────────────────────────────────────
+
+    def _label_value(self, card_x: float, label: str, value: str, url: str = ""):
+        """Render a label + value row with proper indentation."""
+        self.set_x(card_x + CARD_PAD)
+        self.set_font("Helvetica", "B", 8)
+        self.set_text_color(100, 100, 100)
+        self.cell(LABEL_W, 5, label + ":",
+                  new_x=XPos.RIGHT, new_y=YPos.TOP)
+        self.set_font("Helvetica", "", 8)
+        val_w = CONTENT_W - CARD_PAD * 2 - LABEL_W
+        if url:
+            self.set_text_color(30, 80, 180)
+            disp = _safe(value)
+            while disp and self.get_string_width(disp) > val_w - 4:
+                disp = disp[:-4] + "..."
+            self.cell(val_w, 5, disp, link=url,
+                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+            self.set_text_color(30, 30, 30)
+        else:
+            self.set_text_color(30, 30, 30)
+            self.multi_cell(val_w, 5, _safe(value),
+                            new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+
+    def _render_audit_line(self, card_x: float, line: str):
+        self.set_x(card_x + CARD_PAD + 3)
+        self.set_font("Courier", "", 7)
+        self.set_text_color(80, 80, 80)
+        self.multi_cell(CONTENT_W - CARD_PAD * 2 - 3, 4.5, line,
+                        new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+
+    # ── card ───────────────────────────────────────────────────────────────────
+
+    def add_uow_card(self, uow: dict):
+        """Add one UoW card. Starts a new page if needed."""
+        ESTIMATED_CARD_H = 72
+        if self.get_y() + ESTIMATED_CARD_H > self.h - 20:
+            self.add_page()
+
+        card_x = MARGIN
+        card_y = self.get_y()
+        card_w = CONTENT_W
+
+        # Light background rectangle (height estimated; redrawn as outline after)
+        self.set_fill_color(248, 249, 250)
+        self.set_draw_color(220, 220, 220)
+        self.set_line_width(0.3)
+        self.rect(card_x, card_y, card_w, ESTIMATED_CARD_H, style="F")
+
+        # ── Title row ──────────────────────────────────────────────────────────
+        self.set_xy(card_x + CARD_PAD, card_y + CARD_PAD)
+        summary = _safe(uow.get("summary") or uow.get("id", ""))
+        title_w = card_w - CARD_PAD * 2 - 42   # leave room for badge
+
+        self.set_font("Helvetica", "B", 10)
+        self.set_text_color(20, 20, 20)
+        while summary and self.get_string_width(summary) > title_w:
+            summary = summary[:-4] + "..."
+        self.cell(title_w, 7, summary,
+                  new_x=XPos.RIGHT, new_y=YPos.TOP)
+
+        # Status badge (right side of title row)
+        status = uow.get("status", "unknown")
+        r, g, b = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
+        self.set_fill_color(r, g, b)
+        self.set_text_color(255, 255, 255)
+        self.set_font("Helvetica", "B", 7.5)
+        badge_text = status.upper()
+        badge_w = max(self.get_string_width(badge_text) + 6, 26)
+        self.cell(badge_w, 7, badge_text, fill=True, align="C",
+                  new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.set_text_color(30, 30, 30)
+
+        self.ln(1)
+
+        # ── Fields ─────────────────────────────────────────────────────────────
+        self._label_value(card_x, "ID", uow.get("id", ""))
+
+        source_url = _source_url(uow.get("source"), uow.get("source_issue_number"))
+        source_display = uow.get("source") or source_url
+        self._label_value(card_x, "Source", source_display or "(none)", url=source_url)
+
+        self._label_value(card_x, "Steward cycles", str(uow.get("steward_cycles", 0)))
+        self._label_value(card_x, "Created", _fmt_ts(uow.get("created_at")))
+        self._label_value(card_x, "Updated", _fmt_ts(uow.get("updated_at")))
+
+        # ── Lifecycle ──────────────────────────────────────────────────────────
+        audit_events = uow.get("_audit_events", [])
+        if audit_events:
+            self.ln(1.5)
+            self.set_x(card_x + CARD_PAD)
+            self.set_font("Helvetica", "B", 7.5)
+            self.set_text_color(100, 100, 100)
+            self.cell(0, 4.5, "Lifecycle (last events):",
+                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+            for ev in audit_events[-4:]:
+                self._render_audit_line(card_x, _fmt_audit_event(ev))
+
+        # ── Outline over background rect ───────────────────────────────────────
+        actual_h = self.get_y() + CARD_PAD - card_y
+        self.set_draw_color(210, 210, 220)
+        self.set_line_width(0.4)
+        self.rect(card_x, card_y, card_w, actual_h, style="D")
+        self.set_y(card_y + actual_h + 4)
+
+
+# ── PDF generation ────────────────────────────────────────────────────────────
+
+def generate_pdf(uows: list[dict], output_path: Path) -> Path:
+    """Render the WOS report PDF and save it to output_path."""
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    pdf = WoSReport(total=len(uows), generated_at=generated_at)
+    pdf.set_margins(MARGIN, MARGIN, MARGIN)
+    pdf.set_auto_page_break(auto=True, margin=18)
+    pdf.add_page()
+
+    if not uows:
+        pdf.set_font("Helvetica", "I", 11)
+        pdf.set_text_color(120, 120, 120)
+        pdf.cell(0, 10, "No units of work found.",
+                 new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="C")
+    else:
+        for uow in uows:
+            pdf.add_uow_card(uow)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pdf.output(str(output_path))
+    return output_path
+
+
+# ── Telegram delivery ─────────────────────────────────────────────────────────
+
+def queue_for_telegram(pdf_path: Path, chat_id: int, caption: str = "") -> Path:
+    """Write an outbox JSON file that instructs lobster_bot to send this PDF."""
+    import uuid
+    OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
+    msg_id = uuid.uuid4().hex[:12]
+    outbox_file = OUTBOX_DIR / f"wos-report-{msg_id}.json"
+    payload = {
+        "chat_id": chat_id,
+        "type": "document",
+        "document_path": str(pdf_path),
+        "filename": pdf_path.name,
+        "caption": caption,
+        "mime_type": "application/pdf",
+    }
+    tmp = outbox_file.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload))
+    tmp.rename(outbox_file)
+    return outbox_file
+
+
+# ── CLI entry point ───────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None):
+    parser = argparse.ArgumentParser(description="Generate WOS Registry PDF report")
+    parser.add_argument("--chat-id", type=int, default=DEFAULT_CHAT_ID,
+                        help="Telegram chat ID to send to")
+    parser.add_argument("--output", type=Path,
+                        help="Output PDF path (default: auto-named in /tmp)")
+    parser.add_argument("--no-send", action="store_true",
+                        help="Generate PDF but do not queue for Telegram delivery")
+    parser.add_argument("--status", type=str, default=None,
+                        help="Filter by status (e.g. active, done, proposed)")
+    args = parser.parse_args(argv)
+
+    if args.output:
+        output_path = args.output
+    else:
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        output_path = Path(tempfile.gettempdir()) / f"wos-report-{ts}.pdf"
+
+    print(f"Loading registry from {REGISTRY_DB}...")
+    uows = fetch_uows(status_filter=args.status)
+    print(f"Found {len(uows)} unit(s) of work")
+
+    print(f"Generating PDF: {output_path}")
+    generate_pdf(uows, output_path)
+    print(f"PDF written: {output_path} ({output_path.stat().st_size:,} bytes)")
+
+    if not args.no_send:
+        caption = f"WOS Registry ({len(uows)} UoWs"
+        if args.status:
+            caption += f", status={args.status}"
+        caption += f") -- {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
+        outbox_file = queue_for_telegram(output_path, args.chat_id, caption)
+        print(f"Queued for Telegram delivery: {outbox_file}")
+    else:
+        print("--no-send: skipping Telegram delivery")
+
+    return str(output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -524,6 +524,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "fastembed"
 version = "0.7.4"
 source = { registry = "https://pypi.org/simple" }
@@ -559,6 +568,69 @@ version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/23ff32561ec8d45a4d48578b4d241369d9270dc50926c017570e60893701/fonttools-4.62.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:40975849bac44fb0b9253d77420c6d8b523ac4dcdcefeff6e4d706838a5b80f7", size = 2871039, upload-time = "2026-03-13T13:52:33.127Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7f/66d3f8a9338a9b67fe6e1739f47e1cd5cee78bd3bc1206ef9b0b982289a5/fonttools-4.62.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9dde91633f77fa576879a0c76b1d89de373cae751a98ddf0109d54e173b40f14", size = 2416346, upload-time = "2026-03-13T13:52:35.676Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/53/5276ceba7bff95da7793a07c5284e1da901cf00341ce5e2f3273056c0cca/fonttools-4.62.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6acb4109f8bee00fec985c8c7afb02299e35e9c94b57287f3ea542f28bd0b0a7", size = 5100897, upload-time = "2026-03-13T13:52:38.102Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a1/40a5c4d8e28b0851d53a8eeeb46fbd73c325a2a9a165f290a5ed90e6c597/fonttools-4.62.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1c5c25671ce8805e0d080e2ffdeca7f1e86778c5cbfbeae86d7f866d8830517b", size = 5071078, upload-time = "2026-03-13T13:52:41.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/d378fca4c65ea1956fee6d90ace6e861776809cbbc5af22388a090c3c092/fonttools-4.62.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a5d8825e1140f04e6c99bb7d37a9e31c172f3bc208afbe02175339e699c710e1", size = 5076908, upload-time = "2026-03-13T13:52:44.122Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d9/ae6a1d0693a4185a84605679c8a1f719a55df87b9c6e8e817bfdd9ef5936/fonttools-4.62.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:268abb1cb221e66c014acc234e872b7870d8b5d4657a83a8f4205094c32d2416", size = 5202275, upload-time = "2026-03-13T13:52:46.591Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6c/af95d9c4efb15cabff22642b608342f2bd67137eea6107202d91b5b03184/fonttools-4.62.1-cp311-cp311-win32.whl", hash = "sha256:942b03094d7edbb99bdf1ae7e9090898cad7bf9030b3d21f33d7072dbcb51a53", size = 2293075, upload-time = "2026-03-13T13:52:48.711Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/bf54c5b3f2be34e1f143e6db838dfdc54f2ffa3e68c738934c82f3b2a08d/fonttools-4.62.1-cp311-cp311-win_amd64.whl", hash = "sha256:e8514f4924375f77084e81467e63238b095abda5107620f49421c368a6017ed2", size = 2344593, upload-time = "2026-03-13T13:52:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/56/6f389de21c49555553d6a5aeed5ac9767631497ac836c4f076273d15bd72/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c22b1014017111c401469e3acc5433e6acf6ebcc6aa9efb538a533c800971c79", size = 2865155, upload-time = "2026-03-13T13:53:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/0e3966edd5ec668d41dfe418787726752bc07e2f5fd8c8f208615e61fa89/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68959f5fc58ed4599b44aad161c2837477d7f35f5f79402d97439974faebfebe", size = 2412802, upload-time = "2026-03-13T13:53:18.878Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68", size = 5013926, upload-time = "2026-03-13T13:53:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1", size = 4964575, upload-time = "2026-03-13T13:53:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069", size = 4953693, upload-time = "2026-03-13T13:53:26.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9", size = 5094920, upload-time = "2026-03-13T13:53:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/53a1e9469331a23dcc400970a27a4caa3d9f6edbf5baab0260285238b884/fonttools-4.62.1-cp313-cp313-win32.whl", hash = "sha256:93c316e0f5301b2adbe6a5f658634307c096fd5aae60a5b3412e4f3e1728ab24", size = 2279928, upload-time = "2026-03-13T13:53:32.352Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/35186529de1db3c01f5ad625bde07c1f576305eab6d86bbda4c58445f721/fonttools-4.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:7aa21ff53e28a9c2157acbc44e5b401149d3c9178107130e82d74ceb500e5056", size = 2330514, upload-time = "2026-03-13T13:53:34.991Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f0/2888cdac391807d68d90dcb16ef858ddc1b5309bfc6966195a459dd326e2/fonttools-4.62.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa1d16210b6b10a826d71bed68dd9ec24a9e218d5a5e2797f37c573e7ec215ca", size = 2864442, upload-time = "2026-03-13T13:53:37.509Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/e521803081f8dc35990816b82da6360fa668a21b44da4b53fc9e77efcd62/fonttools-4.62.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aa69d10ed420d8121118e628ad47d86e4caa79ba37f968597b958f6cceab7eca", size = 2410901, upload-time = "2026-03-13T13:53:40.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782", size = 4999608, upload-time = "2026-03-13T13:53:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae", size = 4912726, upload-time = "2026-03-13T13:53:45.405Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7", size = 4951422, upload-time = "2026-03-13T13:53:48.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a", size = 5060979, upload-time = "2026-03-13T13:53:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3c/12eea4a4cf054e7ab058ed5ceada43b46809fce2bf319017c4d63ae55bb4/fonttools-4.62.1-cp314-cp314-win32.whl", hash = "sha256:49a445d2f544ce4a69338694cad575ba97b9a75fff02720da0882d1a73f12800", size = 2283733, upload-time = "2026-03-13T13:53:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/67/74b070029043186b5dd13462c958cb7c7f811be0d2e634309d9a1ffb1505/fonttools-4.62.1-cp314-cp314-win_amd64.whl", hash = "sha256:1eecc128c86c552fb963fe846ca4e011b1be053728f798185a1687502f6d398e", size = 2335663, upload-time = "2026-03-13T13:53:56.23Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c5/4d2ed3ca6e33617fc5624467da353337f06e7f637707478903c785bd8e20/fonttools-4.62.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1596aeaddf7f78e21e68293c011316a25267b3effdaccaf4d59bc9159d681b82", size = 2947288, upload-time = "2026-03-13T13:53:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e9/7ab11ddfda48ed0f89b13380e5595ba572619c27077be0b2c447a63ff351/fonttools-4.62.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8f8fca95d3bb3208f59626a4b0ea6e526ee51f5a8ad5d91821c165903e8d9260", size = 2449023, upload-time = "2026-03-13T13:54:01.642Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4", size = 5137599, upload-time = "2026-03-13T13:54:04.495Z" },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b", size = 4920933, upload-time = "2026-03-13T13:54:07.557Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87", size = 5016232, upload-time = "2026-03-13T13:54:10.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c", size = 5042987, upload-time = "2026-03-13T13:54:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "fpdf2"
+version = "2.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/f2/72feae0b2827ed38013e4307b14f95bf0b3d124adfef4d38a7d57533f7be/fpdf2-2.8.7.tar.gz", hash = "sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9", size = 362351, upload-time = "2026-02-28T05:39:16.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/0a/cf50ecffa1e3747ed9380a3adfc829259f1f86b3fdbd9e505af789003141/fpdf2-2.8.7-py3-none-any.whl", hash = "sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19", size = 327056, upload-time = "2026-02-28T05:39:14.619Z" },
 ]
 
 [[package]]
@@ -875,6 +947,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "fastembed" },
+    { name = "fpdf2" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "psutil" },
@@ -914,6 +987,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastembed", specifier = ">=0.3.0" },
+    { name = "fpdf2", specifier = ">=2.8.7" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },


### PR DESCRIPTION
## Summary

- Adds `src/wos_report.py`: generates a clean A4 PDF of the WOS registry (one card per UoW with title, source URL, status badge, steward_cycles, timestamps, and last 4 audit events) and queues it for Telegram delivery via the outbox.
- Adds document outbox support to `src/bot/lobster_bot.py`: when a JSON file with `type: "document"` lands in `~/messages/outbox/`, lobster_bot calls `send_document()` to deliver the file.
- Adds `fpdf2` dependency (`pyproject.toml` + `uv.lock`).
- Documents the `/wos pdf [status]` command in `.claude/sys.dispatcher.bootup.md`: dispatcher replies immediately with "Generating WOS PDF..." and delegates to a subagent that runs `wos_report.py`; lobster_bot delivers the PDF file automatically.

## Invocation

```
# From dispatcher (subagent prompt):
uv run ~/lobster/src/wos_report.py --chat-id 8075091586

# With status filter:
uv run ~/lobster/src/wos_report.py --chat-id 8075091586 --status active

# Test only (no send):
uv run ~/lobster/src/wos_report.py --no-send --output /tmp/test.pdf
```

## Test plan

- [x] `uv run src/wos_report.py --no-send --output /tmp/wos-test.pdf` runs cleanly and produces a valid 8KB PDF with 10 UoW cards
- [ ] End-to-end: run without `--no-send`, confirm outbox JSON appears in `~/messages/outbox/`, confirm lobster_bot picks it up and sends to Telegram
- [ ] `/wos pdf` command in Telegram triggers the subagent dispatch flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)