### PR TITLE
docs: add Type C job category for cron-direct non-LLM scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Never use cron for user-space jobs. Never use systemd tools for system-level inf
 
 - **Type A (LLM subagent tasks):** Run a prompt, do work, return output. The cron + jobs.json `enabled` field is the correct dispatch gate. Systemd was intentionally excluded — job dispatch is not process management. Jobs are prompts, not processes. Runtime enable/disable lives in jobs.json without touching cron.
 - **Type B (long-running services):** The dispatcher, MCP servers, Telegram bot, health daemons. These are processes. Systemd is the right tool here when/if Lobster moves to fully-automated operation.
+- **Type C (cron-direct non-LLM scripts):** Pure Python scripts invoked directly by cron — no inbox message written, no LLM round-trip. The script reads jobs.json itself to check the `enabled` gate and logs to `scheduled-jobs/logs/` directly. `dispatch: "cron-direct"` in jobs.json identifies these entries. Examples: `executor-heartbeat.py`, `steward-heartbeat.py`.
 
 ## Key Directories
 


### PR DESCRIPTION
## Summary

CLAUDE.md's job typology was left incomplete after the heartbeat migration (PR #470). That PR introduced `executor-heartbeat.py` and `steward-heartbeat.py` as pure Python scripts fired directly by cron — no inbox message, no LLM round-trip — and labeled them `"type": "B"` in jobs.json. But Type B in CLAUDE.md means long-running services (dispatcher, MCP servers, Telegram bot) managed by systemd. The conflict meant the type field on those jobs was actively misleading.

This PR adds **Type C** to resolve the ambiguity:

- **Type C (cron-direct non-LLM scripts):** Pure Python scripts invoked directly by cron. The script self-checks jobs.json for the `enabled` gate, logs to `scheduled-jobs/logs/` directly, and does no LLM round-trip. Distinguished in jobs.json by `dispatch: "cron-direct"`.

The `type` field on `steward-heartbeat` and `executor-heartbeat` in the live jobs.json has been updated from `"B"` to `"C"` to match.

No runtime behavior changed. The heartbeat scripts themselves are unmodified.

## Functional patterns

Pure documentation and data label change — no code logic involved.

## Tests run

- [x] `git diff CLAUDE.md` — reviewed, addition is accurate and consistent with existing style
- [ ] Full test suite — not applicable, docs-only change

**Blocked items needing attention before merge:** none