### PR TITLE
feat(upstream-sync): two-pass conflict resolution + hot-zone pre-diff + false-conflict detection

### DIFF
--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -6,9 +6,11 @@
 #
 # Behavior:
 #   1. Fetch upstream/main
+#   1b. Hot-zone pre-diff: log upstream changes to known sensitive files
 #   2. Attempt git merge
 #   3. Clean merge → push to origin, log silently
 #   4. Conflicts → abort merge, write an inbox message for Dan to review
+#       (false-conflict detection: log net-zero resolved files as false positives)
 #
 # Usage:
 #   ./sync-upstream.sh [--chat-id <id>] [--dry-run]
@@ -21,6 +23,12 @@
 #   0 - Success (clean merge or already up to date)
 #   1 - Conflict alert sent (merge aborted, human judgment needed)
 #   2 - General error
+#
+# Merge cadence:
+#   Configured via cron in crontab. Current default: twice daily (8am, 8pm).
+#   To change frequency, run: cron-manage.sh edit upstream-sync
+#   or update the cron expression in: scripts/install.sh (search MERGE_CADENCE)
+#   MERGE_CADENCE="0 8,20 * * *"  # twice daily — edit this to change schedule
 #===============================================================================
 
 set -euo pipefail
@@ -36,6 +44,13 @@ LOG_FILE="$WORKSPACE_DIR/logs/upstream-sync.log"
 CHAT_ID="8075091586"
 DRY_RUN=false
 LOCK_FILE="/tmp/lobster-upstream-sync.lock"
+
+# Hot-zone files: upstream changes to these are always logged before merge
+# because they contain fork-specific additions that are prone to conflicts.
+HOT_ZONE_FILES=(
+    ".claude/sys.dispatcher.bootup.md"
+    "src/bot/lobster_bot.py"
+)
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -154,6 +169,58 @@ file_conflict_block() {
     echo "$local_log" | sed 's/^/    /'
 }
 
+# Log upstream diff for hot-zone files before attempting merge.
+# Pure function: reads git state, emits log lines, no side effects on repo.
+log_hot_zone_diff() {
+    local any_changes=false
+    for file in "${HOT_ZONE_FILES[@]}"; do
+        local diff_stat
+        diff_stat=$(git -C "$LOBSTER_DIR" diff HEAD upstream/main -- "$file" 2>/dev/null | head -40 || true)
+        if [ -n "$diff_stat" ]; then
+            if ! $any_changes; then
+                log INFO "--- Hot-zone pre-diff (files with upstream changes) ---"
+                any_changes=true
+            fi
+            log INFO "Hot-zone changed: $file"
+            echo "$diff_stat" | sed 's/^/  /' | tee -a "$LOG_FILE"
+        fi
+    done
+    if $any_changes; then
+        log INFO "--- End hot-zone pre-diff ---"
+    else
+        log INFO "Hot-zone files unchanged in upstream/main — no pre-diff needed"
+    fi
+}
+
+# Check if a conflicting file is a false conflict: upstream's version of the
+# file is identical to what we have in HEAD. If so, accepting either side
+# produces no net change and the "conflict" is spurious.
+# Returns 0 (true/is false conflict) if upstream's blob == HEAD's blob.
+# Must be called while MERGE_HEAD is still valid (before git merge --abort).
+is_false_conflict() {
+    local file="$1"
+    local our_blob upstream_blob
+    our_blob=$(git -C "$LOBSTER_DIR" show "HEAD:$file" 2>/dev/null || true)
+    upstream_blob=$(git -C "$LOBSTER_DIR" show "MERGE_HEAD:$file" 2>/dev/null || true)
+    [ "$our_blob" = "$upstream_blob" ]
+}
+
+# Scan conflicting files for false positives (net-zero diffs) while MERGE_HEAD
+# is still valid. Logs candidates so they can be promoted to Tier 1 in future.
+detect_false_conflicts() {
+    local conflicting="$1"
+    local false_positives=()
+    while IFS= read -r file; do
+        if is_false_conflict "$file"; then
+            false_positives+=("$file")
+            log INFO "False-conflict candidate (identical content vs upstream): $file"
+        fi
+    done <<< "$conflicting"
+    if [ "${#false_positives[@]}" -gt 0 ]; then
+        log INFO "False-conflict summary: ${false_positives[*]} — consider promoting to Tier 1 auto-resolution"
+    fi
+}
+
 # Build the full conflict report as a plain string
 build_conflict_report() {
     local conflicting="$1"
@@ -247,6 +314,16 @@ main() {
         log INFO "upstream/main is $behind commit(s) ahead — merging"
     fi
 
+    # Step 2b: Hot-zone pre-diff
+    # Diff known sensitive files against upstream before the merge so that any
+    # fork-specific additions in those files are visible in the log before git
+    # starts producing conflict markers.
+    if $DRY_RUN; then
+        log INFO "[dry-run] Would: log_hot_zone_diff"
+    else
+        log_hot_zone_diff
+    fi
+
     # Step 3: Attempt merge
     log INFO "Attempting merge of upstream/main..."
     local merge_exit=0
@@ -290,6 +367,10 @@ main() {
     fi
 
     log WARN "Conflicting files: $(echo "$conflicting" | tr '\n' ' ')"
+
+    # Detect false conflicts (net-zero files) before aborting — MERGE_HEAD is
+    # still valid here, and is_false_conflict compares staged resolution to HEAD.
+    detect_false_conflicts "$conflicting"
 
     # Build conflict report before aborting (we need MERGE_HEAD for git log)
     local report


### PR DESCRIPTION
## What this solves

The upstream sync process was a single-pass system: any Tier 2 conflict (Python files, bootup files, CLAUDE.md) immediately escalated to Dan, even when the conflict was straightforward — a fork addition sitting next to an upstream change that didn't actually overlap. Dan asked for a second intelligent-resolution pass before escalation, so the process tries harder before asking for human judgment.

## Changes

### Two-pass conflict resolution (LLM task prompt)

Previously: Tier 2 conflict → abort immediately → alert Dan.

Now:
```
Tier 2 conflict detected
        |
        v
  Pass 2: Intelligent merge agent
  - Examine conflict markers
  - Check for <!-- FORK: [PR#] --> annotations
  - Accept upstream if no overlap with fork additions
  - Preserve fork blocks, accept upstream changes around them
        |
   resolved?
   yes → push, notify Dan with Pass 2 summary
   no  → abort, escalate to Dan with "Pass 2 also failed"
```

The escalation message now leads with "Pass 2 conflict resolution failed" so Dan knows a second attempt was made before the ping.

### Hot-zone pre-diff (shell script)

Before every merge attempt, `sync-upstream.sh` now diffs the two highest-conflict-risk files against `upstream/main` and logs the output:

```bash
HOT_ZONE_FILES=(
    ".claude/sys.dispatcher.bootup.md"
    "src/bot/lobster_bot.py"
)
```

This means the log always shows what upstream changed in sensitive files before git starts producing conflict markers — useful for post-mortem and for the Pass 2 agent reading the log.

### False-conflict detection (shell script)

After identifying conflicting files, the script now calls `detect_false_conflicts()` while `MERGE_HEAD` is still valid. It compares each conflicting file's HEAD blob vs MERGE_HEAD blob — if they're identical, the conflict is spurious (git saw a textual conflict but the content is the same). These are logged as candidates for Tier 1 auto-resolution in future cycles.

### Fork marker convention (documented in task prompt)

Fork-specific additions in bootup and config files should be wrapped:
```
<!-- FORK: [PR#] -->
...fork-specific content...
<!-- /FORK -->
```

This gives the Pass 2 agent a deterministic signal: if the conflict is inside a FORK block, preserve our version and accept upstream changes around it.

### Cadence made configurable (script comment)

Added a `MERGE_CADENCE` comment to the script header with the current value and instructions for changing it. The actual cron schedule is unchanged.

## What is out of scope

- The Tier 1 auto-resolution logic (dependency files) is unchanged.
- The actual merge cadence (twice daily) is unchanged — only the comment documenting it is new.
- The `upstream-sync.md` task file is instance-specific (hardcoded chat_id) and lives in `~/lobster-workspace/scheduled-jobs/tasks/` — it is updated directly at runtime, not in this PR. The PR contains only the committed shell script change.

## Functional patterns used

- Pure functions for all git-reading operations (`log_hot_zone_diff`, `is_false_conflict`, `detect_false_conflicts`) — no repo side effects, only reads and log output.
- Side effects isolated to `write_inbox_alert` and the `main()` function's mutation steps, same as before.

## Tests run
- [x] `bash -n scripts/sync-upstream.sh` — syntax check clean
- [x] Manual dry-run review of full script flow — all new steps correctly gated behind `if $DRY_RUN` or placed before destructive operations
- [ ] Live upstream sync run — not run (would modify the live repo); the shell script changes are observational only (logging, not merge-altering)

## Manual test

The hot-zone pre-diff and false-conflict detection are read-only operations (git show, git diff) that produce log output only. They do not alter merge behavior. The two-pass logic is in the LLM task prompt, not in shell code, so no integration test is possible without a live conflict scenario. Safe to merge.