### PR TITLE
fix: add side-effects: none as canonical explicit null case

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -117,10 +117,11 @@ mark_processed(message_id)
 ```
 **Emoji side-effect legend (v4):** see `~/lobster-workspace/design/dispatcher-emoji-legend.md`. Append a `side-effects:` code block at the END of each message (not inline) when there are meaningful side effects. Use the 10-signal set: `🤖 spawned`, `✅ done`, `🐙 PR`, `🔀 merged`, `🗑️ closed`, `⚠️ blocked`, `📝 wrote`, `🔍 read`, `🔧 config`, `💬 decide`.
 
-**COMPACTION-STABLE CANONICAL:** Every subagent reply that has side effects MUST end with a signal footer code block using label `side-effects:` — not `signals:`, not `effects:`, not any other label. The canonical label is `side-effects:` and this must be injected verbatim into every subagent prompt that involves user-facing work with side effects. Example:
-```side-effects:
-✅ 🐙
-```
+**COMPACTION-STABLE CANONICAL:** Every subagent reply that references completed work MUST include a signal footer using label `side-effects:` — not `signals:`, not `effects:`, not any other label. Two valid forms:
+- **With side effects:** end with a `side-effects:` code block — e.g. ` ```side-effects:\n✅ 🐙\n``` `
+- **No side effects:** write `side-effects: none` on its own line (not a code block)
+
+Do NOT omit the footer entirely. Silent omission is wrong; `side-effects: none` is the canonical explicit null.
 
 If you find yourself reaching for `Read`, `Bash`, `mcp__github__*`, `WebFetch`, or any tool not in the core loop list, stop. Write "On it.", spawn a subagent, and return to the loop.
 

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -173,13 +173,13 @@ The `artifacts` field is accepted by the inbox server and surfaced in the `subag
 
 **Never put large content in `text` directly.** The dispatcher's context window pays the cost of relaying whatever is in `text`. A 1,000-line report in `text` stalls the main loop and may trigger a health-check restart. Artifacts are read lazily, after the message is picked up, and do not bloat the inbox message itself.
 
-## Signal Footer (Required for Replies with Side Effects)
+## Signal Footer (Required on All Replies Referencing Completed Work)
 
 **Canonical label: `side-effects:`** — this is the only accepted label. Do not use `signals:`, `effects:`, or any other variant.
 
-Every `send_reply` that references completed work (created, merged, built, deployed, wrote, fixed, implemented, etc.) **must end with a `side-effects:` code block** listing the relevant emoji signals. The hook `hooks/signal-footer-check.py` enforces this and will block the call if it is missing.
+Every `send_reply` that references completed work (created, merged, built, deployed, wrote, fixed, implemented, etc.) **must include a signal footer**. The hook `hooks/signal-footer-check.py` enforces this and will block the call if it is missing. Do NOT omit the footer entirely — use the explicit null form when there are no side effects.
 
-Correct format:
+**When you have side effects:** end the message with a `side-effects:` code block listing the relevant emoji signals.
 
 ````
 Your reply text here.
@@ -188,6 +188,14 @@ Your reply text here.
 ✅ 🐙 📝
 ```
 ````
+
+**When you have NO side effects:** write `side-effects: none` on its own line (not a code block).
+
+```
+Your reply text here.
+
+side-effects: none
+```
 
 Signal legend (10-signal set):
 - `🤖` spawned — subagent or background task launched
@@ -201,7 +209,7 @@ Signal legend (10-signal set):
 - `🔧` config — configuration changed
 - `💬` decide — decision made or surfaced
 
-**The label `side-effects:` is authoritative.** The hook validates on code block presence, but the label must be `side-effects:` exactly — any other label is wrong and will cause drift across compaction.
+**The label `side-effects:` is authoritative.** The hook validates on code block presence or the explicit null line, but the label must be `side-effects:` exactly — any other label is wrong and will cause drift across compaction.
 
 ## Surfacing Observations (`write_observation`)
 

--- a/hooks/signal-footer-check.py
+++ b/hooks/signal-footer-check.py
@@ -40,6 +40,10 @@ ACTION_RES = [re.compile(p, re.IGNORECASE) for p in ACTION_KEYWORDS]
 # This enforces the canonical format from sys.subagent.bootup.md.
 SIDE_EFFECTS_BLOCK_RE = re.compile(r"```side-effects:[^`]*```", re.DOTALL)
 
+# Match the explicit null case: a bare "side-effects: none" line (not a code block).
+# This is the canonical way to declare that a message has no side effects.
+SIDE_EFFECTS_NONE_RE = re.compile(r"^side-effects:\s*none\s*$", re.MULTILINE | re.IGNORECASE)
+
 
 def has_action_keywords(text: str) -> bool:
     return any(r.search(text) for r in ACTION_RES)
@@ -47,12 +51,18 @@ def has_action_keywords(text: str) -> bool:
 
 def has_signal_footer(text: str) -> bool:
     """
-    Returns True if the message contains a ```side-effects: ... ``` code block.
+    Returns True if the message contains either:
+    1. A ```side-effects: ... ``` code block (for messages with side effects)
+    2. A bare "side-effects: none" line (explicit null — for messages with no side effects)
+
     The label must be exactly "side-effects:" — no other label is accepted.
     This matches the canonical format enforced by sys.subagent.bootup.md and
     sys.dispatcher.bootup.md.
     """
     if SIDE_EFFECTS_BLOCK_RE.search(text):
+        return True
+
+    if SIDE_EFFECTS_NONE_RE.search(text):
         return True
 
     return False
@@ -79,8 +89,9 @@ def main():
     if has_action_keywords(text) and not has_signal_footer(text):
         print(
             "BLOCKED: Message references completed work but has no signal footer. "
-            "Add a ```side-effects: ... ``` code block at the end. "
-            "Example: ```side-effects:\n✅ 🐙\n``` — label must be exactly 'side-effects:' (not 'signals:' or anything else).",
+            "Either add a ```side-effects: ... ``` code block listing emoji signals, "
+            "or write 'side-effects: none' on its own line if there are truly no side effects. "
+            "Label must be exactly 'side-effects:' (not 'signals:' or anything else).",
             file=sys.stderr,
         )
         sys.exit(2)


### PR DESCRIPTION
## What problem this solves

After PR #441 canonicalized the `side-effects:` label and tightened the hook to only accept ` ```side-effects: ... ``` ` blocks, there was no sanctioned way to say "this message intentionally has no side effects." The only correct action was to omit the footer — which is structurally indistinguishable from accidentally forgetting it. Silent omission is exactly the class of drift #441 was trying to prevent.

The explicit null form `side-effects: none` (a bare line, not a code block) gives agents a positive, verifiable declaration that the footer was considered and a nil result was intentional.

## What changed

**hooks/signal-footer-check.py:** `has_signal_footer()` now accepts two valid forms:
1. A ` ```side-effects: ... ``` ` code block (messages with side effects — unchanged)
2. A bare `side-effects: none` line (explicit null — new)

The BLOCKED error message is updated to describe both valid forms so agents know exactly what to write. The `SIDE_EFFECTS_NONE_RE` regex is case-insensitive to tolerate minor capitalization variation.

**sys.subagent.bootup.md:** The Signal Footer section header is updated from "Required for Replies with Side Effects" to "Required on All Replies Referencing Completed Work" — because the footer is now required regardless of whether side effects exist. Both forms are documented with worked examples. Silent omission is explicitly prohibited.

**sys.dispatcher.bootup.md:** The COMPACTION-STABLE CANONICAL statement is updated to cover both cases with inline examples. The previous statement only described the code block form.

## What this does not change

Action keyword detection, main hook dispatch logic, and the code block acceptance criterion are all unchanged. The only new acceptance path is `side-effects: none`.

## Functional patterns

The `has_signal_footer()` function remains a pure predicate — two regex checks composed with `or`. The explicit null regex (`SIDE_EFFECTS_NONE_RE`) is a separate named constant rather than an inline literal, keeping the two acceptance criteria independently readable.

## Tests run

- [x] `python3 -c "import ast; ast.parse(open('hooks/signal-footer-check.py').read())"` — syntax valid
- [x] Functional tests (7 cases: correct code block, bare `side-effects: none`, case-insensitive null, wrong label `signals:`, missing footer, no action keyword, non-send_reply tool) — all pass
- [ ] Full unit suite (`uv run pytest tests/unit/`) — skipped: no test file for this hook exists in the repo

Closes: follow-on to #441