### PR TITLE
feat: migrate heartbeat jobs to Type B (cron → script direct)

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -18,7 +18,11 @@ transitioning the UoW to 'ready-for-steward' or 'failed'. The Steward picks
 up the result on its next heartbeat cycle.
 
 Cron schedule (every 3 minutes, offset by 90s from steward-heartbeat):
-    */3 * * * * sleep 90 && uv run ~/lobster/scheduled-tasks/executor-heartbeat.py
+    */3 * * * * sleep 90 && cd ~/lobster && uv run scheduled-tasks/executor-heartbeat.py >> ~/lobster-workspace/scheduled-jobs/logs/executor-heartbeat.log 2>&1
+
+Type B dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+involvement). The jobs.json enabled gate is checked at the top of main() so that
+runtime enable/disable (wos start/stop) is respected without touching cron.
 
 Run standalone:
     uv run ~/lobster/scheduled-tasks/executor-heartbeat.py [--dry-run]
@@ -29,6 +33,7 @@ Design reference: docs/wos-v2-design.md § Executor, § Phase 2 build plan PR4 (
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -56,6 +61,31 @@ logging.basicConfig(
     datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 log = logging.getLogger("executor-heartbeat")
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type B dispatch path
+# ---------------------------------------------------------------------------
+
+def _is_job_enabled(job_name: str) -> bool:
+    """
+    Return True if the job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when:
+    - jobs.json is absent
+    - the job entry is missing
+    - the file is unreadable or malformed
+
+    This mirrors the gate logic in dispatch-job.sh so Type B (cron → script)
+    jobs respect the same runtime enable/disable toggle as Type A jobs.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+    try:
+        data = json.loads(jobs_file.read_text())
+        return bool(data.get("jobs", {}).get(job_name, {}).get("enabled", True))
+    except Exception:
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +257,12 @@ def main() -> int:
         log.info("Executor heartbeat starting (DRY RUN)")
     else:
         log.info("Executor heartbeat starting")
+
+    # jobs.json enabled gate — respect runtime enable/disable toggled via
+    # the dispatcher 'wos start/stop' commands or direct jobs.json edits.
+    if not _is_job_enabled("executor-heartbeat"):
+        log.info("Executor heartbeat: skipped (disabled in jobs.json)")
+        return 0
 
     from src.orchestration.steward import is_bootup_candidate_gate_active
     log.info("BOOTUP_CANDIDATE_GATE = %s", is_bootup_candidate_gate_active())

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -21,7 +21,11 @@ doc) is deferred to Phase 3. The startup sweep running on every 3-minute
 heartbeat invocation achieves finer coverage.
 
 Cron schedule (every 3 minutes):
-    */3 * * * * uv run ~/lobster/scheduled-tasks/steward-heartbeat.py
+    */3 * * * * cd ~/lobster && uv run scheduled-tasks/steward-heartbeat.py >> ~/lobster-workspace/scheduled-jobs/logs/steward-heartbeat.log 2>&1
+
+Type B dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+involvement). The jobs.json enabled gate is checked at the top of main() so that
+runtime enable/disable is respected without touching cron.
 
 Run standalone:
     uv run ~/lobster/scheduled-tasks/steward-heartbeat.py [--dry-run]
@@ -33,6 +37,7 @@ Phase 2 dependency: requires schema migration to have been applied:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -81,6 +86,31 @@ logging.basicConfig(
     datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 log = logging.getLogger("steward-heartbeat")
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type B dispatch path
+# ---------------------------------------------------------------------------
+
+def _is_job_enabled(job_name: str) -> bool:
+    """
+    Return True if the job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when:
+    - jobs.json is absent
+    - the job entry is missing
+    - the file is unreadable or malformed
+
+    This mirrors the gate logic in dispatch-job.sh so Type B (cron → script)
+    jobs respect the same runtime enable/disable toggle as Type A jobs.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+    try:
+        data = json.loads(jobs_file.read_text())
+        return bool(data.get("jobs", {}).get(job_name, {}).get("enabled", True))
+    except Exception:
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -309,6 +339,12 @@ def main() -> int:
         log.info("Steward heartbeat starting (DRY RUN)")
     else:
         log.info("Steward heartbeat starting")
+
+    # jobs.json enabled gate — respect runtime enable/disable toggled via
+    # the dispatcher commands or direct jobs.json edits.
+    if not _is_job_enabled("steward-heartbeat"):
+        log.info("Steward heartbeat: skipped (disabled in jobs.json)")
+        return 0
 
     gate_active = is_bootup_candidate_gate_active()
     log.info("BOOTUP_CANDIDATE_GATE = %s", gate_active)


### PR DESCRIPTION
## What this changes

Infrastructure polling jobs (executor-heartbeat, steward-heartbeat) were running as Type A: cron fired dispatch-job.sh, which wrote an inbox message, the dispatcher spawned an LLM subagent, and that subagent's only job was to run a shell command. One full LLM round-trip per 3-minute cycle, just to call a Python script.

This PR eliminates that round-trip. Cron now calls the scripts directly. The scripts run, log to files, and exit. No inbox message, no dispatcher involvement, no subagent, no task file.

The one behavior that needed to be preserved: the jobs.json `enabled` flag. Previously dispatch-job.sh checked this before writing the inbox message. In the new flow, the scripts check it themselves — a `_is_job_enabled()` helper is added to both scripts. It reads jobs.json, defaults to True on any failure, and exits 0 early if the job is disabled. This means `wos start/stop` and manual jobs.json edits continue to work as expected.

## Before / after

```
Before (Type A):
  cron (*/3) → dispatch-job.sh → inbox/message.json → dispatcher → subagent (claude -p) → script

After (Type B):
  cron (*/3) → script directly → logs/steward-heartbeat.log
  cron (*/3 + 90s sleep) → script directly → logs/executor-heartbeat.log
```

The jobs.json enabled gate is the only new code in the scripts. All WOS orchestration logic, DB access, TTL recovery, and dispatch behavior is unchanged.

## Runtime changes (applied directly, not in this PR)

- Crontab: old `dispatch-job.sh steward-heartbeat` and `dispatch-job.sh executor-heartbeat` entries removed; replaced with direct script calls using unique markers `# LOBSTER-STEWARD-HEARTBEAT` and `# LOBSTER-EXECUTOR-HEARTBEAT`
- jobs.json: `"type": "B"` and `"dispatch": "cron-direct"` added to both entries; `task_file` set to null
- Task files in `scheduled-jobs/tasks/`: annotated as archived (kept for history)

## Tests run

- [x] `cd ~/lobster && uv run scheduled-tasks/executor-heartbeat.py --dry-run` — clean exit 0, all phases logged
- [x] `cd ~/lobster && uv run scheduled-tasks/steward-heartbeat.py --dry-run` — clean exit 0, all 3 phases logged
- [x] jobs.json gate logic verified: `enabled: false` returns False, missing file returns True (default)
- [ ] Live cron fire — next scheduled fire at next 3-minute boundary; cannot pre-run, but direct script tests confirm correctness

## Functional patterns used

Pure function (`_is_job_enabled`) with explicit default-on-failure, no side effects. Gate check is at the entry boundary of `main()` before any DB or orchestration work.