### PR TITLE
fix: ban side-effects: none, remove missing-footer requirement

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -122,12 +122,10 @@ mark_processed(message_id)
 
 **Spawned agent format:** Use `🚀 spawned  <task-name>` (not `🤖 spawned`) where `<task-name>` is the descriptive slug of the task. List each spawned agent on its own line when multiple agents are launched.
 
-**COMPACTION-STABLE CANONICAL:** Every subagent reply that references completed work MUST include a signal footer using label `side-effects:` — not `signals:`, not `effects:`, not any other label. Two valid forms:
+**COMPACTION-STABLE CANONICAL:** When a reply has meaningful side effects, end it with a `side-effects:` code block using label `side-effects:` — not `signals:`, not `effects:`, not any other label. When there are no side effects, write NO footer at all — omit it completely. `side-effects: none` is explicitly forbidden.
+
 - **With side effects:** end with a `side-effects:` code block — e.g. ` ```side-effects:\n✅ 🐙\n``` `
-- **No side effects:** write `side-effects: none` on its own line (not a code block)
-
-Do NOT omit the footer entirely. Silent omission is wrong; `side-effects: none` is the canonical explicit null.
-
+- **No side effects:** omit the footer entirely. Do NOT write `side-effects: none`.
 If you find yourself reaching for `Read`, `Bash`, `mcp__github__*`, `WebFetch`, or any tool not in the core loop list, stop. Write "On it.", spawn a subagent, and return to the loop.
 
 **Code internals questions → delegate, don't speculate**

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -177,7 +177,7 @@ The `artifacts` field is accepted by the inbox server and surfaced in the `subag
 
 **Canonical label: `side-effects:`** — this is the only accepted label. Do not use `signals:`, `effects:`, or any other variant.
 
-Every `send_reply` that references completed work (created, merged, built, deployed, wrote, fixed, implemented, etc.) **must include a signal footer**. The hook `hooks/signal-footer-check.py` enforces this and will block the call if it is missing. Do NOT omit the footer entirely — use the explicit null form when there are no side effects.
+When a `send_reply` has side effects, include a signal footer. When there are no side effects, omit the footer entirely. The hook `hooks/signal-footer-check.py` validates footer labels and blocks `side-effects: none` in any form.
 
 **When you have side effects:** end the message with a `side-effects:` code block listing the relevant emoji signals.
 
@@ -189,13 +189,7 @@ Your reply text here.
 ```
 ````
 
-**When you have NO side effects:** write `side-effects: none` on its own line (not a code block).
-
-```
-Your reply text here.
-
-side-effects: none
-```
+**When you have NO side effects:** write nothing — omit the footer completely. Do NOT write `side-effects: none`.
 
 Signal legend (10-signal set):
 - `🤖` spawned — subagent or background task launched
@@ -209,7 +203,7 @@ Signal legend (10-signal set):
 - `🔧` config — configuration changed
 - `💬` decide — decision made or surfaced
 
-**The label `side-effects:` is authoritative.** The hook validates on code block presence or the explicit null line, but the label must be `side-effects:` exactly — any other label is wrong and will cause drift across compaction.
+**The label `side-effects:` is authoritative.** The hook validates the code block label and blocks wrong labels — `side-effects:` is the only accepted label. Any other label is wrong and will cause drift across compaction.
 
 ## Surfacing Observations (`write_observation`)
 

--- a/hooks/signal-footer-check.py
+++ b/hooks/signal-footer-check.py
@@ -3,7 +3,12 @@
 Signal footer enforcement hook for send_reply.
 
 Fires before mcp__lobster-inbox__send_reply tool calls.
-Blocks messages that reference completed work but have no signal footer code block.
+
+Convention:
+- When a message has side effects: end with a ```side-effects: ... ``` code block.
+- When a message has no side effects: omit the footer entirely — write nothing.
+- `side-effects: none` in any form is BANNED. Omit the footer instead.
+- Any footer-like code block with a wrong label (signals:, effects:, etc.) is blocked.
 
 Exit codes:
   0 - Allow the tool call
@@ -15,34 +20,17 @@ import re
 import sys
 
 
-# Keywords indicating completed actions (case-insensitive)
-ACTION_KEYWORDS = [
-    r"\bmerged\b",
-    r"\bmerge\b",
-    r" PR #\d+",
-    r"\bpull request\b",
-    r"\bspawned\b",
-    r"\bbuilt\b",
-    r"\bwrote\b",
-    r"\bscheduled\b",
-    r"\bdeleted\b",
-    r"\bcreated\b",
-    r"\bfixed\b",
-    r"\bimplemented\b",
-    r"\bdeployed\b",
-    r"\binstalled\b",
-]
-
-ACTION_RES = [re.compile(p, re.IGNORECASE) for p in ACTION_KEYWORDS]
-
 # Match a side-effects code block with the canonical label.
 # Only "side-effects:" is accepted — no other label is valid.
 # This enforces the canonical format from sys.subagent.bootup.md.
 SIDE_EFFECTS_BLOCK_RE = re.compile(r"```side-effects:[^`]*```", re.DOTALL)
 
-# Match the explicit null case: a bare "side-effects: none" line (not a code block).
-# This is the canonical way to declare that a message has no side effects.
-SIDE_EFFECTS_NONE_RE = re.compile(r"^side-effects:\s*none\s*$", re.MULTILINE | re.IGNORECASE)
+# Match "side-effects: none" in any form:
+# 1. As a bare line: "side-effects: none"
+# 2. As a code block: ```side-effects:\nnone\n```
+# Both forms are banned — omit the footer entirely instead.
+SIDE_EFFECTS_NONE_BARE_RE = re.compile(r"^side-effects:\s*none\s*$", re.MULTILINE | re.IGNORECASE)
+SIDE_EFFECTS_NONE_BLOCK_RE = re.compile(r"```side-effects:\s*\nnone\s*\n```", re.DOTALL | re.IGNORECASE)
 
 # Wrong-label patterns: fenced code blocks that look like footers but use the wrong label.
 # Ordered from most specific to most general to return the most useful error message.
@@ -63,26 +51,12 @@ WRONG_NULL_PATTERNS = [
 ]
 
 
-def has_action_keywords(text: str) -> bool:
-    return any(r.search(text) for r in ACTION_RES)
-
-
-def has_signal_footer(text: str) -> bool:
-    """
-    Returns True if the message contains either:
-    1. A ```side-effects: ... ``` code block (for messages with side effects)
-    2. A bare "side-effects: none" line (explicit null — for messages with no side effects)
-
-    The label must be exactly "side-effects:" — no other label is accepted.
-    This matches the canonical format enforced by sys.subagent.bootup.md and
-    sys.dispatcher.bootup.md.
-    """
-    if SIDE_EFFECTS_BLOCK_RE.search(text):
+def has_side_effects_none(text: str) -> bool:
+    """Returns True if the message contains a banned 'side-effects: none' in any form."""
+    if SIDE_EFFECTS_NONE_BARE_RE.search(text):
         return True
-
-    if SIDE_EFFECTS_NONE_RE.search(text):
+    if SIDE_EFFECTS_NONE_BLOCK_RE.search(text):
         return True
-
     return False
 
 
@@ -91,7 +65,7 @@ def detect_wrong_label(text: str) -> str | None:
     Returns a human-readable description of the wrong label found, or None if
     no wrong-label footer is detected.
 
-    Only fires when has_signal_footer() is False — i.e., no canonical footer is present.
+    Only fires when no canonical side-effects block is present.
     """
     for pattern, override_label in WRONG_LABEL_PATTERNS:
         m = pattern.search(text)
@@ -125,24 +99,29 @@ def main():
     if not text:
         sys.exit(0)
 
-    if has_action_keywords(text) and not has_signal_footer(text):
+    # Check 1: "side-effects: none" in any form is banned.
+    # The canonical convention is to omit the footer entirely when there are no side effects.
+    if has_side_effects_none(text):
+        print(
+            "BLOCKED: `side-effects: none` is no longer valid. "
+            "Omit the footer entirely when there are no side effects.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Check 2: If a footer-like code block is present, its label must be exactly "side-effects:".
+    # A canonical side-effects block is valid — allow it.
+    # A wrong-label block is blocked.
+    if not SIDE_EFFECTS_BLOCK_RE.search(text):
         wrong_label = detect_wrong_label(text)
         if wrong_label is not None:
             print(
                 f"BLOCKED: Wrong footer label — must be exactly `side-effects:` (got `{wrong_label}`). "
-                "Use ```side-effects:\\n<signals>\\n``` for messages with side effects, "
-                "or `side-effects: none` on its own line for messages with no side effects.",
+                "Use ```side-effects:\\n<signals>\\n``` for messages with side effects. "
+                "Omit the footer entirely when there are no side effects.",
                 file=sys.stderr,
             )
-        else:
-            print(
-                "BLOCKED: Message references completed work but has no signal footer. "
-                "Either add a ```side-effects: ... ``` code block listing emoji signals, "
-                "or write 'side-effects: none' on its own line if there are truly no side effects. "
-                "Label must be exactly 'side-effects:' (not 'signals:' or anything else).",
-                file=sys.stderr,
-            )
-        sys.exit(2)
+            sys.exit(2)
 
     sys.exit(0)
 


### PR DESCRIPTION
## What changed and why

Before this PR, the signal footer convention had two valid forms: a `side-effects:` code block (for messages with side effects) and a bare `side-effects: none` line (explicit null). Dan has decided `side-effects: none` is banned — the correct way to express no side effects is to omit the footer entirely.

This PR enforces that decision at the hook level and removes it from the docs.

## Hook changes (`hooks/signal-footer-check.py`)

Three behavioral changes, one removal:

**Removed:** The hook no longer requires a footer on action messages. The "message references completed work but has no signal footer" block is gone. Missing footers are now silently allowed.

**Added:** `side-effects: none` in any form is now explicitly blocked with a clear error. The hook catches both:
- Bare line: `side-effects: none`  
- Code block form: ` ```side-effects:\nnone\n``` `

**Kept:** Wrong-label detection from PR #479 is unchanged — if a footer-like code block is present, its label must be exactly `side-effects:`.

New hook decision tree:
```
side-effects: none (any form)  → BLOCKED
```side-effects:``` with wrong label → BLOCKED
```side-effects:``` with correct content → ALLOWED
No footer at all → ALLOWED
```

## Doc changes

`sys.dispatcher.bootup.md` and `sys.subagent.bootup.md` had stale text from before the convention was updated. Both said things like "write `side-effects: none` on its own line" and "do NOT omit the footer entirely — silent omission is wrong." Replaced with the current convention: omit entirely when no side effects, `side-effects: none` is explicitly forbidden.

`user.base.bootup.md` (not in the repo, only in `lobster-user-config`) already had the correct text and required no changes.

## Tests run
- [x] `python3 hooks/signal-footer-check.py` (8 manual cases via subprocess) — all passed: allows missing footer, allows valid block, blocks bare `side-effects: none`, blocks code-block `side-effects: none`, blocks wrong labels
- [x] `uv run pytest tests/unit/test_hooks/` — 200 passed, 0 failed
- [x] `uv run pytest tests/ -k signal` — 39 passed, 0 failed

**Blocked items needing attention before merge:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)