### PR TITLE
docs+fix(executor): document result.json output contract and add post-write validation (#500)

### DIFF
--- a/docs/wos-v2-design.md
+++ b/docs/wos-v2-design.md
@@ -283,6 +283,29 @@ Begin executing the prescribed workflow only after the transaction commits.
 
 > **Atomicity lineage:** This claim sequence inherits the same atomic-claim pattern that Lobster's inbox uses to prevent concurrent double-processing. In Lobster's inbox, a message is claimed via an atomic filesystem move (`inbox/` → `processing/`); no two agents can claim the same file because the move is atomic at the OS level. WOS uses the equivalent mechanism at the database layer: the status transition from `ready-for-executor` to `active` is executed inside a SQLite transaction with optimistic locking — if two Executors race, only one wins the transition. The recovery equivalence also holds: Lobster's `processing/` sweep on startup (finding abandoned in-flight messages) maps directly to WOS's startup sweep over stale `active` records. Same pattern, different substrate.
 
+**Executor Output Contract — required for every Executor implementation:**
+
+Every Executor **must** write `{output_ref}.result.json` before transitioning the UoW to `ready-for-steward`. This applies to all exit paths: complete, partial, failed, and blocked. An Executor that transitions without writing this file is in contract violation.
+
+Path derivation (mirrors `executor-contract.md §Schema`):
+- Primary: replace extension → `foo.json` becomes `foo.result.json`
+- Fallback (no extension): append suffix → `/path/to/artifact` becomes `/path/to/artifact.result.json`
+
+Minimum required fields in the result file:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `uow_id` | yes | Must match the UoW's `id` field |
+| `outcome` | yes | `"complete"` \| `"partial"` \| `"failed"` \| `"blocked"` |
+| `success` | yes | `true` iff `outcome == "complete"` |
+| `reason` | for non-complete | Human-readable explanation |
+
+The Steward's `_assess_completion` reads this file to route the UoW. If the file is absent and `success_criteria` is set, the Steward cannot declare done — it will cycle to the hard cap (5 retries) and surface to Dan. **Absence of the result file is a contract violation, not an ambiguous state.**
+
+Full schema, outcome enum, Steward interpretation table, and failure taxonomy: **[`docs/executor-contract.md`](executor-contract.md)**.
+
+The Lobster `Executor` class (`src/orchestration/executor.py`) implements this contract: `_write_result_json()` is called at every intentional exit point, and the exception handler writes a `failed` result before re-raising. New Executor implementations (custom executor types, test doubles) must replicate this pattern.
+
 The Steward/Executor loop continues until the Steward declares convergence:
 
 ```

--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -37,6 +37,7 @@ Canonical output path convention (from executor-contract.md):
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import subprocess
@@ -46,6 +47,8 @@ from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from pathlib import Path
 from typing import Protocol
+
+log = logging.getLogger("executor")
 
 from orchestration.registry import Registry, UoW, UoWStatus
 from orchestration.result_writer import write_result as _write_subagent_result
@@ -193,6 +196,28 @@ def _write_output_ref_content(output_ref: str, content: str) -> None:
     p = Path(output_ref)
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(content)
+
+
+def _validate_result_json_written(uow_id: str, output_ref: str) -> None:
+    """
+    Warn if result.json was not written at an intentional exit point.
+
+    This is a contract violation guard (executor-contract.md): every intentional
+    exit (complete, partial, failed, blocked) must produce a result file. This
+    function logs a WARNING — it does not raise — so the UoW transition still
+    proceeds. The Steward will detect the missing file and surface to Dan if needed.
+
+    Called after every _write_result_json() call at intentional exit points.
+    """
+    result_path = _result_json_path(output_ref)
+    if not result_path.exists():
+        log.warning(
+            "Executor contract violation: result.json not found after write for UoW %s "
+            "(expected: %s). Steward will be unable to assess completion deterministically. "
+            "See docs/executor-contract.md.",
+            uow_id,
+            result_path,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -492,8 +517,9 @@ class Executor:
             executor_id=executor_id or None,
         )
 
-        # Step 5: Write result.json
+        # Step 5: Write result.json (executor-contract.md: required at every intentional exit)
         _write_result_json(output_ref, result)
+        _validate_result_json_written(uow_id, output_ref)
 
         # Step 6: Transition to ready-for-steward (audit before status update, single transaction)
         self.registry.complete_uow(uow_id, output_ref)
@@ -528,6 +554,7 @@ class Executor:
         )
         _write_output_ref_content(output_ref, f"partial: {reason}")
         _write_result_json(output_ref, result)
+        _validate_result_json_written(uow_id, output_ref)
         self.registry.complete_uow(uow_id, output_ref)
         return result
 
@@ -551,6 +578,7 @@ class Executor:
         )
         _write_output_ref_content(output_ref, f"blocked: {reason}")
         _write_result_json(output_ref, result)
+        _validate_result_json_written(uow_id, output_ref)
         self.registry.complete_uow(uow_id, output_ref)
         return result
 


### PR DESCRIPTION
## What problem does this solve?

The Executor's `result.json` output contract — which every Executor implementation must honor — was not spelled out in the Executor section of `docs/wos-v2-design.md`. A new Executor author reading the design doc would see the claim sequence and the execution steps, but no explicit statement that they must write `{output_ref}.result.json` before transitioning. They would omit the file, the Steward would be unable to assess completion deterministically, and every UoW would cycle to the hard cap (5 retries) — creating spurious Dan notifications and wasting resources.

The contract exists in `docs/executor-contract.md` and is referenced in the Steward↔Executor Contract section, but the Executor section itself had no contract statement.

## What changed

**`docs/wos-v2-design.md`**: Added an "Executor Output Contract" subsection directly in the Executor section, immediately after the claim sequence. Includes:
- Required fields table (uow_id, outcome, success, reason)
- Path derivation rules (primary: replace extension; fallback: append suffix)
- The consequence of absence: Steward cannot declare done, cycles to hard cap, surfaces to Dan
- Statement that absence is a contract violation, not an ambiguous state
- Reference to `executor-contract.md` as the full specification
- Note that the Lobster `Executor` class already implements this; new implementations must replicate the pattern

**`src/orchestration/executor.py`**: Added `import logging` and a module-level `log = logging.getLogger("executor")`. Extracted `_validate_result_json_written()` — a helper that logs a `WARNING` if `result.json` is absent immediately after `_write_result_json()` at every intentional exit point (`_run_execution`, `report_partial`, `report_blocked`). The helper does not raise — UoW transition proceeds, and the Steward detects the missing file via its existing `_assess_completion` path.

## What this does not change

- The executor contract itself is unchanged — `_write_result_json()` already ran at every exit point
- `ExecutorResult`, `ExecutorOutcome`, and all dataclass shapes are unchanged
- `executor-contract.md` is unchanged (it was already correct)
- No test behavior is changed; no new tests were needed (the validation path is a log warning on a condition that the write itself should prevent)

## Functional patterns

Pure data transformation: `_validate_result_json_written()` takes immutable inputs (`uow_id: str`, `output_ref: str`), computes the expected path, and emits a log line. No state mutation. Side effects (logging) are isolated at the function boundary, consistent with the module's existing pattern.

## Tests run

- [x] `uv run pytest tests/ -k "executor" -x -q` in the worktree — 77 passed, 2 xfailed, 0 failed
- [ ] Integration tests requiring a live WOS pipeline — skipped: not available in this environment

Closes #500

Oracle review required before merge.