### PR TITLE
feat: IssueSource Protocol — foundation for GardenCaretaker (PR 1/5)

### DIFF
--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -1,2 +1,14 @@
 # Work Orchestration System
 # Registry, CLI, and dispatcher handler integration
+
+from .issue_source import IssueSnapshot, IssueSource, SourceRef, source_ref_from_str, source_ref_to_str
+from .github_issue_source import GitHubIssueSource
+
+__all__ = [
+    "IssueSnapshot",
+    "IssueSource",
+    "SourceRef",
+    "source_ref_from_str",
+    "source_ref_to_str",
+    "GitHubIssueSource",
+]

--- a/src/orchestration/github_issue_source.py
+++ b/src/orchestration/github_issue_source.py
@@ -1,0 +1,94 @@
+"""Concrete IssueSource implementation for GitHub repos via gh CLI.
+
+This is the only module in the codebase that may call subprocess to invoke gh.
+GardenCaretaker receives GitHubIssueSource instances at construction time and
+never calls gh directly.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Iterator
+
+from .issue_source import IssueSnapshot, SourceRef, source_ref_from_str, source_ref_to_str
+
+
+class GitHubIssueSource:
+    """IssueSource for a single GitHub repo.
+
+    Wraps all gh CLI calls and JSON parsing. Satisfies IssueSource (structural
+    subtyping — no explicit base class needed).
+    """
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo          # e.g. "dcetlin/Lobster"
+        self.substrate = "github"
+
+    def scan(self) -> Iterator[IssueSnapshot]:
+        """Yield all open issues via gh CLI.
+
+        Uses --limit 200 as a practical upper bound; increase if repos grow
+        beyond that. Yields IssueSnapshot value objects — no gh types escape
+        this module.
+        """
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", self.repo,
+                "--state", "open",
+                "--json", "number,title,state,labels,body,createdAt,updatedAt,url",
+                "--limit", "200",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        issues = json.loads(result.stdout)
+        for issue in issues:
+            yield self._to_snapshot(issue)
+
+    def get_issue(self, source_ref: str) -> IssueSnapshot | None:
+        """Fetch a single issue by source_ref.
+
+        Returns None if the issue is not found (deleted, transferred, or the
+        issue number does not exist in this repo). CalledProcessError from gh
+        (non-zero exit) is mapped to None — it is not re-raised.
+        """
+        ref = source_ref_from_str(source_ref)
+        try:
+            result = subprocess.run(
+                [
+                    "gh", "issue", "view", ref.entity_id,
+                    "--repo", self.repo,
+                    "--json", "number,title,state,labels,body,createdAt,updatedAt,url",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            issue = json.loads(result.stdout)
+            return self._to_snapshot(issue)
+        except subprocess.CalledProcessError:
+            return None  # issue not found / deleted / transferred
+
+    def _to_snapshot(self, issue: dict) -> IssueSnapshot:
+        """Map a gh JSON issue dict to an IssueSnapshot value object.
+
+        This is a pure function — its only input is the dict and self.substrate.
+        All gh field names are confined to this method.
+        """
+        ref = SourceRef(
+            substrate=self.substrate,
+            entity_type="issue",
+            entity_id=str(issue["number"]),
+        )
+        return IssueSnapshot(
+            source_ref=source_ref_to_str(ref),
+            title=issue["title"],
+            state=issue["state"].lower(),
+            labels=tuple(lbl["name"] for lbl in issue.get("labels", [])),
+            body=issue.get("body") or "",
+            created_at=issue["createdAt"],
+            updated_at=issue["updatedAt"],
+            url=issue["url"],
+        )

--- a/src/orchestration/issue_source.py
+++ b/src/orchestration/issue_source.py
@@ -1,0 +1,83 @@
+"""IssueSource Protocol — substrate-agnostic abstraction for issue tracking sources.
+
+Defines the normalized value objects and Protocol that isolate all source-system
+knowledge from GardenCaretaker. Any class implementing scan() and get_issue()
+satisfies the Protocol (structural subtyping — no base class required).
+"""
+from __future__ import annotations
+
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import Iterator, Protocol
+
+
+@dataclass(frozen=True)
+class IssueSnapshot:
+    """Value object — a point-in-time view of an issue from any source.
+
+    Carries no GitHub-specific fields. The source_ref string encodes substrate
+    identity (e.g. "github:issue/42") without leaking substrate knowledge into
+    GardenCaretaker.
+    """
+
+    source_ref: str           # canonical string: "github:issue/42"
+    title: str
+    state: str                # "open" | "closed" | "deleted"
+    labels: tuple[str, ...]
+    body: str
+    created_at: str           # ISO 8601
+    updated_at: str           # ISO 8601
+    url: str
+
+
+SourceRef = namedtuple("SourceRef", ["substrate", "entity_type", "entity_id"])
+"""Structured representation of a source identifier.
+
+Example:
+    SourceRef(substrate='github', entity_type='issue', entity_id='42')
+"""
+
+
+def source_ref_to_str(ref: SourceRef) -> str:
+    """Serialize a SourceRef to its canonical string form.
+
+    Example:
+        source_ref_to_str(SourceRef('github', 'issue', '42')) == 'github:issue/42'
+    """
+    return f"{ref.substrate}:{ref.entity_type}/{ref.entity_id}"
+
+
+def source_ref_from_str(s: str) -> SourceRef:
+    """Parse a canonical source_ref string into a SourceRef namedtuple.
+
+    Example:
+        source_ref_from_str('github:issue/42')
+        # → SourceRef(substrate='github', entity_type='issue', entity_id='42')
+
+    Raises:
+        ValueError: if the string does not conform to '<substrate>:<type>/<id>'
+    """
+    substrate, rest = s.split(":", 1)
+    entity_type, entity_id = rest.split("/", 1)
+    return SourceRef(substrate=substrate, entity_type=entity_type, entity_id=entity_id)
+
+
+class IssueSource(Protocol):
+    """Structural subtyping — any class implementing scan() and get_issue() qualifies.
+
+    GardenCaretaker depends only on this Protocol. Concrete implementations
+    (GitHubIssueSource, or any future in-memory stub) are injected at construction
+    time and never imported by the caretaker directly.
+    """
+
+    def scan(self) -> Iterator[IssueSnapshot]:
+        """Yield all currently open issues from this source."""
+        ...
+
+    def get_issue(self, source_ref: str) -> IssueSnapshot | None:
+        """Fetch a single issue by source_ref.
+
+        Returns None if the issue is not found (deleted, transferred, or the
+        source_ref does not exist in this source). Never raises for missing issues.
+        """
+        ...

--- a/tests/unit/test_orchestration/test_issue_source.py
+++ b/tests/unit/test_orchestration/test_issue_source.py
@@ -1,0 +1,279 @@
+"""Unit tests for IssueSource Protocol, IssueSnapshot, SourceRef, and GitHubIssueSource.
+
+All tests are pure — no subprocess calls, no network access. GitHubIssueSource
+is tested by exercising _to_snapshot() directly with fixture dicts, keeping the
+tests fast and substrate-independent.
+"""
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.orchestration.github_issue_source import GitHubIssueSource
+from src.orchestration.issue_source import (
+    IssueSnapshot,
+    SourceRef,
+    source_ref_from_str,
+    source_ref_to_str,
+)
+
+
+# ---------------------------------------------------------------------------
+# SourceRef round-trip
+# ---------------------------------------------------------------------------
+
+class TestSourceRefRoundTrip:
+    def test_to_str_then_from_str_round_trips(self):
+        ref = SourceRef(substrate="github", entity_type="issue", entity_id="42")
+        assert source_ref_from_str(source_ref_to_str(ref)) == ref
+
+    def test_to_str_produces_canonical_format(self):
+        ref = SourceRef(substrate="github", entity_type="issue", entity_id="42")
+        assert source_ref_to_str(ref) == "github:issue/42"
+
+    def test_from_str_parses_canonical_format(self):
+        ref = source_ref_from_str("github:issue/42")
+        assert ref == SourceRef(substrate="github", entity_type="issue", entity_id="42")
+
+    def test_from_str_preserves_substrate(self):
+        ref = source_ref_from_str("github:issue/42")
+        assert ref.substrate == "github"
+
+    def test_from_str_preserves_entity_type(self):
+        ref = source_ref_from_str("github:issue/42")
+        assert ref.entity_type == "issue"
+
+    def test_from_str_preserves_entity_id(self):
+        ref = source_ref_from_str("github:issue/42")
+        assert ref.entity_id == "42"
+
+    def test_large_issue_number_round_trips(self):
+        ref = SourceRef(substrate="github", entity_type="issue", entity_id="9999")
+        assert source_ref_from_str(source_ref_to_str(ref)) == ref
+
+    def test_entity_id_with_path_separator_preserved(self):
+        """entity_id containing '/' should not be split further."""
+        ref = source_ref_from_str("github:pr/10/comments")
+        assert ref.entity_id == "10/comments"
+
+
+# ---------------------------------------------------------------------------
+# IssueSnapshot immutability
+# ---------------------------------------------------------------------------
+
+class TestIssueSnapshotImmutability:
+    def _make_snapshot(self, **overrides) -> IssueSnapshot:
+        defaults = dict(
+            source_ref="github:issue/1",
+            title="Test issue",
+            state="open",
+            labels=("bug",),
+            body="body text",
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-02T00:00:00Z",
+            url="https://github.com/owner/repo/issues/1",
+        )
+        defaults.update(overrides)
+        return IssueSnapshot(**defaults)
+
+    def test_snapshot_is_frozen(self):
+        snapshot = self._make_snapshot()
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            snapshot.title = "modified"  # type: ignore[misc]
+
+    def test_snapshot_state_is_not_mutable(self):
+        snapshot = self._make_snapshot()
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            snapshot.state = "closed"  # type: ignore[misc]
+
+    def test_labels_is_tuple(self):
+        snapshot = self._make_snapshot(labels=("bug", "enhancement"))
+        assert isinstance(snapshot.labels, tuple)
+
+    def test_two_equal_snapshots_are_equal(self):
+        a = self._make_snapshot()
+        b = self._make_snapshot()
+        assert a == b
+
+    def test_snapshot_with_different_title_not_equal(self):
+        a = self._make_snapshot(title="A")
+        b = self._make_snapshot(title="B")
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# GitHubIssueSource._to_snapshot — fixture-driven, no subprocess
+# ---------------------------------------------------------------------------
+
+GH_ISSUE_FIXTURE = {
+    "number": 42,
+    "title": "Fix the thing",
+    "state": "OPEN",
+    "labels": [{"name": "bug"}, {"name": "good first issue"}],
+    "body": "Here is the body.",
+    "createdAt": "2026-03-01T10:00:00Z",
+    "updatedAt": "2026-03-15T12:30:00Z",
+    "url": "https://github.com/dcetlin/Lobster/issues/42",
+}
+
+
+class TestGitHubIssueSourceToSnapshot:
+    def setup_method(self):
+        self.source = GitHubIssueSource(repo="dcetlin/Lobster")
+
+    def test_source_ref_is_canonical_string(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.source_ref == "github:issue/42"
+
+    def test_title_mapped_correctly(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.title == "Fix the thing"
+
+    def test_state_is_lowercased(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.state == "open"
+
+    def test_labels_extracted_from_name_field(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.labels == ("bug", "good first issue")
+
+    def test_body_preserved(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.body == "Here is the body."
+
+    def test_created_at_preserved(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.created_at == "2026-03-01T10:00:00Z"
+
+    def test_updated_at_preserved(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.updated_at == "2026-03-15T12:30:00Z"
+
+    def test_url_preserved(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert snap.url == "https://github.com/dcetlin/Lobster/issues/42"
+
+    def test_none_body_coerced_to_empty_string(self):
+        fixture = dict(GH_ISSUE_FIXTURE, body=None)
+        snap = self.source._to_snapshot(fixture)
+        assert snap.body == ""
+
+    def test_missing_labels_defaults_to_empty_tuple(self):
+        fixture = {k: v for k, v in GH_ISSUE_FIXTURE.items() if k != "labels"}
+        snap = self.source._to_snapshot(fixture)
+        assert snap.labels == ()
+
+    def test_returns_issue_snapshot_type(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        assert isinstance(snap, IssueSnapshot)
+
+    def test_result_is_immutable(self):
+        snap = self.source._to_snapshot(GH_ISSUE_FIXTURE)
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            snap.title = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# GitHubIssueSource.scan — mock subprocess
+# ---------------------------------------------------------------------------
+
+class TestGitHubIssueSourceScan:
+    def setup_method(self):
+        self.source = GitHubIssueSource(repo="dcetlin/Lobster")
+
+    def test_scan_yields_snapshots(self):
+        import json
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps([GH_ISSUE_FIXTURE])
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            snapshots = list(self.source.scan())
+
+        assert len(snapshots) == 1
+        assert snapshots[0].source_ref == "github:issue/42"
+
+    def test_scan_passes_correct_repo(self):
+        import json
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps([])
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            list(self.source.scan())
+
+        call_args = mock_run.call_args[0][0]
+        assert "--repo" in call_args
+        repo_idx = call_args.index("--repo")
+        assert call_args[repo_idx + 1] == "dcetlin/Lobster"
+
+    def test_scan_requests_open_state(self):
+        import json
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps([])
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            list(self.source.scan())
+
+        call_args = mock_run.call_args[0][0]
+        assert "--state" in call_args
+        state_idx = call_args.index("--state")
+        assert call_args[state_idx + 1] == "open"
+
+    def test_scan_empty_repo_yields_nothing(self):
+        import json
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps([])
+
+        with patch("subprocess.run", return_value=mock_result):
+            snapshots = list(self.source.scan())
+
+        assert snapshots == []
+
+
+# ---------------------------------------------------------------------------
+# GitHubIssueSource.get_issue — mock subprocess
+# ---------------------------------------------------------------------------
+
+class TestGitHubIssueSourceGetIssue:
+    def setup_method(self):
+        self.source = GitHubIssueSource(repo="dcetlin/Lobster")
+
+    def test_get_issue_returns_snapshot_on_success(self):
+        import json
+        import subprocess
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(GH_ISSUE_FIXTURE)
+
+        with patch("subprocess.run", return_value=mock_result):
+            snap = self.source.get_issue("github:issue/42")
+
+        assert snap is not None
+        assert snap.source_ref == "github:issue/42"
+
+    def test_get_issue_returns_none_on_not_found(self):
+        import subprocess
+
+        with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "gh")):
+            snap = self.source.get_issue("github:issue/999")
+
+        assert snap is None
+
+    def test_get_issue_passes_entity_id_as_positional(self):
+        import json
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(GH_ISSUE_FIXTURE)
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            self.source.get_issue("github:issue/42")
+
+        call_args = mock_run.call_args[0][0]
+        # entity_id "42" should appear after "view"
+        view_idx = call_args.index("view")
+        assert call_args[view_idx + 1] == "42"


### PR DESCRIPTION
## What this solves

GardenCaretaker needs to manage UoW lifecycle against GitHub issues without embedding GitHub knowledge in its core logic. Before this PR, there was no seam — cultivator.py called gh CLI directly and all parsing was inline. This PR introduces that seam so PRs 2-5 can build on a substrate-agnostic foundation.

## What changed

Three files, zero behavior change to the registry or any existing component:

**`src/orchestration/issue_source.py`** — defines the abstraction:
- `IssueSnapshot`: frozen dataclass carrying the normalized view of any issue (no GitHub types)
- `IssueSource`: structural Protocol (no base class) — any class implementing `scan()` and `get_issue()` satisfies it
- `SourceRef`: namedtuple with `source_ref_to_str` / `source_ref_from_str` helpers for the canonical `"github:issue/42"` string format stored in the registry

**`src/orchestration/github_issue_source.py`** — the only module in the codebase permitted to call subprocess for GitHub operations. Wraps `gh issue list` (scan) and `gh issue view` (get_issue). `CalledProcessError` from gh maps to `None` rather than propagating — missing/deleted/transferred issues are not errors at the protocol level. `_to_snapshot` is a pure function that confines all gh field name knowledge to one method.

**`src/orchestration/__init__.py`** — exports the new public types.

## Functional patterns used

- **Pure functions**: `source_ref_to_str`, `source_ref_from_str`, `_to_snapshot` — no side effects, referentially transparent
- **Immutability**: `IssueSnapshot` is a frozen dataclass; `SourceRef` is a namedtuple (both immutable)
- **Structural subtyping (Protocol)**: GardenCaretaker will depend only on the Protocol, never on `GitHubIssueSource` directly — any in-memory stub satisfies it in tests without mocking subprocess

## What is not changed

No changes to the registry, steward, executor, cultivator, or any existing orchestration code. The `__init__.py` addition is additive-only. The 7 pre-existing failures in `test_issue_sweeper.py` (missing `scheduled-tasks/issue-sweeper.py`, decommissioned in #438) are unaffected.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_issue_source.py -v` — 32 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/ -v` — 380 passed, 7 pre-existing failures (issue-sweeper decommissioned in #438, unrelated to this PR)

Closes nothing — foundational PR, no issue to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)