### PR TITLE
fix: WOS_MESSAGE_TYPE_DISPATCH table + Tier-1 gate for wos_execute compaction resilience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ These gates must survive context compaction. If any trigger cannot be stated fro
 | **No self-relay** | When `sent_reply_to_user == True` or message type is `subagent_notification`, mark_processed without calling send_reply. | Structural — the message type routes it; no discretion needed. |
 | **Relay filter** | If the key signal in a send_reply to Dan is buried past paragraph 2, move it to the lead. | Advisory — apply before every send_reply. |
 | **PR Merge Gate** | Every code PR must pass oracle review before merge. Flow: open PR → oracle agent → verdict in oracle/decisions.md → if APPROVED dispatch merge agent; if NEEDS_CHANGES dispatch fix agent → re-oracle → repeat. Merge agent must confirm latest oracle/decisions.md entry for this PR is APPROVED before merging. | Advisory — never dispatch a merge agent without first confirming oracle approval in decisions.md. |
+| **WOS Execute Gate** | A message with `type: "wos_execute"` must be routed by calling `route_wos_message(msg)` from `src/orchestration/dispatcher_handlers.py` — never by re-reading prose that may be absent after compaction. | Structural — if you receive a `wos_execute` message, call `route_wos_message` unconditionally; the import is always available. |
 
 ## Project Directory Convention
 

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -15,6 +15,13 @@ The dispatcher calls these handlers when it recognizes:
   decide retry <uow-id>                → handle_decide_retry(uow_id, registry)
   decide close <uow-id>                → handle_decide_close(uow_id, registry)
   type: "wos_execute"                  → handle_wos_execute(uow_id, instructions, output_ref)
+
+## Compaction-resilient dispatch
+
+WOS_MESSAGE_TYPE_DISPATCH maps inbox message types to handler descriptors.
+The dispatcher calls route_wos_message(msg) to dispatch type-routed messages
+instead of relying on prose instructions that can be lost under context compaction.
+Import and call this table unconditionally — Python imports survive compaction.
 """
 
 from __future__ import annotations
@@ -22,7 +29,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .registry import Registry
@@ -425,3 +432,113 @@ def handle_wos_stop() -> str:
         "UoWs already active will continue running; TTL recovery handles any that stall.\n"
         f"Config: `{_WOS_CONFIG_PATH}`"
     )
+
+
+# ---------------------------------------------------------------------------
+# Compaction-resilient message-type dispatch table
+#
+# Maps inbox message `type` values to handler descriptors.  The dispatcher
+# calls route_wos_message(msg) instead of embedding routing logic in prose
+# instructions — prose can be lost under context compaction, Python imports
+# cannot.
+#
+# Dispatcher integration (add to main loop):
+#
+#     from src.orchestration.dispatcher_handlers import route_wos_message
+#
+#     if msg.get("type") in WOS_MESSAGE_TYPE_DISPATCH:
+#         result = route_wos_message(msg)
+#         # result["action"] tells the dispatcher what to do next
+#         # See route_wos_message docstring for the result schema.
+# ---------------------------------------------------------------------------
+
+WOS_MESSAGE_TYPE_DISPATCH: dict[str, str] = {
+    # message type → handler name (used as a stable, compaction-safe key)
+    "wos_execute": "handle_wos_execute",
+}
+
+
+def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Route an inbox message whose `type` is listed in WOS_MESSAGE_TYPE_DISPATCH.
+
+    This is the compaction-resilient entry point for WOS message routing.  The
+    dispatcher should call this function rather than conditionally re-reading
+    prose documentation that may not survive context compaction.
+
+    For ``type: "wos_execute"`` the function extracts the required fields and
+    builds the subagent prompt via ``handle_wos_execute``.  The dispatcher is
+    still responsible for spawning the subagent Task and for all
+    mark_processing / mark_processed bookkeeping — this function is pure.
+
+    Args:
+        msg: The raw inbox message dict as returned by ``wait_for_messages``.
+             Must contain ``type`` and the type-specific payload fields.
+
+    Returns:
+        A dict with the following keys:
+
+        ``action`` (str):
+            What the dispatcher must do.  Currently always ``"spawn_subagent"``
+            for ``wos_execute`` messages.
+
+        ``task_id`` (str):
+            The ``task_id`` to pass to the Task tool (e.g. ``"wos-<uow_id>"``).
+
+        ``prompt`` (str):
+            The prompt string to pass to the background subagent Task call.
+
+        ``message_type`` (str):
+            Echo of ``msg["type"]`` — lets callers confirm which branch fired.
+
+    Raises:
+        KeyError: if a required field is missing from ``msg``.
+        ValueError: if ``msg["type"]`` is not in ``WOS_MESSAGE_TYPE_DISPATCH``.
+
+    Example dispatcher integration::
+
+        from src.orchestration.dispatcher_handlers import (
+            route_wos_message,
+            WOS_MESSAGE_TYPE_DISPATCH,
+        )
+
+        msg_type = msg.get("type", "")
+        if msg_type in WOS_MESSAGE_TYPE_DISPATCH:
+            routing = route_wos_message(msg)
+            # routing["action"] == "spawn_subagent"
+            # spawn Task(routing["prompt"], run_in_background=True,
+            #             task_id=routing["task_id"])
+            mark_processed(message_id)
+    """
+    msg_type: str = msg.get("type", "")
+
+    if msg_type not in WOS_MESSAGE_TYPE_DISPATCH:
+        raise ValueError(
+            f"route_wos_message: unrecognised message type {msg_type!r}. "
+            f"Known types: {sorted(WOS_MESSAGE_TYPE_DISPATCH)}"
+        )
+
+    if msg_type == "wos_execute":
+        uow_id: str = msg["uow_id"]
+        instructions: str = msg["instructions"]
+        # output_ref may be supplied by the Executor, or derived from uow_id
+        output_ref: str = msg.get(
+            "output_ref",
+            str(
+                Path.home()
+                / "lobster-workspace"
+                / "orchestration"
+                / "outputs"
+                / f"{uow_id}.result.json"
+            ),
+        )
+        prompt = handle_wos_execute(uow_id, instructions, output_ref)
+        return {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{uow_id}",
+            "prompt": prompt,
+            "message_type": msg_type,
+        }
+
+    # Unreachable given the guard above, but satisfies exhaustiveness checkers
+    raise ValueError(f"route_wos_message: no branch for type {msg_type!r}")


### PR DESCRIPTION
## What this fixes

A `wos_execute` inbox message arriving after context compaction could fall through with no handler. The only routing mechanism was a prose section in `sys.dispatcher.bootup.md` that describes the multi-step dispatch sequence — if that section was absent from working context, the dispatcher had no structural fallback.

This PR installs two complementary fixes:

**Option 3 (primary) — Python dispatch table.** `WOS_MESSAGE_TYPE_DISPATCH` is a dict in `dispatcher_handlers.py` that maps inbox message types to handler names. `route_wos_message(msg)` is the compaction-resilient entry point: it reads the type, extracts the required fields, calls `handle_wos_execute`, and returns `{"action": "spawn_subagent", "task_id": ..., "prompt": ...}`. A Python import cannot be compacted away; prose can. The dispatcher calls `route_wos_message` rather than reconstructing the dispatch logic from memory.

**Option 1 (belt-and-suspenders) — Tier-1 gate entry.** A one-sentence gate was added to `CLAUDE.md → Dispatcher: Tier-1 Gate Register`: "A message with `type: wos_execute` must be routed by calling `route_wos_message(msg)` — never by re-reading prose that may be absent after compaction." Gates survive compaction because they fit in one sentence and are verified at every session start. This guards against the failure mode where the dispatcher forgets to consult the dispatch table at all.

Prose in `sys.dispatcher.bootup.md` that describes the step-by-step wos_execute handling is unchanged — it remains correct reference documentation for human reviewers, just no longer the sole routing mechanism.

## What is not changed

- No WOS orchestration logic was modified. `handle_wos_execute` is unchanged. `executor.py`, `registry.py`, `steward.py`, and all heartbeat scripts are untouched.
- `route_wos_message` is pure: no MCP tools, no network calls, no side effects. The dispatcher is still responsible for spawning the Task and all `mark_processing`/`mark_processed` bookkeeping.
- The existing prose section in `sys.dispatcher.bootup.md` was not modified (edit permission was correctly restricted for that system file).

## Functional patterns used

Pure functions throughout: `route_wos_message` and `handle_wos_execute` are both pure — they take data in and return data out. The dispatch table is an immutable mapping (`dict[str, str]`). Pattern matching (`msg.get("type") in WOS_MESSAGE_TYPE_DISPATCH`) at the call site keeps routing declarative.

## Tests run

- [x] Smoke test of `WOS_MESSAGE_TYPE_DISPATCH` and `route_wos_message` via `uv run python -c` — dispatch table lookup, field extraction, default output_ref derivation, ValueError on unknown type — all assertions passed
- [x] `uv run python -m py_compile src/orchestration/dispatcher_handlers.py` — syntax clean
- [x] `uv run pytest tests/integration/ -q --tb=short` — 120 passed, 3 skipped, 1 warning; 1 pre-existing failure (`TestBootupCandidateGate::test_bootup_candidate_blocked_when_gate_is_open`) confirmed to fail on dcetlin/Lobster main before my changes

Closes #400