### PR TITLE
feat(wos): replace BOOTUP_CANDIDATE_GATE with runtime execution flag

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1662,9 +1662,29 @@ Status: `proposed → pending`"
   Reply with the returned string. No confirmation prompt needed — the command is
   intentional and the effect is visible on the next steward-heartbeat cycle (~3 min).
 
+- `/wos start` (or "wos start") — Enable WOS execution by setting `execution_enabled: true`
+  in `~/lobster-workspace/data/wos-config.json`. executor-heartbeat will begin dispatching
+  ready-for-executor UoWs on its next cycle (~90 seconds).
+  Handle directly (no subagent — fast config write). Call:
+  ```python
+  from src.orchestration.dispatcher_handlers import handle_wos_start
+  reply = handle_wos_start()
+  ```
+  Reply with the returned string.
+
+- `/wos stop` (or "wos stop") — Disable WOS execution by setting `execution_enabled: false`
+  in `~/lobster-workspace/data/wos-config.json`. executor-heartbeat will skip dispatch on
+  its next cycle. UoWs already active continue running; TTL recovery handles stalls.
+  Handle directly (no subagent — fast config write). Call:
+  ```python
+  from src.orchestration.dispatcher_handlers import handle_wos_stop
+  reply = handle_wos_stop()
+  ```
+  Reply with the returned string.
+
 **Note:** Decide actions (Retry / Close on stuck UoWs) are handled via inline button callbacks — see "Handling WOS Surface Messages" section above.
 
-`/wos status`, `/wos unblock`, and `/confirm` are handled directly in the dispatcher (no subagent — fast CLI calls).
+`/wos status`, `/wos unblock`, `/wos start`, `/wos stop`, and `/confirm` are handled directly in the dispatcher (no subagent — fast CLI calls).
 `/wos pdf` requires a subagent — dispatch it and reply "Generating WOS PDF..." immediately.
 
 

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -231,6 +231,10 @@ def main() -> int:
     from src.orchestration.steward import is_bootup_candidate_gate_active
     log.info("BOOTUP_CANDIDATE_GATE = %s", is_bootup_candidate_gate_active())
 
+    from src.orchestration.dispatcher_handlers import is_execution_enabled
+    execution_enabled = is_execution_enabled()
+    log.info("WOS execution_enabled = %s", execution_enabled)
+
     from src.orchestration.registry import Registry
 
     db_path = _default_db_path()
@@ -240,9 +244,17 @@ def main() -> int:
 
     registry = Registry(db_path)
 
-    # Phase 1: TTL recovery — must run before dispatch so the Steward can
-    # re-diagnose stalled UoWs on its next pass.
+    # Phase 1: TTL recovery — always runs regardless of execution_enabled so
+    # that stalled active UoWs are recovered even when dispatch is paused.
     run_ttl_recovery(registry, dry_run=dry_run)
+
+    if not execution_enabled:
+        log.info(
+            "Executor heartbeat: execution disabled (wos-config.json execution_enabled=false) "
+            "— skipping dispatch. Use 'wos start' to enable."
+        )
+        log.info("Executor heartbeat complete")
+        return 0
 
     try:
         result = run_executor_cycle(registry, dry_run=dry_run)

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -9,6 +9,8 @@ The dispatcher calls these handlers when it recognizes:
   /approve <uow-id>        → handle_approve(uow_id, registry)
   /wos status [status]     → handle_wos_status(status, registry)
   /wos unblock             → handle_wos_unblock()
+  /wos start               → handle_wos_start()
+  /wos stop                → handle_wos_stop()
   decide retry <uow-id>    → handle_decide_retry(uow_id, registry)
   decide close <uow-id>    → handle_decide_close(uow_id, registry)
   type: "wos_execute"      → handle_wos_execute(uow_id, instructions, output_ref)
@@ -16,6 +18,7 @@ The dispatcher calls these handlers when it recognizes:
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -33,6 +36,49 @@ from .registry import ApproveConfirmed, ApproveExpired, ApproveNotFound, Approve
 _GATE_CLEARED_FLAG: Path = Path(
     os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
 ) / "data" / "wos-gate-cleared"
+
+
+# ---------------------------------------------------------------------------
+# WOS execution config — runtime start/stop for executor dispatch
+# ---------------------------------------------------------------------------
+
+_WOS_CONFIG_PATH: Path = Path(
+    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+) / "data" / "wos-config.json"
+
+_DEFAULT_WOS_CONFIG: dict = {"execution_enabled": False}
+
+
+def read_wos_config() -> dict:
+    """Read wos-config.json from disk and return its contents as a dict.
+
+    Returns _DEFAULT_WOS_CONFIG if the file does not exist or cannot be parsed.
+    Reads from disk on every call so that runtime changes take effect immediately
+    on the next executor-heartbeat cycle without requiring a restart.
+    """
+    try:
+        with _WOS_CONFIG_PATH.open() as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return dict(_DEFAULT_WOS_CONFIG)
+
+
+def is_execution_enabled() -> bool:
+    """Return True if WOS execution is enabled in wos-config.json.
+
+    Reads from disk on every call — cron processes get a fresh value on each
+    invocation. Default is False (safe) when the file is absent or unreadable.
+    """
+    return bool(read_wos_config().get("execution_enabled", False))
+
+
+def _write_wos_config(config: dict) -> None:
+    """Write config dict to wos-config.json atomically (write-then-rename)."""
+    _WOS_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _WOS_CONFIG_PATH.with_suffix(".json.tmp")
+    with tmp.open("w") as fh:
+        json.dump(config, fh)
+    tmp.rename(_WOS_CONFIG_PATH)
 
 
 def handle_approve(uow_id: str, *, registry: "Registry") -> str:
@@ -256,4 +302,73 @@ def handle_wos_unblock() -> str:
         "All 27 bootup-candidate UoWs (#271-#298) will be processed on the next "
         "steward-heartbeat cycle (within 3 minutes).\n"
         f"Flag: `{_GATE_CLEARED_FLAG}`"
+    )
+
+
+def handle_wos_start() -> str:
+    """
+    Handle /wos start (or "wos start").
+
+    Sets execution_enabled: true in wos-config.json so that executor-heartbeat
+    dispatches UoWs on its next cycle (within ~90 seconds).
+
+    Idempotent: calling /wos start when already started returns a notice.
+
+    Returns a human-readable Telegram message describing the outcome.
+    """
+    config = read_wos_config()
+    if config.get("execution_enabled"):
+        return (
+            "WOS execution is already enabled.\n"
+            "executor-heartbeat is dispatching UoWs normally."
+        )
+
+    try:
+        _write_wos_config({**config, "execution_enabled": True})
+    except OSError as exc:
+        return (
+            f"Failed to write wos-config.json: {exc}\n"
+            f"Path: `{_WOS_CONFIG_PATH}`"
+        )
+
+    return (
+        "WOS execution enabled.\n"
+        "executor-heartbeat will dispatch ready-for-executor UoWs on its next cycle "
+        "(within ~90 seconds).\n"
+        f"Config: `{_WOS_CONFIG_PATH}`"
+    )
+
+
+def handle_wos_stop() -> str:
+    """
+    Handle /wos stop (or "wos stop").
+
+    Sets execution_enabled: false in wos-config.json so that executor-heartbeat
+    skips dispatch on its next cycle. UoWs already active are not affected —
+    TTL recovery will handle any that stall.
+
+    Idempotent: calling /wos stop when already stopped returns a notice.
+
+    Returns a human-readable Telegram message describing the outcome.
+    """
+    config = read_wos_config()
+    if not config.get("execution_enabled"):
+        return (
+            "WOS execution is already disabled.\n"
+            "executor-heartbeat is skipping dispatch."
+        )
+
+    try:
+        _write_wos_config({**config, "execution_enabled": False})
+    except OSError as exc:
+        return (
+            f"Failed to write wos-config.json: {exc}\n"
+            f"Path: `{_WOS_CONFIG_PATH}`"
+        )
+
+    return (
+        "WOS execution disabled.\n"
+        "executor-heartbeat will skip dispatch on its next cycle (within ~90 seconds).\n"
+        "UoWs already active will continue running; TTL recovery handles any that stall.\n"
+        f"Config: `{_WOS_CONFIG_PATH}`"
     )


### PR DESCRIPTION
## Summary

The WOS executor previously had no runtime way to pause or resume dispatch — the `BOOTUP_CANDIDATE_GATE` constant was hardcoded and required manual file manipulation to change. This PR replaces it with a `wos-config.json` file that executor-heartbeat reads on every cycle, giving the dispatcher (and Dan) a clean `wos start` / `wos stop` interface.

## What changed

- **`dispatcher_handlers.py`**: Added `read_wos_config()`, `is_execution_enabled()`, `_write_wos_config()`, `handle_wos_start()`, and `handle_wos_stop()`. The config file is `~/lobster-workspace/data/wos-config.json`. Reads from disk on every call so cron processes always see the current state. Atomic writes (write-then-rename). Default is `false` (safe) when the file is absent.

- **`executor-heartbeat.py`**: Now reads `is_execution_enabled()` after startup. If disabled, TTL recovery still runs (stalled active UoWs are recovered) but dispatch is skipped with an info log. The `BOOTUP_CANDIDATE_GATE` log line is retained for observability.

- **`sys.dispatcher.bootup.md`**: Documents `wos start` and `wos stop` commands alongside the existing `wos unblock` pattern — same handling pattern (direct, no subagent, fast file write).

## What is out of scope

- `steward-heartbeat.py` and `steward.py` are untouched — the `BOOTUP_CANDIDATE_GATE` / `bootup-candidate` label filtering in the Steward is a separate concern from executor dispatch and is not changed here.
- `wos-config.json` is a runtime file, not committed to the repo. The initial state (`execution_enabled: false`) must be created on the live host. This is noted in "Before merge" below.

## State transitions

```
Before:
  executor-heartbeat → check BOOTUP_CANDIDATE_GATE (hardcoded) → dispatch or skip

After:
  executor-heartbeat → read wos-config.json → check execution_enabled → dispatch or skip
                                                        ^
  "wos start" → write execution_enabled: true  --------+
  "wos stop"  → write execution_enabled: false ---------+
```

The `BOOTUP_CANDIDATE_GATE` check remains in `steward-heartbeat.py` — only the executor dispatch path is gated by the new config.

## Functional patterns

Pure functions throughout: `read_wos_config()`, `is_execution_enabled()`, and the handlers are all side-effect-free except at their explicit write boundary (`_write_wos_config`). Handlers return strings; the dispatcher handles all MCP I/O. Immutable config update via dict spread (`{**config, "execution_enabled": True}`).

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/ -x -q` — 355 passed, 0 failed
- [x] Smoke test of `handle_wos_start`, `handle_wos_stop`, `is_execution_enabled` with a temp config file — all assertions passed

## Before merge

The live host needs `~/lobster-workspace/data/wos-config.json` created with `{"execution_enabled": false}`. This preserves the current blocked state after deploy. The config file is not in the repo — it must be created on the host as part of the upgrade. This can be done before or after merge.