### PR TITLE
fix(steward): _llm_prescribe timeout configurability and fallback observability

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -43,12 +43,38 @@ log = logging.getLogger("steward")
 # LLM prescription dispatch
 # ---------------------------------------------------------------------------
 
-# Hard timeout for the claude -p prescription call (seconds). If exceeded,
-# falls back to the deterministic template.
-_LLM_PRESCRIPTION_TIMEOUT_SECS = 60
+# Default timeout for the claude -p prescription call (seconds). Override
+# via LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS env var for installs where
+# functional-engineer subagents need more time (typical: 2-10 minutes).
+_LLM_PRESCRIPTION_TIMEOUT_SECS_DEFAULT = 600
+
+def _get_llm_prescription_timeout() -> int:
+    """Return the LLM prescription timeout in seconds.
+
+    Reads LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS from the environment.
+    Falls back to _LLM_PRESCRIPTION_TIMEOUT_SECS_DEFAULT (600s) if absent
+    or non-integer.  Pure function with respect to state — env reads are
+    isolated here so the rest of the module stays deterministic in tests
+    (monkeypatch os.environ as needed).
+    """
+    raw = os.environ.get("LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS", "")
+    if raw.strip():
+        try:
+            return int(raw.strip())
+        except ValueError:
+            log.warning(
+                "_get_llm_prescription_timeout: invalid env value %r, using default %d",
+                raw, _LLM_PRESCRIPTION_TIMEOUT_SECS_DEFAULT,
+            )
+    return _LLM_PRESCRIPTION_TIMEOUT_SECS_DEFAULT
 
 # claude binary — resolved from PATH at call time.
 _CLAUDE_BIN = "claude"
+
+# Number of consecutive LLM prescription fallbacks that trigger an early-warning
+# inbox message.  Each cycle that falls back to deterministic increments the
+# consecutive count.  A successful LLM call resets it to zero.
+_LLM_FALLBACK_WARNING_THRESHOLD = 3
 
 
 # ---------------------------------------------------------------------------
@@ -703,21 +729,36 @@ Respond with a JSON object only (no markdown, no explanation outside the JSON):
     # which does not accept a separate --system flag in basic invocation mode.
     prompt = f"{system_prompt}\n\n{user_prompt}"
 
+    timeout_secs = _get_llm_prescription_timeout()
+
     try:
         proc = subprocess.run(
             [_CLAUDE_BIN, "-p", prompt, "--output-format", "text"],
             capture_output=True,
             text=True,
-            timeout=_LLM_PRESCRIPTION_TIMEOUT_SECS,
+            timeout=timeout_secs,
         )
         if proc.returncode != 0:
             log.warning(
-                "_llm_prescribe: claude -p exited %d for %s, falling back",
+                "_llm_prescribe: claude -p exited %d for %s, falling back "
+                "(stderr: %s)",
                 proc.returncode, uow.id,
+                proc.stderr.strip()[:200] if proc.stderr else "<none>",
             )
             return None
 
         raw_text = proc.stdout.strip()
+
+        # Classify empty-output case separately: claude exited 0 but returned
+        # nothing.  This typically means the binary is unavailable, the model
+        # refused, or stdout was silently discarded.
+        if not raw_text:
+            log.warning(
+                "_llm_prescribe: claude -p returned empty stdout for %s "
+                "(exit 0), falling back",
+                uow.id,
+            )
+            return None
 
         # Strip markdown code fences if present
         if raw_text.startswith("```"):
@@ -727,14 +768,48 @@ Respond with a JSON object only (no markdown, no explanation outside the JSON):
                 if not line.startswith("```")
             ).strip()
 
-        parsed = json.loads(raw_text)
+        # Classify parse failures: distinguish non-JSON (refusal / error prose)
+        # from structurally-valid JSON that doesn't match the expected schema.
+        try:
+            parsed = json.loads(raw_text)
+        except json.JSONDecodeError as exc:
+            log.warning(
+                "_llm_prescribe: non-JSON output from claude -p for %s "
+                "(JSONDecodeError: %s) — output preview: %r, falling back",
+                uow.id, exc, raw_text[:200],
+            )
+            return None
+
+        if not isinstance(parsed, dict):
+            log.warning(
+                "_llm_prescribe: unexpected JSON type %s for %s "
+                "(expected dict), falling back",
+                type(parsed).__name__, uow.id,
+            )
+            return None
 
         instructions = str(parsed.get("instructions", "")).strip()
         success_criteria_check = str(parsed.get("success_criteria_check", "")).strip()
-        estimated_cycles = int(parsed.get("estimated_cycles", 1))
+
+        # Validate estimated_cycles; wrong schema (e.g. string instead of int)
+        # is logged as a schema mismatch rather than a generic parse failure.
+        raw_cycles = parsed.get("estimated_cycles", 1)
+        try:
+            estimated_cycles = int(raw_cycles)
+        except (TypeError, ValueError):
+            log.warning(
+                "_llm_prescribe: schema mismatch for %s — "
+                "estimated_cycles=%r is not an integer, defaulting to 1",
+                uow.id, raw_cycles,
+            )
+            estimated_cycles = 1
 
         if not instructions:
-            log.warning("_llm_prescribe: LLM returned empty instructions, falling back")
+            log.warning(
+                "_llm_prescribe: LLM returned empty instructions field for %s, "
+                "falling back",
+                uow.id,
+            )
             return None
 
         log.debug(
@@ -749,19 +824,15 @@ Respond with a JSON object only (no markdown, no explanation outside the JSON):
 
     except subprocess.TimeoutExpired:
         log.warning(
-            "_llm_prescribe: claude -p timed out for %s after %ds, falling back",
-            uow.id, _LLM_PRESCRIPTION_TIMEOUT_SECS,
-        )
-        return None
-    except (json.JSONDecodeError, ValueError, KeyError) as exc:
-        log.warning(
-            "_llm_prescribe: failed to parse claude -p output for %s (%s: %s), falling back",
-            uow.id, type(exc).__name__, exc,
+            "_llm_prescribe: claude -p timed out for %s after %ds "
+            "(LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS=%d), falling back",
+            uow.id, timeout_secs, timeout_secs,
         )
         return None
     except Exception as exc:  # noqa: BLE001
         log.warning(
-            "_llm_prescribe: LLM call failed for %s (%s: %s), falling back to deterministic template",
+            "_llm_prescribe: LLM call failed for %s (%s: %s), "
+            "falling back to deterministic template",
             uow.id, type(exc).__name__, exc,
         )
         return None
@@ -802,6 +873,93 @@ def _fetch_prior_prescriptions(
 
     # Return the last `limit` entries (oldest-first ordering preserved).
     return prescriptions[-limit:] if prescriptions else []
+
+
+def _count_consecutive_llm_fallbacks(current_log_str: str | None) -> int:
+    """
+    Count how many consecutive prescription events at the tail of steward_log
+    used the deterministic fallback path (prescription_path == "fallback").
+
+    Scans prescription and reentry_prescription events in reverse order and
+    stops at the first event that used the LLM path or at the beginning of the
+    log.  Returns 0 when the log is absent, empty, or the last prescription
+    used the LLM path.
+
+    Pure function — reads only current_log_str; no side effects.
+    """
+    if not current_log_str:
+        return 0
+
+    prescription_events: list[dict[str, Any]] = []
+    for line in current_log_str.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if entry.get("event") in ("prescription", "reentry_prescription"):
+            prescription_events.append(entry)
+
+    # Count consecutive fallbacks from the most recent prescription backwards.
+    consecutive = 0
+    for event in reversed(prescription_events):
+        if event.get("prescription_path") == "fallback":
+            consecutive += 1
+        else:
+            break
+
+    return consecutive
+
+
+def _notify_llm_fallback_warning(
+    uow: UoW,
+    consecutive_fallbacks: int,
+) -> None:
+    """
+    Write an inbox message to Dan when _llm_prescribe has fallen back to the
+    deterministic template for _LLM_FALLBACK_WARNING_THRESHOLD consecutive
+    cycles on the same UoW.
+
+    Uses the same inbox path as _default_notify_dan_early_warning.  In tests,
+    the caller can skip this function entirely by checking the threshold before
+    calling — or monkeypatch it to capture the call.
+    """
+    uow_id = uow.id
+    admin_chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", _DAN_CHAT_ID)
+    log.warning(
+        "WOS LLM FALLBACK: UoW %s has fallen back to deterministic prescription "
+        "%d consecutive times — LLM prescription path may be broken",
+        uow_id, consecutive_fallbacks,
+    )
+    msg_id = str(uuid.uuid4())
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "chat_id": admin_chat_id,
+        "text": (
+            f"WOS: `{uow_id}` LLM prescription has fallen back to deterministic "
+            f"for {consecutive_fallbacks} consecutive cycles. "
+            "Check `LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS` and `claude -p` availability. "
+            "Prescription quality is degraded until LLM path recovers."
+        ),
+        "timestamp": time.time(),
+        "metadata": {
+            "type": "wos_llm_fallback_warning",
+            "uow_id": uow_id,
+            "consecutive_llm_fallbacks": consecutive_fallbacks,
+        },
+    }
+    inbox_dir = Path(os.path.expanduser("~/messages/inbox"))
+    try:
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        (inbox_dir / f"{msg_id}.json").write_text(
+            json.dumps(msg, indent=2), encoding="utf-8"
+        )
+        log.info("WOS LLM fallback warning written to inbox: %s", msg_id)
+    except OSError as exc:
+        log.error("Failed to write WOS LLM fallback warning to inbox: %s", exc)
 
 
 def _build_deterministic_prescription_instructions(
@@ -1789,6 +1947,32 @@ def _process_uow(
     }
     current_log_str = _append_steward_log_entry(registry, uow_id, current_log_str, prescription_log_entry)
 
+    # LLM fallback observability: count consecutive fallbacks from the updated
+    # steward_log (which already includes this cycle's prescription_path) and
+    # write an audit entry when falling back.  The consecutive count is computed
+    # after appending so this cycle's fallback is included in the tally.
+    if prescription_path == "fallback":
+        consecutive_fallbacks = _count_consecutive_llm_fallbacks(current_log_str)
+        log.warning(
+            "_llm_prescribe fallback: UoW %s using deterministic template "
+            "(consecutive fallbacks: %d)",
+            uow_id, consecutive_fallbacks,
+        )
+        if not dry_run:
+            registry.append_audit_log(uow_id, {
+                "event": "llm_prescribe_fallback",
+                "actor": _ACTOR_STEWARD,
+                "uow_id": uow_id,
+                "steward_cycles": cycles,
+                "consecutive_llm_fallbacks": consecutive_fallbacks,
+                "timestamp": _now_iso(),
+            })
+        # Fire early-warning inbox message at threshold (exact match so we
+        # notify once per threshold crossing, not on every subsequent fallback).
+        # Fires regardless of dry_run so tests can capture it.
+        if consecutive_fallbacks == _LLM_FALLBACK_WARNING_THRESHOLD:
+            _notify_llm_fallback_warning(uow, consecutive_fallbacks)
+
     if not dry_run:
         # Write workflow artifact to disk first
         artifact_path = _write_workflow_artifact(
@@ -1832,6 +2016,7 @@ def _process_uow(
             "workflow_primitive": selected_executor_type,
             "prescribed_skills": prescribed_skills,
             "instructions_preview": instructions[:80],
+            "prescription_path": prescription_path,
             "timestamp": _now_iso(),
         })
 

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -1922,6 +1922,234 @@ class TestLlmPrescription:
         assert result["instructions"] == "Implement the feature."
         assert result["estimated_cycles"] == 2
 
+    # --- New tests for issue #506: timeout observability and JSON classification ---
+
+    def test_llm_prescribe_timeout_configurable_via_env(self, monkeypatch):
+        """_llm_prescribe uses LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS env var for timeout."""
+        import subprocess as _subprocess
+        steward = _import_steward()
+
+        captured_timeouts = []
+
+        def mock_run(cmd, **kwargs):
+            captured_timeouts.append(kwargs.get("timeout"))
+            stdout = json.dumps({
+                "instructions": "Do the work.",
+                "success_criteria_check": "Work done.",
+                "estimated_cycles": 1,
+            })
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
+        monkeypatch.setenv("LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS", "300")
+
+        uow = self._make_uow()
+        result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
+
+        assert result is not None
+        assert len(captured_timeouts) == 1
+        assert captured_timeouts[0] == 300
+
+    def test_llm_prescribe_timeout_defaults_to_600(self, monkeypatch):
+        """_llm_prescribe uses 600s default timeout when env var is not set."""
+        import subprocess as _subprocess
+        steward = _import_steward()
+
+        captured_timeouts = []
+
+        def mock_run(cmd, **kwargs):
+            captured_timeouts.append(kwargs.get("timeout"))
+            raise _subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 0))
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
+        monkeypatch.delenv("LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS", raising=False)
+
+        uow = self._make_uow()
+        result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
+
+        assert result is None
+        assert captured_timeouts[0] == 600
+
+    def test_llm_prescribe_empty_stdout_returns_none(self, monkeypatch):
+        """_llm_prescribe returns None when claude -p exits 0 but stdout is empty."""
+        import subprocess as _subprocess
+        steward = _import_steward()
+
+        def mock_run(cmd, **kwargs):
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
+
+        uow = self._make_uow()
+        result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
+        assert result is None
+
+    def test_llm_prescribe_wrong_json_schema_non_dict(self, monkeypatch):
+        """_llm_prescribe returns None when claude -p returns a JSON array (not a dict)."""
+        import subprocess as _subprocess
+        steward = _import_steward()
+
+        def mock_run(cmd, **kwargs):
+            # Valid JSON but wrong schema — list instead of dict
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout='["a", "b"]', stderr="")
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
+
+        uow = self._make_uow()
+        result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
+        assert result is None
+
+    def test_llm_prescribe_schema_mismatch_estimated_cycles_defaults(self, monkeypatch):
+        """_llm_prescribe defaults estimated_cycles to 1 when the field is a non-integer."""
+        import subprocess as _subprocess
+        steward = _import_steward()
+
+        def mock_run(cmd, **kwargs):
+            stdout = json.dumps({
+                "instructions": "Do the work.",
+                "success_criteria_check": "Work done.",
+                "estimated_cycles": "several",  # wrong type — should be int
+            })
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
+
+        uow = self._make_uow()
+        result = steward._llm_prescribe(uow, "executor_orphan", "no prior output")
+
+        assert result is not None
+        assert result["estimated_cycles"] == 1
+
+    def test_count_consecutive_llm_fallbacks_empty_log(self):
+        """_count_consecutive_llm_fallbacks returns 0 for None or empty log."""
+        steward = _import_steward()
+        assert steward._count_consecutive_llm_fallbacks(None) == 0
+        assert steward._count_consecutive_llm_fallbacks("") == 0
+
+    def test_count_consecutive_llm_fallbacks_all_fallback(self):
+        """_count_consecutive_llm_fallbacks counts consecutive fallbacks at log tail."""
+        steward = _import_steward()
+
+        log_entries = [
+            json.dumps({"event": "prescription", "prescription_path": "fallback"}),
+            json.dumps({"event": "reentry_prescription", "prescription_path": "fallback"}),
+            json.dumps({"event": "reentry_prescription", "prescription_path": "fallback"}),
+        ]
+        log_str = "\n".join(log_entries)
+
+        assert steward._count_consecutive_llm_fallbacks(log_str) == 3
+
+    def test_count_consecutive_llm_fallbacks_reset_after_llm_success(self):
+        """_count_consecutive_llm_fallbacks resets count when an LLM success appears."""
+        steward = _import_steward()
+
+        log_entries = [
+            json.dumps({"event": "prescription", "prescription_path": "fallback"}),
+            json.dumps({"event": "reentry_prescription", "prescription_path": "llm"}),
+            json.dumps({"event": "reentry_prescription", "prescription_path": "fallback"}),
+            json.dumps({"event": "reentry_prescription", "prescription_path": "fallback"}),
+        ]
+        log_str = "\n".join(log_entries)
+
+        # Only the 2 fallbacks at the tail count — the earlier fallback is preceded
+        # by an LLM success which resets the streak.
+        assert steward._count_consecutive_llm_fallbacks(log_str) == 2
+
+    def test_count_consecutive_llm_fallbacks_last_was_llm(self):
+        """_count_consecutive_llm_fallbacks returns 0 when the last prescription used LLM."""
+        steward = _import_steward()
+
+        log_entries = [
+            json.dumps({"event": "prescription", "prescription_path": "fallback"}),
+            json.dumps({"event": "reentry_prescription", "prescription_path": "llm"}),
+        ]
+        log_str = "\n".join(log_entries)
+
+        assert steward._count_consecutive_llm_fallbacks(log_str) == 0
+
+    def test_llm_fallback_warning_fires_at_threshold(self, db_path, registry, tmp_path, monkeypatch):
+        """_notify_llm_fallback_warning is called when consecutive fallbacks reach threshold."""
+        steward = _import_steward()
+        _ensure_registry_has_phase2_methods(registry)
+
+        warning_calls = []
+
+        def mock_notify(uow, consecutive_fallbacks):
+            warning_calls.append({"uow_id": uow.id, "count": consecutive_fallbacks})
+
+        monkeypatch.setattr("src.orchestration.steward._notify_llm_fallback_warning", mock_notify)
+
+        # Prepopulate steward_log with (threshold-1) fallback entries so this
+        # cycle becomes the Nth consecutive fallback and trips the threshold.
+        threshold = steward._LLM_FALLBACK_WARNING_THRESHOLD
+        prior_fallbacks = "\n".join(
+            json.dumps({"event": "prescription" if i == 0 else "reentry_prescription",
+                        "prescription_path": "fallback"})
+            for i in range(threshold - 1)
+        )
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=threshold - 1,
+            success_criteria="PR opened",
+            steward_log=prior_fallbacks,
+        )
+        conn.close()
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+
+        # Prescriber always returns None → deterministic fallback
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=artifact_dir,
+            llm_prescriber=lambda *a, **kw: None,
+        )
+
+        assert len(warning_calls) == 1
+        assert warning_calls[0]["uow_id"] == uow_id
+        assert warning_calls[0]["count"] == threshold
+
+    def test_llm_fallback_audit_entry_written_on_fallback(self, db_path, registry, tmp_path):
+        """An llm_prescribe_fallback audit entry is written when LLM prescription falls back."""
+        steward = _import_steward()
+        _ensure_registry_has_phase2_methods(registry)
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=0,
+            success_criteria="PR opened",
+        )
+        conn.close()
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=artifact_dir,
+            llm_prescriber=lambda *a, **kw: None,
+        )
+
+        audit_entries = steward._fetch_audit_entries(registry, uow_id)
+        # audit_log stores the full entry dict as JSON in the `note` column.
+        fallback_notes = [
+            json.loads(e["note"])
+            for e in audit_entries
+            if e.get("event") == "llm_prescribe_fallback"
+        ]
+        assert len(fallback_notes) == 1
+        assert fallback_notes[0]["uow_id"] == uow_id
+        assert fallback_notes[0]["consecutive_llm_fallbacks"] == 1
+
     def test_end_to_end_prescription_with_llm_stub(self, db_path, registry, tmp_path):
         """Full _process_uow call uses LLM prescription stub and writes instructions to artifact."""
         _ensure_registry_has_phase2_methods(registry)


### PR DESCRIPTION
## What problem this solves

`_llm_prescribe` was silently falling back to the deterministic prescription template on every cycle. The 60s hardcoded timeout was shorter than any real functional-engineer subagent call (typically 2-10 minutes), so `subprocess.TimeoutExpired` fired consistently. When it did, the steward logged a single `WARNING` line and carried on — no audit trail, no inbox notification, no signal to Dan that prescription quality was degraded.

The same silent fallback happened when `claude -p` exited 0 with empty stdout or returned non-JSON output. All three error classes were caught by the same handler, making it impossible to distinguish "binary missing" from "model returned an error message" from "JSON wrong schema" without grepping raw logs.

## What changed

**Timeout is now configurable.** `_get_llm_prescription_timeout()` reads `LOBSTER_LLM_PRESCRIPTION_TIMEOUT_SECS` from the environment and defaults to 600s (10 minutes). The previous 60s hardcoded value guaranteed every real call timed out. Existing installs will get 600s automatically; the env var lets operators tune it without a code change.

**JSON error paths are now classified.** Three cases that previously collapsed into one handler are now reported distinctly:
- Empty stdout (exit 0, no output) — typically means the binary is unavailable or the model refused silently
- Non-JSON output (prose refusal or error message) — logs the first 200 chars of the output so the reason is visible
- Wrong JSON schema (array instead of dict; `estimated_cycles` is a non-integer) — schema mismatch is logged and, for `estimated_cycles`, defaults to 1 rather than returning None

**Fallback is now visible in the audit trail.** When `_llm_prescribe` falls back, `_process_uow` writes an `llm_prescribe_fallback` entry to `audit_log` with a `consecutive_llm_fallbacks` count. Previously this appeared only as a WARNING in the log file.

**Consecutive-fallback early warning.** `_count_consecutive_llm_fallbacks()` is a pure function that scans `steward_log` prescription events from the tail and returns the streak length. When that streak reaches `_LLM_FALLBACK_WARNING_THRESHOLD` (3), `_notify_llm_fallback_warning()` writes an inbox message to Dan. The warning fires on the exact threshold cycle (not every subsequent one) so Dan gets a single clear signal rather than repeated noise.

**`prescription_path` is now included in the `steward_prescription` audit entry** in addition to the existing `steward_log` entry, so fallback vs LLM path is visible in audit queries without parsing JSONL.

## Functional patterns

Pure functions: `_count_consecutive_llm_fallbacks` takes only the log string and returns an integer — no side effects, fully testable without a DB. `_get_llm_prescription_timeout` isolates the env read. `_notify_llm_fallback_warning` is the side-effect boundary for inbox writes, matching the pattern of `_default_notify_dan_early_warning`.

## Flow: before vs after

Before:
```
_llm_prescribe -> TimeoutExpired (60s) -> log.warning -> None
_build_prescription_instructions -> deterministic fallback (silent)
_process_uow -> continues normally, no audit entry
```

After:
```
_llm_prescribe -> TimeoutExpired (600s default or env) -> log.warning with timeout value -> None
_build_prescription_instructions -> deterministic fallback
_process_uow -> writes llm_prescribe_fallback audit entry
             -> if consecutive count == threshold: writes inbox message to Dan
```

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestLlmPrescription -q` — 21 passed (10 existing, 11 new), 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestFetchPriorPrescriptions -q` — 8 passed
- [x] `uv run pytest tests/unit/test_orchestration/ --ignore=tests/unit/test_orchestration/test_steward.py -q --tb=no` — 404 passed, 1 pre-existing failure in `test_registry_cli.py::TestApproveCommand::test_approve_idempotent_on_pending` (confirmed failing on `main` before this branch)
- [x] `uv run python -c "import ast; ast.parse(...); print('Syntax OK')"` — Syntax OK on steward.py
- [ ] Full `test_steward.py` suite — skipped: test file exceeds 300s even on `main`; the class-level runs above cover all changed paths
- [ ] Integration tests (`tests/integration/`) — skipped: require a live DB and artifact infrastructure not available in this environment

**Blocked items needing attention before merge:** none. The pre-existing `test_approve_idempotent_on_pending` failure is unrelated and also present on `main`.

Closes #506