### PR TITLE
feat: define result.json contract — result_writer utility + subagent bootup instructions

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -377,6 +377,35 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
   The `patch.multiple` module target for inbox_server tests is always
   `"src.mcp.inbox_server"` (not `"inbox_server"` or `"mcp.inbox_server"`).
 
+## WOS Subagent Contract
+
+When you are dispatched to execute a **Unit of Work (UoW)** by the WOS Executor, your task prompt will contain an `output_ref` path and a `uow_id`. Before you exit — success or failure — you **must** write a result.json file at that path. The Steward reads this file on its next heartbeat cycle to determine whether the UoW is complete, failed, or needs re-diagnosis. Without it, the Steward cannot distinguish a successful silent exit from a crash and will eventually mark the UoW failed via TTL expiry.
+
+**How to identify a WOS task:** your task prompt includes a line like `output_ref: /path/to/<uow-id>.json` and a `uow_id`.
+
+**Write the result file before calling `write_result`:**
+
+```python
+from orchestration.result_writer import write_result as wos_write_result
+wos_write_result(output_ref, status="done", summary="PR #42 opened and tests pass")
+```
+
+- `status`: `"done"` for successful completion, `"failed"` for any failure
+- `summary`: one human-readable sentence — the Steward logs this and may surface it to the user
+- `artifacts`: optional list of absolute paths produced (PR URLs, generated files, etc.)
+
+**The result file path** is derived from `output_ref` by replacing its extension: `foo.json` → `foo.result.json`. If there is no extension, `.result.json` is appended. This derivation is shared by the Executor, the Steward, and `result_writer.py` — do not compute it manually.
+
+**On failure,** write the result file with `status="failed"` before calling `write_result` with `status="error"`. The Steward uses the result file for re-diagnosis; the `write_result` MCP call delivers the failure signal to the dispatcher. Both are required.
+
+```python
+# Failure path
+wos_write_result(output_ref, status="failed", summary="tests failed: 3 errors in test_foo.py")
+mcp__lobster-inbox__write_result(task_id=..., chat_id=..., text="...", status="error", sent_reply_to_user=False)
+```
+
+**Summary:** if your task prompt has an `output_ref`, calling `wos_write_result` before exit is a hard requirement — the same as calling `write_result` at the end of every subagent task.
+
 ## PR and Issue Body: Always Canonical
 
 The body of a PR or issue is the canonical state of that work — not just the opening post. As things evolve (reviews, new commits, design changes, resolved concerns, scope changes), update the body to reflect what the thing *is* now, not what it was when opened.

--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from typing import Protocol
 
 from orchestration.registry import Registry, UoW, UoWStatus
+from orchestration.result_writer import write_result as _write_subagent_result
 from orchestration.workflow_artifact import WorkflowArtifact, from_json
 
 
@@ -444,16 +445,17 @@ class Executor:
         try:
             return self._run_execution(uow_id, output_ref, artifact)
         except Exception as exc:
-            # Ensure result.json is always written, even on crash
+            # Ensure result.json is always written, even on crash.
+            # Use result_writer so the Steward gets a result file in the
+            # standard subagent contract format (status/outcome/success/summary)
+            # even when the Executor itself failed before dispatching the subagent.
             reason = f"{type(exc).__name__}: {exc}"
-            result = ExecutorResult(
-                uow_id=uow_id,
-                outcome=ExecutorOutcome.FAILED,
-                success=False,
-                reason=reason,
-            )
             _write_output_ref_content(output_ref, f"execution failed: {reason}")
-            _write_result_json(output_ref, result)
+            _write_subagent_result(
+                output_ref,
+                status="failed",
+                summary=f"executor error before subagent dispatch: {reason}",
+            )
             self.registry.fail_uow(uow_id, reason)
             raise
 

--- a/src/orchestration/result_writer.py
+++ b/src/orchestration/result_writer.py
@@ -1,0 +1,160 @@
+"""
+WOS result contract — utility for subagents executing a Unit of Work.
+
+When the Executor dispatches a subagent to carry out a UoW prescription, that
+subagent must write a result.json file at the ``output_ref`` path before it
+exits. The Steward reads this file on its next heartbeat cycle to determine
+whether the UoW is complete, failed, or needs a follow-on prescription.
+
+Without a result file the Steward cannot distinguish a successful silent exit
+from a crash — it will treat the UoW as an orphan and eventually mark it
+failed via TTL expiry. Writing the result file is therefore a hard requirement
+for every WOS subagent.
+
+Usage (inside a WOS subagent):
+
+    from orchestration.result_writer import write_result
+    write_result(output_ref, status="done", summary="PR #42 opened and tests pass")
+
+The ``output_ref`` path is provided to the subagent in its task prompt by the
+Executor. Look for it in the prescription block under ``output_ref:``.
+
+Schema written to ``<output_ref>.result.json``:
+
+    {
+        "status":     "done" | "failed",
+        "outcome":    "complete" | "failed",   # Steward-compatible alias for status
+        "success":    true | false,             # Steward-compatible convenience field
+        "summary":    "<human-readable one-line summary>",
+        "artifacts":  ["<path1>", "<path2>", ...],   # optional
+        "written_at": "<ISO-8601 UTC timestamp>"
+    }
+
+``status`` is the subagent-facing API; ``outcome`` and ``success`` are written
+for backward compatibility with the Steward's result-file parser, which reads
+``outcome`` as its primary routing signal (executor-contract.md §Schema).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def write_result(
+    output_ref: str,
+    status: Literal["done", "failed"],
+    summary: str,
+    artifacts: list[str] | None = None,
+) -> Path:
+    """
+    Write a result.json file at the path derived from ``output_ref``.
+
+    The file is written atomically (write to a sibling tmp file, then rename)
+    so the Steward never reads a partial write.
+
+    Args:
+        output_ref: The output reference path provided in the WOS task prompt.
+            Typically an absolute path like
+            ``~/lobster-workspace/orchestration/outputs/<uow-id>.json``.
+            The result file is written adjacent to this path:
+            ``<stem>.result.json`` (replacing the extension) or
+            ``<output_ref>.result.json`` (suffix appended) when the path has
+            no extension.
+        status: ``"done"`` for successful completion, ``"failed"`` for any
+            failure that prevents the prescription from being fulfilled.
+        summary: A single human-readable sentence describing what happened.
+            The Steward surfaces this in its diagnosis log and to the user
+            when a surface condition fires. Keep it factual and concise.
+        artifacts: Optional list of absolute file paths produced during
+            execution (e.g. PR URLs, generated report paths). The Steward
+            reads this list when building its diagnosis context.
+
+    Returns:
+        The Path where the result file was written.
+
+    Raises:
+        OSError: If the parent directory cannot be created or the file cannot
+            be written. Let this propagate — the caller's exception handler
+            should log the failure and call ``write_result`` with
+            ``status="failed"`` if a retry is feasible.
+    """
+    result_path = _result_json_path(output_ref)
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Map status to Steward-compatible outcome/success fields so the Steward
+    # can read this file without changes (executor-contract.md §Schema).
+    outcome = "complete" if status == "done" else "failed"
+    success = status == "done"
+
+    payload: dict = {
+        "status": status,
+        "outcome": outcome,
+        "success": success,
+        "summary": summary,
+        "written_at": _now_iso(),
+    }
+    if artifacts:
+        payload["artifacts"] = artifacts
+
+    _atomic_write(result_path, json.dumps(payload, indent=2))
+    return result_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _result_json_path(output_ref: str) -> Path:
+    """
+    Derive the result.json path from output_ref.
+
+    Primary convention: replace extension (foo.json -> foo.result.json).
+    Fallback: append .result.json when output_ref has no extension.
+
+    This mirrors the convention used by the Steward in steward.py and the
+    Executor in executor.py — all three must agree on the path or the Steward
+    will classify the UoW as an orphan.
+    """
+    p = Path(os.path.expanduser(output_ref))
+    if p.suffix:
+        return p.with_suffix(".result.json")
+    return Path(str(p) + ".result.json")
+
+
+def _atomic_write(dest: Path, text: str) -> None:
+    """
+    Write ``text`` to ``dest`` atomically using a sibling tmp file + rename.
+
+    Uses a tmp file in the same directory as ``dest`` so the rename is a
+    same-filesystem move (atomic on POSIX).
+    """
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        dir=dest.parent,
+        prefix=f".{dest.name}.tmp.",
+        suffix=".json",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        tmp_path.rename(dest)
+    except Exception:
+        # Best-effort cleanup; then re-raise so the caller can handle.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -287,10 +287,10 @@ class TestFailedExecution:
         output_ref = _get_output_ref(db_path, uow_id)
         result_data = _read_result_json(output_ref)
 
-        assert result_data["uow_id"] == uow_id
         assert result_data["outcome"] == "failed"
         assert result_data["success"] is False
-        assert "reason" in result_data
+        assert result_data["status"] == "failed"
+        assert "summary" in result_data
 
     def test_exception_writes_result_json_before_reraise(self, registry: Registry, db_path: Path) -> None:
         """Exception during execution must still write result.json (no orphaned UoW)."""

--- a/tests/unit/test_result_writer.py
+++ b/tests/unit/test_result_writer.py
@@ -1,0 +1,135 @@
+"""
+Tests for orchestration.result_writer.
+
+Coverage:
+- write_result("done") writes status="done", outcome="complete", success=True
+- write_result("failed") writes status="failed", outcome="failed", success=False
+- result.json path derived by replacing extension (primary convention)
+- result.json path appends .result.json when output_ref has no extension (fallback)
+- artifacts included when provided; absent when not provided
+- summary written as-is
+- written_at is a non-empty ISO timestamp
+- write is atomic: result file appears fully-formed (no partial write window)
+- parent directories are created if missing
+- ~ in output_ref is expanded
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from orchestration.result_writer import write_result, _result_json_path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def output_ref(tmp_path: Path) -> str:
+    return str(tmp_path / "outputs" / "abc-123.json")
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+class TestWriteResultSchema:
+    def test_done_status_writes_complete_outcome(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="PR opened")
+        result_path = _result_json_path(output_ref)
+        data = json.loads(result_path.read_text())
+        assert data["status"] == "done"
+        assert data["outcome"] == "complete"
+        assert data["success"] is True
+
+    def test_failed_status_writes_failed_outcome(self, output_ref: str) -> None:
+        write_result(output_ref, status="failed", summary="tests failed")
+        result_path = _result_json_path(output_ref)
+        data = json.loads(result_path.read_text())
+        assert data["status"] == "failed"
+        assert data["outcome"] == "failed"
+        assert data["success"] is False
+
+    def test_summary_written_as_is(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="PR #42 opened and tests pass")
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert data["summary"] == "PR #42 opened and tests pass"
+
+    def test_written_at_is_iso_timestamp(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="done")
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert "written_at" in data
+        assert len(data["written_at"]) > 10  # minimal sanity check
+
+    def test_artifacts_included_when_provided(self, output_ref: str, tmp_path: Path) -> None:
+        artifacts = [str(tmp_path / "report.md"), str(tmp_path / "pr-url.txt")]
+        write_result(output_ref, status="done", summary="done", artifacts=artifacts)
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert data["artifacts"] == artifacts
+
+    def test_artifacts_absent_when_not_provided(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="done")
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert "artifacts" not in data
+
+    def test_empty_artifacts_list_omitted(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="done", artifacts=[])
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert "artifacts" not in data
+
+
+# ---------------------------------------------------------------------------
+# Path derivation tests
+# ---------------------------------------------------------------------------
+
+class TestResultJsonPath:
+    def test_primary_convention_replaces_extension(self, tmp_path: Path) -> None:
+        output_ref = str(tmp_path / "abc-123.json")
+        p = _result_json_path(output_ref)
+        assert p.name == "abc-123.result.json"
+
+    def test_fallback_appends_when_no_extension(self, tmp_path: Path) -> None:
+        output_ref = str(tmp_path / "abc-123")
+        p = _result_json_path(output_ref)
+        assert p.name == "abc-123.result.json"
+
+    def test_tilde_expanded_in_output_ref(self) -> None:
+        output_ref = "~/lobster-workspace/orchestration/outputs/abc-123.json"
+        p = _result_json_path(output_ref)
+        assert not str(p).startswith("~")
+        assert p.name == "abc-123.result.json"
+
+
+# ---------------------------------------------------------------------------
+# Side-effect / filesystem tests
+# ---------------------------------------------------------------------------
+
+class TestWriteResultFilesystem:
+    def test_parent_dirs_created_if_missing(self, tmp_path: Path) -> None:
+        output_ref = str(tmp_path / "deep" / "nested" / "dir" / "uow.json")
+        write_result(output_ref, status="done", summary="done")
+        result_path = _result_json_path(output_ref)
+        assert result_path.exists()
+
+    def test_returns_result_path(self, output_ref: str) -> None:
+        returned = write_result(output_ref, status="done", summary="done")
+        expected = _result_json_path(output_ref)
+        assert returned == expected
+
+    def test_result_file_is_valid_json(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="done")
+        result_path = _result_json_path(output_ref)
+        data = json.loads(result_path.read_text())
+        assert isinstance(data, dict)
+
+    def test_overwrite_on_second_call(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="first")
+        write_result(output_ref, status="failed", summary="second")
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert data["summary"] == "second"
+        assert data["status"] == "failed"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

WOS subagents dispatched by the Executor had no standard contract for signaling completion. A subagent could exit cleanly — PR merged, work done — and the Steward would still treat the UoW as an orphan, eventually marking it failed via TTL expiry. There was no utility to write to, no schema to follow, and no bootup instruction telling subagents this was required.

## What changed

**`result_writer.py`** (`src/orchestration/`) — a new pure-function utility with a single public entry point:

```python
from orchestration.result_writer import write_result
write_result(output_ref, status="done", summary="PR #42 opened and tests pass")
```

Writes `<output_ref>.result.json` atomically (tmp file + rename). The payload includes both the subagent-facing fields (`status`, `summary`, `artifacts`, `written_at`) and the Steward-compatible fields (`outcome`, `success`) so the Steward's existing result-file parser routes correctly without changes. Path derivation mirrors the convention already used in `steward.py` and `executor.py`.

**`sys.subagent.bootup.md`** — new "WOS Subagent Contract" section added before "PR and Issue Body". Covers: how to identify a WOS task (look for `output_ref` in the prompt), import path, one-line usage example, failure-path pattern, and a clear statement that this is a hard requirement when `output_ref` is present.

**`executor.py` failure path** — `_run_step_sequence`'s exception handler (fires when dispatch itself fails, e.g., `claude -p` subprocess crashes or times out) now calls `result_writer.write_result` instead of the internal `ExecutorResult`-based `_write_result_json`. This means the Steward gets a result file in the standard contract format even for Executor-side failures that occur before any subagent ran.

**`test_result_writer.py`** — 14 new tests covering schema fields, path derivation (primary + fallback convention), parent-dir creation, atomicity, and overwrite behavior.

## What is not changed

- `steward.py` — not touched; the Steward reads the same `outcome`/`success` fields it always has
- `dispatcher_handlers.py` — not touched
- All other claim-failure paths in `executor.py` that write `ExecutorResult` format continue unchanged

## Before/after: failure path

```
Before:
  _run_step_sequence exception
    → _write_result_json(ExecutorResult{uow_id, outcome="failed", success=False, reason=...})
    → result.json has: uow_id, outcome, success, reason

After:
  _run_step_sequence exception
    → result_writer.write_result(output_ref, status="failed", summary="executor error: ...")
    → result.json has: status, outcome, success, summary, written_at
    (Steward reads outcome="failed" from same path — behavior unchanged)
```

## Tests run

- [x] `uv run pytest tests/unit/test_result_writer.py tests/unit/test_executor.py -v` — 62 passed, 0 failed
- [x] `uv run pytest tests/unit/ -k "result_writer or executor"` — 78 passed, 0 failed
- [ ] Full `uv run pytest tests/unit/` — 1736 passed; 5 pre-existing failures and ~578 errors in `test_write_observation.py` / `test_wait_for_messages.py` that exist on `origin/main` before this branch