### PR TITLE
docs: update wos-v2-design.md for Phase 2 completion; add WOS runtime control to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,16 @@ For changes that affect existing installs (new cron entries, new directories, co
 - `~/messages/audio/` - Voice message audio files
 - `~/messages/task-outputs/` - Outputs from scheduled jobs
 
+## WOS Runtime Execution Control
+
+WOS executor dispatch is gated by `~/lobster-workspace/data/wos-config.json`:
+
+- `execution_enabled: true` — executor-heartbeat dispatches UoWs normally
+- `execution_enabled: false` — executor-heartbeat skips dispatch (TTL recovery still runs)
+- File absent — treated as `false` (safe default)
+
+Toggle via dispatcher commands: `wos start` sets `execution_enabled: true`; `wos stop` sets it `false`. These are handled directly in the dispatcher (no subagent). See `src/orchestration/dispatcher_handlers.py` for implementation.
+
 ## Permissions
 
 This system runs with `--dangerously-skip-permissions`. All tool calls are pre-authorized. Execute tasks directly without asking for permission.

--- a/docs/wos-v2-design.md
+++ b/docs/wos-v2-design.md
@@ -78,13 +78,13 @@ Philosophy session
     -> seeds -> GitHub issues
                -> UoW Registrar   [Phase 1 — operational]
                  -> UoWRegistry   [Phase 1 — operational]
-                   -> Steward/Executor loop  [Phase 2 — not yet built]
+                   -> Steward/Executor loop  [Phase 2 — operational]
                      -> artifacts / done
 ```
 
 This pipeline applies beyond philosophy sessions: any source of seeds (Telegram observations, nightly health scans, direct requests) flows through the same funnel — GitHub issue as the universal entry point, UoW Registrar as the gate into the execution substrate.
 
-**Operational status note:** The Cultivator is not yet built. Until it is, philosophy session outputs (bootup candidates, seeds) reach GitHub via manual filing — the Cultivator stage is bypassed entirely. The pipeline diagram above is the design target; the `ASPIRATIONAL` label marks stages that are not yet operational. Do not read the diagram as a description of current system behavior.
+**Operational status note:** The Cultivator is not yet built. Until it is, philosophy session outputs (bootup candidates, seeds) reach GitHub via manual filing — the Cultivator stage is bypassed entirely. The Steward/Executor loop (Phase 2) is operational as of 2026-03-31. The pipeline diagram above reflects current system behavior at Phase 2; the `ASPIRATIONAL` label marks stages that remain unbuilt.
 
 ---
 
@@ -467,22 +467,18 @@ Steward cycle 2:
 
 **Phase 1 to Phase 2 transition:** Both pre-Phase-2 blocking gates are now resolved (2026-03-30). (1) Workflow artifact format — Option C: structured envelope + instructions field. (2) Trigger evaluation mode — polling via `evaluate_condition(uow)`. See Resolved Decisions for full rationale. Steward MVP build can begin.
 
-### Phase 2: Steward + Executor [next]
+### Phase 2: Steward + Executor [complete]
 
-**Pre-Phase-2 gates: CLEARED as of 2026-03-30.** Both blocking gates are resolved:
-1. Workflow artifact format — Option C: structured envelope + instructions field. See Resolved Decisions.
-2. Trigger evaluation mode — polling via `evaluate_condition(uow)`. See Resolved Decisions.
+**Phase 2 completion status: COMPLETE as of 2026-03-31.** All seven PRs merged (see #301 umbrella):
+- PR0 (#309): schema migration — Phase 2 fields + `executor_uow_view` — MERGED
+- PR1 (#302): WorkflowArtifact struct (`src/orchestration/workflow_artifact.py`) — MERGED
+- PR2 (#303): Steward heartbeat script (`scheduled-tasks/steward-heartbeat.py`) — MERGED
+- PR3 (#304): `evaluate_condition(uow)` callable + Registrar sweep wiring — MERGED
+- PR4 (#305): Executor MVP — 6-step atomic claim, LLM dispatch, `output_ref`, return to Steward — MERGED
+- PR5 (#306): Observation Loop — stall detection for `active` UoWs within steward heartbeat — MERGED
+- PR6 (#307): Startup sweep (crash recovery) — classify orphaned `active` and `ready-for-executor` UoWs — MERGED
 
-**Phase 2 build can begin.**
-
-**What to build:** Seven PRs in sequence (see #301 umbrella):
-- PR0 (#309): schema migration — add all Phase 2 fields (`workflow_artifact`, `prescribed_skills`, `steward_cycles`, `timeout_at`, `estimated_runtime`, `steward_agenda`, `steward_log`) + `executor_uow_view`
-- PR1 (#302): WorkflowArtifact struct (`src/orchestration/workflow_artifact.py`) with `to_json()` / `from_json()`
-- PR2 (#303): Steward heartbeat script (`scheduled-tasks/steward-heartbeat.py`) — diagnose/prescribe/re-entry loop
-- PR3 (#304): `evaluate_condition(uow)` callable + Registrar sweep wiring (`pending → ready-for-steward`)
-- PR4 (#305): Executor MVP — 6-step atomic claim, execute via LLM dispatch, write `output_ref`, return to Steward
-- PR5 (#306): Observation Loop — stall detection for `active` UoWs within steward heartbeat
-- PR6 (#307): Startup sweep (crash recovery) — classify orphaned `active` and `ready-for-executor` UoWs
+**Runtime execution control (PR #428):** Executor dispatch is gated by `~/lobster-workspace/data/wos-config.json` (`execution_enabled: true/false`). Enabled via `wos start` / `wos stop` dispatcher commands. Default is `false` (safe) when the file is absent. This replaced the prior `BOOTUP_CANDIDATE_GATE` hardcoded constant for executor dispatch. Note: `BOOTUP_CANDIDATE_GATE` (bootup-candidate label filtering) remains active in the Steward and is a separate concern from executor dispatch.
 
 **Note on Routing Classifier, Hook System, and Cultivator:** These are NOT Phase 2 deliverables. The Routing Classifier and Conditional Hook System are defined in issue #168 and are Phase 3 scope. The `route_reason` field exists in the schema and the Steward writes it as free text in Phase 2; the Routing Classifier that parses and assigns postures systematically is Phase 3. The Cultivator (philosophy pipeline classification agent) is aspirational and not in any current phase scope.
 


### PR DESCRIPTION
## Summary

Two structural doc fixes now that the full WOS sprint (Tiers 0–7) is complete:

- **wos-v2-design.md** still described Phase 2 (Steward/Executor) as \"not yet built\" and \"[next]\". Updated to reflect operational reality: pipeline diagram, operational status note, and Phase 2 section header all corrected. Added a note on PR #428's `wos-config.json` runtime execution gate, which replaced the hardcoded `BOOTUP_CANDIDATE_GATE` for executor dispatch.

- **CLAUDE.md** had no entry for `wos-config.json`, `execution_enabled`, or the `wos start` / `wos stop` commands. Added a concise "WOS Runtime Execution Control" section.

## What changed

**wos-v2-design.md**
- Pipeline diagram: `[Phase 2 — not yet built]` → `[Phase 2 — operational]`
- Operational status note: Steward/Executor is live; note updated accordingly
- Phase 2 section: `[next]` → `[complete]`; \"What to build\" list replaced with MERGED status for each of the seven PRs (#309–#307)
- New paragraph documenting PR #428 runtime execution control: `wos-config.json`, `execution_enabled` flag, `wos start`/`wos stop` commands, and the distinction from `BOOTUP_CANDIDATE_GATE` (which remains active in the Steward for bootup-candidate label filtering — a separate concern)

**CLAUDE.md**
- New section "WOS Runtime Execution Control" covering: config file path, `execution_enabled` semantics, safe default (absent = false), and dispatcher commands

## What is out of scope

- No changes to `BOOTUP_CANDIDATE_GATE` usage in `steward.py`, `startup-sweep.py`, or tests — that filtering path is unchanged and intentionally separate from executor dispatch
- No changes to source code

## Tests run

- [x] `git diff --stat` — 2 files, 22 insertions, 16 deletions; content verified by reading both files after edit
- [ ] Full test suite — not run; changes are documentation-only with no code modifications