### PR TITLE
fix(inbox_server): replace hardcoded /home/admin/ path in bisque connection URL handler

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -8683,10 +8683,11 @@ async def handle_get_bisque_connection_url(arguments: dict[str, Any]) -> list[Te
     # Read token
     token_file = _MESSAGES / "config" / "dashboard-token"
     if not token_file.exists():
+        venv_python = _REPO_DIR / ".venv" / "bin" / "python3"
+        dashboard_server = _REPO_DIR / "src" / "dashboard" / "server.py"
         return [TextContent(type="text", text=(
             "Dashboard token not found. Start the dashboard server first:\n"
-            "nohup /home/admin/lobster/.venv/bin/python3 "
-            "/home/admin/lobster/src/dashboard/server.py --host 0.0.0.0 --port 9100 &"
+            f"nohup {venv_python} {dashboard_server} --host 0.0.0.0 --port 9100 &"
         ))]
     token = token_file.read_text().strip()
     if not token:


### PR DESCRIPTION
## Summary

- Replaces hardcoded `/home/admin/lobster/` paths in `handle_get_bisque_connection_url` error message with dynamic paths built from `_REPO_DIR`
- `_REPO_DIR` already respects `LOBSTER_INSTALL_DIR` env var and falls back to `Path.home() / "lobster"`, so the fix works for any install user
- Surgical change: 3 lines touched in the error-message-only branch (token file missing path)

## Test plan

- [ ] Verify `_REPO_DIR` is defined at file scope before line 8683 (it is, at line 784)
- [ ] Confirm the f-string renders correct paths when token file is absent
- [ ] No other code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)