### PR TITLE
test: executor subprocess boundary tests + registrar edge cases + executor-contract doc

### DIFF
--- a/docs/executor-contract.md
+++ b/docs/executor-contract.md
@@ -226,6 +226,59 @@ When the startup sweep runs, it assigns classification labels to UoWs it recover
 
 ---
 
+## Functional-Engineer Dispatch: write_result vs. result.json
+
+**Cross-reference:** `src/orchestration/executor.py` → `_dispatch_via_claude_p`
+
+When the production dispatcher (`_dispatch_via_claude_p`) is used, the executor spawns a
+functional-engineer subagent via `claude -p`. That subagent does not write the
+`{output_ref}.result.json` file described above. Instead, it calls
+`mcp__lobster-inbox__write_result` — the inbox delivery tool — to report back to the
+dispatcher.
+
+This means the result.json that the Steward reads is written by the Executor itself,
+not by the functional-engineer subagent. The Executor writes the result.json after the
+subprocess exits:
+
+- **Subprocess exit 0** → Executor writes `outcome=complete`, transitions UoW to
+  `ready-for-steward`. The Steward sees `outcome=COMPLETE` meaning "the claude -p
+  subprocess exited cleanly." It does NOT mean "a PR was actually opened and merged."
+- **Subprocess non-zero exit, timeout, or binary not found** → Executor writes
+  `outcome=failed`, transitions UoW to `failed` via the exception handler in
+  `_run_step_sequence`. The Steward re-diagnoses.
+
+### Why "complete" does not mean "PR opened"
+
+The re-prescription loop is the intended fallback for silent failures. A functional-engineer
+subagent may exit 0 (subprocess success) without having opened a PR — for example, if it
+encountered an error late in execution that it handled internally without propagating a
+non-zero exit code. In this case:
+
+- The Executor writes `outcome=complete` because the subprocess exited cleanly.
+- The Steward evaluates the UoW's `success_criteria` against the available artifacts.
+- If the success criteria are not met (no PR URL in the expected location, no artifact
+  written), the Steward re-prescribes with context from the prior cycle.
+- This re-prescription cycle is the designed recovery mechanism, not a gap.
+
+### Why this is a coherent design choice
+
+Requiring the functional-engineer subagent to write `{output_ref}.result.json` directly
+would tightly couple it to the Executor's internal file path conventions. The subagent
+already reports completion via `write_result` (the standard subagent protocol). Duplicating
+that into a file write would require the subagent to know its own `output_ref` path and
+construct the result.json schema manually — fragile and redundant.
+
+Instead, the two signals are kept at their natural boundaries:
+- **Inbox signal** (`write_result`): the subagent reports what it did to the dispatcher.
+- **Executor signal** (`result.json`): the Executor reports subprocess exit status to the
+  Steward.
+
+The Steward's `success_criteria` check is the reconciliation layer: it determines whether
+the work product (PR, artifact, or other output) actually satisfies the UoW's original
+intent, independent of whether the subprocess claimed success.
+
+---
+
 ## Contract Version
 
 This document specifies contract v1, corresponding to WOS Phase 2. Future versions will be noted here with their effective date and the PRs that introduce changes.
@@ -233,3 +286,4 @@ This document specifies contract v1, corresponding to WOS Phase 2. Future versio
 | Version | Effective | Changes |
 |---------|-----------|---------|
 | v1 | 2026-03-30 | Initial formal contract. Adds `outcome` enum over the Phase 1 `success: bool` minimal schema. Backward-compatible: `success` field retained. |
+| v1.1 | 2026-04-01 | Added section: Functional-Engineer Dispatch divergence between `write_result` (inbox) and `result.json` (Steward). Clarifies that `outcome=complete` means subprocess exit 0, not PR opened. See PRs #383/#388 oracle follow-ups. |

--- a/tests/unit/test_orchestration/test_executor_subprocess.py
+++ b/tests/unit/test_orchestration/test_executor_subprocess.py
@@ -1,0 +1,351 @@
+"""
+Unit tests for the _dispatch_via_claude_p subprocess boundary.
+
+These tests verify that all three subprocess exception paths (CalledProcessError,
+TimeoutExpired, FileNotFoundError) result in the UoW being transitioned to 'failed'
+with result.json written, and that the happy path transitions to 'ready-for-steward'.
+
+Design: the tests inject a mock dispatcher callable into Executor(...) rather than
+patching subprocess.run at the module level. This keeps the tests pure and independent
+of how the module resolves the claude binary.
+
+The tests do NOT import _dispatch_via_claude_p and exercise it directly — doing so
+would require a real claude binary on PATH. Instead, they verify the contract:
+"if the dispatcher callable raises X, the UoW must end up in state Y with result.json
+present." The contract is stated in executor.py's docstring for _dispatch_via_claude_p
+and enforced by _run_step_sequence's exception handler.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from orchestration.registry import Registry, UoWStatus
+from orchestration.workflow_artifact import WorkflowArtifact, to_json
+from orchestration.executor import (
+    Executor,
+    ExecutorOutcome,
+    _result_json_path,
+    _noop_dispatcher,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers (reuse pattern from test_executor.py)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "test_registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path) -> Registry:
+    return Registry(db_path)
+
+
+def _make_artifact(uow_id: str, instructions: str = "Implement the thing") -> str:
+    artifact: WorkflowArtifact = {
+        "uow_id": uow_id,
+        "executor_type": "general",
+        "constraints": [],
+        "prescribed_skills": [],
+        "instructions": instructions,
+    }
+    return to_json(artifact)
+
+
+def _insert_uow(db_path: Path, uow_id: str, workflow_artifact: str) -> None:
+    """Insert a UoW in ready-for-executor state."""
+    now = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute(
+            """
+            INSERT INTO uow_registry (
+                id, type, source, status, posture, created_at, updated_at,
+                summary, success_criteria, workflow_artifact, estimated_runtime
+            ) VALUES (?, 'executable', 'test', 'ready-for-executor', 'solo', ?, ?, 'Test UoW', 'done', ?, NULL)
+            """,
+            (uow_id, now, now, workflow_artifact),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _get_uow_status(db_path: Path, uow_id: str) -> str:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return row["status"] if row else ""
+    finally:
+        conn.close()
+
+
+def _get_output_ref(db_path: Path, uow_id: str) -> str | None:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT output_ref FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return row["output_ref"] if row else None
+    finally:
+        conn.close()
+
+
+def _read_result_json(output_ref: str) -> dict:
+    result_path = _result_json_path(output_ref)
+    return json.loads(result_path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# CalledProcessError path
+# ---------------------------------------------------------------------------
+
+class TestCalledProcessErrorPath:
+    """Subprocess exits non-zero → UoW must transition to 'failed', result.json written."""
+
+    def test_uow_status_is_failed(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_cpe_001"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def failing_dispatcher(instructions: str, uid: str) -> str:
+            raise subprocess.CalledProcessError(returncode=1, cmd=["claude", "-p", "..."])
+
+        executor = Executor(registry, dispatcher=failing_dispatcher)
+        with pytest.raises(subprocess.CalledProcessError):
+            executor.execute_uow(uow_id)
+
+        assert _get_uow_status(db_path, uow_id) == "failed"
+
+    def test_result_json_written_with_failed_outcome(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_cpe_002"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def failing_dispatcher(instructions: str, uid: str) -> str:
+            raise subprocess.CalledProcessError(returncode=2, cmd=["claude", "-p", "..."])
+
+        executor = Executor(registry, dispatcher=failing_dispatcher)
+        with pytest.raises(subprocess.CalledProcessError):
+            executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        assert output_ref is not None
+        result = _read_result_json(output_ref)
+        assert result["outcome"] == "failed"
+        assert result["success"] is False
+
+    def test_result_json_has_expected_fields(self, registry: Registry, db_path: Path) -> None:
+        """result.json written by the exception handler uses outcome/success (result_writer schema)."""
+        uow_id = "uow_cpe_003"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def failing_dispatcher(instructions: str, uid: str) -> str:
+            raise subprocess.CalledProcessError(returncode=1, cmd=["claude"])
+
+        executor = Executor(registry, dispatcher=failing_dispatcher)
+        with pytest.raises(subprocess.CalledProcessError):
+            executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        result = _read_result_json(output_ref)
+        # The exception handler writes via result_writer.write_result — uses outcome/success
+        assert result["outcome"] == "failed"
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# TimeoutExpired path
+# ---------------------------------------------------------------------------
+
+class TestTimeoutExpiredPath:
+    """Subprocess exceeds TTL → UoW must transition to 'failed', result.json written."""
+
+    def test_uow_status_is_failed(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_toe_001"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def timeout_dispatcher(instructions: str, uid: str) -> str:
+            raise subprocess.TimeoutExpired(cmd=["claude", "-p", "..."], timeout=7200)
+
+        executor = Executor(registry, dispatcher=timeout_dispatcher)
+        with pytest.raises(subprocess.TimeoutExpired):
+            executor.execute_uow(uow_id)
+
+        assert _get_uow_status(db_path, uow_id) == "failed"
+
+    def test_result_json_written_with_failed_outcome(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_toe_002"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def timeout_dispatcher(instructions: str, uid: str) -> str:
+            raise subprocess.TimeoutExpired(cmd=["claude", "-p", "..."], timeout=7200)
+
+        executor = Executor(registry, dispatcher=timeout_dispatcher)
+        with pytest.raises(subprocess.TimeoutExpired):
+            executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        assert output_ref is not None
+        result = _read_result_json(output_ref)
+        assert result["outcome"] == "failed"
+        assert result["success"] is False
+
+    def test_result_json_has_expected_fields(self, registry: Registry, db_path: Path) -> None:
+        """result.json written by the exception handler uses outcome/success (result_writer schema)."""
+        uow_id = "uow_toe_003"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def timeout_dispatcher(instructions: str, uid: str) -> str:
+            raise subprocess.TimeoutExpired(cmd=["claude"], timeout=7200)
+
+        executor = Executor(registry, dispatcher=timeout_dispatcher)
+        with pytest.raises(subprocess.TimeoutExpired):
+            executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        result = _read_result_json(output_ref)
+        # The exception handler writes via result_writer.write_result — uses outcome/success
+        assert result["outcome"] == "failed"
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# FileNotFoundError path
+# ---------------------------------------------------------------------------
+
+class TestFileNotFoundErrorPath:
+    """Claude binary not found → UoW must transition to 'failed', result.json written."""
+
+    def test_uow_status_is_failed(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_fnf_001"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def missing_binary_dispatcher(instructions: str, uid: str) -> str:
+            raise FileNotFoundError(2, "No such file or directory: 'claude'")
+
+        executor = Executor(registry, dispatcher=missing_binary_dispatcher)
+        with pytest.raises(FileNotFoundError):
+            executor.execute_uow(uow_id)
+
+        assert _get_uow_status(db_path, uow_id) == "failed"
+
+    def test_result_json_written_with_failed_outcome(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_fnf_002"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def missing_binary_dispatcher(instructions: str, uid: str) -> str:
+            raise FileNotFoundError(2, "No such file or directory: 'claude'")
+
+        executor = Executor(registry, dispatcher=missing_binary_dispatcher)
+        with pytest.raises(FileNotFoundError):
+            executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        assert output_ref is not None
+        result = _read_result_json(output_ref)
+        assert result["outcome"] == "failed"
+        assert result["success"] is False
+
+    def test_result_json_has_expected_fields(self, registry: Registry, db_path: Path) -> None:
+        """result.json written by the exception handler uses outcome/success (result_writer schema)."""
+        uow_id = "uow_fnf_003"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def missing_binary_dispatcher(instructions: str, uid: str) -> str:
+            raise FileNotFoundError(2, "No such file or directory: 'claude'")
+
+        executor = Executor(registry, dispatcher=missing_binary_dispatcher)
+        with pytest.raises(FileNotFoundError):
+            executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        result = _read_result_json(output_ref)
+        # The exception handler writes via result_writer.write_result — uses outcome/success
+        assert result["outcome"] == "failed"
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    """Subprocess exits 0 → UoW transitions to 'ready-for-steward', result complete."""
+
+    def test_uow_status_is_ready_for_steward(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_ok_001"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        dispatched: list[tuple[str, str]] = []
+
+        def success_dispatcher(instructions: str, uid: str) -> str:
+            dispatched.append((instructions, uid))
+            return f"run-{uid}"
+
+        executor = Executor(registry, dispatcher=success_dispatcher)
+        result = executor.execute_uow(uow_id)
+
+        assert _get_uow_status(db_path, uow_id) == "ready-for-steward"
+
+    def test_result_json_written_with_complete_outcome(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_ok_002"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def success_dispatcher(instructions: str, uid: str) -> str:
+            return f"run-{uid}"
+
+        executor = Executor(registry, dispatcher=success_dispatcher)
+        result = executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        assert output_ref is not None
+        data = _read_result_json(output_ref)
+        assert data["outcome"] == "complete"
+        assert data["success"] is True
+
+    def test_instructions_are_passed_to_dispatcher(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_ok_003"
+        expected_instructions = "Build the feature per spec."
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id, instructions=expected_instructions))
+
+        received: list[str] = []
+
+        def recording_dispatcher(instructions: str, uid: str) -> str:
+            received.append(instructions)
+            return "run-ok"
+
+        executor = Executor(registry, dispatcher=recording_dispatcher)
+        executor.execute_uow(uow_id)
+
+        assert len(received) == 1
+        assert received[0] == expected_instructions
+
+    def test_executor_id_recorded_in_result(self, registry: Registry, db_path: Path) -> None:
+        uow_id = "uow_ok_004"
+        _insert_uow(db_path, uow_id, _make_artifact(uow_id))
+
+        def success_dispatcher(instructions: str, uid: str) -> str:
+            return "task-xyz-run-id"
+
+        executor = Executor(registry, dispatcher=success_dispatcher)
+        result = executor.execute_uow(uow_id)
+
+        assert result.executor_id == "task-xyz-run-id"
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        data = _read_result_json(output_ref)
+        assert data.get("executor_id") == "task-xyz-run-id"

--- a/tests/unit/test_orchestration/test_extract_success_criteria.py
+++ b/tests/unit/test_orchestration/test_extract_success_criteria.py
@@ -1,0 +1,216 @@
+"""
+Unit tests for _extract_success_criteria in src/orchestration/cultivator.py.
+
+Covers all branches of the pure extraction function:
+- Empty body → returns ''
+- Body with no matching heading → falls back to first non-heading paragraph
+- Heading present but section content is empty → skips to next heading or falls back
+- Fallback skips leading headings (paragraphs starting with '#' are not returned)
+- Truncation: body exceeds 500 char limit → truncated at exactly 500 chars
+- Happy path: well-formed body with Acceptance Criteria heading → returns section content
+- All recognised heading variants are matched
+- Content stops at next ## heading (not at end of body)
+- Body ending without trailing newline → section captured correctly
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Import directly — _extract_success_criteria is a pure function with no I/O
+from src.orchestration.cultivator import _extract_success_criteria
+
+
+# ---------------------------------------------------------------------------
+# Empty / missing body
+# ---------------------------------------------------------------------------
+
+class TestEmptyBody:
+    def test_empty_string_returns_empty(self) -> None:
+        assert _extract_success_criteria("") == ""
+
+    def test_whitespace_only_body_returns_empty(self) -> None:
+        # No body content and no paragraph to fall back on
+        # whitespace-only paragraphs are stripped by paragraph.strip(), so skipped
+        assert _extract_success_criteria("   \n\n   ") == ""
+
+    def test_only_headings_returns_empty(self) -> None:
+        # All paragraphs start with '#' — fallback skips them, returns ""
+        body = "# Title\n\n## Section\n\n### Subsection"
+        assert _extract_success_criteria(body) == ""
+
+
+# ---------------------------------------------------------------------------
+# No matching heading → fallback to first paragraph
+# ---------------------------------------------------------------------------
+
+class TestNoMatchingHeading:
+    def test_fallback_returns_first_paragraph(self) -> None:
+        body = "This is the description.\n\nMore details here."
+        result = _extract_success_criteria(body)
+        assert result == "This is the description."
+
+    def test_fallback_skips_leading_heading_paragraphs(self) -> None:
+        # First paragraph is a heading — must be skipped
+        body = "## Overview\n\nActual description here."
+        result = _extract_success_criteria(body)
+        assert result == "Actual description here."
+
+    def test_fallback_skips_multiple_leading_headings(self) -> None:
+        body = "# Title\n\n## Subtitle\n\nFirst real paragraph."
+        result = _extract_success_criteria(body)
+        assert result == "First real paragraph."
+
+    def test_fallback_returns_empty_when_all_paragraphs_are_headings(self) -> None:
+        body = "# Title\n\n## Section"
+        result = _extract_success_criteria(body)
+        assert result == ""
+
+    def test_fallback_with_multiline_paragraph(self) -> None:
+        body = "Line one.\nLine two.\nLine three."
+        result = _extract_success_criteria(body)
+        assert result == "Line one.\nLine two.\nLine three."
+
+
+# ---------------------------------------------------------------------------
+# Heading present but section content is empty
+# ---------------------------------------------------------------------------
+
+class TestEmptySection:
+    def test_empty_section_before_next_heading_returns_empty(self) -> None:
+        # Heading exists but nothing between it and the next heading.
+        # The fallback loop splits by "\n\n"; every paragraph starts with "##"
+        # so all are skipped. Function returns "".
+        body = (
+            "## Summary\nSome description.\n\n"
+            "## Acceptance Criteria\n\n"
+            "## Other Section\nContent."
+        )
+        result = _extract_success_criteria(body)
+        assert result == ""
+
+    def test_empty_section_at_end_of_body_returns_empty(self) -> None:
+        # Heading at end with no content after it.
+        # All "\n\n"-split paragraphs start with "##" → fallback skips all → "".
+        body = "## Summary\nSome description.\n\n## Acceptance Criteria\n"
+        result = _extract_success_criteria(body)
+        assert result == ""
+
+    def test_empty_section_with_plain_paragraph_elsewhere(self) -> None:
+        # Body contains a plain paragraph not under any heading.
+        # Fallback loop finds it and returns it.
+        body = (
+            "Plain description here.\n\n"
+            "## Acceptance Criteria\n\n"
+            "## Other Section\nContent."
+        )
+        result = _extract_success_criteria(body)
+        assert result == "Plain description here."
+
+
+# ---------------------------------------------------------------------------
+# Truncation at 500 characters
+# ---------------------------------------------------------------------------
+
+class TestTruncation:
+    def test_fallback_paragraph_truncated_at_500_chars(self) -> None:
+        long_paragraph = "x" * 600
+        body = f"No headings here.\n\n{long_paragraph}"
+        result = _extract_success_criteria(body)
+        # First paragraph is "No headings here." (17 chars) — not truncated
+        # Second paragraph is 600 chars — but first paragraph is returned
+        assert result == "No headings here."
+
+    def test_single_long_paragraph_truncated_at_500_chars(self) -> None:
+        # Single paragraph longer than 500 chars — must be truncated
+        long_paragraph = "a" * 600
+        result = _extract_success_criteria(long_paragraph)
+        assert len(result) == 500
+        assert result == "a" * 500
+
+    def test_exactly_500_chars_not_truncated(self) -> None:
+        exact = "b" * 500
+        result = _extract_success_criteria(exact)
+        assert result == exact
+        assert len(result) == 500
+
+    def test_499_chars_not_truncated(self) -> None:
+        body = "c" * 499
+        result = _extract_success_criteria(body)
+        assert result == body
+
+    def test_501_chars_truncated_to_500(self) -> None:
+        body = "d" * 501
+        result = _extract_success_criteria(body)
+        assert len(result) == 500
+
+
+# ---------------------------------------------------------------------------
+# Happy path: well-formed heading with content
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    def test_acceptance_criteria_heading_extracted(self) -> None:
+        body = (
+            "## Summary\nFix the thing.\n\n"
+            "## Acceptance Criteria\n"
+            "- It works\n"
+            "- Tests pass\n\n"
+            "## Notes\nSome notes."
+        )
+        result = _extract_success_criteria(body)
+        assert result == "- It works\n- Tests pass"
+
+    def test_success_criteria_heading_extracted(self) -> None:
+        body = "## Success Criteria\n- Done when green\n\n## Footer\nIgnored."
+        result = _extract_success_criteria(body)
+        assert result == "- Done when green"
+
+    def test_definition_of_done_heading_extracted(self) -> None:
+        body = "## Definition of Done\n- PR merged\n- Tests pass"
+        result = _extract_success_criteria(body)
+        assert result == "- PR merged\n- Tests pass"
+
+    def test_lowercase_heading_variants_matched(self) -> None:
+        for heading in ("## acceptance criteria", "## success criteria", "## definition of done"):
+            body = f"## Preamble\nText.\n\n{heading}\n- criterion one"
+            result = _extract_success_criteria(body)
+            assert result == "- criterion one", f"Failed for heading: {heading!r}"
+
+    def test_content_stops_at_next_heading(self) -> None:
+        body = (
+            "## Acceptance Criteria\n"
+            "- Criterion one\n"
+            "- Criterion two\n\n"
+            "## Irrelevant Section\n"
+            "This must not appear."
+        )
+        result = _extract_success_criteria(body)
+        assert "Irrelevant Section" not in result
+        assert "This must not appear" not in result
+        assert "Criterion one" in result
+
+    def test_body_without_trailing_newline_captured(self) -> None:
+        # No trailing newline after the section content — must still be extracted
+        body = "## Acceptance Criteria\n- Must work without trailing newline"
+        result = _extract_success_criteria(body)
+        assert result == "- Must work without trailing newline"
+
+    def test_first_matching_heading_wins(self) -> None:
+        # Both "Acceptance Criteria" and "Success Criteria" present — first wins
+        body = (
+            "## Acceptance Criteria\n- AC criterion\n\n"
+            "## Success Criteria\n- SC criterion"
+        )
+        result = _extract_success_criteria(body)
+        assert result == "- AC criterion"
+
+    def test_multiline_criteria_section_preserved(self) -> None:
+        body = (
+            "## Acceptance Criteria\n"
+            "- Line one\n"
+            "- Line two\n"
+            "- Line three"
+        )
+        result = _extract_success_criteria(body)
+        assert result == "- Line one\n- Line two\n- Line three"


### PR DESCRIPTION
## Summary

Three non-blocking follow-up items from the oracle review of PRs #383 and #388. No production code is modified — tests and docs only.

- **Executor subprocess boundary:** The oracle flagged that `_dispatch_via_claude_p` had no test coverage for its three failure exit paths. New tests in `test_executor_subprocess.py` inject mock dispatchers that raise `CalledProcessError`, `TimeoutExpired`, and `FileNotFoundError` and verify that in each case the UoW transitions to `failed` and `result.json` is written. Happy path verifies `ready-for-steward` transition and complete outcome.

- **`_extract_success_criteria` edge cases:** The oracle noted that only the happy path was covered. New tests in `test_extract_success_criteria.py` exercise: empty body, no matching heading (fallback to first paragraph), fallback skipping heading-only paragraphs, empty section content, 500-char truncation (exact boundary conditions), all six heading variants, section stops at next `##`, and bodies without trailing newlines.

- **Executor contract doc:** `docs/executor-contract.md` already existed. Added a new section clarifying that the functional-engineer subagent calls `mcp__lobster-inbox__write_result` (inbox delivery) rather than writing the `{output_ref}.result.json` file directly. This means `outcome=complete` in the Steward's result.json means "subprocess exited 0", not "PR was opened." The re-prescription loop is the designed fallback for silent subagent failures. Documented as a coherent design choice, cross-referenced to `_dispatch_via_claude_p`.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_executor_subprocess.py tests/unit/test_orchestration/test_extract_success_criteria.py -v` — 37 passed, 0 failed
- [x] `uv run pytest tests/unit/test_executor.py -v` — 48 passed, 0 failed (existing executor tests unaffected)

## Manual test

N/A — no systemd, cron, external services, file I/O, or DB schema changes.

Relates to #383, #388