### PR TITLE
fix: guard steward_log parser against non-dict JSON entries

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -630,6 +630,8 @@ def _llm_prescribe(
                 if not line.strip():
                     continue
                 entry = json.loads(line)
+                if not isinstance(entry, dict):
+                    continue
                 event = entry.get("event", "")
                 if event in ("prescription", "reentry_prescription"):
                     assessment = entry.get("completion_assessment", "")
@@ -869,6 +871,8 @@ def _fetch_prior_prescriptions(
         try:
             entry = json.loads(line)
         except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(entry, dict):
             continue
         if entry.get("event") in ("prescription", "reentry_prescription"):
             prescriptions.append(entry)


### PR DESCRIPTION
## Summary

- `steward.py` `_llm_prescribe` and `_fetch_prior_prescriptions` both call `entry.get()` directly after `json.loads()`, assuming the result is always a dict.
- If any `steward_log` line is a JSON array (or other non-dict type), `entry.get()` raises `AttributeError`, which is not caught by the existing `except (json.JSONDecodeError, KeyError)` or `except (json.JSONDecodeError, TypeError)` clauses.
- The UoW is then silently skipped on every steward cycle.
- Fix: add `if not isinstance(entry, dict): continue` guard in both parsers (2 lines added, no logic change for valid entries).

## Test plan
- [ ] Verified locally: a log string containing `[1, 2, 3]` as one line followed by a valid prescription dict — the array line is skipped and the dict is parsed correctly.
- [ ] Existing steward unit tests (run locally, no regressions on affected logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)