### PR TITLE
fix: canonicalize signal footer format — prevent compaction drift

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -117,6 +117,11 @@ mark_processed(message_id)
 ```
 **Emoji side-effect legend (v4):** see `~/lobster-workspace/design/dispatcher-emoji-legend.md`. Append a `side-effects:` code block at the END of each message (not inline) when there are meaningful side effects. Use the 10-signal set: `🤖 spawned`, `✅ done`, `🐙 PR`, `🔀 merged`, `🗑️ closed`, `⚠️ blocked`, `📝 wrote`, `🔍 read`, `🔧 config`, `💬 decide`.
 
+**COMPACTION-STABLE CANONICAL:** Every subagent reply that has side effects MUST end with a signal footer code block using label `side-effects:` — not `signals:`, not `effects:`, not any other label. The canonical label is `side-effects:` and this must be injected verbatim into every subagent prompt that involves user-facing work with side effects. Example:
+```side-effects:
+✅ 🐙
+```
+
 If you find yourself reaching for `Read`, `Bash`, `mcp__github__*`, `WebFetch`, or any tool not in the core loop list, stop. Write "On it.", spawn a subagent, and return to the loop.
 
 **Code internals questions → delegate, don't speculate**

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -173,6 +173,36 @@ The `artifacts` field is accepted by the inbox server and surfaced in the `subag
 
 **Never put large content in `text` directly.** The dispatcher's context window pays the cost of relaying whatever is in `text`. A 1,000-line report in `text` stalls the main loop and may trigger a health-check restart. Artifacts are read lazily, after the message is picked up, and do not bloat the inbox message itself.
 
+## Signal Footer (Required for Replies with Side Effects)
+
+**Canonical label: `side-effects:`** — this is the only accepted label. Do not use `signals:`, `effects:`, or any other variant.
+
+Every `send_reply` that references completed work (created, merged, built, deployed, wrote, fixed, implemented, etc.) **must end with a `side-effects:` code block** listing the relevant emoji signals. The hook `hooks/signal-footer-check.py` enforces this and will block the call if it is missing.
+
+Correct format:
+
+````
+Your reply text here.
+
+```side-effects:
+✅ 🐙 📝
+```
+````
+
+Signal legend (10-signal set):
+- `🤖` spawned — subagent or background task launched
+- `✅` done — task completed
+- `🐙` PR — pull request opened or updated
+- `🔀` merged — PR or branch merged
+- `🗑️` closed — issue or PR closed
+- `⚠️` blocked — work is blocked
+- `📝` wrote — file or doc written
+- `🔍` read — file or data read
+- `🔧` config — configuration changed
+- `💬` decide — decision made or surfaced
+
+**The label `side-effects:` is authoritative.** The hook validates on code block presence, but the label must be `side-effects:` exactly — any other label is wrong and will cause drift across compaction.
+
 ## Surfacing Observations (`write_observation`)
 
 Use `write_observation` to send structured side-channel information to the dispatcher — things you noticed that are separate from your primary result. This is distinct from `write_result`, which delivers the final answer to the user. Observations go to the dispatcher for routing (to the user, to memory, or to a log), not directly to the user.

--- a/hooks/signal-footer-check.py
+++ b/hooks/signal-footer-check.py
@@ -33,31 +33,12 @@ ACTION_KEYWORDS = [
     r"\binstalled\b",
 ]
 
-# Emoji signals from the legend (used in signal footers)
-SIGNAL_EMOJIS = [
-    "\U0001f916",  # 🤖
-    "\u2705",      # ✅
-    "\U0001f419",  # 🐙
-    "\U0001f500",  # 🔀
-    "\U0001f5d1",  # 🗑️
-    "\u26a0",      # ⚠️
-    "\U0001f4dd",  # 📝
-    "\U0001f50d",  # 🔍
-    "\U0001f527",  # 🔧
-    "\U0001f4ac",  # 💬
-]
-
 ACTION_RES = [re.compile(p, re.IGNORECASE) for p in ACTION_KEYWORDS]
 
-# Match a closing code fence (``` possibly with trailing whitespace/newline)
-CODE_BLOCK_END_RE = re.compile(r"```\s*$", re.MULTILINE)
-
-# Match a line that contains only emoji signal characters and optional multipliers like "x2"
-# This line must be at or near the end of the message
-SIGNAL_LINE_RE = re.compile(
-    r"^[" + "".join(re.escape(e) for e in SIGNAL_EMOJIS) + r"\s️xX\d]+$",
-    re.MULTILINE,
-)
+# Match a side-effects code block with the canonical label.
+# Only "side-effects:" is accepted — no other label is valid.
+# This enforces the canonical format from sys.subagent.bootup.md.
+SIDE_EFFECTS_BLOCK_RE = re.compile(r"```side-effects:[^`]*```", re.DOTALL)
 
 
 def has_action_keywords(text: str) -> bool:
@@ -66,28 +47,13 @@ def has_action_keywords(text: str) -> bool:
 
 def has_signal_footer(text: str) -> bool:
     """
-    Returns True if the message ends with either:
-    1. A markdown code block (``` ... ```)
-    2. A trailing line containing only emoji signal characters
+    Returns True if the message contains a ```side-effects: ... ``` code block.
+    The label must be exactly "side-effects:" — no other label is accepted.
+    This matches the canonical format enforced by sys.subagent.bootup.md and
+    sys.dispatcher.bootup.md.
     """
-    stripped = text.strip()
-
-    # Check for closing code block at the end
-    if stripped.endswith("```"):
+    if SIDE_EFFECTS_BLOCK_RE.search(text):
         return True
-
-    # Check for a code block anywhere near the end (last 200 chars)
-    tail = stripped[-200:]
-    if CODE_BLOCK_END_RE.search(tail):
-        return True
-
-    # Check last non-empty line for emoji-only signal line
-    lines = stripped.splitlines()
-    non_empty_lines = [l for l in lines if l.strip()]
-    if non_empty_lines:
-        last_line = non_empty_lines[-1].strip()
-        if SIGNAL_LINE_RE.match(last_line):
-            return True
 
     return False
 
@@ -113,7 +79,8 @@ def main():
     if has_action_keywords(text) and not has_signal_footer(text):
         print(
             "BLOCKED: Message references completed work but has no signal footer. "
-            "Add a code block at the end listing your side-effect signals (🤖 ✅ 🐙 🔀 etc.).",
+            "Add a ```side-effects: ... ``` code block at the end. "
+            "Example: ```side-effects:\n✅ 🐙\n``` — label must be exactly 'side-effects:' (not 'signals:' or anything else).",
             file=sys.stderr,
         )
         sys.exit(2)


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What problem this solves

The signal footer label was underdefined across the system. The dispatcher bootup file mentioned `side-effects:` in one inline sentence but provided no compaction-stable statement of it as the canonical label. The enforcement hook accepted **any** closing code fence — bare ` ``` `, `signals:`, `effects:`, whatever — as a valid footer. This meant a compaction summary could encode `signals:` instead of `side-effects:`, survive hook validation, and silently persist across sessions. The audit identified exactly this drift.

## What changed

**sys.subagent.bootup.md:** Added an explicit "Signal Footer" section. Names `side-effects:` as the only accepted label, provides a correct example, lists the 10-signal legend, and notes that the format must exactly match what `signal-footer-check.py` validates. This is the primary reference subagents read before composing replies.

**sys.dispatcher.bootup.md:** Added a `COMPACTION-STABLE CANONICAL` statement immediately after the existing emoji legend line. The statement spells out the label verbatim and includes a worked example. Because compaction tends to drop inline parentheticals while preserving bolded standalone statements, this phrasing survives context compaction where the prior single-sentence mention did not.

**hooks/signal-footer-check.py:** Tightened `has_signal_footer()` to only match ` ```side-effects: ... ``` ` blocks. Removed the fallback bare-fence and emoji-only-line detection paths — these were the routes by which wrong-label footers passed validation. Simplified to a single regex. Updated the BLOCKED error message to name the required label explicitly so the agent knows exactly what to fix.

## What this does not change

The action keyword list and main hook dispatch logic are unchanged. The hook still fires only on `send_reply` calls with action keywords — the scope of enforcement is the same. Only the acceptance criterion for a valid footer is narrowed.

## Functional patterns

Pure function (`has_signal_footer`) with a single regex predicate replacing a multi-branch imperative chain. The old three-branch implementation (ends-with-fence, tail-scan, emoji-line) was the surface area that allowed wrong formats through; the replacement is a single structural check.

## Tests run

- [x] `python3 -c "import ast; ast.parse(open('hooks/signal-footer-check.py').read())"` — syntax valid
- [x] Inline functional tests (5 cases: correct label, wrong label `signals:`, bare fence, no footer, multiline) — all pass
- [ ] Full unit suite (`uv run pytest tests/unit/`) — skipped: no test file for this hook exists in the repo