### PR TITLE
fix(steward): add prescription_source field to steward_prescription audit entry

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -1831,6 +1831,7 @@ def _process_uow(
             "steward_cycles": new_cycles,
             "workflow_primitive": selected_executor_type,
             "prescribed_skills": prescribed_skills,
+            "prescription_source": "llm" if _llm_path_taken[0] else "deterministic",
             "instructions_preview": instructions[:80],
             "timestamp": _now_iso(),
         })

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -1265,6 +1265,79 @@ class TestObservability:
                 "prescription event must be in audit_log"
             )
 
+    def test_prescription_audit_includes_prescription_source_deterministic(self, db_path, registry, tmp_path):
+        """steward_prescription audit entry has prescription_source='deterministic' when LLM path is bypassed."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=0,
+            output_ref=None,
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            llm_prescriber=None,  # Force deterministic path
+        )
+
+        if _get_uow(db_path, uow_id)["status"] == "ready-for-executor":
+            entries = _audit_entries(db_path, uow_id)
+            presc_entry = next(
+                (e for e in entries if e.get("event") == "steward_prescription"), None
+            )
+            assert presc_entry is not None, "steward_prescription audit entry must exist"
+            # The audit payload is stored as JSON in the 'note' column
+            import json as _json
+            note_data = _json.loads(presc_entry["note"])
+            assert note_data.get("prescription_source") == "deterministic", (
+                f"prescription_source must be 'deterministic' when LLM is bypassed, got {note_data.get('prescription_source')!r}"
+            )
+
+    def test_prescription_audit_includes_prescription_source_llm(self, db_path, registry, tmp_path):
+        """steward_prescription audit entry has prescription_source='llm' when LLM prescriber succeeds."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=0,
+            output_ref=None,
+        )
+        conn.close()
+
+        def stub_llm_prescriber(uow, posture, gap, issue_body=""):
+            return {"instructions": "Do the thing.", "success_criteria_check": ""}
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            llm_prescriber=stub_llm_prescriber,
+        )
+
+        if _get_uow(db_path, uow_id)["status"] == "ready-for-executor":
+            entries = _audit_entries(db_path, uow_id)
+            presc_entry = next(
+                (e for e in entries if e.get("event") == "steward_prescription"), None
+            )
+            assert presc_entry is not None, "steward_prescription audit entry must exist"
+            # The audit payload is stored as JSON in the 'note' column
+            import json as _json
+            note_data = _json.loads(presc_entry["note"])
+            assert note_data.get("prescription_source") == "llm", (
+                f"prescription_source must be 'llm' when LLM prescriber succeeds, got {note_data.get('prescription_source')!r}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Test: BOOTUP_CANDIDATE_GATE constant defined at module level


### PR DESCRIPTION
## What problem does this solve

Before this change, the `steward_prescription` audit entry gave no indication of which prescription path was taken — LLM or deterministic fallback. When the `claude` binary is absent or the LLM call fails, the Steward silently degrades to the deterministic template, but the audit log looks identical in both cases. This makes it impossible to detect LLM degradation from logs alone without inspecting UoW content, and prevents any metrics on LLM vs. deterministic prescription rates.

This was flagged during oracle review of PR #490: "The fallback is correct behavior, but the silent degradation is invisible."

## What changed

`prescription_source: "llm" | "deterministic"` is added to the `steward_prescription` audit entry. The `_llm_path_taken` sentinel was already being computed in `_prescribe_uow` (line 1774 of `steward.py`) — it simply was not being forwarded into the audit dict. This is a two-line change to the audit payload.

No other audit events, UoW fields, or code paths are modified.

## Functional patterns

Pure data addition — no control flow change. The sentinel read (`_llm_path_taken[0]`) is a pure boolean projection into an immutable dict literal.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestObservability -v` — 4 passed (2 new, 2 existing)
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -q` — 70 passed, 1 failed (pre-existing: `TestModuleConstants::test_bootup_candidate_gate_constant_exists` also fails on `main` at the same count)
- [x] `uv run pytest tests/unit/ -q` — 2746 passed, 88 failed; all failures also present on `main` before this change

Closes #494