### PR TITLE
fix: detect wrong footer labels in signal-footer-check hook

### DIFF
--- a/hooks/signal-footer-check.py
+++ b/hooks/signal-footer-check.py
@@ -44,6 +44,24 @@ SIDE_EFFECTS_BLOCK_RE = re.compile(r"```side-effects:[^`]*```", re.DOTALL)
 # This is the canonical way to declare that a message has no side effects.
 SIDE_EFFECTS_NONE_RE = re.compile(r"^side-effects:\s*none\s*$", re.MULTILINE | re.IGNORECASE)
 
+# Wrong-label patterns: fenced code blocks that look like footers but use the wrong label.
+# Ordered from most specific to most general to return the most useful error message.
+WRONG_LABEL_PATTERNS = [
+    # Explicit common wrong labels
+    (re.compile(r"```(signals):[^`]*```", re.DOTALL), None),
+    (re.compile(r"```(effects):[^`]*```", re.DOTALL), None),
+    (re.compile(r"```(side_effects):[^`]*```", re.DOTALL), None),
+    # "side-effects" without colon (malformed — missing colon)
+    (re.compile(r"```(side-effects)\s[^`]*```", re.DOTALL), "side-effects (missing colon — label must be `side-effects:`)"),
+    # Any fenced code block whose label contains "signal", "effect", or "side"
+    (re.compile(r"```([a-z_-]*(?:signal|effect|side)[a-z_-]*):[^`]*```", re.DOTALL | re.IGNORECASE), None),
+]
+
+# Wrong null-form patterns: bare "label: none" lines with wrong label
+WRONG_NULL_PATTERNS = [
+    re.compile(r"^(signals|effects|side_effects):\s*none\s*$", re.MULTILINE | re.IGNORECASE),
+]
+
 
 def has_action_keywords(text: str) -> bool:
     return any(r.search(text) for r in ACTION_RES)
@@ -68,6 +86,27 @@ def has_signal_footer(text: str) -> bool:
     return False
 
 
+def detect_wrong_label(text: str) -> str | None:
+    """
+    Returns a human-readable description of the wrong label found, or None if
+    no wrong-label footer is detected.
+
+    Only fires when has_signal_footer() is False — i.e., no canonical footer is present.
+    """
+    for pattern, override_label in WRONG_LABEL_PATTERNS:
+        m = pattern.search(text)
+        if m:
+            label = override_label if override_label is not None else m.group(1)
+            return label
+
+    for pattern in WRONG_NULL_PATTERNS:
+        m = pattern.search(text)
+        if m:
+            return m.group(1) + ": none"
+
+    return None
+
+
 def main():
     try:
         data = json.load(sys.stdin)
@@ -87,13 +126,22 @@ def main():
         sys.exit(0)
 
     if has_action_keywords(text) and not has_signal_footer(text):
-        print(
-            "BLOCKED: Message references completed work but has no signal footer. "
-            "Either add a ```side-effects: ... ``` code block listing emoji signals, "
-            "or write 'side-effects: none' on its own line if there are truly no side effects. "
-            "Label must be exactly 'side-effects:' (not 'signals:' or anything else).",
-            file=sys.stderr,
-        )
+        wrong_label = detect_wrong_label(text)
+        if wrong_label is not None:
+            print(
+                f"BLOCKED: Wrong footer label — must be exactly `side-effects:` (got `{wrong_label}`). "
+                "Use ```side-effects:\\n<signals>\\n``` for messages with side effects, "
+                "or `side-effects: none` on its own line for messages with no side effects.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "BLOCKED: Message references completed work but has no signal footer. "
+                "Either add a ```side-effects: ... ``` code block listing emoji signals, "
+                "or write 'side-effects: none' on its own line if there are truly no side effects. "
+                "Label must be exactly 'side-effects:' (not 'signals:' or anything else).",
+                file=sys.stderr,
+            )
         sys.exit(2)
 
     sys.exit(0)


### PR DESCRIPTION
## What problem this solves

`signal-footer-check.py` blocked messages with wrong footer labels (e.g., ` ```signals: ✅ ``` `) with the same generic error as a completely missing footer. The author knew footers were required — they just used the wrong label — but the error gave no specific correction target. This ambiguity made the hook less useful as a teaching instrument.

## What this changes

Adds `detect_wrong_label()`, a pure function that runs only after `has_signal_footer()` returns `False`. It matches:

- Fenced code blocks whose label contains "signal", "effect", or "side" but is not exactly `side-effects:`
- Bare null-form lines like `signals: none` or `effects: none`

When a wrong label is detected, the block message names the actual label:

> "Wrong footer label — must be exactly `side-effects:` (got `signals:`). Use ` ```side-effects:\n<signals>\n``` ` for messages with side effects..."

When no footer is present at all, the existing generic message is unchanged.

## What is out of scope

The allow path, action keyword detection, and canonical footer detection are unmodified. This only changes the error message in the block path.

## Functional patterns

`detect_wrong_label` is a pure function — takes text, returns `str | None`, no side effects. Pattern matching is done via a prioritized list of compiled regexes, returning on the first match.

## Tests run
- [x] 8 inline test cases run directly against `hooks/signal-footer-check.py`:
  - valid: correct `side-effects:` block → exit 0
  - valid: `side-effects: none` → exit 0
  - blocked: completely missing footer → exit 2, generic message
  - blocked: ` ```signals: ✅ ``` ` → exit 2, "Wrong footer label...got `signals`"
  - blocked: ` ```effects: ✅ ``` ` → exit 2, "Wrong footer label...got `effects`"
  - blocked: `signals: none` → exit 2, "Wrong footer label...got `signals: none`"
  - allow: no action keywords → exit 0
  - All 8 PASS