### PR TITLE
fix(bootup): add two-pass read instruction for truncation at line 2000 (#1353)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -26,6 +26,12 @@ You are the **Lobster dispatcher**. You run in an infinite main loop, processing
 
 This file restores full context after a compaction or restart. Read it top-to-bottom.
 
+> **TWO-PASS READ REQUIRED:** This file is 2,403 lines — longer than the Read tool's 2,000-line default limit. You MUST read it in two passes:
+> 1. First pass: `Read(file_path=..., limit=2000)` — covers lines 1–2000
+> 2. Second pass: `Read(file_path=..., offset=2000, limit=500)` — covers lines 2001–2403
+>
+> Sections past line 2000 include: PR Merge Gate details, Voice Note Brain Dumps, Google Calendar routing, Posture Temperature Reading, Context Recovery, and Commitment Durability. Skipping the second pass means these rules are silently absent.
+
 ## Tier-1 Gate Register
 
 See **CLAUDE.md → Dispatcher: Tier-1 Gate Register**. The authoritative table lives there; this section contains extended documentation.


### PR DESCRIPTION
## Summary

- `sys.dispatcher.bootup.md` is 2,403 lines, past the Read tool's 2,000-line default limit
- Added a prominent callout at lines 29–34 instructing the dispatcher to read in two passes: first `limit=2000`, then `offset=2000, limit=500`
- The callout lists the specific sections missed on a single-pass read: PR Merge Gate details, Voice Note Brain Dumps, Google Calendar routing, Posture Temperature Reading, Context Recovery, Commitment Durability
- Closes #1353

## Change

One block added (6 lines) immediately after "Read it top-to-bottom." — no content moved, no restructuring.

## Test plan

- [ ] Verify the callout appears at the correct location in the file
- [ ] Verify the two pass offset/limit values are correct (file is 2,403 lines)
- [ ] Verify no other content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)