### PR TITLE
health-check: reduce usage-limit retry interval from 4 hours to 10 minutes

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1385,9 +1385,10 @@ check_usage_limit() {
 }
 
 # is_limit_wait — returns 0 if a recent usage-limit event was recorded and
-# the limit-wait window has not yet expired.  Conservatively uses a 4-hour
-# guard since reset times are hard to parse reliably.
-LIMIT_WAIT_MAX_SECONDS=14400  # 4 hours
+# the limit-wait window has not yet expired.  Uses a 10-minute retry interval
+# so the system recovers quickly on false positives rather than sitting dead
+# for 4 hours.
+LIMIT_WAIT_MAX_SECONDS=600  # 10 minutes
 
 is_limit_wait() {
     [[ -f "$LIMIT_WAIT_STATE_FILE" ]] || return 1


### PR DESCRIPTION
## What this fixes

When `is_limit_wait()` detects a usage-limit event, it suppresses crash recovery for a flat 4-hour window (`LIMIT_WAIT_MAX_SECONDS=14400`). This means a false positive — a spurious rate-limit log line that doesn't reflect an actual limit — parks the system dead for 4 hours with no recovery path. Even on real limits that clear in under an hour, the system waits the full 4 hours before retrying.

The 4-hour window was a conservative guess, not a precise reset interval. It has no upside over a short retry loop.

## What changed

`LIMIT_WAIT_MAX_SECONDS` in `scripts/health-check-v3.sh` changed from `14400` (4 hours) to `600` (10 minutes). The comment block above the constant was updated to match.

No logic changed. On a real limit, Claude exits quickly after each retry and `is_limit_wait()` re-arms the 10-minute suppression window — so the system still avoids hammering restarts. On a false positive or an early limit clear, normal operation resumes within 10 minutes instead of up to 4 hours.

## Behaviour before and after

```
Before:
  limit detected → suppress restarts for 4 hours → resume

After:
  limit detected → suppress restarts for 10 minutes → retry
                       ↑                                  ↓
                       └──── limit still active: re-arm ──┘
                             limit cleared: resume normally
```

## Functional patterns

Pure constant — no control flow changed. The retry loop is an emergent property of the existing `is_limit_wait()` guard re-arming on each health-check cycle.

## Tests run

- [x] Manual diff review of `scripts/health-check-v3.sh` — single constant and comment changed, no logic altered
- [ ] Live health-check end-to-end test — skipped: requires a running Lobster instance and a simulated usage-limit event

Closes #518