### PR TITLE
wos: auto-advance pending→ready-for-steward on approve (#484)

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -94,7 +94,7 @@ def handle_approve(uow_id: str, *, registry: "Registry") -> str:
         case ApproveConfirmed():
             return (
                 f"UoW `{uow_id}` confirmed.\n"
-                f"Status: `proposed \u2192 pending`"
+                f"Status: `proposed \u2192 ready-for-steward` (via pending)"
             )
         case ApproveNotFound():
             return (
@@ -167,16 +167,19 @@ def handle_wos_status(status: str | None, *, registry: "Registry") -> str:
     """
     Handle /wos status [status].
 
-    When status is None, returns active + pending records (the useful default
-    for "what's running and what's queued?").
+    When status is None, returns active + ready-for-steward + pending records
+    (the useful default for "what's running and what's queued?"). Pending is
+    included for backward compatibility with any UoWs that were written before
+    the auto-advance change; in normal operation pending is never a resting state.
 
     Format per record: <id> | <summary> | source: <source> | created: <date>
     """
     if status is None:
         active = registry.list(status="active")
+        ready_for_steward = registry.list(status="ready-for-steward")
         pending = registry.list(status="pending")
-        records = active + pending
-        header = "Active + pending UoWs:"
+        records = active + ready_for_steward + pending
+        header = "Active + queued UoWs:"
     else:
         records = registry.list(status=status)
         header = f"UoWs with status `{status}`:"

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -485,7 +485,13 @@ class Registry:
 
     def approve(self, uow_id: str) -> ApproveResult:
         """
-        Transition a UoW from proposed → pending.
+        Transition a UoW from proposed → ready-for-steward (atomically, via pending).
+
+        The pending status is no longer a resting state: on /approve, the UoW
+        transitions proposed → pending → ready-for-steward in a single transaction.
+        Both audit entries are written in the same transaction so the full history
+        is preserved without leaving the UoW stranded in pending awaiting the
+        6am GardenCaretaker run.
 
         Returns a typed ApproveResult:
         - ApproveConfirmed: transition succeeded
@@ -513,6 +519,8 @@ class Registry:
                     return ApproveExpired(id=uow_id)
                 case UoWStatus.PROPOSED:
                     now = _now_iso()
+                    # Write two audit entries — proposed→pending then pending→ready-for-steward —
+                    # so the full history is preserved even though pending is never a resting state.
                     self._write_audit(
                         conn,
                         uow_id=uow_id,
@@ -520,8 +528,16 @@ class Registry:
                         from_status=UoWStatus.PROPOSED,
                         to_status=UoWStatus.PENDING,
                     )
+                    self._write_audit(
+                        conn,
+                        uow_id=uow_id,
+                        event="status_change",
+                        from_status=UoWStatus.PENDING,
+                        to_status=UoWStatus.READY_FOR_STEWARD,
+                        note="auto-advanced: pending is not a resting state",
+                    )
                     conn.execute(
-                        "UPDATE uow_registry SET status = 'pending', updated_at = ? WHERE id = ?",
+                        "UPDATE uow_registry SET status = 'ready-for-steward', updated_at = ? WHERE id = ?",
                         (now, uow_id),
                     )
                     conn.commit()

--- a/tests/unit/test_orchestration/test_dispatcher_integration.py
+++ b/tests/unit/test_orchestration/test_dispatcher_integration.py
@@ -100,21 +100,28 @@ class TestHandleWosExecute:
 
 
 class TestHandleApprove:
-    def test_success_message_contains_status_transition(self, registry, uow_id):
+    def test_success_message_contains_ready_for_steward(self, registry, uow_id):
+        """approve now goes proposed → ready-for-steward; response reflects that."""
+        response = handle_approve(uow_id, registry=registry)
+        assert "ready-for-steward" in response.lower()
+        assert uow_id in response
+
+    def test_success_message_notes_pending_via(self, registry, uow_id):
+        """Response mentions 'via pending' so the user knows the intermediate step."""
         response = handle_approve(uow_id, registry=registry)
         assert "pending" in response.lower()
-        assert uow_id in response
 
     def test_not_found_message(self, registry):
         response = handle_approve("nonexistent-id", registry=registry)
         assert "not found" in response.lower()
         assert "/wos status proposed" in response
 
-    def test_already_pending_message(self, registry, uow_id):
+    def test_already_ready_for_steward_message(self, registry, uow_id):
+        """After approve, second approve returns ApproveSkipped with current ready-for-steward status."""
         registry.approve(uow_id)
         response = handle_approve(uow_id, registry=registry)
-        # Should mention current status, not raise
-        assert "pending" in response.lower()
+        # Should mention current status (ready-for-steward), not raise
+        assert "ready-for-steward" in response.lower()
 
     def test_expired_message(self, registry):
         today = datetime.now(timezone.utc).date().isoformat()
@@ -129,7 +136,7 @@ class TestHandleConfirmAlias:
 
     def test_confirm_alias_delegates_to_approve(self, registry, uow_id):
         response = handle_confirm(uow_id, registry=registry)
-        assert "pending" in response.lower()
+        assert "ready-for-steward" in response.lower()
         assert uow_id in response
 
 
@@ -153,13 +160,14 @@ class TestHandleWosStatus:
         assert r.id in response
         assert "Status test issue" in response
 
-    def test_defaults_to_active_and_pending(self, registry):
+    def test_defaults_to_active_and_queued(self, registry):
+        """Default /wos status shows active + ready-for-steward (+ pending for backward compat)."""
         today = datetime.now(timezone.utc).date().isoformat()
         r1 = registry.upsert(issue_number=230, title="Active issue", sweep_date=today, success_criteria="Test completion.")
         registry.set_status_direct(r1.id, "active")
-        r2 = registry.upsert(issue_number=231, title="Pending issue", sweep_date=today, success_criteria="Test completion.")
-        registry.approve(r2.id)
-        # No status arg → returns active + pending
+        r2 = registry.upsert(issue_number=231, title="Approved issue", sweep_date=today, success_criteria="Test completion.")
+        registry.approve(r2.id)  # now lands on ready-for-steward, not pending
+        # No status arg → returns active + ready-for-steward + pending
         response = handle_wos_status(None, registry=registry)
         assert r1.id in response
         assert r2.id in response

--- a/tests/unit/test_orchestration/test_garden_caretaker.py
+++ b/tests/unit/test_orchestration/test_garden_caretaker.py
@@ -355,12 +355,38 @@ class TestTend:
         assert len(expired) == 1
 
     def test_tend_archives_pending_uow_when_source_closed(self, registry: Registry) -> None:
+        """pending is no longer a resting state — approve() lands on ready-for-steward.
+        A UoW that has been approved (ready-for-steward) and whose source closes is
+        surfaced to the Steward (not archived) because in-flight work is involved.
+        """
         upsert_result = registry.upsert(issue_number=11, title="Pending issue", success_criteria="Test completion.")
-        # Move to pending via approve
+        # approve() now lands on ready-for-steward, not pending
         registry.approve(upsert_result.id)
+        uow = registry.get(upsert_result.id)
+        assert uow.status.value == "ready-for-steward"
 
         snap = _snapshot(source_ref="github:issue/11", state="closed")
         source = _make_source(issue_map={"github:issue/11": snap})
+        caretaker = GardenCaretaker(source=source, registry=registry)
+
+        result = caretaker.tend()
+
+        # ready-for-steward + source closed → surface (not archive), per reconciliation table.
+        # The UoW remains in ready-for-steward (the surface action writes an audit entry and
+        # keeps the status; the Steward will close it on its next cycle).
+        assert result["surfaced_to_steward"] == 1
+        assert result["archived"] == 0
+        uow_after = registry.get(upsert_result.id)
+        assert uow_after.status.value == "ready-for-steward"
+
+    def test_tend_archives_pending_uow_set_directly_when_source_closed(self, registry: Registry) -> None:
+        """Legacy: a UoW manually set to pending (pre-auto-advance) is archived when source closes."""
+        upsert_result = registry.upsert(issue_number=111, title="Legacy pending issue", success_criteria="Test completion.")
+        # Bypass approve() to simulate a legacy pending UoW
+        registry.set_status_direct(upsert_result.id, "pending")
+
+        snap = _snapshot(source_ref="github:issue/111", state="closed")
+        source = _make_source(issue_map={"github:issue/111": snap})
         caretaker = GardenCaretaker(source=source, registry=registry)
 
         result = caretaker.tend()

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -390,7 +390,8 @@ class TestRepoFromIssueUrl:
 # ---------------------------------------------------------------------------
 
 class TestApprove:
-    def test_approve_transitions_proposed_to_pending(self, registry):
+    def test_approve_transitions_proposed_to_ready_for_steward(self, registry):
+        """approve() now skips pending as a resting state — goes straight to ready-for-steward."""
         from src.orchestration.registry import ApproveConfirmed
         today = datetime.now(timezone.utc).date().isoformat()
         result = registry.upsert(issue_number=50, title="Issue 50", sweep_date=today, success_criteria="Test completion.")
@@ -398,21 +399,30 @@ class TestApprove:
         approve_result = registry.approve(uow_id)
         assert isinstance(approve_result, ApproveConfirmed)
         assert approve_result.id == uow_id
+        uow = registry.get(uow_id)
+        assert uow.status.value == "ready-for-steward"
 
-    def test_approve_writes_audit_entry(self, registry, db_path):
+    def test_approve_writes_audit_entries_for_both_transitions(self, registry, db_path):
+        """approve() writes two audit entries: proposed→pending and pending→ready-for-steward."""
         today = datetime.now(timezone.utc).date().isoformat()
         result = registry.upsert(issue_number=51, title="Issue 51", sweep_date=today, success_criteria="Test completion.")
         uow_id = result.id
         registry.approve(uow_id)
         conn = _open_db(db_path)
-        audit = conn.execute(
+        pending_entry = conn.execute(
             "SELECT * FROM audit_log WHERE uow_id = ? AND event = 'status_change' AND to_status = 'pending'",
             (uow_id,)
         ).fetchone()
+        ready_entry = conn.execute(
+            "SELECT * FROM audit_log WHERE uow_id = ? AND event = 'status_change' AND to_status = 'ready-for-steward'",
+            (uow_id,)
+        ).fetchone()
         conn.close()
-        assert audit is not None
+        assert pending_entry is not None, "audit entry for proposed→pending must exist"
+        assert ready_entry is not None, "audit entry for pending→ready-for-steward must exist"
 
-    def test_approve_idempotent_on_already_pending(self, registry):
+    def test_approve_idempotent_on_already_ready_for_steward(self, registry):
+        """After approve, second approve returns ApproveSkipped with current_status=ready-for-steward."""
         from src.orchestration.registry import ApproveSkipped
         today = datetime.now(timezone.utc).date().isoformat()
         result = registry.upsert(issue_number=52, title="Issue 52", sweep_date=today, success_criteria="Test completion.")
@@ -421,7 +431,7 @@ class TestApprove:
         # Second approve returns ApproveSkipped, not an error
         approve_result = registry.approve(uow_id)
         assert isinstance(approve_result, ApproveSkipped)
-        assert approve_result.current_status == "pending"
+        assert approve_result.current_status == "ready-for-steward"
         assert "already" in approve_result.reason.lower()
 
     def test_approve_returns_not_found_on_nonexistent(self, registry):
@@ -445,6 +455,7 @@ class TestApprove:
 
 class TestList:
     def test_list_by_status(self, registry):
+        """approve() lands on ready-for-steward, not pending (pending is no longer a resting state)."""
         from src.orchestration.registry import UoW
         today = datetime.now(timezone.utc).date().isoformat()
         r1 = registry.upsert(issue_number=60, title="Issue 60", sweep_date=today, success_criteria="Test completion.")
@@ -452,12 +463,13 @@ class TestList:
         r3 = registry.upsert(issue_number=62, title="Issue 62", sweep_date=today, success_criteria="Test completion.")
         registry.approve(r2.id)
         proposed = registry.list(status="proposed")
+        ready_for_steward = registry.list(status="ready-for-steward")
         pending = registry.list(status="pending")
         assert len(proposed) == 2
-        assert len(pending) == 1
+        assert len(ready_for_steward) == 1
+        assert len(pending) == 0  # pending is never a resting state after approve()
         assert all(isinstance(u, UoW) for u in proposed)
-        assert all(isinstance(u, UoW) for u in pending)
-        assert pending[0].id == r2.id
+        assert ready_for_steward[0].id == r2.id
 
     def test_list_returns_all_when_no_filter(self, registry):
         today = datetime.now(timezone.utc).date().isoformat()


### PR DESCRIPTION
## What problem this solves

After a UoW was confirmed via \`/approve\`, it landed in \`pending\` status and stayed there until the GardenCaretaker ran at 6am. Confirmed work was invisible to the Steward for up to 18 hours — the opposite of "automated."

The fix: \`approve()\` now transitions \`proposed → pending → ready-for-steward\` in a single atomic transaction. Both audit entries are written so the full history is preserved, but \`pending\` is never a resting state. The Steward picks up the UoW on its next 3-minute heartbeat.

## Flow change

Before:
```
/approve → proposed → pending (rests here until 6am GardenCaretaker)
                              → ready-for-steward (only after GardenCaretaker)
```

After:
```
/approve → proposed → pending → ready-for-steward (atomically, in one transaction)
```

The Steward heartbeat runs every 3 minutes, so confirmed UoWs are now diagnosed within 3 minutes instead of up to 18 hours.

## What changed

**\`src/orchestration/registry.py\`** — \`approve()\` now writes two audit entries (proposed→pending, then pending→ready-for-steward) and sets the final status to \`ready-for-steward\` in a single transaction. The \`pending\` status is preserved in the enum and audit trail for backward compatibility and historical rows.

**\`src/orchestration/dispatcher_handlers.py\`** — \`handle_approve()\` response updated to say "ready-for-steward (via pending)" so the user knows the intermediate step. \`handle_wos_status(None)\` default view now includes \`ready-for-steward\` alongside \`active\` and \`pending\` (approved UoWs now land there immediately).

**Tests** — Five test updates across \`test_registry.py\`, \`test_dispatcher_integration.py\`, and \`test_garden_caretaker.py\` to reflect the new post-approve resting state. One new test for the legacy pending→archive path via direct \`set_status_direct\`.

## Functional patterns used

Pure functions, immutable audit trail (two entries in one transaction), optimistic-lock pattern unchanged.

## What is NOT changed

- The \`UoWStatus.PENDING\` enum value is preserved — backward compatible.
- No change to GardenCaretaker's behavior for existing pending UoWs.
- No change to the Steward's processing logic.
- steward.py is not modified.

## Tests run

- [x] \`uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_dispatcher_integration.py tests/unit/test_orchestration/test_garden_caretaker.py -q\` — 137 passed, 0 failed

Closes #484.