### PR TITLE
fix: filter chat_id=0 agents from reconciler inbox notifications

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -9348,6 +9348,20 @@ def _build_reconciler_message(
         }
 
 
+def _is_internal_agent(session: dict) -> bool:
+    """Return True when the session belongs to a system/internal agent (chat_id=0/empty).
+
+    Internal agents (chat_id=0) have no real user to notify.  Reconciler
+    notifications for these sessions would land in the inbox as no-ops —
+    the dispatcher must read each one only to discover there is nothing to relay.
+
+    Pure function: reads session dict, no side effects.
+    """
+    raw = session.get("chat_id")
+    chat_id_str = str(raw).strip() if raw is not None else ""
+    return chat_id_str in ("0", "", "None")
+
+
 def _enqueue_reconciler_notification(session: dict, outcome: str) -> None:
     """Write a structured inbox message for a reconciler-detected session transition.
 
@@ -9359,6 +9373,10 @@ def _enqueue_reconciler_notification(session: dict, outcome: str) -> None:
     the user's Telegram — the dispatcher decides whether to re-queue, escalate,
     or drop silently.
 
+    Internal/system agents (chat_id=0) are silently dropped for both outcomes —
+    no real user exists to notify, and writing a no-op inbox message forces the
+    dispatcher to read and discard it on every cycle.
+
     Also marks the session as notified_at to prevent duplicate notifications
     on the next reconciler cycle.
 
@@ -9366,39 +9384,21 @@ def _enqueue_reconciler_notification(session: dict, outcome: str) -> None:
         session: Session dict from get_active_sessions() or get_unnotified_completed().
         outcome: 'completed' or 'dead'.
     """
-    # Dead sessions with no real user don't need dispatcher action — route to
-    # debug log only, not the inbox. The dispatcher cannot notify a user
-    # (no chat_id) or take any meaningful action. Logging preserves observability.
-    if outcome == "dead":
+    # System agents (chat_id=0/empty) have no real user — skip inbox for all outcomes.
+    # Logging preserves observability without polluting the dispatcher inbox.
+    if _is_internal_agent(session):
+        _agent_id = session.get("id", "")
         _chat_id = session.get("chat_id")
-        _chat_id_str = str(_chat_id).strip() if _chat_id is not None else ""
-        if _chat_id_str in ("0", "", "None"):
-            _agent_id = session.get("id", "")
-            log.debug(
-                "[reconciler] Dead session %r has no real user (chat_id=%r) — "
-                "skipping inbox notification (logged to debug only)",
-                _agent_id, _chat_id,
-            )
-            return
+        log.debug(
+            "[reconciler] Session %r is internal (chat_id=%r, outcome=%r) — "
+            "skipping inbox notification",
+            _agent_id, _chat_id, outcome,
+        )
+        return
 
     # Idempotency guard — if already notified, skip
     if session.get("notified_at"):
         return
-
-    # Dead sessions with no real user don't need dispatcher action — route to
-    # debug log only, not the inbox. The dispatcher cannot notify a user
-    # (no chat_id) or take any meaningful action. Logging preserves observability.
-    if outcome == "dead":
-        _chat_id = session.get("chat_id")
-        _chat_id_str = str(_chat_id).strip() if _chat_id is not None else ""
-        if _chat_id_str in ("0", "", "None"):
-            _agent_id = session.get("id", "")
-            log.debug(
-                "[reconciler] Dead session %r has no real user (chat_id=%r) — "
-                "skipping inbox notification (logged to debug only)",
-                _agent_id, _chat_id,
-            )
-            return
 
     agent_id = session.get("id", "")
     now = datetime.now(timezone.utc)

--- a/tests/unit/test_mcp_server/test_ghost_session_fixes.py
+++ b/tests/unit/test_mcp_server/test_ghost_session_fixes.py
@@ -9,10 +9,12 @@ Two bugs caused cascading WFM stale restarts:
 
 This module tests the fix:
 
-  Fix 1 (restored, scoped): _enqueue_reconciler_notification() now skips inbox
-         write for dead sessions where chat_id is 0, "", or None. These have no
-         real user — the dispatcher cannot notify anyone or take meaningful action.
-         Completed sessions are unaffected (they always write to inbox).
+  Fix 1 (restored, extended in #462): _enqueue_reconciler_notification() now
+         skips inbox write for sessions where chat_id is 0, "", or None — for
+         ALL outcomes (completed and dead). These have no real user — the
+         dispatcher cannot notify anyone or take meaningful action.  Before #462,
+         only dead sessions were suppressed; completed ghost notifications produced
+         no-op inbox reads.
          The `should_drop` field has been removed from _build_reconciler_message()
          in favor of this pre-write guard.
 
@@ -353,26 +355,26 @@ class TestGhostSessionCascadePrevented:
 def _should_skip_dead_no_user(session: dict, outcome: str) -> bool:
     """Pure function mirroring the early-return guard in _enqueue_reconciler_notification().
 
-    Dead sessions with chat_id 0, "", or None have no real user — the
-    dispatcher cannot notify anyone or take meaningful action. Route to debug
-    log only, not the inbox.
+    Sessions with chat_id 0, "", or None have no real user — the dispatcher
+    cannot notify anyone or take meaningful action.  Route to debug log only,
+    not the inbox.  This applies to ALL outcomes (completed AND dead) as of
+    issue #462: completed ghost notifications were no-op reads for the dispatcher.
 
-    Completed sessions always write to inbox regardless of chat_id, because
-    completed agent results need to be processed even for cron subagents.
+    Note: the function name is retained for backward-compat with the test suite;
+    the scope now covers all outcomes, not just dead.
     """
-    if outcome != "dead":
-        return False
     _chat_id = session.get("chat_id")
     _chat_id_str = str(_chat_id).strip() if _chat_id is not None else ""
     return _chat_id_str in ("0", "", "None")
 
 
 class TestGhostChatIdNoInboxNotification:
-    """Dead sessions with no real user must not write to the inbox.
+    """Internal/system sessions (chat_id=0) must not write to the inbox for any outcome.
 
     The guard in _enqueue_reconciler_notification() returns early (logging to
-    debug only) when outcome=='dead' and chat_id is 0, empty, or None.
-    Completed sessions and dead sessions with real users are unaffected.
+    debug only) when chat_id is 0, empty, or None — regardless of whether the
+    outcome is 'dead' or 'completed' (issue #462).  Sessions with a real user
+    chat_id are unaffected.
     """
 
     @pytest.mark.parametrize("chat_id,should_skip", [
@@ -393,15 +395,17 @@ class TestGhostChatIdNoInboxNotification:
         )
 
     @pytest.mark.parametrize("chat_id", ["0", 0, "", None, "None"])
-    def test_completed_outcome_never_skipped(self, chat_id):
-        """Completed sessions with ghost chat_ids still write to inbox.
+    def test_completed_outcome_internal_agent_skipped(self, chat_id):
+        """Completed sessions with ghost chat_ids are skipped (issue #462).
 
-        Completed agent results need to be processed even when there's no user
-        to notify directly — the dispatcher handles them.
+        Before #462, only dead sessions with chat_id=0 were suppressed.
+        Completed ghost sessions still wrote no-op inbox messages that the
+        dispatcher had to read and discard.  The fix extends the filter to
+        all outcomes.
         """
         session = dict(_GHOST_SESSION, chat_id=chat_id)
-        assert _should_skip_dead_no_user(session, "completed") is False, (
-            f"completed sessions must never be skipped, chat_id={chat_id!r}"
+        assert _should_skip_dead_no_user(session, "completed") is True, (
+            f"completed internal sessions must be skipped, chat_id={chat_id!r}"
         )
 
     def test_dead_real_user_not_skipped(self):
@@ -455,21 +459,19 @@ class TestGhostChatIdNoInboxNotification:
             f"Expected 1 inbox file for dead real-user session, got {len(files)}: {files}"
         )
 
-    def test_integration_enqueue_writes_completed_ghost(self, inbox_server_module, tmp_path):
-        """Integration: completed ghost session (chat_id=0) DOES write to inbox.
+    def test_integration_enqueue_skips_completed_ghost(self, inbox_server_module, tmp_path):
+        """Integration: completed ghost session (chat_id=0) does NOT write to inbox (issue #462).
 
-        Completed results are always forwarded — only dead+no-user is suppressed.
+        Before #462, only dead sessions with chat_id=0 were suppressed.  Completed
+        ghost sessions produced no-op inbox messages the dispatcher had to read and
+        discard.  The fix extends the filter to both outcomes.
         """
-        import os
-
         inbox_dir = tmp_path / "inbox"
         inbox_dir.mkdir()
 
         original_inbox_dir = inbox_server_module.INBOX_DIR
-        inbox_server_module.INBOX_DIR = original_inbox_dir
+        inbox_server_module.INBOX_DIR = inbox_dir
         try:
-            # Patch INBOX_DIR for the call
-            inbox_server_module.INBOX_DIR = inbox_dir
             inbox_server_module._enqueue_reconciler_notification(
                 dict(_GHOST_SESSION, notified_at=None), outcome="completed"
             )
@@ -477,6 +479,6 @@ class TestGhostChatIdNoInboxNotification:
             inbox_server_module.INBOX_DIR = original_inbox_dir
 
         files = list(inbox_dir.iterdir())
-        assert len(files) == 1, (
-            f"Expected 1 inbox file for completed ghost session, got {len(files)}: {files}"
+        assert files == [], (
+            f"Expected no inbox files for completed ghost session (issue #462), got: {files}"
         )

--- a/tests/unit/test_mcp_server/test_reconciler_chat_filter.py
+++ b/tests/unit/test_mcp_server/test_reconciler_chat_filter.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for reconciler chat_id=0 filter (issue #462).
+
+System/internal agents (chat_id=0) previously generated inbox notifications
+even though the dispatcher cannot relay them to any user — every such message
+was a no-op read that the dispatcher had to process and discard.
+
+The fix extracts a pure helper (_is_internal_agent) and applies it uniformly
+to both 'completed' and 'dead' outcomes in _enqueue_reconciler_notification,
+replacing the previous partial filter that only covered 'dead'.
+
+Strategy:
+  - _is_internal_agent: pure predicate, tested exhaustively over all sentinel values
+  - _enqueue_reconciler_notification: tested with mocked I/O to verify no inbox
+    message is written and set_notified is NOT called for chat_id=0 agents
+    (we do not want to accidentally consume the notified_at slot for internal agents)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the helpers under test
+# ---------------------------------------------------------------------------
+
+from src.mcp.inbox_server import _is_internal_agent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_session(
+    agent_id: str = "agent-1",
+    chat_id: object = "42",
+    status: str = "completed",
+    description: str = "test task",
+    notified_at: object = None,
+    elapsed_seconds: int | None = 60,
+    output_file: str | None = None,
+) -> dict:
+    return {
+        "id": agent_id,
+        "status": status,
+        "chat_id": chat_id,
+        "description": description,
+        "task_id": agent_id,
+        "source": "telegram",
+        "elapsed_seconds": elapsed_seconds,
+        "notified_at": notified_at,
+        "output_file": output_file,
+        "input_summary": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: _is_internal_agent (pure predicate)
+# ---------------------------------------------------------------------------
+
+
+class TestIsInternalAgent:
+    """_is_internal_agent correctly identifies sessions with no real user."""
+
+    def test_integer_zero_is_internal(self):
+        assert _is_internal_agent(_make_session(chat_id=0)) is True
+
+    def test_string_zero_is_internal(self):
+        assert _is_internal_agent(_make_session(chat_id="0")) is True
+
+    def test_empty_string_is_internal(self):
+        assert _is_internal_agent(_make_session(chat_id="")) is True
+
+    def test_none_chat_id_is_internal(self):
+        session = _make_session()
+        session["chat_id"] = None
+        assert _is_internal_agent(session) is True
+
+    def test_string_none_is_internal(self):
+        assert _is_internal_agent(_make_session(chat_id="None")) is True
+
+    def test_whitespace_only_is_internal(self):
+        assert _is_internal_agent(_make_session(chat_id="  ")) is True
+
+    def test_real_user_chat_id_is_not_internal(self):
+        assert _is_internal_agent(_make_session(chat_id="8075091586")) is False
+
+    def test_numeric_real_chat_id_is_not_internal(self):
+        assert _is_internal_agent(_make_session(chat_id=8075091586)) is False
+
+    def test_small_positive_chat_id_is_not_internal(self):
+        assert _is_internal_agent(_make_session(chat_id="1")) is False
+
+    def test_missing_chat_id_key_is_internal(self):
+        session = {"id": "x", "status": "completed"}
+        assert _is_internal_agent(session) is True
+
+    def test_pure_same_input_same_output(self):
+        session = _make_session(chat_id="0")
+        assert _is_internal_agent(session) == _is_internal_agent(session)
+
+    def test_does_not_mutate_session(self):
+        session = _make_session(chat_id="0")
+        original = dict(session)
+        _is_internal_agent(session)
+        assert session == original
+
+
+# ---------------------------------------------------------------------------
+# Tests: _enqueue_reconciler_notification — internal agent filtering
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueReconcilerNotificationFilter:
+    """Internal agents must never produce inbox messages for any outcome."""
+
+    def _run(
+        self,
+        session: dict,
+        outcome: str,
+        tmp_path: Path,
+    ) -> tuple[list[dict], MagicMock]:
+        """Run _enqueue_reconciler_notification with patched I/O.
+
+        Returns (written_messages, mock_session_store).
+        """
+        written: list[dict] = []
+
+        def fake_atomic_write(path: Path, data: dict) -> None:
+            written.append(data)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(data))
+
+        mock_store = MagicMock()
+
+        with (
+            patch("src.mcp.inbox_server.INBOX_DIR", tmp_path),
+            patch("src.mcp.inbox_server.atomic_write_json", side_effect=fake_atomic_write),
+            patch("src.mcp.inbox_server._session_store", mock_store),
+            patch("src.mcp.inbox_server._read_last_output", return_value=None),
+        ):
+            from src.mcp.inbox_server import _enqueue_reconciler_notification
+            _enqueue_reconciler_notification(session, outcome)
+
+        return written, mock_store
+
+    # -- completed outcome --
+
+    def test_completed_internal_agent_no_inbox_message(self, tmp_path):
+        session = _make_session(chat_id="0", status="completed")
+        written, _ = self._run(session, "completed", tmp_path)
+        assert written == [], "chat_id=0 completed agent must not write to inbox"
+
+    def test_completed_internal_agent_set_notified_not_called(self, tmp_path):
+        """Internal agents are dropped before the notified_at write — no DB side effect."""
+        session = _make_session(chat_id="0", status="completed")
+        _, mock_store = self._run(session, "completed", tmp_path)
+        mock_store.set_notified.assert_not_called()
+
+    def test_completed_empty_chat_id_no_inbox_message(self, tmp_path):
+        session = _make_session(chat_id="", status="completed")
+        written, _ = self._run(session, "completed", tmp_path)
+        assert written == []
+
+    def test_completed_none_chat_id_no_inbox_message(self, tmp_path):
+        session = _make_session(status="completed")
+        session["chat_id"] = None
+        written, _ = self._run(session, "completed", tmp_path)
+        assert written == []
+
+    # -- dead outcome --
+
+    def test_dead_internal_agent_no_inbox_message(self, tmp_path):
+        session = _make_session(chat_id="0", status="dead")
+        written, _ = self._run(session, "dead", tmp_path)
+        assert written == [], "chat_id=0 dead agent must not write to inbox"
+
+    def test_dead_internal_agent_set_notified_not_called(self, tmp_path):
+        session = _make_session(chat_id="0", status="dead")
+        _, mock_store = self._run(session, "dead", tmp_path)
+        mock_store.set_notified.assert_not_called()
+
+    # -- real user — must still receive notifications --
+
+    def test_completed_real_user_writes_inbox_message(self, tmp_path):
+        session = _make_session(chat_id="8075091586", status="completed")
+        written, _ = self._run(session, "completed", tmp_path)
+        assert len(written) == 1
+        assert written[0]["type"] == "subagent_result"
+        assert written[0]["chat_id"] == "8075091586"
+
+    def test_dead_real_user_writes_inbox_message(self, tmp_path):
+        session = _make_session(chat_id="8075091586", status="dead")
+        written, _ = self._run(session, "dead", tmp_path)
+        assert len(written) == 1
+        assert written[0]["type"] == "agent_failed"
+
+    def test_completed_real_user_set_notified_called(self, tmp_path):
+        session = _make_session(agent_id="my-agent", chat_id="8075091586", status="completed")
+        _, mock_store = self._run(session, "completed", tmp_path)
+        mock_store.set_notified.assert_called_once_with("my-agent")
+
+    # -- idempotency guard still works for real users --
+
+    def test_already_notified_real_user_no_duplicate(self, tmp_path):
+        session = _make_session(chat_id="8075091586", status="completed", notified_at="2026-01-01T00:00:00")
+        written, _ = self._run(session, "completed", tmp_path)
+        assert written == [], "already-notified session must not write again"


### PR DESCRIPTION
## What this fixes

System/internal agents (chat_id=0) were silently generating inbox notifications that the dispatcher had to read and discard on every reconciler cycle. The existing filter only covered `dead` outcomes; `completed` ghost sessions still wrote no-op `subagent_result` messages to inbox/. Issue #462.

## What changed

A pure predicate `_is_internal_agent(session)` is extracted and applied as the **first** check in `_enqueue_reconciler_notification`, before the idempotency guard. It returns True for chat_id values of `0`, `""`, or `None` — matching the sentinel set already used by the startup sweep.

The previous implementation had two problems:
1. The `dead` filter only ran when `outcome == "dead"`, leaving `completed` outcomes unguarded
2. The same `dead` filter block appeared **twice** (once before and once after the idempotency guard) — a copy-paste artifact with no semantic difference; the second block was unreachable if the first fired

Both are resolved: one uniform check covers all outcomes, the duplicate is removed.

**No behavior change for real users.** Sessions with a real chat_id still write to inbox for both `completed` and `dead` outcomes, and `set_notified` is still called after a successful write.

**Functional patterns used:** pure predicate extraction (`_is_internal_agent`), early return at the I/O boundary to isolate the side effect (inbox write), immutable session dict (read-only).

## Before / after notification flow

```
Before (broken):
  _enqueue_reconciler_notification(session, "completed")
    → outcome == "dead"? no → skip check
    → idempotency guard
    → outcome == "dead"? no → skip check  [duplicate, unreachable]
    → write to inbox/  ← ghost sessions reached here for 'completed'

After (fixed):
  _enqueue_reconciler_notification(session, "completed")
    → _is_internal_agent(session)?
      yes → log.debug + return             [all outcomes covered]
    → idempotency guard
    → write to inbox/
```

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_reconciler_chat_filter.py -v` — 22 passed, 0 failed (new tests for _is_internal_agent and _enqueue_reconciler_notification filter behavior)
- [x] `uv run pytest tests/unit/test_mcp_server/test_reconciler_startup_sweep.py tests/unit/test_mcp_server/test_reconciler_mtime_gate.py tests/unit/test_mcp_server/test_reconciler_timeout.py tests/unit/test_mcp_server/test_ghost_session_fixes.py tests/unit/test_mcp_server/test_agent_failure_recovery.py -v` — 151 passed, 0 failed
- [x] `uv run pytest tests/unit/test_mcp_server/ -q` — 573 passed; 70 pre-existing failures in `test_write_observation.py` confirmed present on `main` before this change, unrelated to reconciler

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)