### PR TITLE
fix(wos): enforce success_criteria at germination, add issue_url field (#488)

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -589,7 +589,7 @@ System) pipeline. Your job is to implement the following prescription and open a
 Follow the functional-engineer protocol:
 1. Read the GitHub issue identified in the prescription (use gh issue view).
 2. Create a worktree branch and implement the changes.
-3. Run tests, then open a PR on dcetlin/Lobster.
+3. Run tests, then open a PR on the repo identified in the prescription's issue URL.
 4. Call write_result with the PR URL and outcome when done.
 
 Do NOT call send_reply. Do NOT call wait_for_messages.

--- a/src/orchestration/garden_caretaker.py
+++ b/src/orchestration/garden_caretaker.py
@@ -192,9 +192,16 @@ class GardenCaretaker:
                 logger.warning("scan: cannot extract issue number from source_ref=%s", snapshot.source_ref)
                 continue
 
+            # Use the issue body as success_criteria — it is the Seed spec.
+            # If the body is empty, fall back to the title so every UoW has
+            # a non-empty anchor (the Steward can refine it on first diagnosis).
+            success_criteria = snapshot.body.strip() if snapshot.body.strip() else snapshot.title
+
             result = self.registry.upsert(
                 issue_number=issue_number,
                 title=snapshot.title,
+                success_criteria=success_criteria,
+                issue_url=snapshot.url or None,
             )
 
             if not isinstance(result, UpsertInserted):

--- a/src/orchestration/migrations/0005_add_issue_url.sql
+++ b/src/orchestration/migrations/0005_add_issue_url.sql
@@ -1,0 +1,7 @@
+-- Migration 0005: add issue_url field to uow_registry
+-- Stores the canonical GitHub issue URL so UoWs are self-describing
+-- and the Steward/Executor no longer need to hardcode the repo to
+-- reconstruct the URL. Populated at proposal time from source_issue_number
+-- + source_repo (or explicitly provided). NULL for pre-existing rows.
+
+ALTER TABLE uow_registry ADD COLUMN issue_url TEXT DEFAULT NULL;

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -165,6 +165,9 @@ class UoW:
     source_ref: str | None = None
     source_last_seen_at: str | None = None
     source_state: str | None = None
+    # Canonical GitHub issue URL (populated after migration 0005)
+    # Eliminates hardcoded repo references in Steward and Executor.
+    issue_url: str | None = None
 
 
 def _now_iso() -> str:
@@ -293,6 +296,7 @@ class Registry:
             source_ref=d.get("source_ref"),
             source_last_seen_at=d.get("source_last_seen_at"),
             source_state=d.get("source_state"),
+            issue_url=d.get("issue_url"),
         )
 
     def _write_audit(
@@ -325,6 +329,8 @@ class Registry:
         sweep_date: str | None = None,
         uow_type: str = "executable",
         success_criteria: str = "",
+        source_repo: str | None = None,
+        issue_url: str | None = None,
     ) -> UpsertResult:
         """
         Propose a UoW for a GitHub issue.
@@ -340,8 +346,28 @@ class Registry:
         - Existing done/failed/expired (any sweep_date) → INSERT new proposed record
         - UNIQUE(issue, sweep_date) conflict + existing is proposed → UPDATE fields
         - UNIQUE(issue, sweep_date) conflict + existing is non-proposed → no-op update (fields unchanged)
+
+        Args:
+            issue_number: GitHub issue number.
+            title: Issue title used as the UoW summary.
+            sweep_date: ISO date string; defaults to today (UTC).
+            uow_type: UoW type tag (default "executable").
+            success_criteria: Prose completion statement. Must not be an empty string;
+                raises ValueError if blank so that germination always has a verifiable goal.
+            source_repo: GitHub repo slug, e.g. "owner/repo". Used to derive issue_url
+                when issue_url is not supplied explicitly.
+            issue_url: Canonical GitHub issue URL. If omitted and source_repo is provided,
+                derived as "https://github.com/{source_repo}/issues/{issue_number}".
         """
-        return self._upsert_typed(issue_number, title, sweep_date, uow_type, success_criteria)
+        if not success_criteria or not success_criteria.strip():
+            raise ValueError(
+                f"success_criteria must not be empty for issue #{issue_number}. "
+                "Provide a prose completion statement that describes what 'done' means."
+            )
+        return self._upsert_typed(
+            issue_number, title, sweep_date, uow_type, success_criteria,
+            source_repo=source_repo, issue_url=issue_url,
+        )
 
     def _upsert_typed(
         self,
@@ -350,10 +376,18 @@ class Registry:
         sweep_date: str | None = None,
         uow_type: str = "executable",
         success_criteria: str = "",
+        source_repo: str | None = None,
+        issue_url: str | None = None,
     ) -> UpsertResult:
         """Core upsert logic returning typed UpsertResult."""
         if sweep_date is None:
             sweep_date = datetime.now(timezone.utc).date().isoformat()
+
+        # Derive issue_url from source_repo when not explicitly provided.
+        # Pure computation: no side effects, deterministic given inputs.
+        resolved_issue_url: str | None = issue_url
+        if resolved_issue_url is None and source_repo:
+            resolved_issue_url = f"https://github.com/{source_repo}/issues/{issue_number}"
 
         conn = self._connect()
         try:
@@ -422,8 +456,9 @@ class Registry:
                 INSERT INTO uow_registry (
                     id, type, source, source_issue_number, sweep_date,
                     status, posture, created_at, updated_at, summary,
-                    success_criteria, route_reason, route_evidence, trigger
-                ) VALUES (?, ?, ?, ?, ?, 'proposed', 'solo', ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}')
+                    success_criteria, route_reason, route_evidence, trigger,
+                    issue_url
+                ) VALUES (?, ?, ?, ?, ?, 'proposed', 'solo', ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?)
                 """,
                 (
                     uow_id,
@@ -436,6 +471,7 @@ class Registry:
                     title,
                     success_criteria,
                     _LEGACY_ROUTE_REASON,
+                    resolved_issue_url,
                 ),
             )
             conn.commit()

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -73,6 +73,11 @@ def cmd_upsert(registry: Registry, args: argparse.Namespace) -> None:
         success_criteria = _extract_success_criteria(issue_body)
     else:
         success_criteria = ""
+    # Enforce the germination contract: success_criteria must not be empty.
+    # Fall back to the title so CLI users without --issue-body still succeed;
+    # callers who need richer criteria should pass --issue-body.
+    if not success_criteria or not success_criteria.strip():
+        success_criteria = args.title
     result = registry.upsert(
         issue_number=args.issue,
         title=args.title,

--- a/src/orchestration/schema.sql
+++ b/src/orchestration/schema.sql
@@ -71,6 +71,12 @@ CREATE TABLE IF NOT EXISTS uow_registry (
     --   Written via NoteAccessor. Excluded from executor_uow_view.
     notes               TEXT    NOT NULL DEFAULT '{}',
 
+    -- issue_url: canonical GitHub issue URL, e.g. "https://github.com/owner/repo/issues/42".
+    --   Populated at proposal time so UoWs are self-describing; eliminates hardcoded
+    --   repo references in Steward and Executor. NULL for pre-migration rows.
+    --   Executor-accessible (included in executor_uow_view).
+    issue_url           TEXT    DEFAULT NULL,
+
     UNIQUE(source_issue_number, sweep_date)
 );
 -- vision_ref: JSON {layer, field, statement, anchored_at}
@@ -99,7 +105,8 @@ SELECT
     id, status, output_ref, started_at, completed_at,
     source_issue_number, summary,
     workflow_artifact, success_criteria, prescribed_skills,
-    steward_cycles, timeout_at, estimated_runtime
+    steward_cycles, timeout_at, estimated_runtime,
+    issue_url
 FROM uow_registry
 WHERE status = 'ready-for-executor';
 -- steward_agenda: Steward-private, excluded from executor_uow_view.

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -1096,9 +1096,32 @@ def _diagnose_uow(
 # GitHub client helper
 # ---------------------------------------------------------------------------
 
-def _default_github_client(issue_number: int) -> dict[str, Any]:
+def _repo_from_issue_url(issue_url: str | None) -> str | None:
+    """Extract 'owner/repo' from a GitHub issue URL.
+
+    Pure function — no side effects.
+
+    Examples:
+        "https://github.com/dcetlin/Lobster/issues/42" → "dcetlin/Lobster"
+        None → None
+        "not-a-url" → None
     """
-    Fetch issue info from GitHub using gh CLI.
+    if not issue_url:
+        return None
+    # URL form: https://github.com/{owner}/{repo}/issues/{number}
+    prefix = "https://github.com/"
+    if not issue_url.startswith(prefix):
+        return None
+    rest = issue_url[len(prefix):]
+    parts = rest.split("/")
+    if len(parts) >= 2:
+        return f"{parts[0]}/{parts[1]}"
+    return None
+
+
+def _fetch_github_issue(issue_number: int, repo: str) -> dict[str, Any]:
+    """
+    Fetch issue info from GitHub using gh CLI for a given repo.
 
     Returns dict with keys: status_code, state, labels (list), body, title.
     On any error, returns status_code=0 with empty fields.
@@ -1108,7 +1131,7 @@ def _default_github_client(issue_number: int) -> dict[str, Any]:
         result = subprocess.run(
             [
                 "gh", "issue", "view", str(issue_number),
-                "--repo", "dcetlin/Lobster",
+                "--repo", repo,
                 "--json", "state,labels,body,title",
             ],
             capture_output=True,
@@ -1127,8 +1150,23 @@ def _default_github_client(issue_number: int) -> dict[str, Any]:
             "title": data.get("title", ""),
         }
     except Exception as e:
-        log.warning("GitHub client error for issue %s: %s", issue_number, e)
+        log.warning("GitHub client error for issue %s (repo=%s): %s", issue_number, repo, e)
         return {"status_code": 0, "state": None, "labels": [], "body": "", "title": ""}
+
+
+def _default_github_client(issue_number: int) -> dict[str, Any]:
+    """
+    Fetch issue info from GitHub using gh CLI.
+
+    Falls back to the hardcoded 'dcetlin/Lobster' repo for UoWs that
+    pre-date the issue_url field (migration 0005). New UoWs provide
+    issue_url and the Steward loop calls _fetch_github_issue directly
+    with the derived repo, bypassing this function.
+
+    Returns dict with keys: status_code, state, labels (list), body, title.
+    On any error, returns status_code=0 with empty fields.
+    """
+    return _fetch_github_issue(issue_number, repo="dcetlin/Lobster")
 
 
 # ---------------------------------------------------------------------------
@@ -1767,9 +1805,20 @@ def run_steward_cycle(
         source_issue_number = uow.source_issue_number
         considered_ids.append(uow_id)
 
+        # Resolve the GitHub client for this UoW. When issue_url is present
+        # (populated at proposal time since migration 0005), derive the repo
+        # from the URL — no hardcoded repo slug. For pre-migration UoWs where
+        # issue_url is NULL, fall back to _github_client (which uses the legacy
+        # hardcoded repo). Pure resolution: no side effects.
+        resolved_repo = _repo_from_issue_url(getattr(uow, "issue_url", None))
+        def _resolve_issue_info(n: int) -> dict[str, Any]:
+            if resolved_repo:
+                return _fetch_github_issue(n, resolved_repo)
+            return _github_client(n)
+
         # BOOTUP_CANDIDATE_GATE: skip if label present and gate is True
         if _gate and source_issue_number:
-            issue_info = _github_client(source_issue_number)
+            issue_info = _resolve_issue_info(source_issue_number)
             labels = issue_info.get("labels", [])
             if "bootup-candidate" in labels:
                 log.debug(
@@ -1780,7 +1829,7 @@ def run_steward_cycle(
                 continue
         else:
             issue_info = (
-                _github_client(source_issue_number)
+                _resolve_issue_info(source_issue_number)
                 if source_issue_number
                 else None
             )

--- a/tests/integration/test_source_tracking.py
+++ b/tests/integration/test_source_tracking.py
@@ -38,7 +38,7 @@ def _now_iso() -> str:
 
 def _seed_uow(registry: Registry, issue_number: int = 1, title: str = "test uow") -> str:
     """Insert a proposed UoW and return its id."""
-    result = registry.upsert(issue_number=issue_number, title=title)
+    result = registry.upsert(issue_number=issue_number, title=title, success_criteria="Test completion.")
     assert isinstance(result, UpsertInserted), f"Expected UpsertInserted, got: {result}"
     return result.id
 

--- a/tests/integration/test_wos_pipeline.py
+++ b/tests/integration/test_wos_pipeline.py
@@ -134,6 +134,7 @@ def _seed_uow(
         issue_number=issue_number,
         title=title,
         sweep_date=sweep_date,
+        success_criteria="Test completion.",
     )
     assert isinstance(result, UpsertInserted), f"Expected UpsertInserted, got: {result}"
     uow_id = result.id
@@ -586,7 +587,7 @@ class TestSchemaHarness:
 
     def test_new_uow_has_steward_executor_column_defaults(self, db, phase2_registry):
         """New UoWs have correct NULL/0 defaults for steward/executor columns."""
-        result = phase2_registry.upsert(issue_number=1001, title="Test record defaults")
+        result = phase2_registry.upsert(issue_number=1001, title="Test record defaults", success_criteria="Test completion.")
         assert isinstance(result, UpsertInserted), f"Expected UpsertInserted, got: {result}"
         uow_id = result.id
 

--- a/tests/integration/test_wos_represcription_cycle.py
+++ b/tests/integration/test_wos_represcription_cycle.py
@@ -109,7 +109,7 @@ def _seed_uow_at_ready_for_steward(
     Returns the uow_id.
     """
     # Insert as proposed
-    result = registry.upsert(issue_number=issue_number, title=title)
+    result = registry.upsert(issue_number=issue_number, title=title, success_criteria="Test completion.")
     assert isinstance(result, UpsertInserted), f"Expected UpsertInserted, got: {result}"
     uow_id = result.id
 

--- a/tests/integration/test_wos_ttl_recovery.py
+++ b/tests/integration/test_wos_ttl_recovery.py
@@ -116,6 +116,7 @@ def _seed_and_activate(registry: Registry, conn: sqlite3.Connection) -> str:
         issue_number=9901,
         title="TTL test: stalled execution",
         sweep_date="2026-03-31",
+        success_criteria="Test completion.",
     )
     assert isinstance(result, UpsertInserted), f"seed failed: {result}"
     uow_id = result.id
@@ -164,6 +165,7 @@ def _seed_ready_for_executor(registry: Registry) -> str:
         issue_number=9902,
         title="TTL test: executor_orphan",
         sweep_date="2026-03-31",
+        success_criteria="Test completion.",
     )
     assert isinstance(result, UpsertInserted), f"seed failed: {result}"
     uow_id = result.id

--- a/tests/test_garden_caretaker.py
+++ b/tests/test_garden_caretaker.py
@@ -206,7 +206,7 @@ class TestScanDuplicatePrevention:
         self, registry: Registry
     ) -> None:
         """A non-terminal UoW for an issue must block re-seeding on the next scan."""
-        registry.upsert(issue_number=10, title="Existing")
+        registry.upsert(issue_number=10, title="Existing", success_criteria="Test completion.")
 
         source = StubIssueSource(scan_issues=[_snap(issue_number=10)])
         caretaker = GardenCaretaker(source=source, registry=registry)
@@ -275,7 +275,7 @@ class TestScanEmptySource:
 class TestTendNoChange:
     def test_open_source_proposed_uow_is_no_op(self, registry: Registry) -> None:
         """An open issue paired with a proposed UoW must produce no state change."""
-        registry.upsert(issue_number=42, title="Open and proposed")
+        registry.upsert(issue_number=42, title="Open and proposed", success_criteria="Test completion.")
         snap = _snap(issue_number=42, state="open")
         source = StubIssueSource(issue_map={"github:issue/42": snap})
         caretaker = GardenCaretaker(source=source, registry=registry)
@@ -290,7 +290,7 @@ class TestTendNoChange:
 
     def test_open_source_pending_uow_is_no_op(self, registry: Registry) -> None:
         """An open issue paired with a pending UoW must produce no state change."""
-        result = registry.upsert(issue_number=43, title="Pending open")
+        result = registry.upsert(issue_number=43, title="Pending open", success_criteria="Test completion.")
         registry.approve(result.id)
 
         snap = _snap(issue_number=43, state="open")
@@ -310,7 +310,7 @@ class TestTendNoChange:
 class TestTendArchiveOnClose:
     def test_closed_source_archives_proposed_uow(self, registry: Registry) -> None:
         """A closed issue with a proposed UoW must be archived (→ expired)."""
-        registry.upsert(issue_number=10, title="Will close")
+        registry.upsert(issue_number=10, title="Will close", success_criteria="Test completion.")
         snap = _snap(issue_number=10, state="closed")
         source = StubIssueSource(issue_map={"github:issue/10": snap})
         caretaker = GardenCaretaker(source=source, registry=registry)
@@ -324,7 +324,7 @@ class TestTendArchiveOnClose:
 
     def test_closed_source_archives_pending_uow(self, registry: Registry) -> None:
         """A closed issue with a pending UoW must also be archived."""
-        upsert = registry.upsert(issue_number=11, title="Pending close")
+        upsert = registry.upsert(issue_number=11, title="Pending close", success_criteria="Test completion.")
         registry.approve(upsert.id)
 
         snap = _snap(issue_number=11, state="closed")
@@ -339,7 +339,7 @@ class TestTendArchiveOnClose:
 
     def test_archive_writes_audit_entry(self, registry: Registry) -> None:
         """tend() archiving a UoW must write an 'archived_by_caretaker' audit entry."""
-        upsert = registry.upsert(issue_number=80, title="Audit on archive")
+        upsert = registry.upsert(issue_number=80, title="Audit on archive", success_criteria="Test completion.")
         snap = _snap(issue_number=80, state="closed")
         source = StubIssueSource(issue_map={"github:issue/80": snap})
         caretaker = GardenCaretaker(source=source, registry=registry)
@@ -356,7 +356,7 @@ class TestTendArchiveOnClose:
 class TestTendSurfaceOnClose:
     def test_closed_source_surfaces_active_uow(self, registry: Registry) -> None:
         """A closed issue with an active UoW must be surfaced to Steward."""
-        upsert = registry.upsert(issue_number=20, title="Active close")
+        upsert = registry.upsert(issue_number=20, title="Active close", success_criteria="Test completion.")
         registry.set_status_direct(upsert.id, "active")
 
         snap = _snap(issue_number=20, state="closed")
@@ -373,7 +373,7 @@ class TestTendSurfaceOnClose:
 
     def test_deleted_source_surfaces_active_uow(self, registry: Registry) -> None:
         """A deleted issue (get_issue returns None) with an active UoW must be surfaced."""
-        upsert = registry.upsert(issue_number=30, title="Active deleted")
+        upsert = registry.upsert(issue_number=30, title="Active deleted", success_criteria="Test completion.")
         registry.set_status_direct(upsert.id, "active")
 
         # Return None from get_issue → source deleted/not found
@@ -388,7 +388,7 @@ class TestTendSurfaceOnClose:
 
     def test_surface_writes_audit_entry(self, registry: Registry) -> None:
         """tend() surfacing a UoW must write a 'surfaced_to_steward' audit entry."""
-        upsert = registry.upsert(issue_number=90, title="Surface audit")
+        upsert = registry.upsert(issue_number=90, title="Surface audit", success_criteria="Test completion.")
         registry.set_status_direct(upsert.id, "active")
 
         snap = _snap(issue_number=90, state="closed")
@@ -409,7 +409,7 @@ class TestTendReactivate:
         self, registry: Registry
     ) -> None:
         """An open source issue paired with an expired UoW must be reactivated."""
-        upsert = registry.upsert(issue_number=50, title="Was expired")
+        upsert = registry.upsert(issue_number=50, title="Was expired", success_criteria="Test completion.")
         registry.set_status_direct(upsert.id, "expired")
 
         snap = _snap(issue_number=50, state="open")
@@ -427,7 +427,7 @@ class TestTendReactivate:
         self, registry: Registry
     ) -> None:
         """An open source issue paired with a failed UoW must also be reactivated."""
-        upsert = registry.upsert(issue_number=51, title="Was failed")
+        upsert = registry.upsert(issue_number=51, title="Was failed", success_criteria="Test completion.")
         registry.set_status_direct(upsert.id, "failed")
 
         snap = _snap(issue_number=51, state="open")
@@ -447,7 +447,7 @@ class TestTendReactivate:
 class TestTendDoneUoWIsExcluded:
     def test_done_uow_excluded_from_tend(self, registry: Registry) -> None:
         """Done UoWs are excluded from tend() entirely — get_issue must not be called."""
-        upsert = registry.upsert(issue_number=60, title="Done issue")
+        upsert = registry.upsert(issue_number=60, title="Done issue", success_criteria="Test completion.")
         registry.set_status_direct(upsert.id, "done")
 
         # The stub source has no entry for this ref — get_issue would return None
@@ -488,7 +488,7 @@ class TestSourceTracking:
         self, registry: Registry
     ) -> None:
         """The archived_by_caretaker audit note must include the source_ref."""
-        upsert = registry.upsert(issue_number=101, title="Source ref audit")
+        upsert = registry.upsert(issue_number=101, title="Source ref audit", success_criteria="Test completion.")
         snap = _snap(issue_number=101, state="closed")
         source = StubIssueSource(issue_map={"github:issue/101": snap})
         caretaker = GardenCaretaker(source=source, registry=registry)
@@ -516,7 +516,7 @@ class TestSourceTracking:
         self, registry: Registry
     ) -> None:
         """The surfaced_to_steward audit note must include the source_ref."""
-        upsert = registry.upsert(issue_number=102, title="Surface source ref")
+        upsert = registry.upsert(issue_number=102, title="Surface source ref", success_criteria="Test completion.")
         registry.set_status_direct(upsert.id, "active")
 
         snap = _snap(issue_number=102, state="closed")

--- a/tests/unit/test_orchestration/test_conditions.py
+++ b/tests/unit/test_orchestration/test_conditions.py
@@ -232,7 +232,7 @@ class TestRegistryStateTrigger:
         from src.orchestration.conditions import evaluate_condition
 
         # Insert a target UoW into the registry and advance it to "done"
-        result = registry.upsert(issue_number=99, title="target UoW")
+        result = registry.upsert(issue_number=99, title="target UoW", success_criteria="Test completion.")
         target_id = result.id
         registry.approve(target_id)
         registry.set_status_direct(target_id, "done")
@@ -248,7 +248,7 @@ class TestRegistryStateTrigger:
     def test_target_uow_not_in_specified_state_returns_false(self, registry, db_path):
         from src.orchestration.conditions import evaluate_condition
 
-        result = registry.upsert(issue_number=100, title="pending target")
+        result = registry.upsert(issue_number=100, title="pending target", success_criteria="Test completion.")
         target_id = result.id
         # UoW stays in "proposed" state
 
@@ -280,7 +280,7 @@ class TestRegistryStateTrigger:
     def test_no_audit_when_state_not_matched(self, registry, db_path):
         """False condition (state not matched) must not write audit entry."""
         from src.orchestration.conditions import evaluate_condition
-        result = registry.upsert(issue_number=101, title="still proposed")
+        result = registry.upsert(issue_number=101, title="still proposed", success_criteria="Test completion.")
         target_id = result.id
 
         uow_id = "uow_rs_silent"

--- a/tests/unit/test_orchestration/test_dispatcher_integration.py
+++ b/tests/unit/test_orchestration/test_dispatcher_integration.py
@@ -22,7 +22,7 @@ def registry(tmp_path: Path):
 @pytest.fixture
 def uow_id(registry) -> str:
     today = datetime.now(timezone.utc).date().isoformat()
-    result = registry.upsert(issue_number=200, title="Test issue for dispatcher", sweep_date=today)
+    result = registry.upsert(issue_number=200, title="Test issue for dispatcher", sweep_date=today, success_criteria="Test completion.")
     return result.id
 
 
@@ -118,7 +118,7 @@ class TestHandleApprove:
 
     def test_expired_message(self, registry):
         today = datetime.now(timezone.utc).date().isoformat()
-        result = registry.upsert(issue_number=201, title="Expiring issue", sweep_date=today)
+        result = registry.upsert(issue_number=201, title="Expiring issue", sweep_date=today, success_criteria="Test completion.")
         registry.set_status_direct(result.id, "expired")
         response = handle_approve(result.id, registry=registry)
         assert "expired" in response.lower()
@@ -136,7 +136,7 @@ class TestHandleConfirmAlias:
 class TestHandleWosStatus:
     def test_returns_active_records(self, registry, tmp_path):
         today = datetime.now(timezone.utc).date().isoformat()
-        r1 = registry.upsert(issue_number=210, title="Running issue", sweep_date=today)
+        r1 = registry.upsert(issue_number=210, title="Running issue", sweep_date=today, success_criteria="Test completion.")
         registry.set_status_direct(r1.id, "active")
         response = handle_wos_status("active", registry=registry)
         assert r1.id in response
@@ -147,7 +147,7 @@ class TestHandleWosStatus:
 
     def test_formats_each_record_with_required_fields(self, registry):
         today = datetime.now(timezone.utc).date().isoformat()
-        r = registry.upsert(issue_number=220, title="Status test issue", sweep_date=today)
+        r = registry.upsert(issue_number=220, title="Status test issue", sweep_date=today, success_criteria="Test completion.")
         response = handle_wos_status("proposed", registry=registry)
         # Each line should contain: id, summary, source, created date
         assert r.id in response
@@ -155,9 +155,9 @@ class TestHandleWosStatus:
 
     def test_defaults_to_active_and_pending(self, registry):
         today = datetime.now(timezone.utc).date().isoformat()
-        r1 = registry.upsert(issue_number=230, title="Active issue", sweep_date=today)
+        r1 = registry.upsert(issue_number=230, title="Active issue", sweep_date=today, success_criteria="Test completion.")
         registry.set_status_direct(r1.id, "active")
-        r2 = registry.upsert(issue_number=231, title="Pending issue", sweep_date=today)
+        r2 = registry.upsert(issue_number=231, title="Pending issue", sweep_date=today, success_criteria="Test completion.")
         registry.approve(r2.id)
         # No status arg → returns active + pending
         response = handle_wos_status(None, registry=registry)

--- a/tests/unit/test_orchestration/test_garden_caretaker.py
+++ b/tests/unit/test_orchestration/test_garden_caretaker.py
@@ -236,7 +236,7 @@ class TestScan:
 
     def test_scan_skips_issue_already_in_registry(self, registry: Registry) -> None:
         # Pre-seed the registry so the issue already has a non-terminal UoW
-        registry.upsert(issue_number=10, title="Existing")
+        registry.upsert(issue_number=10, title="Existing", success_criteria="Test completion.")
 
         snap = _snapshot(source_ref="github:issue/10")
         source = _make_source(scan_issues=[snap])
@@ -322,7 +322,7 @@ class TestScan:
 class TestTend:
     def test_tend_noop_when_source_open(self, registry: Registry) -> None:
         # Seed a proposed UoW
-        upsert = registry.upsert(issue_number=42, title="Open issue")
+        upsert = registry.upsert(issue_number=42, title="Open issue", success_criteria="Test completion.")
         assert upsert
 
         snap = _snapshot(source_ref="github:issue/42", state="open")
@@ -338,7 +338,7 @@ class TestTend:
         assert len(proposed) == 1
 
     def test_tend_archives_proposed_uow_when_source_closed(self, registry: Registry) -> None:
-        registry.upsert(issue_number=10, title="Will close")
+        registry.upsert(issue_number=10, title="Will close", success_criteria="Test completion.")
 
         snap = _snapshot(source_ref="github:issue/10", state="closed")
         source = _make_source(issue_map={"github:issue/10": snap})
@@ -355,7 +355,7 @@ class TestTend:
         assert len(expired) == 1
 
     def test_tend_archives_pending_uow_when_source_closed(self, registry: Registry) -> None:
-        upsert_result = registry.upsert(issue_number=11, title="Pending issue")
+        upsert_result = registry.upsert(issue_number=11, title="Pending issue", success_criteria="Test completion.")
         # Move to pending via approve
         registry.approve(upsert_result.id)
 
@@ -371,7 +371,7 @@ class TestTend:
     def test_tend_surfaces_to_steward_when_source_closed_and_active(
         self, registry: Registry
     ) -> None:
-        upsert_result = registry.upsert(issue_number=20, title="Active issue")
+        upsert_result = registry.upsert(issue_number=20, title="Active issue", success_criteria="Test completion.")
         # Manually set to active (bypassing normal flow for test setup)
         registry.set_status_direct(upsert_result.id, "active")
 
@@ -391,7 +391,7 @@ class TestTend:
     def test_tend_surfaces_to_steward_when_source_deleted_and_active(
         self, registry: Registry
     ) -> None:
-        upsert_result = registry.upsert(issue_number=30, title="Active deleted")
+        upsert_result = registry.upsert(issue_number=30, title="Active deleted", success_criteria="Test completion.")
         registry.set_status_direct(upsert_result.id, "active")
 
         # source.get_issue returns None → deleted
@@ -407,7 +407,7 @@ class TestTend:
     def test_tend_reactivates_archived_uow_when_source_reopens(
         self, registry: Registry
     ) -> None:
-        upsert_result = registry.upsert(issue_number=50, title="Was expired")
+        upsert_result = registry.upsert(issue_number=50, title="Was expired", success_criteria="Test completion.")
         # Simulate archived (expired) UoW
         registry.set_status_direct(upsert_result.id, "expired")
 
@@ -425,7 +425,7 @@ class TestTend:
         assert proposed[0].id == upsert_result.id
 
     def test_tend_noop_for_done_uow_with_closed_source(self, registry: Registry) -> None:
-        upsert_result = registry.upsert(issue_number=60, title="Done issue")
+        upsert_result = registry.upsert(issue_number=60, title="Done issue", success_criteria="Test completion.")
         registry.set_status_direct(upsert_result.id, "done")
 
         # tend() does not fetch done UoWs — they are excluded from _fetch_active_uows
@@ -440,7 +440,7 @@ class TestTend:
         assert registry.query(status="done")[0].id == upsert_result.id
 
     def test_tend_handles_source_error_gracefully(self, registry: Registry) -> None:
-        registry.upsert(issue_number=70, title="Error case")
+        registry.upsert(issue_number=70, title="Error case", success_criteria="Test completion.")
 
         source = MagicMock()
         source.get_issue.side_effect = Exception("network error")
@@ -454,7 +454,7 @@ class TestTend:
 
     def test_tend_audit_log_written_on_archive(self, registry: Registry) -> None:
         import sqlite3
-        upsert_result = registry.upsert(issue_number=80, title="Audit check")
+        upsert_result = registry.upsert(issue_number=80, title="Audit check", success_criteria="Test completion.")
 
         snap = _snapshot(source_ref="github:issue/80", state="closed")
         source = _make_source(issue_map={"github:issue/80": snap})
@@ -474,7 +474,7 @@ class TestTend:
 
     def test_tend_audit_log_written_on_surface(self, registry: Registry) -> None:
         import sqlite3
-        upsert_result = registry.upsert(issue_number=90, title="Surface audit")
+        upsert_result = registry.upsert(issue_number=90, title="Surface audit", success_criteria="Test completion.")
         registry.set_status_direct(upsert_result.id, "active")
 
         snap = _snapshot(source_ref="github:issue/90", state="closed")
@@ -496,7 +496,7 @@ class TestTend:
     def test_tend_archives_proposed_uow_when_source_deleted(
         self, registry: Registry
     ) -> None:
-        registry.upsert(issue_number=100, title="Deleted source")
+        registry.upsert(issue_number=100, title="Deleted source", success_criteria="Test completion.")
 
         source = _make_source(issue_map={"github:issue/100": None})
         caretaker = GardenCaretaker(source=source, registry=registry)

--- a/tests/unit/test_orchestration/test_migrations.py
+++ b/tests/unit/test_orchestration/test_migrations.py
@@ -276,7 +276,7 @@ class TestRegistryIntegration:
         from src.orchestration.registry import Registry, UpsertInserted
         db_path = tmp_path / "reg.db"
         reg = Registry(db_path)
-        result = reg.upsert(issue_number=42, title="Post-migration UoW", sweep_date="2026-01-01")
+        result = reg.upsert(issue_number=42, title="Post-migration UoW", sweep_date="2026-01-01", success_criteria="Test completion.")
         assert isinstance(result, UpsertInserted)
 
     def test_notes_column_accessible_after_registry_init(self, tmp_path: Path) -> None:

--- a/tests/unit/test_orchestration/test_phase2_schema_migration.py
+++ b/tests/unit/test_orchestration/test_phase2_schema_migration.py
@@ -348,9 +348,25 @@ class TestPreMigrationUoWSurvival:
 
         today = "2026-01-01"
         from src.orchestration.registry import UpsertInserted
-        result = reg.upsert(issue_number=1001, title="Pre-migration UoW", sweep_date=today)
-        assert isinstance(result, UpsertInserted)
-        uow_id = result.id
+        # Pre-migration simulation: insert directly via SQL to bypass the
+        # success_criteria validation enforced by upsert() (this mimics rows
+        # that existed before issue_url and success_criteria enforcement).
+        import uuid
+        from datetime import datetime, timezone
+        uow_id = f"uow_{datetime.now(timezone.utc).strftime('%Y%m%d')}_{uuid.uuid4().hex[:6]}"
+        conn = reg._connect()
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "INSERT INTO uow_registry (id, type, source, source_issue_number, sweep_date, "
+            "status, posture, created_at, updated_at, summary, success_criteria, "
+            "route_reason, route_evidence, trigger) "
+            "VALUES (?, 'executable', 'github:issue/1001', 1001, ?, 'proposed', 'solo', "
+            "?, ?, 'Pre-migration UoW', '', 'phase1-default: no classifier', '{}', '{\"type\": \"immediate\"}')",
+            (uow_id, today, now, now),
+        )
+        conn.commit()
+        conn.close()
 
         # Run migration
         migration_result = _run_migration(db_path)
@@ -363,7 +379,8 @@ class TestPreMigrationUoWSurvival:
         assert record is not None, f"get() returned None for id {uow_id}"
         assert record.id == uow_id
         assert record.workflow_artifact is None
-        # success_criteria is NOT NULL DEFAULT '' — pre-migration rows get '' after migration
+        # Pre-migration rows have empty success_criteria — the schema allows '' for legacy rows.
+        # New UoWs created via upsert() are now rejected if success_criteria is blank.
         assert record.success_criteria == ""
         assert record.prescribed_skills is None
         assert record.steward_cycles == 0
@@ -373,19 +390,23 @@ class TestPreMigrationUoWSurvival:
         assert record.steward_log is None
 
     def test_new_uow_after_migration_has_correct_defaults(self, migrated_db):
-        """New UoW created after migration has all Phase 2 fields with correct defaults."""
+        """New UoW created after migration stores supplied success_criteria."""
         from src.orchestration.registry import Registry, UpsertInserted
         reg = Registry(migrated_db)
-        result = reg.upsert(issue_number=1002, title="Post-migration UoW", sweep_date="2026-01-02")
+        result = reg.upsert(
+            issue_number=1002,
+            title="Post-migration UoW",
+            sweep_date="2026-01-02",
+            success_criteria="PR merged with all tests green.",
+        )
         assert isinstance(result, UpsertInserted)
         uow_id = result.id
 
         record = reg.get(uow_id)
         assert record is not None
         assert record.workflow_artifact is None
-        # success_criteria is NOT NULL DEFAULT '' — new UoWs default to ''
-        # (Application layer: UoW Registrar must reject empty success_criteria at germination)
-        assert record.success_criteria == ""
+        # success_criteria is enforced non-empty at upsert time (issue #488).
+        assert record.success_criteria == "PR merged with all tests green."
         assert record.prescribed_skills is None
         assert record.steward_cycles == 0
         assert record.timeout_at is None

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -80,8 +80,8 @@ class TestSchemaInit:
         conn.close()
         # Duplicate upsert with same issue+sweep_date should not create second row
         today = datetime.now(timezone.utc).date().isoformat()
-        uow_a = registry.upsert(issue_number=999, title="Test A", sweep_date=today)
-        uow_b = registry.upsert(issue_number=999, title="Test A again", sweep_date=today)
+        uow_a = registry.upsert(issue_number=999, title="Test A", sweep_date=today, success_criteria="Test completion.")
+        uow_b = registry.upsert(issue_number=999, title="Test A again", sweep_date=today, success_criteria="Test completion.")
         conn2 = _open_db(db_path)
         count = conn2.execute(
             "SELECT COUNT(*) as c FROM uow_registry WHERE source_issue_number = 999"
@@ -98,7 +98,7 @@ class TestUpsert:
     def test_insert_new_proposed_record(self, registry, db_path):
         from src.orchestration.registry import UpsertInserted
         today = datetime.now(timezone.utc).date().isoformat()
-        result = registry.upsert(issue_number=1, title="First issue", sweep_date=today)
+        result = registry.upsert(issue_number=1, title="First issue", sweep_date=today, success_criteria="Test completion.")
         assert isinstance(result, UpsertInserted)
         assert result.id.startswith("uow_")
 
@@ -144,7 +144,7 @@ class TestUpsert:
 
     def test_audit_entry_on_insert(self, registry, db_path):
         today = datetime.now(timezone.utc).date().isoformat()
-        result = registry.upsert(issue_number=2, title="Issue with audit", sweep_date=today)
+        result = registry.upsert(issue_number=2, title="Issue with audit", sweep_date=today, success_criteria="Test completion.")
         conn = _open_db(db_path)
         audit = conn.execute(
             "SELECT * FROM audit_log WHERE uow_id = ?", (result.id,)
@@ -158,17 +158,17 @@ class TestUpsert:
         today = datetime.now(timezone.utc).date().isoformat()
         yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
         # First sweep: insert proposed
-        first = registry.upsert(issue_number=10, title="Issue 10", sweep_date=yesterday)
+        first = registry.upsert(issue_number=10, title="Issue 10", sweep_date=yesterday, success_criteria="Test completion.")
         assert isinstance(first, UpsertInserted)
         # Second sweep (different date): should skip since non-terminal exists
-        second = registry.upsert(issue_number=10, title="Issue 10", sweep_date=today)
+        second = registry.upsert(issue_number=10, title="Issue 10", sweep_date=today, success_criteria="Test completion.")
         assert isinstance(second, UpsertSkipped)
         assert "proposed" in second.reason
 
     def test_skip_if_pending_already_exists(self, registry, db_path):
         from src.orchestration.registry import UpsertSkipped
         today = datetime.now(timezone.utc).date().isoformat()
-        first = registry.upsert(issue_number=11, title="Issue 11", sweep_date=today)
+        first = registry.upsert(issue_number=11, title="Issue 11", sweep_date=today, success_criteria="Test completion.")
         # Manually set to pending
         conn = _open_db(db_path)
         conn.execute("UPDATE uow_registry SET status='pending' WHERE id=?", (first.id,))
@@ -176,64 +176,213 @@ class TestUpsert:
         conn.close()
         # Next sweep should skip
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).date().isoformat()
-        second = registry.upsert(issue_number=11, title="Issue 11", sweep_date=tomorrow)
+        second = registry.upsert(issue_number=11, title="Issue 11", sweep_date=tomorrow, success_criteria="Test completion.")
         assert isinstance(second, UpsertSkipped)
 
     def test_skip_if_active_already_exists(self, registry, db_path):
         from src.orchestration.registry import UpsertSkipped
         today = datetime.now(timezone.utc).date().isoformat()
-        first = registry.upsert(issue_number=12, title="Issue 12", sweep_date=today)
+        first = registry.upsert(issue_number=12, title="Issue 12", sweep_date=today, success_criteria="Test completion.")
         conn = _open_db(db_path)
         conn.execute("UPDATE uow_registry SET status='active' WHERE id=?", (first.id,))
         conn.commit()
         conn.close()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).date().isoformat()
-        second = registry.upsert(issue_number=12, title="Issue 12", sweep_date=tomorrow)
+        second = registry.upsert(issue_number=12, title="Issue 12", sweep_date=tomorrow, success_criteria="Test completion.")
         assert isinstance(second, UpsertSkipped)
 
     def test_reinsert_after_done(self, registry):
         from src.orchestration.registry import UpsertInserted
         today = datetime.now(timezone.utc).date().isoformat()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).date().isoformat()
-        first = registry.upsert(issue_number=20, title="Issue 20", sweep_date=today)
+        first = registry.upsert(issue_number=20, title="Issue 20", sweep_date=today, success_criteria="Test completion.")
         registry.set_status_direct(first.id, "done")
         # New sweep should create a fresh proposed record
-        second = registry.upsert(issue_number=20, title="Issue 20", sweep_date=tomorrow)
+        second = registry.upsert(issue_number=20, title="Issue 20", sweep_date=tomorrow, success_criteria="Test completion.")
         assert isinstance(second, UpsertInserted)
 
     def test_reinsert_after_failed(self, registry):
         from src.orchestration.registry import UpsertInserted
         today = datetime.now(timezone.utc).date().isoformat()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).date().isoformat()
-        first = registry.upsert(issue_number=21, title="Issue 21", sweep_date=today)
+        first = registry.upsert(issue_number=21, title="Issue 21", sweep_date=today, success_criteria="Test completion.")
         registry.set_status_direct(first.id, "failed")
-        second = registry.upsert(issue_number=21, title="Issue 21", sweep_date=tomorrow)
+        second = registry.upsert(issue_number=21, title="Issue 21", sweep_date=tomorrow, success_criteria="Test completion.")
         assert isinstance(second, UpsertInserted)
 
     def test_reinsert_after_expired(self, registry):
         from src.orchestration.registry import UpsertInserted
         today = datetime.now(timezone.utc).date().isoformat()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).date().isoformat()
-        first = registry.upsert(issue_number=22, title="Issue 22", sweep_date=today)
+        first = registry.upsert(issue_number=22, title="Issue 22", sweep_date=today, success_criteria="Test completion.")
         registry.set_status_direct(first.id, "expired")
-        second = registry.upsert(issue_number=22, title="Issue 22", sweep_date=tomorrow)
+        second = registry.upsert(issue_number=22, title="Issue 22", sweep_date=tomorrow, success_criteria="Test completion.")
         assert isinstance(second, UpsertInserted)
 
     def test_unique_conflict_does_not_overwrite_non_proposed(self, registry, db_path):
         """Same issue_number + sweep_date conflict must not overwrite pending/active."""
         today = datetime.now(timezone.utc).date().isoformat()
-        first = registry.upsert(issue_number=30, title="Issue 30", sweep_date=today)
+        first = registry.upsert(issue_number=30, title="Issue 30", sweep_date=today, success_criteria="Test completion.")
         # Transition to pending
         conn = _open_db(db_path)
         conn.execute("UPDATE uow_registry SET status='pending' WHERE id=?", (first.id,))
         conn.commit()
         conn.close()
         # Same sweep_date conflict — should leave status as pending
-        registry.upsert(issue_number=30, title="Issue 30 updated", sweep_date=today)
+        registry.upsert(issue_number=30, title="Issue 30 updated", sweep_date=today, success_criteria="Test completion.")
         conn2 = _open_db(db_path)
         row = conn2.execute("SELECT status FROM uow_registry WHERE id=?", (first.id,)).fetchone()
         conn2.close()
         assert row["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Issue #488: success_criteria enforcement and issue_url population
+# ---------------------------------------------------------------------------
+
+class TestSuccessCriteriaEnforcement:
+    """upsert() must reject empty success_criteria (issue #488)."""
+
+    def test_empty_string_raises_value_error(self, registry):
+        """Calling upsert() with success_criteria='' raises ValueError."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        with pytest.raises(ValueError, match="success_criteria must not be empty"):
+            registry.upsert(
+                issue_number=8001,
+                title="Missing criteria",
+                sweep_date=today,
+                success_criteria="",
+            )
+
+    def test_whitespace_only_raises_value_error(self, registry):
+        """Calling upsert() with success_criteria='   ' raises ValueError."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        with pytest.raises(ValueError, match="success_criteria must not be empty"):
+            registry.upsert(
+                issue_number=8002,
+                title="Whitespace criteria",
+                sweep_date=today,
+                success_criteria="   ",
+            )
+
+    def test_non_empty_criteria_succeeds(self, registry, db_path):
+        """upsert() with a non-empty success_criteria stores it correctly."""
+        from src.orchestration.registry import UpsertInserted
+        today = datetime.now(timezone.utc).date().isoformat()
+        criteria = "Migration applied, tests green, PR merged."
+        result = registry.upsert(
+            issue_number=8003,
+            title="Valid criteria",
+            sweep_date=today,
+            success_criteria=criteria,
+        )
+        assert isinstance(result, UpsertInserted)
+        conn = _open_db(db_path)
+        row = conn.execute(
+            "SELECT success_criteria FROM uow_registry WHERE id = ?", (result.id,)
+        ).fetchone()
+        conn.close()
+        assert row["success_criteria"] == criteria
+
+
+class TestIssueUrlPopulation:
+    """issue_url is stored at proposal time (issue #488)."""
+
+    def test_explicit_issue_url_stored(self, registry, db_path):
+        """When issue_url is passed explicitly, it is persisted."""
+        from src.orchestration.registry import UpsertInserted
+        today = datetime.now(timezone.utc).date().isoformat()
+        url = "https://github.com/owner/repo/issues/42"
+        result = registry.upsert(
+            issue_number=42,
+            title="Issue with explicit URL",
+            sweep_date=today,
+            success_criteria="Widget works.",
+            issue_url=url,
+        )
+        assert isinstance(result, UpsertInserted)
+        conn = _open_db(db_path)
+        row = conn.execute(
+            "SELECT issue_url FROM uow_registry WHERE id = ?", (result.id,)
+        ).fetchone()
+        conn.close()
+        assert row["issue_url"] == url
+
+    def test_issue_url_derived_from_source_repo(self, registry, db_path):
+        """When source_repo is passed and issue_url is None, URL is derived."""
+        from src.orchestration.registry import UpsertInserted
+        today = datetime.now(timezone.utc).date().isoformat()
+        result = registry.upsert(
+            issue_number=99,
+            title="Issue with derived URL",
+            sweep_date=today,
+            success_criteria="Done.",
+            source_repo="myorg/myrepo",
+        )
+        assert isinstance(result, UpsertInserted)
+        conn = _open_db(db_path)
+        row = conn.execute(
+            "SELECT issue_url FROM uow_registry WHERE id = ?", (result.id,)
+        ).fetchone()
+        conn.close()
+        assert row["issue_url"] == "https://github.com/myorg/myrepo/issues/99"
+
+    def test_no_source_repo_no_issue_url_stored_null(self, registry, db_path):
+        """When neither source_repo nor issue_url is provided, issue_url is NULL."""
+        from src.orchestration.registry import UpsertInserted
+        today = datetime.now(timezone.utc).date().isoformat()
+        result = registry.upsert(
+            issue_number=100,
+            title="No URL",
+            sweep_date=today,
+            success_criteria="Done.",
+        )
+        assert isinstance(result, UpsertInserted)
+        conn = _open_db(db_path)
+        row = conn.execute(
+            "SELECT issue_url FROM uow_registry WHERE id = ?", (result.id,)
+        ).fetchone()
+        conn.close()
+        assert row["issue_url"] is None
+
+    def test_uow_value_object_carries_issue_url(self, registry):
+        """registry.get() returns a UoW with issue_url populated."""
+        from src.orchestration.registry import UpsertInserted
+        today = datetime.now(timezone.utc).date().isoformat()
+        url = "https://github.com/dcetlin/Lobster/issues/488"
+        result = registry.upsert(
+            issue_number=488,
+            title="Schema gaps",
+            sweep_date=today,
+            success_criteria="Migration applied.",
+            issue_url=url,
+        )
+        assert isinstance(result, UpsertInserted)
+        uow = registry.get(result.id)
+        assert uow is not None
+        assert uow.issue_url == url
+
+
+class TestRepoFromIssueUrl:
+    """_repo_from_issue_url pure function (issue #488)."""
+
+    def test_extracts_owner_repo_from_valid_url(self):
+        from src.orchestration.steward import _repo_from_issue_url
+        assert _repo_from_issue_url(
+            "https://github.com/dcetlin/Lobster/issues/42"
+        ) == "dcetlin/Lobster"
+
+    def test_returns_none_for_none_input(self):
+        from src.orchestration.steward import _repo_from_issue_url
+        assert _repo_from_issue_url(None) is None
+
+    def test_returns_none_for_non_github_url(self):
+        from src.orchestration.steward import _repo_from_issue_url
+        assert _repo_from_issue_url("https://gitlab.com/org/repo/issues/1") is None
+
+    def test_returns_none_for_empty_string(self):
+        from src.orchestration.steward import _repo_from_issue_url
+        assert _repo_from_issue_url("") is None
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +393,7 @@ class TestApprove:
     def test_approve_transitions_proposed_to_pending(self, registry):
         from src.orchestration.registry import ApproveConfirmed
         today = datetime.now(timezone.utc).date().isoformat()
-        result = registry.upsert(issue_number=50, title="Issue 50", sweep_date=today)
+        result = registry.upsert(issue_number=50, title="Issue 50", sweep_date=today, success_criteria="Test completion.")
         uow_id = result.id
         approve_result = registry.approve(uow_id)
         assert isinstance(approve_result, ApproveConfirmed)
@@ -252,7 +401,7 @@ class TestApprove:
 
     def test_approve_writes_audit_entry(self, registry, db_path):
         today = datetime.now(timezone.utc).date().isoformat()
-        result = registry.upsert(issue_number=51, title="Issue 51", sweep_date=today)
+        result = registry.upsert(issue_number=51, title="Issue 51", sweep_date=today, success_criteria="Test completion.")
         uow_id = result.id
         registry.approve(uow_id)
         conn = _open_db(db_path)
@@ -266,7 +415,7 @@ class TestApprove:
     def test_approve_idempotent_on_already_pending(self, registry):
         from src.orchestration.registry import ApproveSkipped
         today = datetime.now(timezone.utc).date().isoformat()
-        result = registry.upsert(issue_number=52, title="Issue 52", sweep_date=today)
+        result = registry.upsert(issue_number=52, title="Issue 52", sweep_date=today, success_criteria="Test completion.")
         uow_id = result.id
         registry.approve(uow_id)
         # Second approve returns ApproveSkipped, not an error
@@ -283,7 +432,7 @@ class TestApprove:
     def test_approve_returns_expired_on_expired(self, registry):
         from src.orchestration.registry import ApproveExpired
         today = datetime.now(timezone.utc).date().isoformat()
-        result = registry.upsert(issue_number=53, title="Issue 53", sweep_date=today)
+        result = registry.upsert(issue_number=53, title="Issue 53", sweep_date=today, success_criteria="Test completion.")
         uow_id = result.id
         registry.set_status_direct(uow_id, "expired")
         approve_result = registry.approve(uow_id)
@@ -298,9 +447,9 @@ class TestList:
     def test_list_by_status(self, registry):
         from src.orchestration.registry import UoW
         today = datetime.now(timezone.utc).date().isoformat()
-        r1 = registry.upsert(issue_number=60, title="Issue 60", sweep_date=today)
-        r2 = registry.upsert(issue_number=61, title="Issue 61", sweep_date=today)
-        r3 = registry.upsert(issue_number=62, title="Issue 62", sweep_date=today)
+        r1 = registry.upsert(issue_number=60, title="Issue 60", sweep_date=today, success_criteria="Test completion.")
+        r2 = registry.upsert(issue_number=61, title="Issue 61", sweep_date=today, success_criteria="Test completion.")
+        r3 = registry.upsert(issue_number=62, title="Issue 62", sweep_date=today, success_criteria="Test completion.")
         registry.approve(r2.id)
         proposed = registry.list(status="proposed")
         pending = registry.list(status="pending")
@@ -312,8 +461,8 @@ class TestList:
 
     def test_list_returns_all_when_no_filter(self, registry):
         today = datetime.now(timezone.utc).date().isoformat()
-        registry.upsert(issue_number=70, title="Issue 70", sweep_date=today)
-        registry.upsert(issue_number=71, title="Issue 71", sweep_date=today)
+        registry.upsert(issue_number=70, title="Issue 70", sweep_date=today, success_criteria="Test completion.")
+        registry.upsert(issue_number=71, title="Issue 71", sweep_date=today, success_criteria="Test completion.")
         all_records = registry.list()
         assert len(all_records) >= 2
 
@@ -330,7 +479,7 @@ class TestGet:
     def test_get_existing_record(self, registry):
         from src.orchestration.registry import UoW
         today = datetime.now(timezone.utc).date().isoformat()
-        inserted = registry.upsert(issue_number=80, title="Issue 80", sweep_date=today)
+        inserted = registry.upsert(issue_number=80, title="Issue 80", sweep_date=today, success_criteria="Test completion.")
         got = registry.get(inserted.id)
         assert isinstance(got, UoW)
         assert got.id == inserted.id
@@ -349,8 +498,8 @@ class TestExpireProposals:
     def test_expires_old_proposed_records(self, registry, db_path):
         old_date = (datetime.now(timezone.utc) - timedelta(days=15)).date().isoformat()
         recent_date = datetime.now(timezone.utc).date().isoformat()
-        old = registry.upsert(issue_number=90, title="Old issue", sweep_date=old_date)
-        recent = registry.upsert(issue_number=91, title="Recent issue", sweep_date=recent_date)
+        old = registry.upsert(issue_number=90, title="Old issue", sweep_date=old_date, success_criteria="Test completion.")
+        recent = registry.upsert(issue_number=91, title="Recent issue", sweep_date=recent_date, success_criteria="Test completion.")
         # Manually backdate the old record's created_at
         conn = _open_db(db_path)
         old_ts = (datetime.now(timezone.utc) - timedelta(days=15)).isoformat()
@@ -364,7 +513,7 @@ class TestExpireProposals:
 
     def test_does_not_expire_non_proposed(self, registry, db_path):
         old_date = (datetime.now(timezone.utc) - timedelta(days=15)).date().isoformat()
-        r = registry.upsert(issue_number=92, title="Active old", sweep_date=old_date)
+        r = registry.upsert(issue_number=92, title="Active old", sweep_date=old_date, success_criteria="Test completion.")
         # Backdate and set to active
         conn = _open_db(db_path)
         old_ts = (datetime.now(timezone.utc) - timedelta(days=15)).isoformat()
@@ -379,7 +528,7 @@ class TestExpireProposals:
 
     def test_expire_writes_audit_entries(self, registry, db_path):
         old_date = (datetime.now(timezone.utc) - timedelta(days=15)).date().isoformat()
-        r = registry.upsert(issue_number=93, title="Expiring", sweep_date=old_date)
+        r = registry.upsert(issue_number=93, title="Expiring", sweep_date=old_date, success_criteria="Test completion.")
         conn = _open_db(db_path)
         old_ts = (datetime.now(timezone.utc) - timedelta(days=15)).isoformat()
         conn.execute("UPDATE uow_registry SET created_at = ? WHERE id = ?", (old_ts, r.id))
@@ -402,7 +551,7 @@ class TestAuditLog:
     def test_audit_log_is_append_only(self, registry, db_path):
         """Approve entries cannot be deleted (test that entries accumulate)."""
         today = datetime.now(timezone.utc).date().isoformat()
-        r = registry.upsert(issue_number=100, title="Issue 100", sweep_date=today)
+        r = registry.upsert(issue_number=100, title="Issue 100", sweep_date=today, success_criteria="Test completion.")
         registry.approve(r.id)
         conn = _open_db(db_path)
         count = conn.execute("SELECT COUNT(*) as c FROM audit_log WHERE uow_id = ?", (r.id,)).fetchone()["c"]
@@ -411,7 +560,7 @@ class TestAuditLog:
 
     def test_all_fields_present_in_audit_entry(self, registry, db_path):
         today = datetime.now(timezone.utc).date().isoformat()
-        r = registry.upsert(issue_number=101, title="Audit fields test", sweep_date=today)
+        r = registry.upsert(issue_number=101, title="Audit fields test", sweep_date=today, success_criteria="Test completion.")
         conn = _open_db(db_path)
         entry = conn.execute("SELECT * FROM audit_log WHERE uow_id = ?", (r.id,)).fetchone()
         conn.close()
@@ -432,7 +581,7 @@ class TestCheckStale:
     def test_check_stale_returns_uow_when_issue_closed(self, registry, db_path):
         from src.orchestration.registry import UoW
         today = datetime.now(timezone.utc).date().isoformat()
-        r = registry.upsert(issue_number=110, title="Issue 110", sweep_date=today)
+        r = registry.upsert(issue_number=110, title="Issue 110", sweep_date=today, success_criteria="Test completion.")
         conn = _open_db(db_path)
         conn.execute("UPDATE uow_registry SET status='active' WHERE id=?", (r.id,))
         conn.commit()
@@ -445,7 +594,7 @@ class TestCheckStale:
 
     def test_check_stale_excludes_open_issues(self, registry, db_path):
         today = datetime.now(timezone.utc).date().isoformat()
-        r = registry.upsert(issue_number=111, title="Issue 111", sweep_date=today)
+        r = registry.upsert(issue_number=111, title="Issue 111", sweep_date=today, success_criteria="Test completion.")
         conn = _open_db(db_path)
         conn.execute("UPDATE uow_registry SET status='active' WHERE id=?", (r.id,))
         conn.commit()
@@ -494,7 +643,7 @@ class TestRegistryCompleteUow:
     def _make_active_uow(self, registry, db_path: Path) -> str:
         """Helper: create a UoW in 'active' status for transition tests."""
         from src.orchestration.registry import UpsertInserted
-        result = registry.upsert(issue_number=9001, title="Test active UoW")
+        result = registry.upsert(issue_number=9001, title="Test active UoW", success_criteria="Test completion.")
         assert isinstance(result, UpsertInserted)
         uow_id = result.id
         registry.approve(uow_id)
@@ -553,7 +702,7 @@ class TestRegistryCompleteUow:
 class TestNoteAccessor:
     def _make_uow_id(self, registry) -> str:
         from src.orchestration.registry import UpsertInserted
-        result = registry.upsert(issue_number=5555, title="NoteAccessor test UoW")
+        result = registry.upsert(issue_number=5555, title="NoteAccessor test UoW", success_criteria="Test completion.")
         assert isinstance(result, UpsertInserted)
         return result.id
 


### PR DESCRIPTION
## What this fixes

Before this PR, two schema enforcement gaps allowed invalid UoWs to propagate silently:

1. **`success_criteria` bypass**: The schema declared `NOT NULL DEFAULT ''`, so every UoW passed germination with an empty string. The Steward silently fell back to the `summary` field, which means completion evaluation had no principled anchor. The design says "a UoW without `success_criteria` is invalid and rejected at germination time."

2. **Hardcoded repo slug**: `steward.py` and `executor.py` hardcoded `"dcetlin/Lobster"` when constructing GitHub API calls and agent prompts. UoWs had no stored URL — the repo had to be guessed from context rather than read from data.

## What changed

### Migration 0005 — `issue_url` field
Adds `issue_url TEXT DEFAULT NULL` to `uow_registry` and exposes it in `executor_uow_view`. NULL for pre-existing rows; populated at proposal time for all new UoWs going forward.

### Registry: `upsert()` validates `success_criteria`
`Registry.upsert()` now raises `ValueError` if `success_criteria` is empty or whitespace-only. The schema retains `DEFAULT ''` so pre-migration rows survive; the enforcement is at the Python API boundary. `upsert()` also accepts `source_repo` and `issue_url` parameters: if `issue_url` is not supplied but `source_repo` is, the URL is derived deterministically as `https://github.com/{source_repo}/issues/{issue_number}`.

### GardenCaretaker: passes `success_criteria` and `issue_url` at scan time
`scan()` now passes `success_criteria=snapshot.body` (falling back to `snapshot.title` when body is empty) and `issue_url=snapshot.url`. Both fields are populated by the `IssueSnapshot` the caretaker already holds — no new I/O.

### Steward: repo resolved from `issue_url`, not hardcoded
New pure helper `_repo_from_issue_url(url)` extracts `owner/repo` from a GitHub issue URL. The main loop uses this to call `_fetch_github_issue(n, repo)` directly when `issue_url` is present. Pre-migration UoWs (where `issue_url` is NULL) fall back to `_default_github_client`, which retains the legacy hardcoded repo as a backward-compatibility fallback.

### Executor: preamble no longer names the repo
The `_FUNCTIONAL_ENGINEER_PREAMBLE` instruction string now says "open a PR on the repo identified in the prescription's issue URL" — the subagent reads the correct repo from the issue URL it fetches in step 1.

## Functional pattern notes
- `_repo_from_issue_url` is a pure function (no side effects, deterministic, directly tested).
- `_upsert_typed` derives `issue_url` from inputs before touching the DB — pure computation before the side-effecting transaction.
- `_resolve_issue_info` in the steward loop is a locally-scoped function that closes over `resolved_repo`, keeping the decision point collocated with the data it uses.

## Flow: before vs. after

Before:
```
GardenCaretaker.scan() → upsert(issue_number, title)
  → success_criteria = "" (DB default, no validation)
  → issue_url = NULL
  → Steward._default_github_client() → "dcetlin/Lobster" hardcoded
```

After:
```
GardenCaretaker.scan() → upsert(issue_number, title, success_criteria=body, issue_url=url)
  → success_criteria="" raises ValueError (germination gate)
  → success_criteria=body stored; issue_url stored
  → Steward: _repo_from_issue_url(uow.issue_url) → "owner/repo"
             _fetch_github_issue(n, repo) — no hardcoding
  → NULL issue_url → fallback to _default_github_client (backward compat)
```

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/ tests/integration/ tests/test_garden_caretaker.py -q` — 601 passed, 3 skipped, 5 xfailed
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py -q` — 60 passed (11 new tests added for the three behaviors)
- [ ] `tests/smoke/test_require_write_result.py::test_dispatcher_skips_enforcement` — skipped: pre-existing failure on main, unrelated to this change
- [ ] `tests/unit/test_reliability.py::TestAuditLog` — skipped: pre-existing failure on main, unrelated to this change

Closes #488