### PR TITLE
feat: add BOOTUP_CANDIDATE_GATE clearing mechanism via /wos unblock

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -929,9 +929,19 @@ Status: `proposed → pending`"
   Reply immediately: "Generating WOS PDF..." then let the bot deliver the file.
   If `[status]` is provided (e.g. `/wos pdf active`), pass `--status <status>` to the script.
 
+- `/wos unblock` — Clear BOOTUP_CANDIDATE_GATE so the Steward processes all UoWs,
+  including those with the `bootup-candidate` label (#271–#298).
+  Handle directly (no subagent — fast file write). Call:
+  ```python
+  from src.orchestration.dispatcher_handlers import handle_wos_unblock
+  reply = handle_wos_unblock()
+  ```
+  Reply with the returned string. No confirmation prompt needed — the command is
+  intentional and the effect is visible on the next steward-heartbeat cycle (~3 min).
+
 **Note:** Decide actions (Retry / Close on stuck UoWs) are handled via inline button callbacks — see "Handling WOS Surface Messages" section above.
 
-`/wos status` and `/confirm` are handled directly in the dispatcher (no subagent — fast CLI calls).
+`/wos status`, `/wos unblock`, and `/confirm` are handled directly in the dispatcher (no subagent — fast CLI calls).
 `/wos pdf` requires a subagent — dispatch it and reply "Generating WOS PDF..." immediately.
 
 

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -228,6 +228,9 @@ def main() -> int:
     else:
         log.info("Executor heartbeat starting")
 
+    from src.orchestration.steward import is_bootup_candidate_gate_active
+    log.info("BOOTUP_CANDIDATE_GATE = %s", is_bootup_candidate_gate_active())
+
     from src.orchestration.registry import Registry
 
     db_path = _default_db_path()

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -50,7 +50,7 @@ _REPO_ROOT = Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from src.orchestration.steward import BOOTUP_CANDIDATE_GATE, run_steward_cycle
+from src.orchestration.steward import is_bootup_candidate_gate_active, run_steward_cycle
 
 # ---------------------------------------------------------------------------
 # Startup sweep — imported from startup-sweep.py (Phase 1 concern)
@@ -310,7 +310,8 @@ def main() -> int:
     else:
         log.info("Steward heartbeat starting")
 
-    log.info("BOOTUP_CANDIDATE_GATE = %s", BOOTUP_CANDIDATE_GATE)
+    gate_active = is_bootup_candidate_gate_active()
+    log.info("BOOTUP_CANDIDATE_GATE = %s", gate_active)
 
     from src.orchestration.registry import Registry
 
@@ -324,7 +325,7 @@ def main() -> int:
     # Phase 1: Startup sweep
     log.info("--- Phase 1: Startup sweep ---")
     try:
-        sweep_result = run_startup_sweep(registry, dry_run=dry_run, bootup_candidate_gate=BOOTUP_CANDIDATE_GATE)
+        sweep_result = run_startup_sweep(registry, dry_run=dry_run, bootup_candidate_gate=gate_active)
         log.info(
             "Startup sweep complete: active_swept=%d executor_orphans=%d "
             "diagnosing=%d skipped_dry_run=%d",
@@ -354,6 +355,7 @@ def main() -> int:
         result = run_steward_cycle(
             registry=registry,
             dry_run=dry_run,
+            bootup_candidate_gate=gate_active,
         )
         log.info(
             "Steward cycle complete: evaluated=%d prescribed=%d done=%d "

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -8,18 +8,30 @@ Telegram. No MCP tools, no network calls — those belong in the dispatcher.
 The dispatcher calls these handlers when it recognizes:
   /approve <uow-id>        → handle_approve(uow_id, registry)
   /wos status [status]     → handle_wos_status(status, registry)
+  /wos unblock             → handle_wos_unblock()
   decide retry <uow-id>    → handle_decide_retry(uow_id, registry)
   decide close <uow-id>    → handle_decide_close(uow_id, registry)
 """
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .registry import Registry
 
 from .registry import ApproveConfirmed, ApproveExpired, ApproveNotFound, ApproveSkipped
+
+
+# ---------------------------------------------------------------------------
+# Gate-cleared flag path — mirrors _GATE_CLEARED_FLAG in steward.py
+# ---------------------------------------------------------------------------
+
+_GATE_CLEARED_FLAG: Path = Path(
+    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+) / "data" / "wos-gate-cleared"
 
 
 def handle_approve(uow_id: str, *, registry: "Registry") -> str:
@@ -133,3 +145,42 @@ def handle_wos_status(status: str | None, *, registry: "Registry") -> str:
         lines.append(f"`{r.id}` | {summary} | source: {source} | created: {created}")
 
     return "\n".join(lines)
+
+
+def handle_wos_unblock() -> str:
+    """
+    Handle /wos unblock.
+
+    Clears BOOTUP_CANDIDATE_GATE by creating the wos-gate-cleared file flag at
+    ~/lobster-workspace/data/wos-gate-cleared.
+
+    Once the flag exists, steward-heartbeat.py and executor-heartbeat.py will
+    read it on their next invocation and process all UoWs — including those
+    with the `bootup-candidate` label — without skipping.
+
+    Idempotent: calling /wos unblock when already unblocked returns a notice
+    rather than an error.
+
+    Returns a human-readable Telegram message describing the outcome.
+    """
+    if _GATE_CLEARED_FLAG.exists():
+        return (
+            "BOOTUP_CANDIDATE_GATE is already cleared.\n"
+            "All UoWs (including bootup-candidates) are being processed normally."
+        )
+
+    try:
+        _GATE_CLEARED_FLAG.parent.mkdir(parents=True, exist_ok=True)
+        _GATE_CLEARED_FLAG.touch()
+    except OSError as exc:
+        return (
+            f"Failed to create gate-cleared flag: {exc}\n"
+            f"Path: `{_GATE_CLEARED_FLAG}`"
+        )
+
+    return (
+        "BOOTUP_CANDIDATE_GATE cleared.\n"
+        "All 27 bootup-candidate UoWs (#271-#298) will be processed on the next "
+        "steward-heartbeat cycle (within 3 minutes).\n"
+        f"Flag: `{_GATE_CLEARED_FLAG}`"
+    )

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -95,9 +95,30 @@ StewardOutcome = Prescribed | Done | Surfaced | RaceSkipped
 # Module-level constants
 # ---------------------------------------------------------------------------
 
+# Path to the file-flag that clears BOOTUP_CANDIDATE_GATE.
+# When this file exists, the gate is cleared and bootup-candidate UoWs are
+# processed normally. Create via `/wos unblock` dispatcher command.
+_GATE_CLEARED_FLAG: Path = Path(
+    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+) / "data" / "wos-gate-cleared"
+
+
+def is_bootup_candidate_gate_active() -> bool:
+    """Return True if BOOTUP_CANDIDATE_GATE is active (blocking bootup-candidates).
+
+    Returns False when the wos-gate-cleared file flag exists, indicating the
+    Phase 2 validation sequence has passed and all UoWs should be processed.
+
+    This function reads from disk on every call so that the gate state is always
+    current — cron processes get a fresh read on every invocation.
+    """
+    return not _GATE_CLEARED_FLAG.exists()
+
+
 # When True, the Steward skips UoWs with the `bootup-candidate` label.
-# This gate is True by default until the Phase 2 validation sequence passes.
-BOOTUP_CANDIDATE_GATE: bool = True
+# Evaluated at module load; re-evaluated on each cron process start.
+# To clear: create ~/lobster-workspace/data/wos-gate-cleared (or /wos unblock).
+BOOTUP_CANDIDATE_GATE: bool = is_bootup_candidate_gate_active()
 
 # Status values — use UoWStatus StrEnum (kept as aliases for backward compat)
 _STATUS_READY_FOR_STEWARD = UoWStatus.READY_FOR_STEWARD

--- a/src/orchestration/wos_dashboard.py
+++ b/src/orchestration/wos_dashboard.py
@@ -172,20 +172,25 @@ def _bootup_gate_status(registry: Any) -> dict[str, Any]:
 
     'gate_open' = True means the gate is active and blocking bootup candidates.
     blocked_count is the number of ready-for-steward UoWs that would be skipped.
+
+    Reads the file flag via is_bootup_candidate_gate_active() so the dashboard
+    always reflects the current on-disk state, not a stale module-load value.
     """
-    from src.orchestration.steward import BOOTUP_CANDIDATE_GATE
+    from src.orchestration.steward import is_bootup_candidate_gate_active
     from src.orchestration.registry import UoWStatus
+
+    gate_active = is_bootup_candidate_gate_active()
 
     # Count UoWs in ready-for-steward (candidates that the gate might block).
     ready_for_steward = registry.list(status=str(UoWStatus.READY_FOR_STEWARD))
     blocked_count = len(ready_for_steward)
 
     return {
-        "gate_open": BOOTUP_CANDIDATE_GATE,
-        "blocked_count": blocked_count if BOOTUP_CANDIDATE_GATE else 0,
+        "gate_open": gate_active,
+        "blocked_count": blocked_count if gate_active else 0,
         "description": (
             "gate is OPEN — bootup-candidate UoWs are skipped by the Steward"
-            if BOOTUP_CANDIDATE_GATE
+            if gate_active
             else "gate is CLOSED — all UoWs are processed normally"
         ),
     }

--- a/tests/unit/test_orchestration/test_dispatcher_integration.py
+++ b/tests/unit/test_orchestration/test_dispatcher_integration.py
@@ -1,5 +1,5 @@
 """
-Tests for dispatcher command handlers for /approve and /wos status.
+Tests for dispatcher command handlers for /approve, /wos status, and /wos unblock.
 
 These test the pure handler functions in isolation — no Telegram or MCP required.
 The handlers receive parsed command arguments and a Registry instance, and return
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 import pytest
 
-from src.orchestration.dispatcher_handlers import handle_approve, handle_confirm, handle_wos_status
+from src.orchestration.dispatcher_handlers import handle_approve, handle_confirm, handle_wos_status, handle_wos_unblock
 
 
 @pytest.fixture
@@ -90,3 +90,61 @@ class TestHandleWosStatus:
         response = handle_wos_status(None, registry=registry)
         assert r1.id in response
         assert r2.id in response
+
+
+class TestHandleWosUnblock:
+    """Tests for handle_wos_unblock — BOOTUP_CANDIDATE_GATE file-flag clearing."""
+
+    def test_creates_flag_file_when_not_present(self, tmp_path, monkeypatch):
+        """Calling unblock when flag absent creates the flag and returns success."""
+        from src.orchestration import dispatcher_handlers
+        flag = tmp_path / "wos-gate-cleared"
+        monkeypatch.setattr(dispatcher_handlers, "_GATE_CLEARED_FLAG", flag)
+
+        assert not flag.exists()
+        response = handle_wos_unblock()
+        assert flag.exists()
+        assert "cleared" in response.lower()
+
+    def test_idempotent_when_already_cleared(self, tmp_path, monkeypatch):
+        """Calling unblock when flag already exists returns a notice, not an error."""
+        from src.orchestration import dispatcher_handlers
+        flag = tmp_path / "wos-gate-cleared"
+        flag.touch()
+        monkeypatch.setattr(dispatcher_handlers, "_GATE_CLEARED_FLAG", flag)
+
+        response = handle_wos_unblock()
+        assert "already" in response.lower() or "cleared" in response.lower()
+        # Flag should still exist
+        assert flag.exists()
+
+    def test_creates_parent_directory_if_missing(self, tmp_path, monkeypatch):
+        """Flag file parent directory is created if it does not exist."""
+        from src.orchestration import dispatcher_handlers
+        flag = tmp_path / "nonexistent" / "subdir" / "wos-gate-cleared"
+        monkeypatch.setattr(dispatcher_handlers, "_GATE_CLEARED_FLAG", flag)
+
+        assert not flag.parent.exists()
+        response = handle_wos_unblock()
+        assert flag.exists()
+        assert "cleared" in response.lower()
+
+    def test_response_mentions_flag_path(self, tmp_path, monkeypatch):
+        """Success response includes the flag path so Dan can verify."""
+        from src.orchestration import dispatcher_handlers
+        flag = tmp_path / "wos-gate-cleared"
+        monkeypatch.setattr(dispatcher_handlers, "_GATE_CLEARED_FLAG", flag)
+
+        response = handle_wos_unblock()
+        assert str(flag) in response
+
+    def test_is_bootup_candidate_gate_active_reflects_flag(self, tmp_path, monkeypatch):
+        """After unblock, is_bootup_candidate_gate_active() returns False."""
+        from src.orchestration import dispatcher_handlers, steward
+        flag = tmp_path / "wos-gate-cleared"
+        monkeypatch.setattr(dispatcher_handlers, "_GATE_CLEARED_FLAG", flag)
+        monkeypatch.setattr(steward, "_GATE_CLEARED_FLAG", flag)
+
+        assert steward.is_bootup_candidate_gate_active() is True
+        handle_wos_unblock()
+        assert steward.is_bootup_candidate_gate_active() is False

--- a/tests/unit/test_orchestration/test_wos_dashboard.py
+++ b/tests/unit/test_orchestration/test_wos_dashboard.py
@@ -7,7 +7,7 @@ Tests cover:
 - _throughput_24h: delegates to execution_outcomes, maps key names
 - _cycle_histogram_last_7d: groups by steward_cycles for completed UoWs
 - _stalled_uows: filters by status + elapsed threshold
-- _bootup_gate_status: reads BOOTUP_CANDIDATE_GATE module constant
+- _bootup_gate_status: calls is_bootup_candidate_gate_active()
 - build_dashboard_data: assembles all sections into a single dict
 - render_text: renders expected section headers and data
 - render_text: empty states render '(none)' placeholders
@@ -259,7 +259,7 @@ class TestBootupGateStatus:
         registry.list.side_effect = lambda status=None: (
             [uow_rfs] if status == "ready-for-steward" else []
         )
-        with patch("src.orchestration.steward.BOOTUP_CANDIDATE_GATE", True):
+        with patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=True):
             result = _bootup_gate_status(registry)
         assert result["gate_open"] is True
         assert result["blocked_count"] == 1
@@ -269,7 +269,7 @@ class TestBootupGateStatus:
         from src.orchestration.wos_dashboard import _bootup_gate_status
         registry = _make_registry([])
         registry.list.side_effect = lambda status=None: []
-        with patch("src.orchestration.steward.BOOTUP_CANDIDATE_GATE", False):
+        with patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=False):
             result = _bootup_gate_status(registry)
         assert result["gate_open"] is False
         assert result["blocked_count"] == 0
@@ -288,7 +288,7 @@ class TestBuildDashboardData:
 
         with patch("src.orchestration.audit_queries.execution_outcomes", return_value={}), \
              patch("src.orchestration.wos_dashboard._fetch_completed_uow_ids_since", return_value=[]), \
-             patch("src.orchestration.steward.BOOTUP_CANDIDATE_GATE", True):
+             patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=True):
             data = build_dashboard_data(registry, db_path)
 
         assert "generated_at" in data
@@ -305,7 +305,7 @@ class TestBuildDashboardData:
 
         with patch("src.orchestration.audit_queries.execution_outcomes", return_value={}), \
              patch("src.orchestration.wos_dashboard._fetch_completed_uow_ids_since", return_value=[]), \
-             patch("src.orchestration.steward.BOOTUP_CANDIDATE_GATE", False):
+             patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=False):
             data = build_dashboard_data(registry, db_path)
 
         # Should parse without error


### PR DESCRIPTION
## What problem this solves

`BOOTUP_CANDIDATE_GATE` was a hardcoded `True` constant with no clearing mechanism. It blocked all 27 bootup-candidate UoWs (#271–#298) from being processed by the Steward, but once Phase 2 validation passes there was no way to clear it short of manually editing the source code and redeploying. The gate had an entrance but no exit.

## What this change does

A file flag at `~/lobster-workspace/data/wos-gate-cleared` now controls the gate: if the file exists, the gate is cleared. The new `/wos unblock` command creates it.

The module constant `BOOTUP_CANDIDATE_GATE` is now evaluated at import time by calling `is_bootup_candidate_gate_active()` — correct for cron processes (fresh import each invocation). `wos_dashboard.py` calls the function directly so the dashboard always reflects current on-disk state, not a cached import-time value.

## Files changed

- **`src/orchestration/steward.py`** — adds `_GATE_CLEARED_FLAG` path, `is_bootup_candidate_gate_active()` function; `BOOTUP_CANDIDATE_GATE` computed via this function at import time
- **`src/orchestration/dispatcher_handlers.py`** — adds `handle_wos_unblock()`: creates flag file, idempotent, creates parent dirs as needed; returns human-readable Telegram response
- **`src/orchestration/wos_dashboard.py`** — `_bootup_gate_status` calls `is_bootup_candidate_gate_active()` for live gate state
- **`scheduled-tasks/steward-heartbeat.py`** — reads gate via `is_bootup_candidate_gate_active()` at startup, passes explicitly to `run_startup_sweep` and `run_steward_cycle`
- **`scheduled-tasks/executor-heartbeat.py`** — logs gate state at startup for observability
- **`.claude/sys.dispatcher.bootup.md`** — documents `/wos unblock` command for dispatcher
- **`tests/unit/test_orchestration/test_dispatcher_integration.py`** — 5 new tests covering: flag creation, idempotency, parent dir creation, response content, and gate-function roundtrip
- **`tests/unit/test_orchestration/test_wos_dashboard.py`** — updated test patches from `BOOTUP_CANDIDATE_GATE` constant to `is_bootup_candidate_gate_active` function

## What is out of scope

Only the gate-clearing mechanism is implemented. No other WOS behavior changes: UoW state machine, Steward prescription logic, Executor dispatch, and `/decide` (blocked UoW resolution — #343) are all untouched.

## Functional patterns used

Pure functions (`is_bootup_candidate_gate_active`, `handle_wos_unblock`) with no side effects except the intentional file write. Side effect (file creation) is isolated at the boundary (`handle_wos_unblock`) and clearly documented. Immutable flag semantics: presence/absence of a file, not mutable state.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/ -q` — 292 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_dispatcher_integration.py -v` — 14 passed (includes 5 new)
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_dashboard.py -v` — 29 passed, 0 failed
- [ ] `uv run pytest tests/integration/test_wos_pipeline.py` — 7 pre-existing failures (same failures on `origin/main`, confirmed); not introduced by this PR

**Pre-existing failures on main (not introduced here):** `TestPhase2SchemaHarness`, `TestObservationLoop::test_active_uow_within_timeout_not_flagged`, `TestConcurrentHeartbeat::test_two_heartbeats_do_not_double_process_any_uow`, `TestBootupCandidateGate` (both tests) — these require a running registry DB that is absent in CI.

Closes the BOOTUP_CANDIDATE_GATE clearing gap (WOS implementation plan item #6).