### PR TITLE
docs: add wos-constitution.md — founding metaphor and system soul

### DIFF
--- a/docs/wos-constitution.md
+++ b/docs/wos-constitution.md
@@ -67,3 +67,10 @@ Neither register colonizes the other. A design document that says "the Cultivato
 ---
 
 The names are the constitution. When in doubt, ask what the name demands.
+
+---
+
+## See Also
+
+- [wos-v2-design.md](wos-v2-design.md) — the full WOS v2 specification: actors, lifecycle, vocabulary, and open decisions
+- [wos-golden-pattern.md](wos-golden-pattern.md) — canonical Python patterns for WOS implementation code

--- a/docs/wos-golden-pattern.md
+++ b/docs/wos-golden-pattern.md
@@ -2,6 +2,8 @@
 
 Reference sketch for new WOS implementation code. When in doubt about how to model a piece of the Work Orchestration System in Python, this document is the baseline.
 
+**Related docs:** [wos-constitution.md](wos-constitution.md) — the founding metaphor and naming constraints that govern all WOS design decisions | [wos-v2-design.md](wos-v2-design.md) — the full WOS v2 specification
+
 ---
 
 ## The Pattern

--- a/docs/wos-v2-design.md
+++ b/docs/wos-v2-design.md
@@ -12,6 +12,8 @@ The v2 model replaces the Phase 1 dispatcher-centric model with a two-actor **St
 
 **Already-embodied pattern:** Lobster's existing dispatcher/subagent architecture IS the Steward/Executor pattern operating informally. The dispatcher already acts as a Steward — it receives a message (a unit of work), diagnoses what kind of work it is, prescribes the appropriate subagent task, dispatches it, and evaluates the result. Background subagents are already Executors — they receive a structured task prompt (the WorkflowArtifact equivalent), execute it, and return results. WOS Phase 2 formalizes this into a tracked, auditable, crash-safe pipeline. The concepts are not new to Lobster; the infrastructure to make them durable and inspectable is what Phase 2 adds.
 
+**Related docs:** [wos-constitution.md](wos-constitution.md) — the founding metaphor and naming constraints that govern WOS design decisions | [wos-golden-pattern.md](wos-golden-pattern.md) — canonical Python patterns for WOS implementation code
+
 ---
 
 ## Vocabulary & Primitives


### PR DESCRIPTION
## Summary

- Adds `docs/wos-constitution.md`, a new document capturing the philosophical and design foundation of the Work Orchestration System
- Sits alongside `wos-v2-design.md` (spec) and `wos-metaphors-and-naming.md` (naming framework) as the constitutional layer — what the system wants to be, not just what it does
- Covers: the biological metaphor as binding design constraint, the pre-metabolic system state, the patient/systematic tension as a feature not a flaw, the pearl bypass gap, and the dual-register principle
- Closes with the keeper-of-names principle: "When in doubt, ask what the name demands"

## Test plan

- [ ] Read the document and verify it coheres with `wos-metaphors-and-naming.md` and `wos-v2-design.md`
- [ ] Confirm no code changes are included
- [ ] Confirm the document is ~400-600 words and prose (not a bullet dump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)