### PR TITLE
fix: normalize result.json status field to match outcome vocabulary

### DIFF
--- a/src/orchestration/result_writer.py
+++ b/src/orchestration/result_writer.py
@@ -22,17 +22,19 @@ Executor. Look for it in the prescription block under ``output_ref:``.
 Schema written to ``<output_ref>.result.json``:
 
     {
-        "status":     "done" | "failed",
-        "outcome":    "complete" | "failed",   # Steward-compatible alias for status
+        "status":     "complete" | "failed",
+        "outcome":    "complete" | "failed",   # Steward routing signal — always matches status
         "success":    true | false,             # Steward-compatible convenience field
         "summary":    "<human-readable one-line summary>",
         "artifacts":  ["<path1>", "<path2>", ...],   # optional
         "written_at": "<ISO-8601 UTC timestamp>"
     }
 
-``status`` is the subagent-facing API; ``outcome`` and ``success`` are written
-for backward compatibility with the Steward's result-file parser, which reads
-``outcome`` as its primary routing signal (executor-contract.md §Schema).
+Both ``status`` and ``outcome`` use identical vocabulary (``"complete"`` /
+``"failed"``) so that any future Steward code reading either field sees a
+consistent value. The Steward's primary routing signal remains ``outcome``
+(executor-contract.md §Schema). ``status="done"`` is still accepted as a
+convenience alias for ``"complete"`` and is normalized before writing.
 """
 
 from __future__ import annotations
@@ -51,7 +53,7 @@ from typing import Literal
 
 def write_result(
     output_ref: str,
-    status: Literal["done", "failed"],
+    status: Literal["done", "complete", "failed"],
     summary: str,
     artifacts: list[str] | None = None,
 ) -> Path:
@@ -69,8 +71,11 @@ def write_result(
             ``<stem>.result.json`` (replacing the extension) or
             ``<output_ref>.result.json`` (suffix appended) when the path has
             no extension.
-        status: ``"done"`` for successful completion, ``"failed"`` for any
-            failure that prevents the prescription from being fulfilled.
+        status: ``"done"`` or ``"complete"`` for successful completion;
+            ``"failed"`` for any failure that prevents the prescription from
+            being fulfilled. ``"done"`` is normalized to ``"complete"`` before
+            writing so that the written ``status`` field always matches the
+            Steward's ``outcome`` vocabulary.
         summary: A single human-readable sentence describing what happened.
             The Steward surfaces this in its diagnosis log and to the user
             when a surface condition fires. Keep it factual and concise.
@@ -90,14 +95,16 @@ def write_result(
     result_path = _result_json_path(output_ref)
     result_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Map status to Steward-compatible outcome/success fields so the Steward
-    # can read this file without changes (executor-contract.md §Schema).
-    outcome = "complete" if status == "done" else "failed"
-    success = status == "done"
+    # Normalize "done" → "complete" so status and outcome use identical
+    # vocabulary. The Steward reads `outcome` as its primary routing signal
+    # (executor-contract.md §Schema), and any future code reading `status`
+    # would also expect "complete", not "done".
+    normalized_status = "complete" if status == "done" else status
+    success = normalized_status == "complete"
 
     payload: dict = {
-        "status": status,
-        "outcome": outcome,
+        "status": normalized_status,
+        "outcome": normalized_status,
         "success": success,
         "summary": summary,
         "written_at": _now_iso(),

--- a/tests/unit/test_result_writer.py
+++ b/tests/unit/test_result_writer.py
@@ -2,8 +2,10 @@
 Tests for orchestration.result_writer.
 
 Coverage:
-- write_result("done") writes status="done", outcome="complete", success=True
+- write_result("done") writes status="complete", outcome="complete", success=True
+- write_result("complete") writes status="complete", outcome="complete", success=True
 - write_result("failed") writes status="failed", outcome="failed", success=False
+- status and outcome fields always use identical vocabulary ("complete"/"failed")
 - result.json path derived by replacing extension (primary convention)
 - result.json path appends .result.json when output_ref has no extension (fallback)
 - artifacts included when provided; absent when not provided
@@ -17,7 +19,6 @@ Coverage:
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
 
 import pytest
@@ -39,13 +40,30 @@ def output_ref(tmp_path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 class TestWriteResultSchema:
-    def test_done_status_writes_complete_outcome(self, output_ref: str) -> None:
+    def test_done_alias_normalizes_to_complete(self, output_ref: str) -> None:
         write_result(output_ref, status="done", summary="PR opened")
         result_path = _result_json_path(output_ref)
         data = json.loads(result_path.read_text())
-        assert data["status"] == "done"
+        assert data["status"] == "complete"
         assert data["outcome"] == "complete"
         assert data["success"] is True
+
+    def test_complete_status_writes_complete_outcome(self, output_ref: str) -> None:
+        write_result(output_ref, status="complete", summary="PR opened")
+        result_path = _result_json_path(output_ref)
+        data = json.loads(result_path.read_text())
+        assert data["status"] == "complete"
+        assert data["outcome"] == "complete"
+        assert data["success"] is True
+
+    def test_status_and_outcome_always_match(self, output_ref: str) -> None:
+        """status and outcome must use identical vocabulary — no divergence."""
+        for val in ("done", "complete", "failed"):
+            write_result(output_ref, status=val, summary="test")  # type: ignore[arg-type]
+            data = json.loads(_result_json_path(output_ref).read_text())
+            assert data["status"] == data["outcome"], (
+                f"status={data['status']!r} != outcome={data['outcome']!r} for input {val!r}"
+            )
 
     def test_failed_status_writes_failed_outcome(self, output_ref: str) -> None:
         write_result(output_ref, status="failed", summary="tests failed")


### PR DESCRIPTION
## What this fixes

result_writer.py was writing `status='done'` while simultaneously writing `outcome='complete'` for the same successful result. The Steward reads `outcome` as its primary routing signal and ignores `status` — so the discrepancy was invisible at runtime. But it created a latent misrouting surface: any future Steward change that reads `status` expecting `'complete'` would find `'done'` and fall through to the unknown-outcome conservative path, triggering unnecessary surfacing to the user.

## What changed

`status` and `outcome` now use identical vocabulary (`"complete"` / `"failed"`). The `write_result` public API still accepts `"done"` as a convenience alias — it is normalized to `"complete"` before the file is written. The written `status` field is now always equal to `outcome`.

The change is confined to `result_writer.py` and its tests. No Steward routing logic was modified — the Steward's `outcome`-first read path is unchanged.

**Functional patterns used:** pure function with explicit normalization (no mutation), single-responsibility mapping (`normalized_status = "complete" if status == "done" else status`).

## Before / after

Before:
```json
{ "status": "done", "outcome": "complete", ... }
```

After:
```json
{ "status": "complete", "outcome": "complete", ... }
```

The Steward's behavior is unchanged — both before and after, it reads `outcome='complete'` and routes to completion. The fix closes the gap for code that might read `status` in the future.

## Tests run

- [x] `uv run pytest tests/unit/test_result_writer.py -v` — 16 passed, 0 failed
- [x] `uv run --with ruff ruff check src/orchestration/result_writer.py tests/unit/test_result_writer.py` — clean, no errors

Closes #403