### PR TITLE
docs: add OODA register table and fix gate priority implication (508, 510)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -297,6 +297,25 @@ These files are private and not in the git repo. They extend and override the de
 
 Before making any structural decision (routing, delegation, gate application, design classification), consult `~/lobster-workspace/oracle/learnings.md` — it contains named failure modes and design patterns that apply across sessions.
 
+---
+
+## OODA Register Table
+
+vision.yaml constraint-3 requires every system decision to traverse the OODA loop at the appropriate register. This table defines the four registers so the constraint is actionable, not just named.
+
+| Register | One-sentence definition | Concrete example | Escalation rule |
+|---|---|---|---|
+| **Deliberative** | Dan is explicitly in the loop; decision is reached through live dialogue or written directive. | Dan says "open a PR for issue 42" in Telegram. | Baseline register — no escalation needed. |
+| **Constrained** | System acts within a pre-specified policy boundary set by Dan; no live input required. | Dispatcher applies the 7-second rule to every tool call. | If the policy boundary does not exist or does not cover this case, escalate to Deliberative. |
+| **Reactive** | System responds to an event within tight latency constraints using a narrow, pre-approved action set. | Health check restarts the dispatcher when wait_for_messages stalls for > 600s. | If the action set would exceed its scope, escalate to Constrained or Deliberative. |
+| **Encoded Orientation** | System acts autonomously, with no live Dan input and no explicit policy boundary — relying on accumulated orientation from vision.yaml and logged decisions. | Dispatcher classifies a message as DESIGN_OPEN without checking with Dan, based on prior logged pattern. | **Requires:** (1) a prior logged decision of the same class AND (2) a traceable vision.yaml anchor. If either is absent, escalate to Deliberative. |
+
+**Escalation path:** Encoded Orientation → Deliberative (bypass intermediate registers when the anchor check fails — do not invent a Constrained boundary to avoid escalation).
+
+**"Escalate to Deliberative" means:** send Dan a message, state the decision class and what anchor is missing, and wait for explicit input before acting. Do not act and report afterward.
+
+---
+
 ## Handling Post-Compact Gate Denial
 
 If any tool call is denied with a message containing "GATE BLOCKED" or "compact-pending":

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,8 @@ These gates must survive context compaction. If any trigger cannot be stated fro
 | Gate | Trigger (one sentence) | Enforcement |
 |------|----------------------|-------------|
 | **7-Second Rule** | Any tool call that is not `wait_for_messages`, `check_inbox`, `mark_processing`, `mark_processed`, `mark_failed`, or `send_reply` must go to a background subagent. | Structural — if you reach for any other tool, stop and delegate. |
-| **Design Gate** | A message is DESIGN_OPEN when no concrete output artifact can be stated in one sentence from the message alone. | Advisory — classify before routing; fire the gate if DESIGN_OPEN. |
-| **Bias to Action** | Fire this gate when DESIGN_OPEN has been ruled out and the message warrants action (references a named artifact, issue, or PR, or uses imperative verbs with concrete objects). | Advisory — fire only after DESIGN_OPEN has been ruled out. |
+| **Design Gate** | A message is DESIGN_OPEN when no concrete output artifact can be stated in one sentence from the message alone. | Advisory — classify before routing; fire the gate if DESIGN_OPEN. **Table position does not imply priority over Bias to Action — mode recognition governs, not row order.** |
+| **Bias to Action** | Fire this gate when DESIGN_OPEN has been ruled out and the message warrants action (references a named artifact, issue, or PR, or uses imperative verbs with concrete objects). | Advisory — fire only after DESIGN_OPEN has been ruled out. **Table position does not imply lower priority than Design Gate — mode recognition governs, not row order.** |
 | **Dispatch template** | Every subagent Task call must include `Minimum viable output: [deliverable]` and `Boundary: do not produce [X]` in its prompt. | Advisory — check before calling Task. |
 | **No self-relay** | When `sent_reply_to_user == True` or message type is `subagent_notification`, mark_processed without calling send_reply. | Structural — the message type routes it; no discretion needed. |
 | **Relay filter** | If the key signal in a send_reply to Dan is buried past paragraph 2, move it to the lead. | Advisory — apply before every send_reply. |


### PR DESCRIPTION
## What this fixes

Two instructional-layer documents contained gaps where named behavioral constraints could not be applied — either because the vocabulary was undefined or because the encoding implied an ordering that contradicts a documented behavioral rule.

**Issue 508 — OODA register vocabulary absent from instructional layer**

vision.yaml constraint-3 names four OODA decision registers and requires agents to escalate to Deliberative when an Encoded Orientation anchor is missing. But none of the four register names were defined anywhere agents read at runtime. An agent told to "escalate to the Deliberative register" had no operational definition of what that meant. Constraint-3 was unenforced by default — not because the rule was wrong, but because the vocabulary needed to apply it was absent from all instructional documents.

This PR adds an OODA Register Table to `sys.dispatcher.bootup.md` using the table-as-compaction-resistant encoding pattern. Each row defines the register in one sentence, gives a concrete example of a decision at that level, and states the escalation rule explicitly. The "escalate to Deliberative" action is defined: send Dan a message, name what anchor is missing, wait for input before acting.

**Issue 510 — table row order implies gate priority**

`user.base.bootup.md` line 148 explicitly prohibits resolving the Design Gate / Bias to Action relationship with a priority rule. The Tier-1 Gate Register table in `CLAUDE.md` lists Design Gate in row 2 and Bias to Action in row 3 — ordering that an agent reading the table will naturally treat as priority by position. This is a cross-document contradiction with behavioral consequence: a priority read produces the wrong answer in exactly the high-stakes ambiguous cases where mode recognition is required.

This PR adds a note to each row's Enforcement cell stating that table position does not imply priority and that mode recognition governs. This is the minimally invasive fix — it does not restructure the table (which could introduce new ambiguity elsewhere) and it makes the override explicit in the row where the confusion arises.

## Functional patterns used

Pure documentation change — no code. The table format is the compaction-resistant encoding pattern documented in `sys.dispatcher.bootup.md` (compression-as-architectural-response oracle pattern).

## Tests run

- [x] `grep -n "OODA\|Deliberative" .claude/sys.dispatcher.bootup.md` — OODA table present at line 302, all four registers defined
- [x] `grep -n "Table position\|mode recognition" CLAUDE.md` — notes present on both Design Gate and Bias to Action rows (lines 134-135)
- [ ] Live dispatcher behavior — not testable without a running session; no code changed, behavioral impact is instructional only

Closes #508
Closes #510