### PR TITLE
fix: steward.py default DB path stale (data/registry.db → orchestration/registry.db)

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -1723,7 +1723,7 @@ def run_steward_cycle(
             workspace = Path(os.environ.get(
                 "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
             ))
-            db_path = workspace / "data" / "registry.db"
+            db_path = workspace / "orchestration" / "registry.db"
         registry = Registry(db_path)
 
     _github_client = github_client or _default_github_client


### PR DESCRIPTION
## Problem

`run_steward_cycle()` in `steward.py` silently opens the wrong database when called without an explicit `registry` or `db_path` argument. The hardcoded fallback was `data/registry.db` — a path that was never created and does not exist on any install. The canonical WOS database is `orchestration/registry.db`, established by Migration 51 in `upgrade.sh`. Both `executor-heartbeat.py` and `steward-heartbeat.py` already use `orchestration/registry.db` via their own `_default_db_path()` helpers. The production heartbeat scripts pass `registry` explicitly, so this mismatch was invisible in normal operation — but any code path that calls `run_steward_cycle()` without a registry argument (direct invocation, integration tests without env override) silently targets a nonexistent file.

## Change

One-line fix to the fallback path in `run_steward_cycle()`:

```
- db_path = workspace / "data" / "registry.db"
+ db_path = workspace / "orchestration" / "registry.db"
```

No other files touched. The production heartbeat scripts and test fixtures are unaffected — they pass an explicit registry or set `REGISTRY_DB_PATH` before reaching this branch.

## Functional patterns

Pure path computation; no state or side effects. The fix is local to the default-argument branch of `run_steward_cycle()`.

## Migration snippet (run manually after merge)

If UoWs accumulated in the wrong location before this fix, migrate them:

```bash
sqlite3 ~/lobster-workspace/data/registry.db ".dump uow_registry" | \
  sqlite3 ~/lobster-workspace/orchestration/registry.db
```

Check row counts before and after:
```bash
sqlite3 ~/lobster-workspace/data/registry.db "SELECT COUNT(*) FROM uow_registry;"
sqlite3 ~/lobster-workspace/orchestration/registry.db "SELECT COUNT(*) FROM uow_registry;"
```

Run only if the source file exists and the canonical DB has 0 rows (or fewer than expected). The `.dump | sqlite3` approach is safe for appending — SQLite will INSERT OR IGNORE if `uow_registry` rows have conflicting primary keys.

## Tests run

- [x] `uv run pytest tests/ -k "steward" -x -q` — 95 passed, 3 xfailed, 0 failed

---

side-effects: steward.py will now write UoWs to orchestration/registry.db (canonical) instead of data/registry.db (stale path)

Closes #397