### PR TITLE
fix: update sweeper template to use 'approve' subcommand (was 'confirm')

### DIFF
--- a/scheduled-tasks/tasks/issue-sweeper.md.template
+++ b/scheduled-tasks/tasks/issue-sweeper.md.template
@@ -94,7 +94,7 @@ uv run ~/lobster/src/orchestration/registry_cli.py upsert \
 After upserting, immediately confirm the UoW so it goes directly to `pending` status:
 
 ```bash
-uv run ~/lobster/src/orchestration/registry_cli.py confirm --id <uow-id>
+uv run ~/lobster/src/orchestration/registry_cli.py approve --id <uow-id>
 ```
 
 The /confirm gate is removed. UoWs are accepted on creation. No manual confirmation from Dan is required.
@@ -146,7 +146,7 @@ Order by created_at (oldest first). All items are labeled "awaiting execution".
 
 Note: The /confirm gate has been removed. UoWs go directly from upsert → confirm → pending.
 If any items appear with status `proposed`, that indicates a sweep ran before this change —
-confirm them manually with `registry_cli.py confirm --id <uow-id>`.
+approve them manually with `registry_cli.py approve --id <uow-id>`.
 
 ### 6b. Build the design visibility list
 


### PR DESCRIPTION
## What and why

The issue-sweeper scheduled task template referenced `registry_cli.py confirm --id <uow-id>` on two lines (97 and 149). PR #335 renamed that subcommand from `confirm` to `approve`. Any sweeper job instance generated from the stale template would fail at the UoW confirmation step with an unrecognized subcommand error.

## Change

Both occurrences in `scheduled-tasks/tasks/issue-sweeper.md.template` updated:
- Line 97: shell command changed from `registry_cli.py confirm` to `registry_cli.py approve`
- Line 149: prose updated from "confirm them manually with `registry_cli.py confirm`" to "approve them manually with `registry_cli.py approve`"

No other files reference this subcommand. No behavior changes — this is a pure rename alignment.

## Functional patterns

Pure text substitution in a template file. No code logic involved.

## Tests run

- [x] Verified no remaining `registry_cli.py confirm` references in `scheduled-tasks/` — 0 matches
- [ ] Live sweeper execution — not run; template is rendered at job instantiation time, not testable in isolation

**Blocked items needing attention before merge:** none

Closes #424