### PR TITLE
fix: correct "Cyles" typo to "Cycles" in WOS report header

### DIFF
--- a/src/wos_report.py
+++ b/src/wos_report.py
@@ -772,7 +772,7 @@ def _render_index_page(pdf: WoSReport, uows: list[dict]) -> None:
 
     # Column layout
     col_widths = [12, 66, 22, 22, 14, 20]
-    col_headers = ["ID", "Summary", "Status", "Created", "Cyles", "Skills"]
+    col_headers = ["ID", "Summary", "Status", "Created", "Cycles", "Skills"]
 
     # Header row
     pdf.set_fill_color(*C_HEADING_BG)


### PR DESCRIPTION
## Summary

- Fix typo in WOS report index page column header: "Cyles" → "Cycles" in `src/wos_report.py` line 775.

## Tests run

- [x] `grep "Cycles" src/wos_report.py` — confirmed typo is fixed
- [ ] `uv run pytest tests/unit/` — skipped: no local environment set up for this repo
- [ ] `uv run ruff check . && uv run mypy .` — skipped: no local environment

**Blocked items needing attention before merge:** CI should confirm no regressions.

## Functional patterns used

- N/A (single-line typo fix)

## Breaking changes / migration notes

None.

Closes #417