### PR TITLE
Fix: populate success_criteria from issue body and compose real steward instructions

### DIFF
--- a/src/orchestration/cultivator.py
+++ b/src/orchestration/cultivator.py
@@ -132,6 +132,62 @@ def _classify_priority(issue: GitHubIssue) -> str:
     return "medium"
 
 
+# Section headings that indicate acceptance/success criteria in issue bodies.
+# Checked in order; first match wins.
+_SUCCESS_CRITERIA_HEADINGS = (
+    "## Acceptance Criteria",
+    "## acceptance criteria",
+    "## Success Criteria",
+    "## success criteria",
+    "## Definition of Done",
+    "## definition of done",
+)
+
+
+def _extract_success_criteria(body: str) -> str:
+    """
+    Extract success criteria from a GitHub issue body.
+
+    Looks for a section headed by one of _SUCCESS_CRITERIA_HEADINGS and returns
+    its content (everything up to the next ## heading or end of body). Falls back
+    to the first paragraph of the body if no criteria section is found.
+
+    Pure function — no I/O, no mutation.
+    """
+    if not body:
+        return ""
+
+    for heading in _SUCCESS_CRITERIA_HEADINGS:
+        idx = body.find(heading)
+        if idx == -1:
+            continue
+        # Advance past the heading line
+        section_start = body.find("\n", idx)
+        if section_start == -1:
+            continue
+        section_start += 1
+        # Find the next ## heading (or end of string)
+        next_heading = body.find("\n##", section_start)
+        if next_heading == -1:
+            section = body[section_start:]
+        else:
+            section = body[section_start:next_heading]
+        criteria = section.strip()
+        if criteria:
+            return criteria
+
+    # Fallback: use the first non-empty paragraph of the body.
+    # This gives the executor something concrete even on issues with no
+    # formal criteria section.
+    for paragraph in body.split("\n\n"):
+        paragraph = paragraph.strip()
+        if paragraph and not paragraph.startswith("#"):
+            # Truncate long paragraphs to keep the field readable.
+            return paragraph[:500] if len(paragraph) > 500 else paragraph
+
+    return ""
+
+
 def classify_issues(issues: list[GitHubIssue]) -> tuple[list[ClassifiedIssue], int]:
     """
     Classify all issues. Returns (classified_issues, skipped_count).
@@ -194,6 +250,7 @@ def promote_to_wos(
         result = registry.upsert(
             issue_number=issue.number,
             title=issue.title,
+            success_criteria=_extract_success_criteria(issue.body),
         )
 
         if isinstance(result, UpsertInserted):

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -317,6 +317,7 @@ class Registry:
         title: str,
         sweep_date: str | None = None,
         uow_type: str = "executable",
+        success_criteria: str = "",
     ) -> UpsertResult:
         """
         Propose a UoW for a GitHub issue.
@@ -333,7 +334,7 @@ class Registry:
         - UNIQUE(issue, sweep_date) conflict + existing is proposed → UPDATE fields
         - UNIQUE(issue, sweep_date) conflict + existing is non-proposed → no-op update (fields unchanged)
         """
-        return self._upsert_typed(issue_number, title, sweep_date, uow_type)
+        return self._upsert_typed(issue_number, title, sweep_date, uow_type, success_criteria)
 
     def _upsert_typed(
         self,
@@ -341,6 +342,7 @@ class Registry:
         title: str,
         sweep_date: str | None = None,
         uow_type: str = "executable",
+        success_criteria: str = "",
     ) -> UpsertResult:
         """Core upsert logic returning typed UpsertResult."""
         if sweep_date is None:
@@ -413,8 +415,8 @@ class Registry:
                 INSERT INTO uow_registry (
                     id, type, source, source_issue_number, sweep_date,
                     status, posture, created_at, updated_at, summary,
-                    route_reason, route_evidence, trigger
-                ) VALUES (?, ?, ?, ?, ?, 'proposed', 'solo', ?, ?, ?, ?, '{}', '{"type": "immediate"}')
+                    success_criteria, route_reason, route_evidence, trigger
+                ) VALUES (?, ?, ?, ?, ?, 'proposed', 'solo', ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}')
                 """,
                 (
                     uow_id,
@@ -425,6 +427,7 @@ class Registry:
                     now,
                     now,
                     title,
+                    success_criteria,
                     _LEGACY_ROUTE_REASON,
                 ),
             )

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -503,23 +503,47 @@ def _build_prescription_instructions(
     uow: UoW,
     reentry_posture: str,
     completion_gap: str,
+    issue_body: str = "",
 ) -> str:
     """
     Build natural language prescription instructions for the Executor.
 
     The instruction is targeted at the specific gap identified.
+
+    Args:
+        uow: The Unit of Work being prescribed.
+        reentry_posture: Categorized executor state from diagnosis.
+        completion_gap: Human-readable rationale for why work is incomplete.
+        issue_body: Raw GitHub issue body text. Used to compose context when
+            success_criteria is absent. Pass empty string if unavailable.
     """
     summary = uow.summary
     success_criteria = uow.success_criteria
     cycles = uow.steward_cycles
 
+    # Build the criteria/context block from whatever is available.
+    # Priority: explicit success_criteria > issue body > nothing.
+    if success_criteria:
+        criteria_block = f"Success criteria: {success_criteria}"
+    elif issue_body:
+        # Truncate very long issue bodies to keep instructions readable.
+        body_excerpt = issue_body.strip()
+        if len(body_excerpt) > 1500:
+            body_excerpt = body_excerpt[:1500] + "\n[...truncated]"
+        criteria_block = f"Issue context:\n{body_excerpt}"
+    else:
+        criteria_block = ""
+
     if cycles == 0:
-        return (
-            f"Execute the following task:\n\n"
-            f"Summary: {summary}\n\n"
-            f"Success criteria: {success_criteria or 'See issue body for details.'}\n\n"
-            f"Write your output to the output_ref path."
-        )
+        parts = [
+            "Execute the following task:",
+            "",
+            f"Summary: {summary}",
+        ]
+        if criteria_block:
+            parts += ["", criteria_block]
+        parts += ["", "Write your output to the output_ref path."]
+        return "\n".join(parts)
 
     posture_context = {
         "execution_complete": "Previous execution completed but output needs improvement.",
@@ -531,13 +555,18 @@ def _build_prescription_instructions(
 
     posture_msg = posture_context.get(reentry_posture, "Continue from previous attempt.")
 
-    return (
-        f"Re-execution pass (cycle {cycles + 1}):\n\n"
-        f"{posture_msg}\n\n"
-        f"Gap identified: {completion_gap}\n\n"
-        f"Original task: {summary}\n\n"
-        f"Success criteria: {success_criteria or 'See issue body for details.'}"
-    )
+    parts = [
+        f"Re-execution pass (cycle {cycles + 1}):",
+        "",
+        posture_msg,
+        "",
+        f"Gap identified: {completion_gap}",
+        "",
+        f"Original task: {summary}",
+    ]
+    if criteria_block:
+        parts += ["", criteria_block]
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -1228,7 +1257,8 @@ def _process_uow(
         completion_gap_for_prescription = completion_rationale
         route_reason = f"steward: {reentry_posture} — {completion_rationale[:120]}"
 
-    instructions = _build_prescription_instructions(uow, reentry_posture, completion_gap_for_prescription)
+    issue_body = issue_info.get("body", "") if issue_info else ""
+    instructions = _build_prescription_instructions(uow, reentry_posture, completion_gap_for_prescription, issue_body)
 
     # Update agenda: mark current pending node as prescribed
     updated_agenda = _mark_current_agenda_node_prescribed(agenda)


### PR DESCRIPTION
## What this fixes

Two gaps in the WOS pipeline that caused every executor prescription to lack actionable context.

**Bug 1 (Closes #386): success_criteria is always empty on new UoWs**

When the cultivator promoted a GitHub issue to WOS, it passed only `issue_number` and `title` to `Registry.upsert()`. The `success_criteria` column defaulted to `''` for every new UoW — even when the issue body contained a clear "## Acceptance Criteria" section. Downstream, the steward's diagnosis logged `success_criteria_missing=True` on every cycle, and completion verification fell back to summary-only heuristics.

**Bug 2 (Closes #387): steward prescriptions said "See issue body for details."**

`_build_prescription_instructions()` had no access to the issue body. When `success_criteria` was empty (always, due to Bug 1), the executor received instructions like:

```
Execute the following task:

Summary: <issue title>

Success criteria: See issue body for details.

Write your output to the output_ref path.
```

The executor had no context — no constraints, no acceptance criteria, no description of the problem.

## What changed

**`cultivator.py`** — new `_extract_success_criteria(body)` pure function. Scans the issue body for `## Acceptance Criteria`, `## Success Criteria`, or `## Definition of Done` sections and returns the section content. Falls back to the first non-heading paragraph (capped at 500 chars) when no criteria section is found. The extracted value is passed to `registry.upsert(success_criteria=...)`.

**`registry.py`** — `upsert()` and `_upsert_typed()` accept a `success_criteria: str = ""` parameter (backward-compatible default). The INSERT statement now populates the column.

**`steward.py`** — `_build_prescription_instructions()` accepts `issue_body: str = ""`. When `success_criteria` is absent, it includes the issue body as an "Issue context:" block (truncated at 1500 chars). The `_process_uow` call site passes `issue_body` from the already-fetched `issue_info`.

## Functional patterns used

- Pure functions for extraction and instruction composition (no side effects, deterministic output)
- Backward-compatible defaults (empty string) so existing UoWs with NULL/empty `success_criteria` are unaffected
- No schema changes

## What is not changed

- DB schema is unchanged
- No existing UoW rows are modified — fix is forward-only
- Steward's completion verification logic and diagnosis table are unchanged
- The `issue_info` GitHub fetch was already happening before my change; I only route the data further downstream

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/ -x -q` — 287 passed, 0 failed
- [x] `uv run pytest tests/unit/ -x -q` (full suite) — 355 passed, 1 pre-existing failure in `test_emit_event.py::TestResolveDebugConfigNoOp` (unrelated `pas` typo in `inbox_server.py`, present on `main` before this branch)

## Areas to review closely

- `_extract_success_criteria`: the heading match is case-sensitive for lowercase variants (`## acceptance criteria`) — verify that covers the repo's actual issue templates
- Truncation thresholds (500 chars for fallback paragraph, 1500 chars for issue body in instructions) — adjust if too aggressive or too loose
- The `issue_body` variable introduced at the prescription call site reuses the existing `issue_info` dict; no new GitHub API call is made