### PR TITLE
fix(steward): check code_keywords before ops_keywords in _select_executor_type

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -528,21 +528,23 @@ def _select_executor_type(uow: "UoW") -> str:
     summary_lower = uow.summary.lower()
     source = (uow.source or "").lower()
 
-    # Infrastructure / ops signals
-    ops_keywords = (
-        "install", "deploy", "cron", "systemd", "migration", "upgrade",
-        "ops", "infra", "server", "config", "script", "setup", "lobster-ops",
-    )
-    if any(kw in summary_lower for kw in ops_keywords):
-        return _EXECUTOR_TYPE_LOBSTER_OPS
-
-    # Code / feature / bug signals — default for GitHub issues
+    # Code / feature / bug signals checked first — these are strong indicators
+    # that win over incidental ops-adjacent terms (e.g. "fix: setup script fails"
+    # should route to functional-engineer, not lobster-ops).
     code_keywords = (
         "bug", "fix", "feat", "feature", "implement", "refactor", "test",
         "pr", "pull request", "issue", "error", "crash", "regression",
     )
     if any(kw in summary_lower for kw in code_keywords):
         return _EXECUTOR_TYPE_FUNCTIONAL_ENGINEER
+
+    # Infrastructure / ops signals — checked after code keywords
+    ops_keywords = (
+        "install", "deploy", "cron", "systemd", "migration", "upgrade",
+        "ops", "infra", "server", "config", "script", "setup", "lobster-ops",
+    )
+    if any(kw in summary_lower for kw in ops_keywords):
+        return _EXECUTOR_TYPE_LOBSTER_OPS
 
     # Default: functional-engineer for anything sourced from a GitHub issue
     if "github:issue" in source:

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -2019,6 +2019,26 @@ class TestSelectExecutorType:
         uow = self._make_uow("do a thing", source="manual")
         assert steward._select_executor_type(uow) == "general"
 
+    def test_fix_prefix_with_ops_terms_returns_functional_engineer(self):
+        # Regression: "fix: setup script fails" contains both code keyword ("fix")
+        # and ops keywords ("setup", "script"). Code keywords must win.
+        steward = _import_steward()
+        uow = self._make_uow("fix: setup script fails")
+        assert steward._select_executor_type(uow) == "functional-engineer"
+
+    def test_fix_prefix_with_migration_term_returns_functional_engineer(self):
+        # Regression: "fix: migration script fails on upgrade" contains "fix"
+        # (code) and "migration", "script" (ops). Code keyword must win.
+        steward = _import_steward()
+        uow = self._make_uow("fix: migration script fails on upgrade")
+        assert steward._select_executor_type(uow) == "functional-engineer"
+
+    def test_pure_ops_term_no_code_keyword_returns_lobster_ops(self):
+        # Pure ops summary with no code keyword should still route to lobster-ops.
+        steward = _import_steward()
+        uow = self._make_uow("upgrade server config and systemd unit", source="manual")
+        assert steward._select_executor_type(uow) == "lobster-ops"
+
 
 # ---------------------------------------------------------------------------
 # Tests: Issue #425 — _assess_completion reads success field from result.json


### PR DESCRIPTION
## Problem

\`_select_executor_type()\` routed summaries containing ops-adjacent terms (\`script\`, \`setup\`, \`migration\`) to \`lobster-ops\` even when a strong code signal was present — because ops keywords were checked first.

Examples that misrouted before this fix:
- \`"fix: setup script fails"\` → \`lobster-ops\` (should be \`functional-engineer\`)
- \`"fix: migration script fails on upgrade"\` → \`lobster-ops\` (should be \`functional-engineer\`)

The semantic intent is that conventional-commit prefixes (\`fix:\`, \`feat:\`, \`refactor:\`, \`test:\`) are unambiguous indicators of code work and should always win in ambiguous cases.

## Change

Swapped the check order in \`_select_executor_type\`: code keywords are evaluated first, ops keywords second. The default fallback (github:issue source → functional-engineer, everything else → general) is unchanged.

This is a pure reordering of two if-blocks. No logic is added or removed; no other routing paths are affected.

## Functional pattern

Pure function, deterministic keyword-precedence via ordered if-guards. No state mutation, no side effects.

## Tests run

- [x] \`uv run pytest tests/unit/test_orchestration/test_steward.py::TestSelectExecutorType -v\` — 9 passed, 0 failed (includes 3 new regression tests for keyword-overlap cases)
- [ ] Full \`test_steward.py\` suite — timed out after 90s; the suite contains integration tests that hang in this environment (pre-existing, unrelated to this change). The \`TestSelectExecutorType\` class is fully isolated and passes cleanly.

**Blocked items needing attention before merge:** none — the timeout is a pre-existing test infrastructure issue, not introduced by this change.

Closes #493