### PR TITLE
fix(steward): hard_cap notification includes steward_log, steward_agenda, summary, and success_criteria (#501)

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -1339,6 +1339,10 @@ def _default_notify_dan(
     Writes a structured JSON message to ~/messages/inbox/ so the Lobster
     dispatcher surfaces it to Dan via Telegram. In tests this is replaced
     by a capturing mock via the `notify_dan` parameter.
+
+    For hard_cap notifications, the body includes steward_log (diagnosis
+    history across all cycles) and steward_agenda (what the Steward was
+    trying to accomplish) so Dan can triage without leaving the inbox thread.
     """
     uow_id = uow.id
     cycles = uow.steward_cycles
@@ -1348,17 +1352,62 @@ def _default_notify_dan(
     )
     msg_id = str(uuid.uuid4())
     if condition == "hard_cap":
+        # Hard cap: exhaustive context so Dan can triage and act without
+        # digging through logs. Include summary, agenda, log, and reason.
         body_lines = [
-            f"🚨 WOS: UoW `{uow_id}` hit cycle cap ({_HARD_CAP_CYCLES}). "
-            f"return_reason: {return_reason}. Surfacing for Dan review.",
+            f"WOS: UoW `{uow_id}` hit hard cap ({_HARD_CAP_CYCLES} cycles). "
+            f"return_reason: {return_reason}.",
         ]
+
+        # UoW summary — what was this trying to accomplish?
+        summary = uow.summary
+        if summary:
+            body_lines.append(f"\nSummary: {summary}")
+
+        # Success criteria — what would done look like?
+        success_criteria = uow.success_criteria
+        if success_criteria:
+            body_lines.append(f"\nSuccess criteria: {success_criteria}")
+
+        # Steward agenda — the structured forecast of what was planned
+        steward_agenda_raw = uow.steward_agenda
+        if steward_agenda_raw:
+            try:
+                agenda = json.loads(steward_agenda_raw)
+                # Render agenda nodes as a compact list for readability
+                agenda_lines: list[str] = []
+                nodes = agenda if isinstance(agenda, list) else [agenda]
+                for node in nodes:
+                    posture = node.get("posture", "?")
+                    status = node.get("status", "?")
+                    context = node.get("context", "")
+                    agenda_lines.append(f"  [{status}] {posture}: {context[:120]}")
+                body_lines.append("\nSteward agenda:\n" + "\n".join(agenda_lines))
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                # If agenda is not valid JSON or not a list, include raw text
+                body_lines.append(f"\nSteward agenda (raw):\n{steward_agenda_raw[:500]}")
+
+        # Steward log — full diagnosis history across all cycles (surface_log == current_log_str)
+        if surface_log:
+            # Show last N log lines to keep the message readable
+            log_lines = [ln for ln in surface_log.strip().splitlines() if ln.strip()]
+            _MAX_LOG_LINES = 20
+            if len(log_lines) > _MAX_LOG_LINES:
+                omitted = len(log_lines) - _MAX_LOG_LINES
+                displayed = log_lines[-_MAX_LOG_LINES:]
+                body_lines.append(
+                    f"\nSteward log (last {_MAX_LOG_LINES} of {len(log_lines)} entries, "
+                    f"{omitted} omitted):\n" + "\n".join(displayed)
+                )
+            else:
+                body_lines.append(f"\nSteward log:\n" + "\n".join(log_lines))
     else:
         body_lines = [
             f"WOS SURFACE: UoW {uow_id} hit condition={condition} "
             f"(steward_cycles={cycles}). Needs human review.",
         ]
-    if surface_log:
-        body_lines.append(f"\nSteward log:\n{surface_log}")
+        if surface_log:
+            body_lines.append(f"\nSteward log:\n{surface_log}")
     # Inline buttons let Dan resolve the stuck UoW without typing commands.
     # The dispatcher routes callback_data="decide_retry:<uow_id>" and
     # callback_data="decide_close:<uow_id>" to handle_decide_retry/close.
@@ -1382,6 +1431,7 @@ def _default_notify_dan(
             "steward_cycles": cycles,
             "return_reason": return_reason,
             "steward_log": surface_log,
+            "steward_agenda": uow.steward_agenda,
         },
     }
     inbox_dir = Path(os.path.expanduser("~/messages/inbox"))


### PR DESCRIPTION
## What problem does this solve?

When a UoW exhausts all 5 Steward cycles (hard cap), `_default_notify_dan` sent Dan a one-line message:

> "WOS: UoW `<id>` hit cycle cap (5). return_reason: <reason>. Surfacing for Dan review."

This is an actionable escalation — the system has given up on automatic recovery. But the message omits everything Dan needs to act: what the UoW was trying to do (`summary`), what completion looks like (`success_criteria`), what the Steward planned (`steward_agenda`), and the full history of what was tried (`steward_log`). In practice, hard-cap failures get deferred or ignored because the cost of triaging manually is too high.

## What changed

**`src/orchestration/steward.py`** — `_default_notify_dan` hard_cap branch:

The hard_cap message body now includes, in order:
1. UoW ID and cycle count (existing)
2. `return_reason` (existing)
3. UoW `summary` — what was this UoW trying to accomplish
4. `success_criteria` — the Seed's anchor: what done looks like
5. `steward_agenda` — rendered as a compact `[status] posture: context` list; falls back to truncated raw text if JSON is malformed, so a corrupted agenda never breaks notification delivery
6. `steward_log` — last 20 entries; when the log is longer, the message notes how many entries were omitted

`steward_agenda` is also added to the `metadata` dict for all conditions (it was absent before).

The non-hard_cap branch is unchanged.

## Before / after

**Before (hard_cap):**
```
WOS: UoW `abc-123` hit cycle cap (5). return_reason: executor_orphan. Surfacing for Dan review.
```

**After (hard_cap):**
```
WOS: UoW `abc-123` hit hard cap (5 cycles). return_reason: executor_orphan.

Summary: Fix the steward prescription prompt to include golden dispatch patterns

Success criteria: PR opened on dcetlin/Lobster that adds the golden patterns to the prescription context

Steward agenda:
  [complete] first_execution: Implement prescription and open PR
  [prescribed] reentry: Verify PR was merged and close UoW

Steward log (last 5 of 12 entries, 7 omitted):
  {"event": "prescription", "steward_cycles": 3, ...}
  ...
```

## What this does not change

- Non-hard_cap surface conditions (`crash_repeated`, etc.) — body format unchanged
- `_default_notify_dan_early_warning` — unchanged
- Message metadata structure for non-hard_cap conditions — `steward_agenda` key added but all existing keys preserved
- Inbox message file format and button structure — unchanged

## Functional patterns

Pure data transformation: `steward_agenda` is parsed as an immutable list of dicts and rendered to a string; no UoW fields are mutated. The fallback branch (malformed JSON) is a defensive pure path. Side effects (inbox file write) remain isolated at the function boundary.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -k "notify or hard_cap or surface" -v` — 10 passed, 0 failed
- [x] `uv run pytest tests/ -k "notify" -x -q` — 9 passed, 0 failed
- [ ] Full steward test suite (`test_steward.py` 69 tests) — timed out after 45s due to tests with live LLM subprocess calls; the 10 hard_cap/notify/surface tests (the affected path) passed cleanly

Closes #501

Oracle review required before merge.