### PR TITLE
feat: prescription quality tracking across steward cycles

### DIFF
--- a/src/orchestration/analytics.py
+++ b/src/orchestration/analytics.py
@@ -1,0 +1,266 @@
+"""
+analytics.py — Prescription quality tracking for the WOS steward pipeline.
+
+The steward_log field on each UoW is a newline-delimited JSON log of every
+Steward decision point. Prescription events carry a ``prescription_path``
+field that records whether the LLM or deterministic fallback path was used.
+
+This module exposes a single public function:
+
+    prescription_quality_summary(registry_path?) -> dict
+
+It queries uow_registry, parses each steward_log, and returns:
+
+  {
+    "per_uow": [
+      {
+        "id":            str,          # UoW UUID
+        "summary":       str,          # issue title / summary
+        "status":        str,          # final/current status
+        "steward_cycles": int,         # total steward cycles from DB column
+        "prescription_paths": list[str],  # ordered "llm"/"fallback" per cycle
+        "llm_count":     int,
+        "fallback_count": int,
+      },
+      ...
+    ],
+    "aggregate": {
+      "total_uows":         int,
+      "uows_with_data":     int,   # UoWs that have >=1 prescription event
+      "avg_cycles_to_done": float | None,
+      "pct_llm":            float | None,   # 0–100
+      "pct_fallback":       float | None,   # 0–100
+      "total_prescriptions": int,
+      "llm_prescriptions":   int,
+      "fallback_prescriptions": int,
+    },
+    "data_gap": str | None,  # human-readable note if data is too sparse
+  }
+
+Design notes:
+- Pure function composition: each concern (connect, query, parse, aggregate)
+  is a separate function. prescription_quality_summary() composes them.
+- No writes. Read-only connection.
+- Graceful on empty/missing DB: returns empty results with a data_gap note.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _default_registry_path() -> Path:
+    """Return the canonical registry DB path, matching audit_queries.py."""
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    workspace = os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+    return Path(workspace) / "orchestration" / "registry.db"
+
+
+def _connect_ro(registry_path: Path) -> sqlite3.Connection:
+    """Open a read-only WAL connection, matching audit_queries.py pattern."""
+    conn = sqlite3.connect(f"file:{registry_path}?mode=ro", uri=True, timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def _fetch_uow_rows(conn: sqlite3.Connection) -> list[dict]:
+    """Return all UoW rows with only the fields needed for quality analysis."""
+    rows = conn.execute(
+        """
+        SELECT id, summary, status, steward_cycles, steward_log
+        FROM uow_registry
+        ORDER BY id ASC
+        """
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _parse_prescription_paths(steward_log_raw: str | None) -> list[str]:
+    """
+    Extract ordered prescription_path values from a newline-delimited
+    steward_log string.
+
+    Returns a list of "llm" or "fallback" strings in cycle order.
+    Events with no ``prescription_path`` key are skipped.
+    """
+    if not steward_log_raw:
+        return []
+
+    paths: list[str] = []
+    for line in steward_log_raw.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        # Only prescription events carry prescription_path
+        if entry.get("event") in ("prescription", "reentry_prescription"):
+            path = entry.get("prescription_path")
+            if path in ("llm", "fallback"):
+                paths.append(path)
+    return paths
+
+
+def _build_per_uow_record(row: dict) -> dict[str, Any]:
+    """Combine DB row fields with parsed steward_log data into a per-UoW dict."""
+    paths = _parse_prescription_paths(row.get("steward_log"))
+    llm_count = paths.count("llm")
+    fallback_count = paths.count("fallback")
+    return {
+        "id": row["id"],
+        "summary": row.get("summary", ""),
+        "status": row.get("status", ""),
+        "steward_cycles": row.get("steward_cycles", 0),
+        "prescription_paths": paths,
+        "llm_count": llm_count,
+        "fallback_count": fallback_count,
+    }
+
+
+def _compute_aggregate(per_uow: list[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Compute aggregate quality metrics from per-UoW records.
+
+    avg_cycles_to_done: mean steward_cycles across UoWs with status='done'.
+    pct_llm / pct_fallback: share of LLM vs fallback across all prescriptions.
+    """
+    total_uows = len(per_uow)
+    uows_with_data = sum(1 for r in per_uow if r["prescription_paths"])
+
+    done_cycles = [
+        r["steward_cycles"]
+        for r in per_uow
+        if r["status"] == "done" and r["steward_cycles"] is not None
+    ]
+    avg_cycles_to_done: float | None = (
+        sum(done_cycles) / len(done_cycles) if done_cycles else None
+    )
+
+    total_prescriptions = sum(r["llm_count"] + r["fallback_count"] for r in per_uow)
+    llm_prescriptions = sum(r["llm_count"] for r in per_uow)
+    fallback_prescriptions = sum(r["fallback_count"] for r in per_uow)
+
+    pct_llm: float | None = None
+    pct_fallback: float | None = None
+    if total_prescriptions > 0:
+        pct_llm = round(100 * llm_prescriptions / total_prescriptions, 1)
+        pct_fallback = round(100 * fallback_prescriptions / total_prescriptions, 1)
+
+    return {
+        "total_uows": total_uows,
+        "uows_with_data": uows_with_data,
+        "avg_cycles_to_done": avg_cycles_to_done,
+        "pct_llm": pct_llm,
+        "pct_fallback": pct_fallback,
+        "total_prescriptions": total_prescriptions,
+        "llm_prescriptions": llm_prescriptions,
+        "fallback_prescriptions": fallback_prescriptions,
+    }
+
+
+def _data_gap_note(aggregate: dict[str, Any]) -> str | None:
+    """
+    Return a human-readable explanation if the data is too sparse to be
+    meaningful, or None if the data is sufficient.
+    """
+    if aggregate["total_uows"] == 0:
+        return (
+            "No UoWs found in registry. Run the steward at least once "
+            "to populate prescription data."
+        )
+    if aggregate["uows_with_data"] == 0:
+        return (
+            f"{aggregate['total_uows']} UoW(s) exist but none have steward "
+            "prescription events yet. The steward writes prescription_path "
+            "on each diagnosis/prescription cycle; data will appear after "
+            "the first steward heartbeat processes a UoW."
+        )
+    if aggregate["total_prescriptions"] < 3:
+        return (
+            f"Only {aggregate['total_prescriptions']} prescription event(s) "
+            "recorded across all UoWs. Metrics will be more meaningful once "
+            "more cycles have completed."
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def prescription_quality_summary(
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    """
+    Query uow_registry and return prescription quality metrics.
+
+    Parameters
+    ----------
+    registry_path:
+        Path to the registry SQLite DB. Defaults to the canonical path
+        resolved from REGISTRY_DB_PATH or LOBSTER_WORKSPACE env vars.
+
+    Returns
+    -------
+    dict with keys:
+        per_uow   — list of per-UoW quality records
+        aggregate — cross-UoW summary metrics
+        data_gap  — human-readable note when data is sparse, else None
+    """
+    path = registry_path if registry_path is not None else _default_registry_path()
+
+    if not path.exists():
+        empty_aggregate = _compute_aggregate([])
+        return {
+            "per_uow": [],
+            "aggregate": empty_aggregate,
+            "data_gap": (
+                f"Registry DB not found at {path}. "
+                "Run the WOS steward at least once to create the database."
+            ),
+        }
+
+    try:
+        conn = _connect_ro(path)
+    except sqlite3.OperationalError as exc:
+        return {
+            "per_uow": [],
+            "aggregate": _compute_aggregate([]),
+            "data_gap": f"Could not open registry DB: {exc}",
+        }
+
+    try:
+        rows = _fetch_uow_rows(conn)
+    except sqlite3.OperationalError as exc:
+        conn.close()
+        return {
+            "per_uow": [],
+            "aggregate": _compute_aggregate([]),
+            "data_gap": f"Could not query uow_registry: {exc}",
+        }
+    finally:
+        conn.close()
+
+    per_uow = [_build_per_uow_record(row) for row in rows]
+    aggregate = _compute_aggregate(per_uow)
+    data_gap = _data_gap_note(aggregate)
+
+    return {
+        "per_uow": per_uow,
+        "aggregate": aggregate,
+        "data_gap": data_gap,
+    }

--- a/src/wos_report.py
+++ b/src/wos_report.py
@@ -23,6 +23,8 @@ import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
+from src.orchestration.analytics import prescription_quality_summary
+
 # ── fpdf2 ──────────────────────────────────────────────────────────────────────
 try:
     from fpdf import FPDF
@@ -824,6 +826,176 @@ def _render_index_page(pdf: WoSReport, uows: list[dict]) -> None:
     pdf.line(MARGIN, pdf.get_y(), PAGE_W - MARGIN, pdf.get_y())
 
 
+# ── prescription quality page ─────────────────────────────────────────────────
+
+def _render_prescription_quality_page(pdf: WoSReport) -> None:
+    """
+    Render a Prescription Quality summary page using analytics.prescription_quality_summary().
+
+    Reads directly from the registry DB (same path REGISTRY_DB points to).
+    If data is sparse, renders the data_gap note instead of an empty table.
+    """
+    try:
+        summary = prescription_quality_summary(registry_path=REGISTRY_DB)
+    except Exception as exc:  # noqa: BLE001
+        # Don't let an analytics failure break the whole report
+        summary = {
+            "per_uow": [],
+            "aggregate": {
+                "total_uows": 0, "uows_with_data": 0,
+                "avg_cycles_to_done": None,
+                "pct_llm": None, "pct_fallback": None,
+                "total_prescriptions": 0,
+                "llm_prescriptions": 0, "fallback_prescriptions": 0,
+            },
+            "data_gap": f"analytics error: {exc}",
+        }
+
+    pdf.add_page()
+
+    # Section title
+    pdf.set_font("Helvetica", "B", 12)
+    pdf.set_text_color(*C_HEADING_TEXT)
+    pdf.cell(0, 8, "Prescription Quality",
+             new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="L")
+    pdf.set_draw_color(*C_GRID_LINE)
+    pdf.set_line_width(0.3)
+    pdf.line(MARGIN, pdf.get_y(), PAGE_W - MARGIN, pdf.get_y())
+    pdf.ln(4)
+    pdf.set_text_color(*C_DARK)
+
+    agg = summary["aggregate"]
+    data_gap = summary.get("data_gap")
+
+    # ── Aggregate metrics ──────────────────────────────────────────────────────
+    pdf.set_font("Helvetica", "B", 9)
+    pdf.set_text_color(*C_HEADING_TEXT)
+    pdf.set_fill_color(*C_HEADING_BG)
+    pdf.cell(CONTENT_W, 5.5, "  AGGREGATE METRICS",
+             fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+    pdf.ln(2)
+    pdf.set_text_color(*C_DARK)
+
+    def _metric_row(label: str, value: str) -> None:
+        pdf.set_font("Helvetica", "B", 8)
+        pdf.set_text_color(*C_MUTED)
+        pdf.cell(60, 5, label + ":", new_x=XPos.RIGHT, new_y=YPos.TOP)
+        pdf.set_font("Helvetica", "", 8)
+        pdf.set_text_color(*C_DARK)
+        pdf.cell(CONTENT_W - 60, 5, value, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+
+    _metric_row("Total UoWs", str(agg["total_uows"]))
+    _metric_row("UoWs with prescription data", str(agg["uows_with_data"]))
+    _metric_row("Total prescriptions", str(agg["total_prescriptions"]))
+
+    if agg["pct_llm"] is not None:
+        _metric_row(
+            "LLM prescriptions",
+            f"{agg['llm_prescriptions']}  ({agg['pct_llm']}%)",
+        )
+        _metric_row(
+            "Fallback prescriptions",
+            f"{agg['fallback_prescriptions']}  ({agg['pct_fallback']}%)",
+        )
+    else:
+        _metric_row("LLM / Fallback split", "no prescription data yet")
+
+    if agg["avg_cycles_to_done"] is not None:
+        _metric_row(
+            "Avg cycles to done",
+            f"{agg['avg_cycles_to_done']:.1f}",
+        )
+    else:
+        _metric_row("Avg cycles to done", "no completed UoWs yet")
+
+    pdf.ln(4)
+
+    # ── Data gap note ──────────────────────────────────────────────────────────
+    if data_gap:
+        pdf.set_font("Helvetica", "I", 8)
+        pdf.set_text_color(140, 100, 40)
+        pdf.multi_cell(CONTENT_W, 5, _safe(f"Note: {data_gap}"),
+                       new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        pdf.ln(3)
+        pdf.set_text_color(*C_DARK)
+
+    # ── Per-UoW table ──────────────────────────────────────────────────────────
+    per_uow = summary["per_uow"]
+    uows_with_data = [r for r in per_uow if r["prescription_paths"]]
+
+    if not uows_with_data:
+        pdf.set_font("Helvetica", "I", 8)
+        pdf.set_text_color(*C_MUTED)
+        pdf.cell(0, 5, "No per-UoW prescription data to display.",
+                 new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        return
+
+    pdf.set_font("Helvetica", "B", 9)
+    pdf.set_text_color(*C_HEADING_TEXT)
+    pdf.set_fill_color(*C_HEADING_BG)
+    pdf.cell(CONTENT_W, 5.5, "  PER-UOW BREAKDOWN",
+             fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+    pdf.ln(2)
+
+    # Table headers
+    col_widths = [12, 58, 22, 14, 16, 16, 44]
+    col_headers = ["ID", "Summary", "Status", "Cycles", "LLM", "Fallback", "Path sequence"]
+
+    pdf.set_fill_color(*C_HEADING_BG)
+    pdf.set_font("Helvetica", "B", 7.5)
+    pdf.set_text_color(*C_HEADING_TEXT)
+    hx = MARGIN
+    hy = pdf.get_y() + 1
+    for w, h in zip(col_widths, col_headers):
+        pdf.set_xy(hx, hy)
+        pdf.cell(w, 5, h, border=0, fill=True, align="L")
+        hx += w
+    pdf.ln(6)
+
+    # Table rows
+    for i, rec in enumerate(uows_with_data):
+        row_y = pdf.get_y()
+        row_bg = (250, 250, 252) if i % 2 == 0 else (255, 255, 255)
+        pdf.set_fill_color(*row_bg)
+        pdf.rect(MARGIN, row_y, sum(col_widths), 5, style="F")
+
+        status = rec.get("status", "")
+        sr, sg, sb = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
+
+        # Compact path display: e.g. "llm llm fallback" → "L L F"
+        path_abbrev = " ".join(
+            "L" if p == "llm" else "F" for p in rec["prescription_paths"][:10]
+        )
+        if len(rec["prescription_paths"]) > 10:
+            path_abbrev += "..."
+
+        values = [
+            _safe(rec["id"][-6:]),
+            _safe((rec["summary"] or "")[:55]),
+            status.upper()[:12],
+            str(rec["steward_cycles"]),
+            str(rec["llm_count"]),
+            str(rec["fallback_count"]),
+            _safe(path_abbrev),
+        ]
+        aligns = ["L", "L", "L", "C", "C", "C", "L"]
+
+        rx = MARGIN
+        for j, (w, val, align) in enumerate(zip(col_widths, values, aligns)):
+            pdf.set_xy(rx, row_y)
+            if j == 2:
+                pdf.set_text_color(sr, sg, sb)
+                pdf.set_font("Helvetica", "B", 7)
+            else:
+                pdf.set_text_color(*C_DARK)
+                pdf.set_font("Helvetica", "", 7)
+            pdf.cell(w, 5, val, border=0, align=align)
+            rx += w
+        pdf.ln(5)
+
+    pdf.set_text_color(*C_DARK)
+
+
 # ── PDF generation ────────────────────────────────────────────────────────────
 
 def generate_pdf(uows: list[dict], output_path: Path) -> Path:
@@ -841,6 +1013,7 @@ def generate_pdf(uows: list[dict], output_path: Path) -> Path:
                  new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="C")
     else:
         _render_index_page(pdf, uows)
+        _render_prescription_quality_page(pdf)
         for uow in uows:
             pdf.add_uow_card(uow)
 

--- a/tests/unit/test_orchestration/test_analytics.py
+++ b/tests/unit/test_orchestration/test_analytics.py
@@ -1,0 +1,355 @@
+"""
+Unit tests for src.orchestration.analytics.prescription_quality_summary().
+
+Tests use an in-memory SQLite DB initialised via the Registry class (same
+pattern as test_audit_queries.py). Steward log entries are injected as raw
+INSERT statements to avoid importing the full steward module.
+
+Coverage:
+- Empty DB (no UoWs): returns empty per_uow, correct data_gap note
+- UoWs present but no prescription events: data_gap note, zero counts
+- Single UoW with llm+fallback mix: correct per-uow and aggregate counts
+- pct_llm / pct_fallback calculation
+- avg_cycles_to_done across done UoWs (non-done UoWs excluded)
+- Missing/corrupted JSON lines in steward_log: gracefully skipped
+- Non-existent DB path: returns data_gap note, no exception
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.orchestration.registry import Registry
+from src.orchestration.analytics import prescription_quality_summary
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+def _init_db(tmp_path: Path) -> Path:
+    """Create a fresh registry DB via Registry (applies schema)."""
+    db_path = tmp_path / "registry.db"
+    Registry(db_path)
+    return db_path
+
+
+def _insert_uow(
+    db_path: Path,
+    *,
+    uow_id: str,
+    summary: str = "test uow",
+    status: str = "pending",
+    steward_cycles: int = 0,
+    steward_log: str | None = None,
+) -> None:
+    """Insert a minimal UoW row for testing."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+            (id, source, status, summary, created_at, updated_at,
+             steward_cycles, steward_log, success_criteria)
+        VALUES (?, ?, ?, ?, '2026-01-01T00:00:00', '2026-01-01T00:00:00',
+                ?, ?, '')
+        """,
+        (uow_id, "github:issue/1", status, summary, steward_cycles, steward_log),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_log(*events: dict) -> str:
+    """Build a newline-delimited JSON steward_log string."""
+    return "\n".join(json.dumps(e) for e in events)
+
+
+def _prescription_event(path: str, cycles: int = 0, reentry: bool = False) -> dict:
+    return {
+        "event": "reentry_prescription" if reentry else "prescription",
+        "steward_cycles": cycles,
+        "prescription_path": path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: missing / empty DB
+# ---------------------------------------------------------------------------
+
+class TestMissingDB:
+    def test_nonexistent_path_returns_data_gap(self, tmp_path):
+        result = prescription_quality_summary(
+            registry_path=tmp_path / "does_not_exist.db"
+        )
+        assert result["per_uow"] == []
+        assert result["data_gap"] is not None
+        assert "not found" in result["data_gap"].lower()
+
+    def test_nonexistent_path_aggregate_zeros(self, tmp_path):
+        result = prescription_quality_summary(
+            registry_path=tmp_path / "does_not_exist.db"
+        )
+        agg = result["aggregate"]
+        assert agg["total_uows"] == 0
+        assert agg["total_prescriptions"] == 0
+        assert agg["pct_llm"] is None
+        assert agg["avg_cycles_to_done"] is None
+
+
+class TestEmptyRegistry:
+    def test_empty_db_has_no_per_uow(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        result = prescription_quality_summary(registry_path=db_path)
+        assert result["per_uow"] == []
+
+    def test_empty_db_data_gap_mentions_no_uows(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        result = prescription_quality_summary(registry_path=db_path)
+        assert result["data_gap"] is not None
+        assert "no uow" in result["data_gap"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: UoWs present but no prescription events
+# ---------------------------------------------------------------------------
+
+class TestNoPrescritionEvents:
+    def test_uows_without_prescription_events_data_gap(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        _insert_uow(db_path, uow_id="uow-1", steward_log=None)
+        _insert_uow(db_path, uow_id="uow-2", steward_log="")
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        assert result["aggregate"]["total_uows"] == 2
+        assert result["aggregate"]["uows_with_data"] == 0
+        assert result["aggregate"]["total_prescriptions"] == 0
+        assert result["data_gap"] is not None
+
+    def test_uow_with_non_prescription_events_excluded(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(
+            {"event": "diagnosis", "steward_cycles": 0},
+            {"event": "steward_closure", "steward_cycles": 1},
+        )
+        _insert_uow(db_path, uow_id="uow-1", steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        assert result["per_uow"][0]["prescription_paths"] == []
+        assert result["aggregate"]["total_prescriptions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: single UoW with prescription data
+# ---------------------------------------------------------------------------
+
+class TestSingleUoW:
+    def test_llm_only_counts(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(
+            _prescription_event("llm", cycles=0),
+            _prescription_event("llm", cycles=1, reentry=True),
+        )
+        _insert_uow(db_path, uow_id="uow-1", steward_cycles=2, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        rec = result["per_uow"][0]
+        assert rec["llm_count"] == 2
+        assert rec["fallback_count"] == 0
+        assert rec["prescription_paths"] == ["llm", "llm"]
+
+    def test_fallback_only_counts(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(_prescription_event("fallback", cycles=0))
+        _insert_uow(db_path, uow_id="uow-1", steward_cycles=1, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        rec = result["per_uow"][0]
+        assert rec["llm_count"] == 0
+        assert rec["fallback_count"] == 1
+
+    def test_mixed_paths(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(
+            _prescription_event("llm", cycles=0),
+            _prescription_event("fallback", cycles=1, reentry=True),
+            _prescription_event("llm", cycles=2, reentry=True),
+        )
+        _insert_uow(db_path, uow_id="uow-1", steward_cycles=3, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        rec = result["per_uow"][0]
+        assert rec["prescription_paths"] == ["llm", "fallback", "llm"]
+        assert rec["llm_count"] == 2
+        assert rec["fallback_count"] == 1
+
+    def test_per_uow_fields_populated(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(_prescription_event("llm"))
+        _insert_uow(
+            db_path, uow_id="uow-abc", summary="My test uow",
+            status="done", steward_cycles=1, steward_log=log
+        )
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        rec = result["per_uow"][0]
+        assert rec["id"] == "uow-abc"
+        assert rec["summary"] == "My test uow"
+        assert rec["status"] == "done"
+        assert rec["steward_cycles"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: aggregate calculations
+# ---------------------------------------------------------------------------
+
+class TestAggregate:
+    def test_pct_llm_and_fallback(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        # 3 llm, 1 fallback → 75% / 25%
+        log = _make_log(
+            _prescription_event("llm"),
+            _prescription_event("llm", reentry=True),
+            _prescription_event("llm", reentry=True),
+            _prescription_event("fallback", reentry=True),
+        )
+        _insert_uow(db_path, uow_id="uow-1", steward_cycles=4, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        agg = result["aggregate"]
+        assert agg["total_prescriptions"] == 4
+        assert agg["llm_prescriptions"] == 3
+        assert agg["fallback_prescriptions"] == 1
+        assert agg["pct_llm"] == 75.0
+        assert agg["pct_fallback"] == 25.0
+
+    def test_avg_cycles_to_done_excludes_non_done(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(_prescription_event("llm"))
+        _insert_uow(db_path, uow_id="uow-done", status="done",
+                    steward_cycles=3, steward_log=log)
+        _insert_uow(db_path, uow_id="uow-active", status="active",
+                    steward_cycles=10, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        # Only the done UoW's cycles count
+        assert result["aggregate"]["avg_cycles_to_done"] == 3.0
+
+    def test_avg_cycles_to_done_none_when_no_done_uows(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(_prescription_event("llm"))
+        _insert_uow(db_path, uow_id="uow-1", status="active",
+                    steward_cycles=5, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        assert result["aggregate"]["avg_cycles_to_done"] is None
+
+    def test_multiple_done_uows_average(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(_prescription_event("llm"))
+        _insert_uow(db_path, uow_id="uow-1", status="done",
+                    steward_cycles=2, steward_log=log)
+        _insert_uow(db_path, uow_id="uow-2", status="done",
+                    steward_cycles=4, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        assert result["aggregate"]["avg_cycles_to_done"] == 3.0
+
+    def test_uows_with_data_count(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log_with = _make_log(_prescription_event("llm"))
+        _insert_uow(db_path, uow_id="uow-1", steward_log=log_with)
+        _insert_uow(db_path, uow_id="uow-2", steward_log=None)  # no data
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        assert result["aggregate"]["total_uows"] == 2
+        assert result["aggregate"]["uows_with_data"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: malformed steward_log
+# ---------------------------------------------------------------------------
+
+class TestMalformedLog:
+    def test_invalid_json_lines_skipped(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        # Mix valid and invalid lines
+        log = (
+            '{"event": "prescription", "prescription_path": "llm"}\n'
+            'this is not json\n'
+            '{"event": "prescription", "prescription_path": "fallback"}\n'
+            '{broken\n'
+        )
+        _insert_uow(db_path, uow_id="uow-1", steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        rec = result["per_uow"][0]
+        # Only the two valid lines with known prescription_path values
+        assert rec["prescription_paths"] == ["llm", "fallback"]
+
+    def test_missing_prescription_path_key_skipped(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(
+            {"event": "prescription"},             # no prescription_path key
+            {"event": "prescription", "prescription_path": "llm"},
+            {"event": "prescription", "prescription_path": "unknown_value"},  # invalid value
+        )
+        _insert_uow(db_path, uow_id="uow-1", steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        # Only the one valid "llm" entry
+        assert result["per_uow"][0]["prescription_paths"] == ["llm"]
+
+    def test_empty_log_string_produces_empty_paths(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        _insert_uow(db_path, uow_id="uow-1", steward_log="   \n  \n  ")
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        assert result["per_uow"][0]["prescription_paths"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: data_gap note logic
+# ---------------------------------------------------------------------------
+
+class TestDataGapNote:
+    def test_no_data_gap_when_sufficient_data(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(
+            _prescription_event("llm"),
+            _prescription_event("fallback", reentry=True),
+            _prescription_event("llm", reentry=True),
+        )
+        _insert_uow(db_path, uow_id="uow-1", steward_cycles=3, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        assert result["data_gap"] is None
+
+    def test_data_gap_when_only_one_prescription(self, tmp_path):
+        db_path = _init_db(tmp_path)
+        log = _make_log(_prescription_event("llm"))
+        _insert_uow(db_path, uow_id="uow-1", steward_cycles=1, steward_log=log)
+
+        result = prescription_quality_summary(registry_path=db_path)
+
+        # Only 1 prescription — below the sparse threshold of 3
+        assert result["data_gap"] is not None
+        assert "1 prescription" in result["data_gap"]


### PR DESCRIPTION
## What problem does this solve

The WOS Steward now uses LLM-class prescriptions (PR #406) and the feedback loop (PR #408) injects prior prescription context. But there was no way to answer: which UoWs needed many cycles before completing? How often does the LLM path succeed vs fall back to the deterministic template? This PR closes that visibility gap.

## What changed

**New: `src/orchestration/analytics.py`**

A single public function `prescription_quality_summary(registry_path?)` that:
- Opens the registry DB read-only
- Queries all UoW rows for `steward_log`, `status`, `steward_cycles`
- Parses each newline-delimited `steward_log` to extract `prescription_path` ("llm" or "fallback") from prescription events
- Returns a dict with per-UoW breakdown and cross-UoW aggregate metrics: `pct_llm`, `pct_fallback`, `avg_cycles_to_done`, `total_prescriptions`
- Surfaces a `data_gap` note (not an error) when the DB is missing or prescription data is sparse

The function is composed entirely from pure helper functions (`_connect_ro`, `_fetch_uow_rows`, `_parse_prescription_paths`, `_build_per_uow_record`, `_compute_aggregate`, `_data_gap_note`). No writes, no side effects.

**Modified: `src/wos_report.py`**

Added `_render_prescription_quality_page()` which renders a new page in the WOS PDF report:
- Aggregate metrics section (LLM/fallback counts and percentages, avg cycles to done)
- Per-UoW breakdown table for UoWs with at least one prescription event
- Data gap note when data is sparse, rendered as a non-fatal advisory

The page is inserted between the index page and the per-UoW cards. If `prescription_quality_summary()` raises unexpectedly, the exception is caught and surfaced as a data_gap note so it never breaks the overall report.

**New: `tests/unit/test_orchestration/test_analytics.py`**

20 unit tests covering: missing DB, empty registry, UoWs with no prescription events, llm-only / fallback-only / mixed paths, aggregate pct_llm calculation, avg_cycles_to_done (done-only, multiple UoWs), malformed/invalid JSON lines in steward_log, and data_gap note logic.

## Functional patterns used

Pure function composition throughout analytics.py: each concern is an isolated function with a clear input/output contract. `prescription_quality_summary` is a composition of those functions with all side effects (DB connection, read) isolated at the boundary.

## Areas to review

- `_parse_prescription_paths`: the filter for `event in ("prescription", "reentry_prescription")` -- confirm this matches the steward_log events written by steward.py (line 1505/1511).
- The `data_gap` threshold of 3 prescriptions is arbitrary -- easy to tune if it produces false negatives.
- `_render_prescription_quality_page` catches all exceptions from `prescription_quality_summary` to protect the PDF render -- analytics errors are silent in the PDF. Acceptable for a first pass.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_analytics.py -v` -- 20 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/ -v` -- 348 passed, 0 failed (no regressions)
- [x] `uv run python -m py_compile src/orchestration/analytics.py src/wos_report.py` -- syntax clean
- [ ] Live PDF render -- skipped: requires production DB and fpdf2 in the live env. No behavior change to existing PDF sections.

Closes #413