### PR TITLE
fix: add recency guard to check_usage_limit to prevent stale log contamination

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1342,9 +1342,14 @@ except Exception as e:
 # check_usage_limit — inspect the last 50 lines of claude-session.log for the
 # Anthropic rate-limit message ("You've hit your limit").
 #
+# Recency guard: if claude-session.log was not modified within the last 10
+# minutes, the function returns 1 immediately without scanning the file.  This
+# prevents a stale limit event from a prior session from suppressing crash
+# recovery in a fresh session indefinitely.
+#
 # Returns:
-#   0  — usage limit detected (caller should NOT escalate to BLACK/restart)
-#   1  — no limit signal found (caller should proceed with normal crash logic)
+#   0  — usage limit detected in a recent (< 10 min) log (caller should NOT escalate to BLACK/restart)
+#   1  — no limit signal found, or log is stale (caller should proceed with normal crash logic)
 #
 # Side effects on detection:
 #   - Writes $LIMIT_WAIT_STATE_FILE with epoch timestamp and optional reset time
@@ -1352,6 +1357,17 @@ except Exception as e:
 #   - Logs at INFO level
 check_usage_limit() {
     if [[ ! -f "$CLAUDE_SESSION_LOG" ]]; then
+        return 1
+    fi
+
+    # Recency guard: only treat a log match as a current event if the file was
+    # modified within the last 10 minutes.  A stale file means the limit message
+    # is from a prior session and must not block crash recovery now.
+    local _now _file_mtime _age
+    _now=$(date +%s)
+    _file_mtime=$(stat -c %Y "$CLAUDE_SESSION_LOG" 2>/dev/null) || return 1
+    _age=$(( _now - _file_mtime ))
+    if (( _age > 600 )); then
         return 1
     fi
 


### PR DESCRIPTION
## What this fixes

Health checks were permanently poisoned by a genuine usage-limit event. Once the string "you've hit your limit" appeared in `claude-session.log`, every subsequent run of `check_usage_limit()` would find it — because the function scanned log content but never checked how old that content was. A limit event from 33+ hours prior kept returning "limit active" indefinitely, suppressing crash recovery and restart logic across sessions.

## The change

A 10-minute file-modification-time guard is added at the top of `check_usage_limit()` before the grep. If `claude-session.log` was not written to within the last 10 minutes, the function returns 1 (no limit detected) immediately without scanning content.

The guard is intentionally tight (10 minutes) because the usage-limit message appears in real time when Claude hits the rate limit. A session that hit the limit 10+ minutes ago has either recovered or the health check would have already recorded the state in `LIMIT_WAIT_STATE_FILE` — which the existing `is_limit_wait()` function handles with its own 4-hour guard.

## Scope

Only `scripts/health-check-v3.sh` is modified. No other scripts, state files, or detection paths are touched. `is_limit_wait()` and `clear_limit_wait()` are unchanged.

## Flow: before vs. after

```
Before:
  health check run
    └─ check_usage_limit()
         └─ file exists? yes
         └─ grep last 50 lines → match found (from 33h ago)
         └─ return 0  ← false positive, restart suppressed forever

After:
  health check run
    └─ check_usage_limit()
         └─ file exists? yes
         └─ file mtime within 10 min? no (33h ago)
         └─ return 1  ← no false positive, crash recovery proceeds
```

## Tests run

- [x] Manual diff review — guard logic is a pure function of `date +%s` and `stat -c %Y`; no side effects introduced before the guard; all existing paths (file absent, stat failure) return 1 safely
- [ ] Live health-check run — requires a running Lobster instance; not available in this environment. The change is isolated to a single early-return path and does not touch alerting, state files, or restart logic.

Fixes #516

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>