### PR TITLE
wos: post-completion GitHub sync — close source issues on done

### DIFF
--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -56,6 +56,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from src.orchestration.steward import is_bootup_candidate_gate_active, run_steward_cycle
+from src.orchestration.github_sync import run_post_completion_sync
 
 # ---------------------------------------------------------------------------
 # Startup sweep — imported from startup-sweep.py (Phase 1 concern)
@@ -410,6 +411,22 @@ def main() -> int:
     except Exception:
         log.exception("Steward main loop failed")
         return 1
+
+    # Phase 4: Post-completion GitHub sync
+    log.info("--- Phase 4: Post-completion GitHub sync ---")
+    try:
+        sync_result = run_post_completion_sync(registry, dry_run=dry_run)
+        log.info(
+            "GitHub sync complete: synced=%d skipped_no_url=%d failed=%d",
+            sync_result.synced,
+            sync_result.skipped_no_url,
+            sync_result.failed,
+        )
+        if sync_result.errors:
+            for err in sync_result.errors:
+                log.warning("GitHub sync error: %s", err)
+    except Exception:
+        log.exception("Post-completion GitHub sync failed — continuing")
 
     log.info("Steward heartbeat complete")
     return 0

--- a/src/orchestration/github_sync.py
+++ b/src/orchestration/github_sync.py
@@ -1,0 +1,362 @@
+"""
+Post-completion GitHub sync — closes source issues when WOS UoWs reach `done`.
+
+When the Steward declares a UoW complete (status=done), the corresponding
+GitHub issue should be closed automatically with a comment summarizing what
+was accomplished. This module implements that sync as a pure sweep function
+that is called by the steward-heartbeat script after the Steward cycle.
+
+Design:
+- All GitHub I/O is isolated in _close_github_issue() — the only function
+  that invokes subprocess.
+- build_closure_comment() is a pure function: same UoW always produces the
+  same comment template. Testable without any subprocess or DB access.
+- run_post_completion_sync() coordinates the sweep: queries done UoWs that
+  have not been synced, attempts to close each issue, and records the result.
+- Idempotency: github_synced_at is set atomically in the same DB write as
+  the audit entry. A failed gh call leaves github_synced_at NULL so the
+  next heartbeat cycle retries.
+- If issue_url is NULL (pre-migration row or manual UoW), the UoW is skipped
+  with a log entry — no error, no retry.
+
+Subprocess protocol:
+  gh issue close <number> --repo <repo> --comment "<text>"
+  gh issue comment <number> --repo <repo> --body "<text>"
+
+The module does not raise on gh errors — subprocess failures are caught,
+logged, and returned in the sync result so the caller can decide how to
+surface them.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .registry import Registry, UoW
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no side effects
+# ---------------------------------------------------------------------------
+
+_ISSUE_URL_RE = re.compile(
+    r"https://github\.com/([^/]+/[^/]+)/issues/(\d+)"
+)
+
+
+def _parse_issue_url(issue_url: str) -> tuple[str, str] | None:
+    """
+    Extract (repo, issue_number) from a canonical GitHub issue URL.
+
+    Returns None if the URL does not match the expected format.
+    Pure function — no side effects.
+
+    >>> _parse_issue_url("https://github.com/dcetlin/Lobster/issues/42")
+    ('dcetlin/Lobster', '42')
+    >>> _parse_issue_url("https://example.com/foo") is None
+    True
+    """
+    m = _ISSUE_URL_RE.match(issue_url)
+    if m is None:
+        return None
+    return m.group(1), m.group(2)
+
+
+def build_closure_comment(uow: "UoW") -> str:
+    """
+    Build the GitHub issue closure comment for a completed UoW.
+
+    Pure function — takes a UoW value object and returns a comment string.
+    The comment summarizes the UoW outcome: what was done, when it was
+    completed, and the UoW ID for cross-referencing in the Lobster registry.
+
+    Args:
+        uow: A typed UoW value object in `done` status.
+
+    Returns:
+        A Markdown-formatted comment string suitable for posting to GitHub.
+    """
+    summary = uow.summary or "(no summary)"
+    uow_id = uow.id
+    completed_at = uow.steward_log  # may be None for pre-Phase-2 UoWs
+
+    lines = [
+        "This issue was completed automatically by the Lobster Work Order System (WOS).",
+        "",
+        f"**UoW ID:** `{uow_id}`",
+        f"**Summary:** {summary}",
+    ]
+
+    if uow.success_criteria:
+        lines.append(f"**Success criteria:** {uow.success_criteria}")
+
+    lines += [
+        "",
+        "_Closed by Lobster WOS post-completion sync._",
+    ]
+
+    return "\n".join(lines)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# GitHub I/O — isolated subprocess calls
+# ---------------------------------------------------------------------------
+
+class GitHubSyncError(Exception):
+    """Raised when a gh CLI call fails during post-completion sync."""
+
+
+def _close_github_issue(
+    repo: str,
+    issue_number: str,
+    comment: str,
+    *,
+    _run: type = subprocess,  # injectable for tests
+) -> None:
+    """
+    Close a GitHub issue and post a summary comment.
+
+    This is the only function in this module that invokes subprocess.
+    All other functions are pure or delegate here.
+
+    The issue is closed with --comment so the closure and summary arrive
+    in a single API call. If the issue is already closed, gh returns a
+    non-zero exit code; we treat this as a success (idempotent close).
+
+    Args:
+        repo: GitHub repo slug, e.g. "dcetlin/Lobster".
+        issue_number: Issue number as a string.
+        comment: Markdown comment to post on closure.
+
+    Raises:
+        GitHubSyncError: If the gh CLI call fails unexpectedly (not "already closed").
+    """
+    try:
+        _run.run(
+            [
+                "gh", "issue", "close", issue_number,
+                "--repo", repo,
+                "--comment", comment,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr or ""
+        # gh exits 1 when the issue is already closed — treat as success.
+        if "already closed" in stderr.lower() or "issue was already closed" in stderr.lower():
+            log.debug(
+                "github_sync: issue #%s in %s is already closed — no-op",
+                issue_number, repo,
+            )
+            return
+        raise GitHubSyncError(
+            f"gh issue close failed for {repo}#{issue_number}: {stderr.strip()}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Registry write — mark synced
+# ---------------------------------------------------------------------------
+
+def _mark_github_synced(registry: "Registry", uow_id: str, synced_at: str) -> None:
+    """
+    Write github_synced_at timestamp and audit entry for a UoW.
+
+    Uses the registry's internal _connect() pattern for a single atomic write.
+    Does not transition the UoW status — this is a field update only.
+    """
+    import json
+    conn = registry._connect()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "UPDATE uow_registry SET github_synced_at = ? WHERE id = ?",
+            (synced_at, uow_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO audit_log (ts, uow_id, event, agent, note)
+            VALUES (?, ?, 'github_sync', 'github_sync', ?)
+            """,
+            (
+                synced_at,
+                uow_id,
+                json.dumps({
+                    "event": "github_sync",
+                    "actor": "github_sync",
+                    "uow_id": uow_id,
+                    "synced_at": synced_at,
+                    "timestamp": synced_at,
+                }),
+            ),
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _query_done_unsynced(registry: "Registry") -> list["UoW"]:
+    """
+    Return done UoWs that have not yet been GitHub-synced.
+
+    Queries for status=done AND github_synced_at IS NULL AND issue_url IS NOT NULL.
+    Skips UoWs without issue_url (pre-migration rows or manual entries).
+
+    Falls back to list(status='done') filtered in Python if the
+    github_synced_at column is absent (pre-migration database).
+    """
+    conn = registry._connect()
+    try:
+        # Check if github_synced_at column exists
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(uow_registry)").fetchall()}
+        if "github_synced_at" not in cols:
+            log.warning("github_sync: github_synced_at column not present — migration 0006 not applied")
+            return []
+
+        rows = conn.execute(
+            """
+            SELECT * FROM uow_registry
+            WHERE status = 'done'
+              AND github_synced_at IS NULL
+              AND issue_url IS NOT NULL
+            ORDER BY updated_at ASC
+            """,
+        ).fetchall()
+        return [registry._row_to_uow(row) for row in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Public sweep API
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PostCompletionSyncResult:
+    """Result of a post-completion GitHub sync sweep."""
+    synced: int
+    skipped_no_url: int
+    failed: int
+    errors: list[str] = field(default_factory=list)
+
+
+def run_post_completion_sync(
+    registry: "Registry",
+    *,
+    dry_run: bool = False,
+    _close_fn: type = None,  # injectable for tests
+) -> PostCompletionSyncResult:
+    """
+    Sweep done UoWs and close their GitHub source issues with a summary comment.
+
+    Called by steward-heartbeat.py after the Steward cycle. Processes only
+    UoWs in `done` status where:
+    - `issue_url` is not NULL (has a known GitHub issue URL)
+    - `github_synced_at` is NULL (not yet synced)
+
+    For each eligible UoW:
+    1. Parse the repo and issue number from `issue_url`.
+    2. Build a closure comment via build_closure_comment().
+    3. Call gh to close the issue and post the comment.
+    4. Write github_synced_at timestamp and audit entry to the registry.
+
+    On gh failure: log the error, increment `failed` counter, and leave
+    github_synced_at NULL so the next heartbeat retries.
+
+    In dry_run mode: log what would be done but do not call gh or write
+    to the registry.
+
+    Args:
+        registry: A Registry instance connected to the WOS database.
+        dry_run: If True, log actions without executing them.
+        _close_fn: Injectable close function for tests (replaces _close_github_issue).
+
+    Returns:
+        PostCompletionSyncResult with counts of synced, skipped, and failed UoWs.
+    """
+    close_fn = _close_fn if _close_fn is not None else _close_github_issue
+
+    try:
+        unsynced = _query_done_unsynced(registry)
+    except Exception as exc:
+        log.error("github_sync: failed to query done UoWs — %s", exc)
+        return PostCompletionSyncResult(synced=0, skipped_no_url=0, failed=1, errors=[str(exc)])
+
+    synced = 0
+    skipped = 0
+    failed = 0
+    errors: list[str] = []
+
+    for uow in unsynced:
+        if not uow.issue_url:
+            # Defensive: _query_done_unsynced already filters, but guard anyway.
+            log.debug("github_sync: UoW %s has no issue_url — skipping", uow.id)
+            skipped += 1
+            continue
+
+        parsed = _parse_issue_url(uow.issue_url)
+        if parsed is None:
+            log.warning(
+                "github_sync: UoW %s has unrecognized issue_url format %r — skipping",
+                uow.id, uow.issue_url,
+            )
+            skipped += 1
+            continue
+
+        repo, issue_number = parsed
+        comment = build_closure_comment(uow)
+
+        if dry_run:
+            log.info(
+                "github_sync (DRY RUN): would close %s#%s for UoW %s",
+                repo, issue_number, uow.id,
+            )
+            synced += 1
+            continue
+
+        try:
+            close_fn(repo=repo, issue_number=issue_number, comment=comment)
+        except GitHubSyncError as exc:
+            error_msg = str(exc)
+            log.error("github_sync: failed to close %s#%s — %s", repo, issue_number, error_msg)
+            errors.append(error_msg)
+            failed += 1
+            continue
+        except Exception as exc:
+            error_msg = f"unexpected error closing {repo}#{issue_number}: {exc}"
+            log.error("github_sync: %s", error_msg)
+            errors.append(error_msg)
+            failed += 1
+            continue
+
+        try:
+            _mark_github_synced(registry, uow.id, _now_iso())
+            synced += 1
+            log.info("github_sync: closed %s#%s for UoW %s", repo, issue_number, uow.id)
+        except Exception as exc:
+            error_msg = f"gh close succeeded but registry write failed for {uow.id}: {exc}"
+            log.error("github_sync: %s", error_msg)
+            errors.append(error_msg)
+            failed += 1
+
+    return PostCompletionSyncResult(
+        synced=synced,
+        skipped_no_url=skipped,
+        failed=failed,
+        errors=errors,
+    )

--- a/src/orchestration/migrations/0006_add_github_synced_at.sql
+++ b/src/orchestration/migrations/0006_add_github_synced_at.sql
@@ -1,0 +1,14 @@
+-- Migration 0006: add github_synced_at column to uow_registry
+--
+-- Tracks whether a completed (done) UoW has had its source GitHub issue
+-- closed with a summary comment. NULL = not yet synced. Non-NULL = ISO
+-- timestamp of when the sync was performed.
+--
+-- The post-completion sync sweep reads done UoWs where github_synced_at
+-- IS NULL and issue_url IS NOT NULL, closes the issue, posts a summary
+-- comment, and then sets github_synced_at = now().
+--
+-- This column is intentionally excluded from executor_uow_view because
+-- Executor subagents have no business reading or writing it.
+
+ALTER TABLE uow_registry ADD COLUMN github_synced_at TEXT DEFAULT NULL;

--- a/tests/unit/test_orchestration/test_github_sync.py
+++ b/tests/unit/test_orchestration/test_github_sync.py
@@ -1,0 +1,230 @@
+"""
+Tests for github_sync.py — post-completion GitHub issue closure.
+
+Tests cover pure functions (build_closure_comment, _parse_issue_url) and
+the sweep logic (run_post_completion_sync) with an injectable close function
+so no subprocess calls are made during testing.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.orchestration.github_sync import (
+    GitHubSyncError,
+    PostCompletionSyncResult,
+    _parse_issue_url,
+    build_closure_comment,
+    run_post_completion_sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def registry(tmp_path: Path):
+    from src.orchestration.registry import Registry
+    return Registry(tmp_path / "registry.db")
+
+
+def _make_done_uow(registry, issue_number: int, issue_url: str | None = None) -> str:
+    """Create a UoW in done status with optional issue_url."""
+    today = datetime.now(timezone.utc).date().isoformat()
+    result = registry.upsert(
+        issue_number=issue_number,
+        title=f"Test issue {issue_number}",
+        sweep_date=today,
+        success_criteria="Test completion.",
+        issue_url=issue_url,
+    )
+    registry.set_status_direct(result.id, "done")
+    return result.id
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+class TestParseIssueUrl:
+    def test_parses_standard_github_url(self):
+        result = _parse_issue_url("https://github.com/dcetlin/Lobster/issues/42")
+        assert result == ("dcetlin/Lobster", "42")
+
+    def test_parses_org_repo_url(self):
+        result = _parse_issue_url("https://github.com/SiderealPress/lobster/issues/100")
+        assert result == ("SiderealPress/lobster", "100")
+
+    def test_returns_none_for_non_github_url(self):
+        assert _parse_issue_url("https://example.com/foo") is None
+
+    def test_returns_none_for_empty_string(self):
+        assert _parse_issue_url("") is None
+
+    def test_returns_none_for_pr_url(self):
+        # PR URLs use /pull/ not /issues/
+        assert _parse_issue_url("https://github.com/dcetlin/Lobster/pull/42") is None
+
+
+class TestBuildClosureComment:
+    def test_returns_string(self, registry):
+        uow_id = _make_done_uow(registry, 1, "https://github.com/dcetlin/Lobster/issues/1")
+        uow = registry.get(uow_id)
+        result = build_closure_comment(uow)
+        assert isinstance(result, str)
+
+    def test_contains_uow_id(self, registry):
+        uow_id = _make_done_uow(registry, 2, "https://github.com/dcetlin/Lobster/issues/2")
+        uow = registry.get(uow_id)
+        result = build_closure_comment(uow)
+        assert uow_id in result
+
+    def test_contains_summary(self, registry):
+        uow_id = _make_done_uow(registry, 3, "https://github.com/dcetlin/Lobster/issues/3")
+        uow = registry.get(uow_id)
+        result = build_closure_comment(uow)
+        assert uow.summary in result
+
+    def test_mentions_wos(self, registry):
+        uow_id = _make_done_uow(registry, 4, "https://github.com/dcetlin/Lobster/issues/4")
+        uow = registry.get(uow_id)
+        result = build_closure_comment(uow)
+        assert "WOS" in result or "Work Order" in result
+
+    def test_pure_same_uow_produces_same_output(self, registry):
+        """build_closure_comment is pure — same UoW always produces same comment."""
+        uow_id = _make_done_uow(registry, 5, "https://github.com/dcetlin/Lobster/issues/5")
+        uow = registry.get(uow_id)
+        assert build_closure_comment(uow) == build_closure_comment(uow)
+
+
+# ---------------------------------------------------------------------------
+# Sweep function tests
+# ---------------------------------------------------------------------------
+
+class TestRunPostCompletionSync:
+    def _noop_close(self, **kwargs) -> None:
+        """Injectable close function that does nothing (simulates successful gh call)."""
+        pass
+
+    def _failing_close(self, **kwargs) -> None:
+        """Injectable close function that always raises GitHubSyncError."""
+        raise GitHubSyncError("simulated gh failure")
+
+    def test_syncs_done_uow_with_issue_url(self, registry):
+        """A done UoW with issue_url gets synced and github_synced_at is set."""
+        uow_id = _make_done_uow(registry, 10, "https://github.com/dcetlin/Lobster/issues/10")
+        result = run_post_completion_sync(registry, _close_fn=self._noop_close)
+        assert result.synced == 1
+        assert result.failed == 0
+        # github_synced_at should now be set
+        conn = registry._connect()
+        row = conn.execute(
+            "SELECT github_synced_at FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        conn.close()
+        assert row["github_synced_at"] is not None
+
+    def test_skips_done_uow_without_issue_url(self, registry):
+        """A done UoW without issue_url produces no sync and no error.
+        The SQL query filters it out (issue_url IS NOT NULL), so skipped_no_url=0
+        and synced=0 — the UoW is simply not in scope for the sync sweep.
+        """
+        _make_done_uow(registry, 11, issue_url=None)
+        result = run_post_completion_sync(registry, _close_fn=self._noop_close)
+        assert result.synced == 0
+        assert result.failed == 0
+        # skipped_no_url=0 because the SQL query already filters null-url UoWs
+        assert result.skipped_no_url == 0
+
+    def test_skips_already_synced_uow(self, registry):
+        """A UoW that is already synced (github_synced_at set) is not re-processed."""
+        uow_id = _make_done_uow(registry, 12, "https://github.com/dcetlin/Lobster/issues/12")
+        # First sync
+        run_post_completion_sync(registry, _close_fn=self._noop_close)
+        # Second sync — should find nothing to process
+        result = run_post_completion_sync(registry, _close_fn=self._noop_close)
+        assert result.synced == 0
+
+    def test_does_not_sync_non_done_uow(self, registry):
+        """Active/proposed UoWs are not touched by the sync sweep."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        result = registry.upsert(
+            issue_number=13,
+            title="Active issue",
+            sweep_date=today,
+            success_criteria="Test done.",
+            issue_url="https://github.com/dcetlin/Lobster/issues/13",
+        )
+        # Leave it in proposed status (not done)
+        sync_result = run_post_completion_sync(registry, _close_fn=self._noop_close)
+        assert sync_result.synced == 0
+
+    def test_records_failure_when_gh_fails(self, registry):
+        """When gh close fails, failed counter is incremented and github_synced_at stays NULL."""
+        uow_id = _make_done_uow(registry, 14, "https://github.com/dcetlin/Lobster/issues/14")
+        result = run_post_completion_sync(registry, _close_fn=self._failing_close)
+        assert result.failed == 1
+        assert result.synced == 0
+        assert len(result.errors) == 1
+        # github_synced_at must remain NULL so retry fires on next heartbeat
+        conn = registry._connect()
+        row = conn.execute(
+            "SELECT github_synced_at FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        conn.close()
+        assert row["github_synced_at"] is None
+
+    def test_dry_run_does_not_write_to_registry(self, registry):
+        """dry_run=True logs but does not write github_synced_at."""
+        uow_id = _make_done_uow(registry, 15, "https://github.com/dcetlin/Lobster/issues/15")
+        result = run_post_completion_sync(registry, dry_run=True, _close_fn=self._noop_close)
+        assert result.synced == 1  # counts as synced in dry_run
+        conn = registry._connect()
+        row = conn.execute(
+            "SELECT github_synced_at FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        conn.close()
+        assert row["github_synced_at"] is None  # not written in dry_run
+
+    def test_processes_multiple_done_uows(self, registry):
+        """Multiple done+unsynced UoWs are all processed in one sweep."""
+        for i in range(3):
+            _make_done_uow(
+                registry,
+                20 + i,
+                f"https://github.com/dcetlin/Lobster/issues/{20 + i}",
+            )
+        result = run_post_completion_sync(registry, _close_fn=self._noop_close)
+        assert result.synced == 3
+
+    def test_close_fn_receives_correct_repo_and_issue_number(self, registry):
+        """The injectable close function receives repo and issue_number from the URL."""
+        calls = []
+
+        def recording_close(*, repo, issue_number, comment):
+            calls.append({"repo": repo, "issue_number": issue_number})
+
+        _make_done_uow(registry, 25, "https://github.com/dcetlin/Lobster/issues/25")
+        run_post_completion_sync(registry, _close_fn=recording_close)
+        assert len(calls) == 1
+        assert calls[0]["repo"] == "dcetlin/Lobster"
+        assert calls[0]["issue_number"] == "25"
+
+    def test_close_fn_receives_comment_with_uow_id(self, registry):
+        """The comment passed to the close function contains the UoW ID."""
+        comments = []
+
+        def capturing_close(*, repo, issue_number, comment):
+            comments.append(comment)
+
+        uow_id = _make_done_uow(registry, 26, "https://github.com/dcetlin/Lobster/issues/26")
+        run_post_completion_sync(registry, _close_fn=capturing_close)
+        assert len(comments) == 1
+        assert uow_id in comments[0]


### PR DESCRIPTION
## What problem this solves

When the Steward marks a UoW done, the source GitHub issue stays open with no record of the completed work. There is no way to tell from GitHub which issues were resolved by WOS, and issues never auto-close even after successful execution.

## What changed

**\`src/orchestration/github_sync.py\`** — New module implementing post-completion sync:
- \`build_closure_comment(uow)\` — pure function that produces a Markdown closure comment from a UoW value object (contains UoW ID, summary, success criteria, WOS attribution)
- \`_parse_issue_url(url)\` — pure function that extracts (repo, issue_number) from a GitHub issue URL
- \`_close_github_issue(repo, issue_number, comment)\` — isolated subprocess call to \`gh issue close --comment\`; tolerates "already closed" gh errors (idempotent)
- \`run_post_completion_sync(registry, dry_run, _close_fn)\` — sweep function that queries done+unsynced UoWs, calls the close function, and writes \`github_synced_at\` to the registry

**\`src/orchestration/migrations/0006_add_github_synced_at.sql\`** — Adds \`github_synced_at TEXT DEFAULT NULL\` column. NULL = not yet synced; non-NULL = ISO timestamp of when the issue was closed.

**\`scheduled-tasks/steward-heartbeat.py\`** — Adds Phase 4 after the Steward cycle: imports and calls \`run_post_completion_sync(registry, dry_run=dry_run)\`. Failures are caught and logged; they do not abort the heartbeat.

## Flow

```
Steward heartbeat:
  Phase 1: Startup sweep
  Phase 2: Observation loop
  Phase 3: Steward main loop
  Phase 4: Post-completion GitHub sync (NEW)
           → find done UoWs where github_synced_at IS NULL AND issue_url IS NOT NULL
           → for each: gh issue close <number> --repo <repo> --comment <summary>
           → write github_synced_at = now() to registry
```

## Idempotency

\`github_synced_at\` is written only after both the gh call and the registry write succeed. A failed gh call leaves it NULL, so the next 3-minute heartbeat retries. \`gh issue close\` with an already-closed issue is treated as success (no error).

## What is NOT changed

- \`steward.py\` is not modified (boundary respected per task spec).
- No changes to registry.py public API — \`github_sync.py\` uses \`registry._connect()\` directly for the \`github_synced_at\` write, following the same pattern used in \`github_issue_source.py\` for source tracking.
- UoWs without \`issue_url\` (pre-migration or manual) are silently skipped.

## Functional patterns used

Pure functions for comment building and URL parsing, injectable close function for test isolation, sweep function with explicit result type (\`PostCompletionSyncResult\`).

## Tests run

- [x] \`uv run pytest tests/unit/test_orchestration/test_github_sync.py -v\` — 19 passed, 0 failed
- [x] \`uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_dispatcher_integration.py tests/unit/test_orchestration/test_github_sync.py -q\` — 106 passed, 0 failed

Relates to #484.