### PR TITLE
feat: add footer-reset skill for side-effects footer drift recovery

### DIFF
--- a/lobster-shop/INDEX.md
+++ b/lobster-shop/INDEX.md
@@ -15,6 +15,7 @@ Browse available skills for your Lobster assistant. Install any skill with one c
 | [Engineering Sensibilities](./engineering-sensibilities/) | PR-review checklist enforcing four engineering principles: fractal structure, golden patterns, maximal elegance, and cognitive clarity — activates on PR reviews and WOS implementation work | Behavioral | Available |
 | [Hibernation](./hibernation/) | Dispatcher hibernation — idle timeout behavior, state file semantics, and how to break the hibernation loop cleanly | Behavioral | Available |
 | [Obsidian KM](./obsidian-km/) | Sync and access your Obsidian vault via Telegram — create, read, search, and manage notes from anywhere | Tool | In Dev |
+| [Footer Reset](./footer-reset/) | Re-inject canonical side-effects footer format and audit recent outbox messages for footer drift — triggered by `/footer-reset` | Behavioral | Available |
 
 ## Templates
 

--- a/lobster-shop/footer-reset/behavior/system.md
+++ b/lobster-shop/footer-reset/behavior/system.md
@@ -1,0 +1,79 @@
+## Footer Reset
+
+When the user sends `/footer-reset`, `/reset-footer`, or when the message mentions footer drift, side-effects label confusion, or signal footer problems, execute the footer reset protocol below.
+
+### Canonical Format Reminder (always inject first)
+
+**The only accepted label is `side-effects:` — no other label is valid.**
+
+Two valid forms:
+
+**With side effects** — end the reply with a fenced code block:
+
+````
+```side-effects:
+✅ 🐙 📝
+```
+````
+
+**No side effects** — write the explicit null on its own line (not a code block):
+
+```
+side-effects: none
+```
+
+**Signal vocabulary (10-signal set):**
+
+| Signal | Meaning |
+|--------|---------|
+| `🤖` | spawned — subagent or background task launched |
+| `✅` | done — task completed |
+| `🐙` | PR — pull request opened or updated |
+| `🔀` | merged — PR or branch merged |
+| `🗑️` | closed — issue or PR closed |
+| `⚠️` | blocked — work is blocked |
+| `📝` | wrote — file or doc written |
+| `🔍` | read — file or data read |
+| `🔧` | config — configuration changed |
+| `💬` | decide — decision made or surfaced |
+
+**Common wrong patterns (all invalid):**
+
+| Wrong | Why it fails |
+|-------|-------------|
+| `` ```signals: ✅ ``` `` | Label must be `side-effects:`, not `signals:` |
+| `` ```effects: ✅ ``` `` | Label must be `side-effects:`, not `effects:` |
+| `` ```side-effects ✅ ``` `` | Missing colon — label is `side-effects:` with colon |
+| `side-effects:` (inline, no code block) | Use a fenced code block for non-null case |
+| Omitting footer entirely | Silent omission fails the hook; use `side-effects: none` explicitly |
+
+---
+
+### How to respond to `/footer-reset`
+
+1. **Immediately send** the canonical reminder above (formatted for Telegram — use bold, code blocks).
+
+2. **Spawn a background subagent** to audit recent outbox messages (follows the 7-second rule). Use this exact prompt:
+
+```
+Run the footer audit and send results to chat_id={chat_id}.
+
+1. Execute:
+   uv run ~/lobster/lobster-shop/footer-reset/src/footer_audit.py
+
+2. Send the EXACT script output as a reply via send_reply to chat_id={chat_id}.
+
+3. If the script fails, send: "Footer audit failed: <error>"
+```
+
+3. Once the subagent result arrives, the dispatcher relays it. No further action needed.
+
+---
+
+### Contextual trigger behavior
+
+When the skill activates contextually (footer drift mention, label confusion, etc.) rather than via explicit command:
+
+- **Do not** proactively inject the full canonical reminder unless the user is clearly confused or asking for guidance.
+- **Do** note the correct format briefly (one sentence) if correcting a drift observation.
+- Spawn the audit subagent only if the user asks for an audit or if anomalies were just surfaced.

--- a/lobster-shop/footer-reset/skill.toml
+++ b/lobster-shop/footer-reset/skill.toml
@@ -1,0 +1,39 @@
+[skill]
+name = "footer-reset"
+version = "1.0.0"
+description = "Re-inject canonical side-effects footer format and audit recent outbox messages for footer drift"
+author = "Lobster"
+category = "behavioral"
+
+[activation]
+mode = "triggered"
+triggers = ["/footer-reset", "/reset-footer"]
+context_patterns = [
+    "when user mentions footer drift",
+    "when user mentions side-effects label confusion",
+    "when user asks about signal footer",
+    "when user asks about side-effects format",
+    "when user asks about missing footers",
+    "when user asks to audit outbox messages",
+]
+
+[layering]
+priority = 60
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/footer-reset", "/reset-footer"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/lobster-shop/footer-reset/src/footer_audit.py
+++ b/lobster-shop/footer-reset/src/footer_audit.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Footer drift audit for recent outbox messages.
+
+Scans ~/messages/outbox/ for messages that reference completed work but
+are missing or have malformed side-effects footers.
+
+Output is pre-formatted for Telegram.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+OUTBOX_DIR = Path.home() / "messages" / "outbox"
+
+# Mirrors ACTION_KEYWORDS from signal-footer-check.py
+ACTION_PATTERNS = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"\bmerged\b",
+        r"\bmerge\b",
+        r" PR #\d+",
+        r"\bpull request\b",
+        r"\bspawned\b",
+        r"\bbuilt\b",
+        r"\bwrote\b",
+        r"\bscheduled\b",
+        r"\bdeleted\b",
+        r"\bcreated\b",
+        r"\bfixed\b",
+        r"\bimplemented\b",
+        r"\bdeployed\b",
+        r"\binstalled\b",
+    ]
+]
+
+# Valid forms
+SIDE_EFFECTS_BLOCK_RE = re.compile(r"```side-effects:[^`]*```", re.DOTALL)
+SIDE_EFFECTS_NONE_RE = re.compile(r"^side-effects:\s*none\s*$", re.MULTILINE | re.IGNORECASE)
+
+# Wrong-label patterns — these are drift signatures
+WRONG_LABEL_PATTERNS = [
+    (re.compile(r"```signals:[^`]*```", re.DOTALL), "wrong label: `signals:` instead of `side-effects:`"),
+    (re.compile(r"```effects:[^`]*```", re.DOTALL), "wrong label: `effects:` instead of `side-effects:`"),
+    (re.compile(r"```side-effects[^:\n][^`]*```", re.DOTALL), "malformed: `side-effects` missing colon"),
+    (re.compile(r"^signals:\s*none\s*$", re.MULTILINE | re.IGNORECASE), "wrong label: `signals: none` instead of `side-effects: none`"),
+]
+
+
+def has_action_keywords(text: str) -> bool:
+    return any(p.search(text) for p in ACTION_PATTERNS)
+
+
+def has_valid_footer(text: str) -> bool:
+    return bool(SIDE_EFFECTS_BLOCK_RE.search(text)) or bool(SIDE_EFFECTS_NONE_RE.search(text))
+
+
+def detect_wrong_labels(text: str) -> list[str]:
+    return [label for pattern, label in WRONG_LABEL_PATTERNS if pattern.search(text)]
+
+
+def load_outbox_messages() -> list[dict]:
+    if not OUTBOX_DIR.exists():
+        return []
+    messages = []
+    for path in sorted(OUTBOX_DIR.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+            data["_path"] = path.name
+            messages.append(data)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return messages
+
+
+def audit_messages(messages: list[dict]) -> tuple[list[dict], list[dict]]:
+    """
+    Returns (missing_footer, wrong_label) anomaly lists.
+    Each entry is a dict with keys: id, text_snippet, issues.
+    """
+    missing_footer = []
+    wrong_label = []
+
+    for msg in messages:
+        text = msg.get("text", "")
+        if not text:
+            continue
+
+        wrong_labels = detect_wrong_labels(text)
+        if wrong_labels:
+            wrong_label.append({
+                "id": msg.get("id", msg["_path"]),
+                "snippet": text[:80].replace("\n", " "),
+                "issues": wrong_labels,
+            })
+
+        if has_action_keywords(text) and not has_valid_footer(text):
+            # Skip if already flagged as wrong-label (overlapping issue)
+            if not wrong_labels:
+                missing_footer.append({
+                    "id": msg.get("id", msg["_path"]),
+                    "snippet": text[:80].replace("\n", " "),
+                    "issues": ["action keywords present but no side-effects footer"],
+                })
+
+    return missing_footer, wrong_label
+
+
+def format_report(messages: list[dict], missing: list[dict], wrong: list[dict]) -> str:
+    total = len(messages)
+    anomaly_count = len(missing) + len(wrong)
+
+    if total == 0:
+        return "Footer audit: outbox is empty — nothing to scan."
+
+    lines = [f"**Footer audit** — {total} outbox message(s) scanned"]
+
+    if anomaly_count == 0:
+        lines.append("No anomalies found. All footers look correct.")
+        return "\n".join(lines)
+
+    lines.append(f"{anomaly_count} anomaly(ies) found:\n")
+
+    if wrong:
+        lines.append("**Wrong label (drift):**")
+        for entry in wrong:
+            snippet = entry["snippet"][:60] + ("..." if len(entry["snippet"]) > 60 else "")
+            for issue in entry["issues"]:
+                lines.append(f"  • `{entry['id']}` — {issue}")
+                lines.append(f"    Preview: _{snippet}_")
+
+    if missing:
+        lines.append("**Missing footer (action message with no footer):**")
+        for entry in missing:
+            snippet = entry["snippet"][:60] + ("..." if len(entry["snippet"]) > 60 else "")
+            lines.append(f"  • `{entry['id']}` — {entry['issues'][0]}")
+            lines.append(f"    Preview: _{snippet}_")
+
+    lines.append("\nCanonical forms:")
+    lines.append("  With effects: ` ```side-effects:\\n✅ 🐙\\n``` `")
+    lines.append("  No effects: `side-effects: none` (bare line)")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    messages = load_outbox_messages()
+    missing, wrong = audit_messages(messages)
+    report = format_report(messages, missing, wrong)
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What problem this solves

When `side-effects:` footer drift occurs — wrong labels like `signals:`, omitted footers on action messages, or formatting deviations — the dispatcher has no in-session tool to re-anchor itself to the canonical format or surface which recent messages were malformed. This is a recovery gap that currently requires manual inspection.

The `/footer-reset` skill closes that gap: one command re-injects the canonical format reminder and triggers an automated outbox audit.

## What this adds

Three files in `lobster-shop/footer-reset/`:

- **`skill.toml`** — triggered skill activated by `/footer-reset` or `/reset-footer`; also fires contextually when messages mention "footer drift", "side-effects label confusion", or "signal footer"
- **`behavior/system.md`** — injects the canonical format reminder (both valid forms, the 10-signal vocabulary, and a table of 5 common wrong patterns), then dispatches a background audit subagent per the 7-second rule
- **`src/footer_audit.py`** — pure-function audit script that scans `~/messages/outbox/*.json`, classifies each message as clean / missing-footer / wrong-label, and returns a pre-formatted Telegram report

The audit script mirrors the exact regex logic from `hooks/signal-footer-check.py` so the two stay consistent on what counts as valid.

## Functional patterns

Pure functions throughout: `has_valid_footer`, `has_action_keywords`, `detect_wrong_labels`, `audit_messages`, and `format_report` are all stateless transforms with no side effects. The script's `main()` is the single I/O boundary.

## What is out of scope

`hooks/signal-footer-check.py` and bootup files are untouched — skill layer only. The audit script reads but never writes outbox messages.

## Tests run

- [x] `uv run lobster-shop/footer-reset/src/footer_audit.py` against live outbox — ran cleanly, reported "outbox is empty — nothing to scan"
- [x] Inline logic tests (5 cases: valid block, valid none, missing footer, wrong label `signals:`, no action keywords) — all 5 PASS
- [ ] Live Telegram `/footer-reset` command test — blocked: requires dispatcher to reload the new skill; safe to merge, no behavior change to existing paths

**Blocked items needing attention before merge:** none — the live command test can run post-merge on the next dispatcher reload.