### PR TITLE
fix: clarify ADMIN_CHAT_ID lookup chain in step 0 (#1354)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -41,7 +41,11 @@ You are a vigilant dispatcher, not a passive relay. When something seems off —
 ## Your Main Loop
 
 0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)` to register this session as the dispatcher. This clears any stale `_dispatcher_session_id` from a previous dispatcher instance and ensures all guarded MCP tools (`send_reply`, `check_inbox`, etc.) work immediately. Without this, a new dispatcher session may be blocked by a stale session ID from the previous instance.
-   - Get ADMIN_CHAT_ID from `lobster.conf` (`grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` or equivalent), or use the `chat_id` from `context-handoff.json` if available.
+   - Get ADMIN_CHAT_ID via the following chain (stop at first success):
+     1. `grep LOBSTER_ADMIN_CHAT_ID ~/lobster-config/config.env | cut -d= -f2`
+     2. `grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf 2>/dev/null | cut -d= -f2` (legacy path)
+     3. Use the `chat_id` from `~/lobster-workspace/meta/context-handoff.json` if available
+     If all three fail, log an error and continue — `session_start` will use `chat_id=0` as fallback.
    - This is the FIRST action before any guarded tools — must fire before the warmup `send_reply` at step 2d.
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])` — pass the Claude session UUID injected by the SessionStart hook. This writes the UUID to `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`, enabling `inject-bootup-context.py` to identify your session as the dispatcher and inject this file on future restarts. Without this call, the primary detection path is never populated and you will receive the subagent bootup file instead of this one.
 1a. Read `~/lobster-user-config/memory/canonical/handoff.md` — user context, active projects, key people, git rules, available integrations.


### PR DESCRIPTION
## Summary

- Step 0 of `sys.dispatcher.bootup.md` instructed the dispatcher to look up ADMIN_CHAT_ID in `~/lobster-config/lobster.conf`, which does not exist in current installs
- The actual config file is `~/lobster-config/config.env` with variable `LOBSTER_ADMIN_CHAT_ID`
- The vague "or equivalent" hedge sent the dispatcher hunting on startup, wasting context budget

## Change

Replace the single ambiguous lookup with an explicit three-step fallback chain:
1. `grep LOBSTER_ADMIN_CHAT_ID ~/lobster-config/config.env` — canonical current path
2. `grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf 2>/dev/null` — legacy path (suppressed if absent)
3. `chat_id` from `context-handoff.json` — last resort

## Tests run

- [x] Verified `~/lobster-config/config.env` contains `LOBSTER_ADMIN_CHAT_ID=8075091586`
- [x] Verified `~/lobster-config/lobster.conf` does not exist (legacy path correctly suppressed with `2>/dev/null`)
- [x] Verified diff is exactly the one intended change

Fixes #1354

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>