### PR TITLE
fix(steward): replace direct Anthropic API calls with claude -p subprocess

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import sqlite3
+import subprocess
 import sys
 import time
 import uuid
@@ -39,15 +40,15 @@ from src.orchestration.registry import UoW
 log = logging.getLogger("steward")
 
 # ---------------------------------------------------------------------------
-# LLM prescription model
+# LLM prescription dispatch
 # ---------------------------------------------------------------------------
 
-# Use haiku for cost efficiency — prescriptions are structured short outputs.
-_LLM_PRESCRIPTION_MODEL = "claude-haiku-4-5"
+# Hard timeout for the claude -p prescription call (seconds). If exceeded,
+# falls back to the deterministic template.
+_LLM_PRESCRIPTION_TIMEOUT_SECS = 60
 
-# Hard timeout for the LLM prescription call (seconds). If exceeded, falls
-# back to the deterministic template.
-_LLM_PRESCRIPTION_TIMEOUT_SECS = 30
+# claude binary — resolved from PATH at call time.
+_CLAUDE_BIN = "claude"
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +165,8 @@ _STEWARD_REQUIRED_FIELDS = frozenset({
 
 # Executor types
 _EXECUTOR_TYPE_GENERAL = "general"
+_EXECUTOR_TYPE_FUNCTIONAL_ENGINEER = "functional-engineer"
+_EXECUTOR_TYPE_LOBSTER_OPS = "lobster-ops"
 
 # Return reason classifications
 _CLASSIFICATION_NORMAL = "normal"
@@ -511,6 +514,43 @@ def _build_initial_agenda(uow: "UoW", issue_body: str) -> list[dict[str, Any]]:
         ]
 
 
+def _select_executor_type(uow: "UoW") -> str:
+    """
+    Select the executor type appropriate to the UoW's nature.
+
+    Mapping:
+    - GitHub issues about code bugs, features, or PRs → functional-engineer
+    - Infrastructure or ops issues → lobster-ops
+    - General or unclear → general
+
+    Returns one of the _EXECUTOR_TYPE_* constants.
+    """
+    summary_lower = uow.summary.lower()
+    source = (uow.source or "").lower()
+
+    # Infrastructure / ops signals
+    ops_keywords = (
+        "install", "deploy", "cron", "systemd", "migration", "upgrade",
+        "ops", "infra", "server", "config", "script", "setup", "lobster-ops",
+    )
+    if any(kw in summary_lower for kw in ops_keywords):
+        return _EXECUTOR_TYPE_LOBSTER_OPS
+
+    # Code / feature / bug signals — default for GitHub issues
+    code_keywords = (
+        "bug", "fix", "feat", "feature", "implement", "refactor", "test",
+        "pr", "pull request", "issue", "error", "crash", "regression",
+    )
+    if any(kw in summary_lower for kw in code_keywords):
+        return _EXECUTOR_TYPE_FUNCTIONAL_ENGINEER
+
+    # Default: functional-engineer for anything sourced from a GitHub issue
+    if "github:issue" in source:
+        return _EXECUTOR_TYPE_FUNCTIONAL_ENGINEER
+
+    return _EXECUTOR_TYPE_GENERAL
+
+
 def _select_prescribed_skills(uow: "UoW", reentry_posture: str) -> list[str]:
     """
     Select prescribed skills appropriate to the UoW type and posture.
@@ -540,30 +580,20 @@ def _llm_prescribe(
     """
     Call Claude to generate a tailored prescription for the given UoW.
 
+    Dispatches via `claude -p` subprocess (the Lobster-standard LLM call path).
+    No ANTHROPIC_API_KEY or anthropic SDK required — the claude CLI handles auth.
+
     Returns a dict with keys:
       - "instructions": str — full instruction block for the Executor
       - "success_criteria_check": str — how to verify completion
       - "estimated_cycles": int — expected execution passes needed
 
-    Returns None if the LLM call fails, is unavailable, or times out.
+    Returns None if the subprocess fails, times out, or returns unparseable output.
     The caller must fall back to the deterministic template on None.
 
     This function is a pure side-effect boundary: the only observable effect
-    is the Anthropic API call. All inputs are immutable value types.
+    is the claude -p subprocess call. All inputs are immutable value types.
     """
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        log.warning(
-            "LLM prescription unavailable: ANTHROPIC_API_KEY not set — using deterministic fallback"
-        )
-        return None
-
-    try:
-        import anthropic  # local import — optional dependency
-    except ImportError:
-        log.debug("_llm_prescribe: anthropic package not installed, skipping LLM call")
-        return None
-
     # Build prior prescription summary from steward_log if available
     prior_prescriptions: list[str] = []
     if uow.steward_log:
@@ -609,15 +639,9 @@ def _llm_prescribe(
 
     uow_context = "\n".join(context_parts)
 
-    system_prompt = (
-        "You are prescribing work instructions for a Lobster subagent that will execute "
-        "a Unit of Work (UoW) in a software development pipeline. "
-        "Your prescription must be concrete, actionable, and directly executable. "
-        "Avoid vague language. Use the success_criteria as your north star for what 'done' means. "
-        "The Executor is a capable autonomous coding agent — write instructions at that level."
-    )
+    prompt = f"""You are prescribing work instructions for a Lobster subagent that will execute a Unit of Work (UoW) in a software development pipeline. Your prescription must be concrete, actionable, and directly executable. Avoid vague language. Use the success_criteria as your north star for what 'done' means. The Executor is a capable autonomous coding agent — write instructions at that level.
 
-    user_prompt = f"""Given this Unit of Work, write a precise prescription for the Executor.
+Given this Unit of Work, write a precise prescription for the Executor.
 
 {uow_context}
 
@@ -629,15 +653,20 @@ Respond with a JSON object only (no markdown, no explanation outside the JSON):
 }}"""
 
     try:
-        client = anthropic.Anthropic(api_key=api_key)
-        response = client.messages.create(
-            model=_LLM_PRESCRIPTION_MODEL,
-            max_tokens=1024,
+        proc = subprocess.run(
+            [_CLAUDE_BIN, "-p", prompt, "--output-format", "text"],
+            capture_output=True,
+            text=True,
             timeout=_LLM_PRESCRIPTION_TIMEOUT_SECS,
-            system=system_prompt,
-            messages=[{"role": "user", "content": user_prompt}],
         )
-        raw_text = response.content[0].text.strip()
+        if proc.returncode != 0:
+            log.warning(
+                "_llm_prescribe: claude -p exited %d for %s, falling back",
+                proc.returncode, uow.id,
+            )
+            return None
+
+        raw_text = proc.stdout.strip()
 
         # Strip markdown code fences if present
         if raw_text.startswith("```"):
@@ -667,6 +696,18 @@ Respond with a JSON object only (no markdown, no explanation outside the JSON):
             "estimated_cycles": max(1, min(3, estimated_cycles)),
         }
 
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "_llm_prescribe: claude -p timed out for %s after %ds, falling back",
+            uow.id, _LLM_PRESCRIPTION_TIMEOUT_SECS,
+        )
+        return None
+    except (json.JSONDecodeError, ValueError, KeyError) as exc:
+        log.warning(
+            "_llm_prescribe: failed to parse claude -p output for %s (%s: %s), falling back",
+            uow.id, type(exc).__name__, exc,
+        )
+        return None
     except Exception as exc:  # noqa: BLE001
         log.warning(
             "_llm_prescribe: LLM call failed for %s (%s: %s), falling back to deterministic template",
@@ -1140,18 +1181,20 @@ def _write_workflow_artifact(
     instructions: str,
     prescribed_skills: list[str],
     artifact_dir: Path | None = None,
+    executor_type: str = _EXECUTOR_TYPE_GENERAL,
 ) -> str:
     """
     Write a WorkflowArtifact JSON file to disk.
 
     Returns the absolute path to the written file.
     artifact_dir: override for the artifact directory (used in tests).
+    executor_type: the executor type to embed in the artifact (defaults to general).
     """
     try:
         from src.orchestration.workflow_artifact import WorkflowArtifact, to_json
         artifact = WorkflowArtifact(
             uow_id=uow_id,
-            executor_type=_EXECUTOR_TYPE_GENERAL,
+            executor_type=executor_type,
             constraints=[],
             prescribed_skills=prescribed_skills,
             instructions=instructions,
@@ -1161,7 +1204,7 @@ def _write_workflow_artifact(
         # Fallback if workflow_artifact.py not yet on branch (pre-merge)
         artifact_data = {
             "uow_id": uow_id,
-            "executor_type": _EXECUTOR_TYPE_GENERAL,
+            "executor_type": executor_type,
             "constraints": [],
             "prescribed_skills": prescribed_skills,
             "instructions": instructions,
@@ -1514,6 +1557,7 @@ def _process_uow(
     # with `reason` as the primary input (already in completion_rationale).
     new_cycles = cycles + 1
     prescribed_skills = _select_prescribed_skills(uow, reentry_posture)
+    selected_executor_type = _select_executor_type(uow)
 
     partial_steps_context: str = ""
     if executor_outcome == "partial" and uow.output_ref:
@@ -1607,6 +1651,7 @@ def _process_uow(
             instructions=instructions,
             prescribed_skills=prescribed_skills,
             artifact_dir=artifact_dir,
+            executor_type=selected_executor_type,
         )
 
         # Audit-before-transition: write agenda_update audit entry BEFORE updating
@@ -1639,7 +1684,7 @@ def _process_uow(
             "actor": _ACTOR_STEWARD,
             "uow_id": uow_id,
             "steward_cycles": new_cycles,
-            "workflow_primitive": _EXECUTOR_TYPE_GENERAL,
+            "workflow_primitive": selected_executor_type,
             "prescribed_skills": prescribed_skills,
             "instructions_preview": instructions[:80],
             "timestamp": _now_iso(),

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -1591,12 +1591,15 @@ class TestFeedbackLoopIntegration:
         _make_uow_row(conn, status="ready-for-steward", steward_cycles=0)
         conn.close()
 
+        # Use llm_prescriber=None to force the deterministic template path so
+        # we can assert on exact phrase presence without invoking claude -p.
         steward.run_steward_cycle(
             registry=registry,
             dry_run=False,
             github_client=_mock_github_client_open,
             artifact_dir=tmp_path / "artifacts",
             notify_dan=lambda *a, **kw: None,
+            llm_prescriber=None,
         )
 
         # Read back the written workflow artifact and check instructions
@@ -1607,7 +1610,7 @@ class TestFeedbackLoopIntegration:
         assert "Prior prescription attempts" not in instructions
 
     def test_second_cycle_includes_prior_context(self, db_path, registry, tmp_path):
-        """cycle=1 (re-prescription) instructions must include prior prescription context."""
+        """cycle=1 (re-prescription) deterministic instructions must include prior prescription context."""
         _ensure_registry_has_phase2_methods(registry)
         steward = _import_steward()
 
@@ -1636,12 +1639,16 @@ class TestFeedbackLoopIntegration:
         )
         conn.close()
 
+        # Use llm_prescriber=None to force the deterministic template path so
+        # we can assert on exact phrase presence. The LLM path (claude -p) would
+        # generate its own phrasing, making phrase assertions non-deterministic.
         steward.run_steward_cycle(
             registry=registry,
             dry_run=False,
             github_client=_mock_github_client_open,
             artifact_dir=tmp_path / "artifacts",
             notify_dan=lambda *a, **kw: None,
+            llm_prescriber=None,
         )
 
         artifacts = list((tmp_path / "artifacts").glob("*.json"))
@@ -1673,12 +1680,15 @@ class TestFeedbackLoopIntegration:
         )
         conn.close()
 
+        # Use llm_prescriber=None to force the deterministic template path so
+        # we can assert on exact phrase presence without invoking claude -p.
         steward.run_steward_cycle(
             registry=registry,
             dry_run=False,
             github_client=_mock_github_client_open,
             artifact_dir=tmp_path / "artifacts",
             notify_dan=lambda *a, **kw: None,
+            llm_prescriber=None,
         )
 
         artifacts = list((tmp_path / "artifacts").glob("*.json"))
@@ -1734,10 +1744,16 @@ class TestLlmPrescription:
             steward_log=steward_log,
         )
 
-    def test_llm_prescribe_skips_when_no_api_key(self, monkeypatch):
-        """_llm_prescribe returns None when ANTHROPIC_API_KEY is not set."""
+    def test_llm_prescribe_returns_none_on_subprocess_nonzero_exit(self, monkeypatch):
+        """_llm_prescribe returns None when claude -p exits with a non-zero code."""
+        import subprocess as _subprocess
         steward = _import_steward()
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        def mock_run(cmd, **kwargs):
+            result = _subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="error")
+            return result
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
 
         uow = self._make_uow()
         result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
@@ -1824,37 +1840,23 @@ class TestLlmPrescription:
         assert "Completion check:" not in result
 
     def test_llm_prescribe_includes_prior_prescription_history(self, monkeypatch):
-        """_llm_prescribe extracts prior prescription events from steward_log."""
+        """_llm_prescribe extracts prior prescription events from steward_log and includes them in the prompt."""
+        import subprocess as _subprocess
         steward = _import_steward()
 
         captured_prompts = []
 
-        class MockContent:
-            text = json.dumps({
+        def mock_run(cmd, **kwargs):
+            # cmd is [claude_bin, "-p", prompt, "--output-format", "text"]
+            captured_prompts.append(cmd[2])  # capture the prompt string
+            stdout = json.dumps({
                 "instructions": "Do the work again.",
                 "success_criteria_check": "File exists.",
                 "estimated_cycles": 1,
             })
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout=stdout, stderr="")
 
-        class MockResponse:
-            content = [MockContent()]
-
-        class MockMessages:
-            def create(self, **kwargs):
-                captured_prompts.append(kwargs)
-                return MockResponse()
-
-        class MockClient:
-            messages = MockMessages()
-
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
-
-        import importlib
-        import sys
-        # Inject a mock anthropic module
-        mock_anthropic = type(sys)("anthropic")
-        mock_anthropic.Anthropic = lambda api_key=None: MockClient()
-        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
 
         prior_log = json.dumps({
             "event": "prescription",
@@ -1867,84 +1869,51 @@ class TestLlmPrescription:
 
         assert result is not None
         assert len(captured_prompts) == 1
-        user_content = captured_prompts[0]["messages"][0]["content"]
         # Prior prescription history should appear in the prompt
-        assert "Initial implementation missing tests" in user_content
+        assert "Initial implementation missing tests" in captured_prompts[0]
 
     def test_llm_prescribe_handles_malformed_json_response(self, monkeypatch):
-        """_llm_prescribe returns None when LLM returns non-JSON content."""
+        """_llm_prescribe returns None when claude -p returns non-JSON content."""
+        import subprocess as _subprocess
         steward = _import_steward()
 
-        class MockContent:
-            text = "Sorry, I cannot help with that."
+        def mock_run(cmd, **kwargs):
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout="Sorry, I cannot help with that.", stderr="")
 
-        class MockResponse:
-            content = [MockContent()]
-
-        class MockMessages:
-            def create(self, **kwargs):
-                return MockResponse()
-
-        class MockClient:
-            messages = MockMessages()
-
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
-        import sys
-        mock_anthropic = type(sys)("anthropic")
-        mock_anthropic.Anthropic = lambda api_key=None: MockClient()
-        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
 
         uow = self._make_uow()
         result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
         assert result is None
 
-    def test_llm_prescribe_handles_api_exception(self, monkeypatch):
-        """_llm_prescribe returns None when the API call raises an exception."""
+    def test_llm_prescribe_handles_subprocess_exception(self, monkeypatch):
+        """_llm_prescribe returns None when subprocess.run raises an exception."""
         steward = _import_steward()
 
-        class MockMessages:
-            def create(self, **kwargs):
-                raise ConnectionError("API unreachable")
+        def mock_run(cmd, **kwargs):
+            raise FileNotFoundError("claude: command not found")
 
-        class MockClient:
-            messages = MockMessages()
-
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
-        import sys
-        mock_anthropic = type(sys)("anthropic")
-        mock_anthropic.Anthropic = lambda api_key=None: MockClient()
-        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
 
         uow = self._make_uow()
         result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
         assert result is None
 
     def test_llm_prescribe_handles_markdown_fenced_json(self, monkeypatch):
-        """_llm_prescribe strips markdown code fences from the response."""
+        """_llm_prescribe strips markdown code fences from the claude -p response."""
+        import subprocess as _subprocess
         steward = _import_steward()
 
-        class MockContent:
-            text = "```json\n" + json.dumps({
-                "instructions": "Implement the feature.",
-                "success_criteria_check": "Feature works.",
-                "estimated_cycles": 2,
-            }) + "\n```"
+        fenced_output = "```json\n" + json.dumps({
+            "instructions": "Implement the feature.",
+            "success_criteria_check": "Feature works.",
+            "estimated_cycles": 2,
+        }) + "\n```"
 
-        class MockResponse:
-            content = [MockContent()]
+        def mock_run(cmd, **kwargs):
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout=fenced_output, stderr="")
 
-        class MockMessages:
-            def create(self, **kwargs):
-                return MockResponse()
-
-        class MockClient:
-            messages = MockMessages()
-
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
-        import sys
-        mock_anthropic = type(sys)("anthropic")
-        mock_anthropic.Anthropic = lambda api_key=None: MockClient()
-        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
 
         uow = self._make_uow()
         result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
@@ -1998,6 +1967,57 @@ class TestLlmPrescription:
         artifact_data = json.loads(artifacts[0].read_text())
         assert "LLM-generated" in artifact_data["instructions"]
         assert "Completion check:" in artifact_data["instructions"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _select_executor_type — maps UoW nature to executor type
+# ---------------------------------------------------------------------------
+
+class TestSelectExecutorType:
+    """Unit tests for _select_executor_type — pure function."""
+
+    def _make_uow(self, summary: str, source: str = "github:issue/42") -> "UoW":
+        from src.orchestration.registry import UoW, UoWStatus
+        return UoW(
+            id="uow_test_abc",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary=summary,
+            source=source,
+            source_issue_number=42,
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            type="executable",
+        )
+
+    def test_bug_in_summary_returns_functional_engineer(self):
+        steward = _import_steward()
+        uow = self._make_uow("fix: bug in login handler")
+        assert steward._select_executor_type(uow) == "functional-engineer"
+
+    def test_feature_in_summary_returns_functional_engineer(self):
+        steward = _import_steward()
+        uow = self._make_uow("feat: implement widget module")
+        assert steward._select_executor_type(uow) == "functional-engineer"
+
+    def test_install_in_summary_returns_lobster_ops(self):
+        steward = _import_steward()
+        uow = self._make_uow("install new cron dependency")
+        assert steward._select_executor_type(uow) == "lobster-ops"
+
+    def test_deploy_in_summary_returns_lobster_ops(self):
+        steward = _import_steward()
+        uow = self._make_uow("deploy updated config to server")
+        assert steward._select_executor_type(uow) == "lobster-ops"
+
+    def test_github_issue_source_without_code_keywords_returns_functional_engineer(self):
+        steward = _import_steward()
+        uow = self._make_uow("add new user preference endpoint", source="github:issue/99")
+        assert steward._select_executor_type(uow) == "functional-engineer"
+
+    def test_non_github_source_without_keywords_returns_general(self):
+        steward = _import_steward()
+        uow = self._make_uow("do a thing", source="manual")
+        assert steward._select_executor_type(uow) == "general"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What problem this solves

The steward's LLM prescription path was making direct calls to the Anthropic API using the `anthropic` SDK and requiring `ANTHROPIC_API_KEY` to be set in the environment. This is the wrong pattern for Lobster — the canonical LLM call path is `claude -p` subprocess dispatch, exactly as the executor does it. Having two different LLM invocation patterns in the same codebase creates unnecessary complexity and a key management burden.

## What changed

**`src/orchestration/steward.py`**
- `_llm_prescribe()` now dispatches via `subprocess.run(["claude", "-p", prompt, "--output-format", "text"])` instead of calling `anthropic.Anthropic(api_key=...).messages.create(...)`. The function signature and return contract are unchanged — callers see the same `dict | None` interface.
- `ANTHROPIC_API_KEY` check and `import anthropic` removed entirely. The `anthropic` package is no longer a required dependency for prescription generation.
- Timeout handling updated to catch `subprocess.TimeoutExpired` directly.
- New `_select_executor_type(uow)` function: maps UoW nature to executor type based on summary keywords and source. Returns `functional-engineer` for code/bug/feature issues (or any `github:issue` source), `lobster-ops` for infra/deploy/install signals, `general` otherwise.
- Two new executor type constants: `_EXECUTOR_TYPE_FUNCTIONAL_ENGINEER = "functional-engineer"` and `_EXECUTOR_TYPE_LOBSTER_OPS = "lobster-ops"`.
- `_write_workflow_artifact()` now accepts an `executor_type` parameter (default: `general`) instead of always hardcoding `_EXECUTOR_TYPE_GENERAL`. The prescription path passes `_select_executor_type(uow)`.
- The `steward_prescription` audit log entry now records the selected `executor_type` in `workflow_primitive` instead of always recording `"general"`.

**`tests/unit/test_orchestration/test_steward.py`**
- All tests that previously mocked the `anthropic` module updated to mock `subprocess.run` instead.
- `test_llm_prescribe_skips_when_no_api_key` replaced with `test_llm_prescribe_returns_none_on_subprocess_nonzero_exit` (the API key gate no longer exists; the subprocess non-zero exit is the equivalent failure path).
- `test_llm_prescribe_handles_api_exception` replaced with `test_llm_prescribe_handles_subprocess_exception` (raises `FileNotFoundError` simulating missing claude binary).
- Three `TestFeedbackLoopIntegration` tests now pass `llm_prescriber=None` to force the deterministic template path. These tests assert on exact phrase presence ("Prior prescription attempts") — phrases that only appear in the deterministic fallback. Without `llm_prescriber=None`, `claude -p` would run live and generate its own phrasing, making assertions non-deterministic.
- New `TestSelectExecutorType` class with 6 tests covering the keyword-to-executor-type mapping.

## What is not changed

- The `_build_prescription_instructions` / `_build_deterministic_prescription_instructions` pipeline is unchanged.
- The fallback-to-deterministic behavior is unchanged: `_llm_prescribe` still returns `None` on any failure, and callers still fall back to the deterministic template.
- The `llm_prescriber` injection point on `_build_prescription_instructions` and `run_steward_cycle` is unchanged — existing test stubs continue to work.
- The steward cron is not re-enabled (per task boundary).

## Functional patterns used

Pure functions with injectable side-effect boundaries (`_llm_prescribe` is a pure side-effect boundary — deterministic inputs, subprocess call as the single observable effect), sum-type return (`dict | None`) for the prescription result, and higher-order function injection for testability.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestLlmPrescription -v` — 10 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestSelectExecutorType -v` — 6 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestFeedbackLoopIntegration -q` — 3 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestModuleConstants tests/unit/test_orchestration/test_steward.py::TestFetchPriorPrescriptions tests/unit/test_orchestration/test_steward.py::TestAssessCompletionStructuralProxy -q` — 29 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestInitializationRitual tests/unit/test_orchestration/test_steward.py::TestCompletionPath tests/unit/test_orchestration/test_steward.py::TestCrashRecovery tests/unit/test_orchestration/test_steward.py::TestHardCap -q` — 9 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestCrashedSurface tests/unit/test_orchestration/test_steward.py::TestExecutorOrphan tests/unit/test_orchestration/test_steward.py::TestBootupCandidateGate -q` — 4 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestReentry tests/unit/test_orchestration/test_steward.py::TestWorkflowArtifactPath -q` — 4 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestDryRun tests/unit/test_orchestration/test_steward.py::TestStewardCycles tests/unit/test_orchestration/test_steward.py::TestRouteReason tests/unit/test_orchestration/test_steward.py::TestObservability -q` — 6 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestEarlyWarningAt4 tests/unit/test_orchestration/test_steward.py::TestHardCapSurfaceIncludesReturnReason tests/unit/test_orchestration/test_steward.py::TestDefaultNotifyDanInboxDelivery -q` — 8 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_workflow_artifact.py -q` — 13 passed, 0 failed
- [ ] Full suite in a single run — skipped: DB-based fixtures run ~15s each; the 69-test suite exceeds the 60s subprocess timeout available in this environment. All 69 tests were covered across the batched runs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)