### PR TITLE
fix: restore nightly-consolidation dispatcher handler (#1267)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1289,6 +1289,61 @@ When a system cron job finishes, `scripts/post-reminder.sh` writes a `cron_remin
 
 **Note:** The triage subagent never calls `send_reply`. It reads the output, applies the heuristic, and calls `write_result` with the appropriate `chat_id` (ADMIN_CHAT_ID for actionable content, 0 for no-ops). The dispatcher's `subagent_result` handler then decides whether to relay or silently drop based on `chat_id` and `sent_reply_to_user`.
 
+## Handling Nightly Consolidation (`type: "consolidation"`)
+
+`scripts/nightly-consolidation.sh` runs at 3 AM via cron and writes a `consolidation` message to the inbox. This triggers a background subagent to synthesize recent memory events into the canonical memory files.
+
+**Message shape:**
+```json
+{
+  "type": "consolidation",
+  "source": "internal",
+  "chat_id": 0,
+  "text": "NIGHTLY CONSOLIDATION: Review today's events...",
+  "timestamp": "2026-01-01T03:00:00+00:00"
+}
+```
+
+**When `wait_for_messages` returns a message with `type: "consolidation"`:**
+
+```
+1. mark_processing(message_id)
+
+2. Spawn background subagent -- this is memory I/O work, never inline:
+
+   consolidation_task_id = f"nightly-consolidation-{msg['id']}"
+
+   Task(
+       subagent_type="nightly-consolidation",
+       run_in_background=True,
+       prompt=(
+           f"---\n"
+           f"task_id: {consolidation_task_id}\n"
+           f"chat_id: 0\n"
+           f"source: system\n"
+           f"---\n\n"
+           f"Nightly consolidation triggered at {msg.get('timestamp', 'unknown time')}.\n\n"
+           f"Synthesize recent memory events into the canonical memory files. "
+           f"See your agent instructions for the full step-by-step procedure."
+       ),
+   )
+
+3. mark_processed(message_id)
+   # Return to wait_for_messages() immediately -- the subagent handles synthesis
+```
+
+**Key fields:**
+- `type` -- always `"consolidation"`
+- `source` -- always `"internal"` (system-generated, not user-facing)
+- `chat_id` -- always `0` (no user to reply to)
+
+**Rules:**
+- Never inline consolidation work -- always a background subagent
+- Subagent result (`task_id` starts with `nightly-consolidation-`) is internal -- mark processed silently, do not relay to user
+- If a consolidation is already in progress (check active sessions for `nightly-consolidation`), skip to avoid duplicate runs
+
+
+
 
 ## Handling Context Warning (`context_warning`)
 

--- a/scripts/nightly-consolidation.sh
+++ b/scripts/nightly-consolidation.sh
@@ -20,13 +20,21 @@ LOBSTER_DIR="$(dirname "$SCRIPT_DIR")"
 MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
 INBOX="$MESSAGES_DIR/inbox"
 TIMESTAMP=$(date +%s%3N)
+WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE_DIR/logs"
+LOG_FILE="$LOG_DIR/nightly-consolidation.log"
 
-# Ensure inbox directory exists
+# Ensure directories exist
 mkdir -p "$INBOX"
+mkdir -p "$LOG_DIR"
+
+log() {
+    echo "[$(date -Iseconds)] $*" | tee -a "$LOG_FILE"
+}
 
 # Dedup guard: skip if a consolidation message is already pending
 if ls "$INBOX"/*_consolidation.json 2>/dev/null | grep -q .; then
-    echo "Consolidation message already pending in inbox. Skipping."
+    log "Consolidation message already pending in inbox. Skipping."
     exit 0
 fi
 
@@ -42,4 +50,4 @@ cat > "$INBOX/${TIMESTAMP}_consolidation.json" << EOF
 }
 EOF
 
-echo "Consolidation message injected at $(date -Iseconds)"
+log "Consolidation message injected."


### PR DESCRIPTION
## Summary

Commit `1481a62` (PR #1206, cleanup: remove plans tool) accidentally removed the `## Handling Nightly Consolidation` section from `.claude/sys.dispatcher.bootup.md`. As a result, the dispatcher has had no handler for `type: "consolidation"` messages since March 31 — the cron fires at 3 AM UTC but the consolidation message stalls unrecognized. `daily-digest.md` is 16 days stale.

## Changes

- **Restore `## Handling Nightly Consolidation` section** to `sys.dispatcher.bootup.md`, matching the version from commit `20a48ad` (originally wired in PR #1199). The section is compatible with subsequent nightly-consolidation agent definition changes in PRs #1222 and #1223.
- **Add logging to `nightly-consolidation.sh`** — each run attempt now writes a timestamped entry to `~/lobster-workspace/logs/nightly-consolidation.log`, making future debugging possible.

## Tests run

- [x] Verified the section text matches the original from commit `20a48ad`
- [x] Verified `git diff` shows only the two intended file changes
- [x] Confirmed the section is inserted after the `cron_reminder` section and before `context_warning`, matching the original placement

Fixes #1267

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>