### PR TITLE
fix: unify cultivator DB path to orchestration/registry.db

### DIFF
--- a/src/orchestration/cultivator.py
+++ b/src/orchestration/cultivator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -209,8 +210,14 @@ def classify_issues(issues: list[GitHubIssue]) -> tuple[list[ClassifiedIssue], i
 # ---------------------------------------------------------------------------
 
 def _build_db_path() -> Path:
-    """Resolve the WOS database path."""
-    return Path.home() / "lobster-workspace" / "data" / "wos.db"
+    """Resolve the WOS database path.
+
+    Uses LOBSTER_WORKSPACE env var when set (consistent with registry_cli,
+    audit_queries, and wos_dashboard). Falls back to the default workspace path.
+    The canonical registry DB lives at orchestration/registry.db.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    return workspace / "orchestration" / "registry.db"
 
 
 def promote_to_wos(


### PR DESCRIPTION
## Summary

UoWs seeded by the cultivator were never visible to the steward or executor because they were writing to different SQLite databases. The cultivator wrote to `data/wos.db`; the steward and executor read from `orchestration/registry.db`. This change fixes the cultivator to write to the canonical path.

The fix is a one-line path change in `_build_db_path()`. The previous path (`data/wos.db`) is now orphaned — it has 188 rows of UoW data from prior cultivator runs, but those UoWs were never visible to the rest of the pipeline. No auto-migration is attempted; the existing `orchestration/registry.db` is authoritative and the old file can be archived manually.

The new path follows the same `LOBSTER_WORKSPACE` env-var pattern already used by `registry_cli`, `audit_queries`, and `wos_dashboard`, making the cultivator consistent with those modules.

**Functional pattern:** pure function — `_build_db_path()` is a side-effect-free resolver; all I/O remains isolated in `promote_to_wos()`.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/ -q` — 287 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 1715 passed, 5 failed (all pre-existing failures in unrelated modules: emit_event, hibernation, memory)
- [ ] `uv run pytest tests/integration/test_wos_pipeline.py` — skipped: pre-existing failure (`test_validate_phase2_schema_raises_on_missing_column` fails on main too)
- [ ] `uv run pytest tests/integration/test_scheduled_execution.py` — skipped: pre-existing failure (`sync_crontab` await bug unrelated to this change)

**Blocked items needing attention before merge:** none