### PR TITLE
fix: inject noop dispatcher in TestOptimisticLock tests — stop ghost inbox writes during test runs

### DIFF
--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -436,12 +436,15 @@ class TestOptimisticLock:
         uow_id = "uow_lock_003"
         _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id))
 
+        def _noop_dispatcher(instructions: str, uid: str) -> str:
+            return "task-noop"
+
         # First executor claims successfully
-        executor1 = Executor(registry)
+        executor1 = Executor(registry, dispatcher=_noop_dispatcher)
         executor1.execute_uow(uow_id)  # transitions to ready-for-steward after success
 
         # Now status is 'ready-for-steward', not 'ready-for-executor'
-        executor2 = Executor(registry)
+        executor2 = Executor(registry, dispatcher=_noop_dispatcher)
         with pytest.raises(RuntimeError, match="optimistic lock failed"):
             executor2.execute_uow(uow_id)
 
@@ -474,8 +477,11 @@ class TestOptimisticLock:
                 results.append(type(exc).__name__)
                 errors.append(exc)
 
-        executor_a = Executor(registry)
-        executor_b = Executor(registry)
+        def _noop_dispatcher(instructions: str, uid: str) -> str:
+            return "task-noop"
+
+        executor_a = Executor(registry, dispatcher=_noop_dispatcher)
+        executor_b = Executor(registry, dispatcher=_noop_dispatcher)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
             fut_a = pool.submit(try_run, executor_a)


### PR DESCRIPTION
## What problem this solves

Every pytest run was writing 2 ghost \"(no text)\" UUID messages to \`~/messages/inbox/\`, flooding the live dispatcher inbox. The culprit was two \`TestOptimisticLock\` tests — \`test_concurrent_claim_silently_aborts_second\` (uow_lock_003) and \`test_truly_concurrent_claim_exactly_one_succeeds\` (uow_lock_004) — that constructed \`Executor(registry)\` without a dispatcher. \`Executor\`'s default dispatcher is \`_dispatch_via_inbox\`, which writes real JSON files to the inbox directory. Because these two tests exercise the success path of the first executor before asserting the lock failure of the second, the default dispatcher ran on every test invocation.

The other three \`TestOptimisticLock\` tests (\`test_rejects_if_not_in_ready_for_executor\`, \`test_rejects_if_status_is_pending\`, \`test_raises_value_error_for_unknown_uow\`) are not affected — they raise before dispatch is ever reached.

## What changed

A local \`_noop_dispatcher\` (returns \`\"task-noop\"\`, no side effects) is injected into the \`Executor(registry, dispatcher=_noop_dispatcher)\` call in each of the two affected tests. This matches the pattern used throughout the rest of \`test_executor.py\` — every other test that exercises the success path defines and injects a fake dispatcher.

Nothing outside \`tests/unit/test_executor.py\` is changed. \`executor.py\`, the registry, and \`_dispatch_via_inbox\` itself are untouched.

## Functional patterns

Pure function injection: the noop dispatcher is a stateless lambda-equivalent — no captures, no side effects — making the test boundary explicit and hermetic.

## Tests run

- [x] \`uv run pytest tests/unit/test_executor.py -v\` — 48 passed, 0 failed