### PR TITLE
fix(dispatch-job): auto-disable on missing task file; inbox dedup guard

### DIFF
--- a/scheduled-tasks/dispatch-job.sh
+++ b/scheduled-tasks/dispatch-job.sh
@@ -69,9 +69,50 @@ fi
 echo "[$START_ISO] Posting dispatch for job: $JOB_NAME" | tee "$LOG_FILE"
 
 # --- Check task file exists ---
+# If the task file is missing, self-heal by disabling the job rather than
+# looping on error every cron fire.
 if [ ! -f "$TASK_FILE" ]; then
-    echo "[$START_ISO] Error: Task file not found: $TASK_FILE" | tee -a "$LOG_FILE"
-    exit 1
+    echo "[$START_ISO] Task file not found: $TASK_FILE — disabling job '$JOB_NAME'" | tee -a "$LOG_FILE"
+    if [ -f "$JOBS_FILE" ]; then
+        JOBS_LOCK="${JOBS_FILE}.lock"
+        (
+            flock -x 9
+            if command -v jq &> /dev/null; then
+                TMP_FILE=$(mktemp)
+                jq --arg name "$JOB_NAME" \
+                   'if .jobs[$name] then .jobs[$name].enabled = false else . end' \
+                   "$JOBS_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$JOBS_FILE"
+            else
+                uv run - \
+                    "$JOBS_FILE" \
+                    "$JOB_NAME" \
+                    << 'PYEOF'
+import json, os, sys
+jobs_file = sys.argv[1]
+job_name  = sys.argv[2]
+with open(jobs_file) as f:
+    data = json.load(f)
+if job_name in data.get('jobs', {}):
+    data['jobs'][job_name]['enabled'] = False
+    tmp = jobs_file + '.tmp.' + str(os.getpid())
+    with open(tmp, 'w') as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, jobs_file)
+PYEOF
+            fi
+        ) 9>"$JOBS_LOCK" 2>/dev/null || true
+    fi
+    exit 0
+fi
+
+# --- Inbox dedup guard ---
+# If a pending dispatch for this job already exists in the inbox (e.g. a
+# previous run is still being processed), skip writing and exit cleanly.
+# This prevents inbox flooding when a subagent outruns its schedule interval.
+EXISTING=$(grep -rl "\"job_name\": \"${JOB_NAME}\"" "$INBOX_DIR" 2>/dev/null | head -1)
+if [ -n "$EXISTING" ]; then
+    echo "[$START_ISO] Pending dispatch already exists for '$JOB_NAME' ($EXISTING) — skipping" | tee -a "$LOG_FILE"
+    exit 0
 fi
 
 # --- Write scheduled_reminder to inbox ---


### PR DESCRIPTION
## What this fixes

Two independent failure modes in `dispatch-job.sh` where a misconfigured or stale scheduled job causes persistent, unrecoverable noise.

**Missing task file (Backport 1)**

Previously, if a job's `.md` file didn't exist, the script exited 1. Since cron doesn't remove a job that errors, it would fire again next interval and error again — forever. The fix: on a missing task file, write `enabled=false` back to `jobs.json` and exit 0. The schedule self-heals rather than looping. The job can be re-enabled manually once the task file is restored.

**Inbox dedup (Backport 2)**

If a subagent takes longer than its schedule interval to complete, the next cron fire would write a second dispatch message for the same job. Over time this floods the inbox with duplicates for the same job, causing the dispatcher to spawn redundant subagents. The fix: before writing a new dispatch message, grep the inbox directory for any existing file containing `"job_name": "<name>"`. If one exists, skip and exit 0.

## What is not changed

- Normal dispatch path (task file exists, no pending inbox message) is unchanged
- The enabled-check fast-path at the top is unchanged
- `last_run` update logic is unchanged
- No other files modified

## Functional patterns

Both guards are pure conditional branches with no side effects beyond their stated purpose (one writes a field to JSON, one reads the filesystem). The dedup check uses a direct `grep -rl` scan rather than parsing JSON, keeping it fast and dependency-free.

## Tests run

- [ ] No automated test suite for shell scripts in this repo — skipped
- [x] Manual inspection: both branches verified against the file before and after the edit

**Blocked items needing attention before merge:** none