### PR TITLE
fix: harden side-effects footer enforcement — four-part fix

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1,5 +1,7 @@
 # Dispatcher Context
 
+**CANONICAL: footer label is `side-effects:` not `signals:`.**
+
 ## Quick Reference (Tier-1 Rules)
 
 | Rule | Trigger | Enforcement |
@@ -116,7 +118,7 @@ Task(
 mark_processed(message_id)
 # <- back to wait_for_messages()
 ```
-**Emoji side-effect legend (v4):** see `~/lobster-workspace/design/dispatcher-emoji-legend.md`. Append a `side-effects:` code block at the END of each message (not inline) when there are meaningful side effects. Use the 10-signal set: `🤖 spawned`, `✅ done`, `🐙 PR`, `🔀 merged`, `🗑️ closed`, `⚠️ blocked`, `📝 wrote`, `🔍 read`, `🔧 config`, `💬 decide`.
+**Emoji side-effect legend (v5):** see `~/lobster-workspace/design/dispatcher-emoji-legend.md`. Append a `side-effects:` code block at the END of each message (not inline) when there are meaningful side effects. Use the 10-signal set: `🤖 spawned`, `✅ done`, `🐙 PR`, `🔀 merged`, `🗑️ closed`, `⚠️ blocked`, `📝 wrote`, `🔍 read`, `🔧 config`, `💬 decide`.
 
 **COMPACTION-STABLE CANONICAL:** Every subagent reply that references completed work MUST include a signal footer using label `side-effects:` — not `signals:`, not `effects:`, not any other label. Two valid forms:
 - **With side effects:** end with a `side-effects:` code block — e.g. ` ```side-effects:\n✅ 🐙\n``` `


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Two sources of label drift exist in the dispatcher bootup: an outdated version tag that signals stale context, and no compaction-stable anchor to prevent `signals:` from re-appearing after a context compaction event. This PR corrects both.

## What changed

The audit identified four fixes. Two were already in place; two needed implementation:

**Already implemented (no changes needed):**
- Fix 1 — `sys.subagent.bootup.md` footer section: present at lines 176–212 with canonical label, both forms, and full legend.
- Fix 2 — `signal-footer-check.py` label validation: the block regex `\`\`\`side-effects:[^` + "`" + `]*\`\`\`` already rejects any non-`side-effects:` label; error message explicitly names `signals:` as wrong.

**Implemented in this PR:**
- Fix 3 — Version tag on line 121 of `sys.dispatcher.bootup.md`: corrected `(v4)` → `(v5)` in the emoji side-effect legend reference. A stale version tag signals to the compactor that this line is from an older state and may be safely elided.
- Fix 4 — Compaction-stable canonical statement: added `**CANONICAL: footer label is \`side-effects:\` not \`signals:\`.**` as the second line of `sys.dispatcher.bootup.md`, immediately after the `h1` heading. A short bolded line near the document top survives compaction summary generation more reliably than the same claim buried in prose mid-document.

## What is not changed

Signal legend content is untouched. The hook logic, the subagent bootup footer section, and all other dispatcher bootup content are unchanged.

## Functional patterns

Pure data transformation (string replace on file content); no behavior logic introduced.

## Tests run

- [x] Manual diff verification — both changes confirmed present at expected locations
- [x] `grep -n "v4\|v5\|side-effect legend"` on patched file — shows `v5` at line 121, clean
- [x] `head -10` on patched file — shows canonical statement at line 3, correct position
- [ ] Full unit suite — skipped: no Python test coverage exists for bootup .md files