### PR TITLE
fix: executor-heartbeat reads wrong DB path (orchestration/registry.db → data/wos.db)

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -69,7 +69,7 @@ def _default_db_path() -> Path:
     env_override = os.environ.get("REGISTRY_DB_PATH")
     if env_override:
         return Path(env_override)
-    return workspace / "orchestration" / "registry.db"
+    return workspace / "data" / "wos.db"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What went wrong

executor-heartbeat.py was silently reading from an empty database on every cycle. The _default_db_path() function returned ~/lobster-workspace/orchestration/registry.db, which does not exist as a populated store. The actual WOS database is at ~/lobster-workspace/data/wos.db (188 UoWs). As a result, every executor-heartbeat invocation found zero ready-for-executor UoWs and dispatched nothing — WOS dispatch was fully stalled without any visible error.

## The fix

One-line change in _default_db_path():

Before: return workspace / "orchestration" / "registry.db"
After:  return workspace / "data" / "wos.db"

This aligns with the correct database path used everywhere else in the system. The REGISTRY_DB_PATH env override is preserved and unchanged.

## Scope

Only scheduled-tasks/executor-heartbeat.py is touched. steward-heartbeat.py and all other scheduled tasks are unmodified.

## Functional patterns

Pure function fix — _default_db_path() remains a side-effect-free path computation; only the fallback path constant changes.

## Tests run

- [ ] Live dry-run (uv run ~/lobster/scheduled-tasks/executor-heartbeat.py --dry-run) — blocked: requires production environment with ~/lobster-workspace/data/wos.db present and wos-config.json configured. Safe to merge; the fix is a single constant substitution and the --dry-run path is unchanged.

Blocked items needing attention before merge: dry-run smoke test should be run on the live host after merge to confirm 188 UoWs are now visible to the executor.

---

side-effects: executor-heartbeat will now see 188 UoWs in data/wos.db instead of empty orchestration/registry.db