### PR TITLE
refactor: centralize WOS/orchestration path constants in paths.py

### DIFF
--- a/scheduled-tasks/auto-router.py
+++ b/scheduled-tasks/auto-router.py
@@ -28,12 +28,22 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.orchestration.paths import SURFACE_QUEUE  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-QUEUE_PATH = Path.home() / "lobster-workspace" / "meta" / "reflective-surface-queue.json"
+QUEUE_PATH = SURFACE_QUEUE
 
 ADMIN_CHAT_ID = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
 

--- a/scheduled-tasks/surface-queue-delivery.py
+++ b/scheduled-tasks/surface-queue-delivery.py
@@ -26,12 +26,22 @@ import uuid
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.orchestration.paths import SURFACE_QUEUE  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-QUEUE_PATH = Path.home() / "lobster-workspace" / "meta" / "reflective-surface-queue.json"
+QUEUE_PATH = SURFACE_QUEUE
 MAX_DELIVER_PER_RUN = 3
 ARCHIVE_AGE_DAYS = 14
 

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -35,24 +35,21 @@ if TYPE_CHECKING:
     from .registry import Registry
 
 from .registry import ApproveConfirmed, ApproveExpired, ApproveNotFound, ApproveSkipped
+from .paths import LOBSTER_WORKSPACE as _LOBSTER_WORKSPACE, WOS_CONFIG as _WOS_CONFIG_PATH_FROM_PATHS
 
 
 # ---------------------------------------------------------------------------
 # Gate-cleared flag path — mirrors _GATE_CLEARED_FLAG in steward.py
 # ---------------------------------------------------------------------------
 
-_GATE_CLEARED_FLAG: Path = Path(
-    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
-) / "data" / "wos-gate-cleared"
+_GATE_CLEARED_FLAG: Path = _LOBSTER_WORKSPACE / "data" / "wos-gate-cleared"
 
 
 # ---------------------------------------------------------------------------
 # WOS execution config — runtime start/stop for executor dispatch
 # ---------------------------------------------------------------------------
 
-_WOS_CONFIG_PATH: Path = Path(
-    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
-) / "data" / "wos-config.json"
+_WOS_CONFIG_PATH: Path = _WOS_CONFIG_PATH_FROM_PATHS
 
 _DEFAULT_WOS_CONFIG: dict = {"execution_enabled": False}
 

--- a/src/orchestration/paths.py
+++ b/src/orchestration/paths.py
@@ -1,0 +1,64 @@
+"""
+Centralized path constants for WOS and orchestration modules.
+
+All key paths are derived from the LOBSTER_WORKSPACE environment variable,
+with a sensible fallback to ~/lobster-workspace. Import from this module
+rather than re-deriving paths inline — inline derivations have caused multiple
+bugs when the path logic drifted between files (#4, #5, #6).
+
+Usage:
+    from src.orchestration.paths import REGISTRY_DB, WOS_CONFIG, SURFACE_QUEUE
+
+Environment variables honored:
+    LOBSTER_WORKSPACE  — workspace root (default: ~/lobster-workspace)
+    LOBSTER_REPO       — repo root (default: ~/lobster)
+"""
+
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Root anchors
+# ---------------------------------------------------------------------------
+
+LOBSTER_WORKSPACE = Path(
+    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+)
+
+LOBSTER_REPO = Path(
+    os.environ.get("LOBSTER_REPO", os.environ.get("LOBSTER_INSTALL_DIR", str(Path.home() / "lobster")))
+)
+
+# ---------------------------------------------------------------------------
+# WOS / orchestration
+# ---------------------------------------------------------------------------
+
+REGISTRY_DB = LOBSTER_WORKSPACE / "orchestration" / "registry.db"
+WOS_CONFIG = LOBSTER_WORKSPACE / "data" / "wos-config.json"
+
+# ---------------------------------------------------------------------------
+# Meta / reflective surface queue
+# ---------------------------------------------------------------------------
+
+META_DIR = LOBSTER_WORKSPACE / "meta"
+SURFACE_QUEUE = META_DIR / "reflective-surface-queue.json"
+
+# Oracle files live in the repo, not the workspace
+ORACLE_DECISIONS = LOBSTER_REPO / "oracle" / "decisions.md"
+ORACLE_LEARNINGS = LOBSTER_REPO / "oracle" / "learnings.md"
+
+# ---------------------------------------------------------------------------
+# Hygiene / auto-router queue
+# ---------------------------------------------------------------------------
+
+# Canonical queue directory — reflective-surface-queue.json lives here.
+# Historical note: an earlier bug used "hygiene/meta/" (which never existed);
+# the canonical location has always been META_DIR (i.e. <workspace>/meta/).
+HYGIENE_QUEUE_DIR = META_DIR
+
+# ---------------------------------------------------------------------------
+# Scheduled jobs
+# ---------------------------------------------------------------------------
+
+SCHEDULED_JOBS_DIR = LOBSTER_WORKSPACE / "scheduled-jobs"
+JOBS_JSON = SCHEDULED_JOBS_DIR / "jobs.json"


### PR DESCRIPTION
## What problem this solves

Three overnight bugs all had the same root cause: key paths were derived inline, scattered across multiple files, and went stale independently. Bugs #4 (auto-router QUEUE_PATH pointed to a path that never existed), #5 (surface-queue-delivery had the same stale QUEUE_PATH), and #6 (dispatcher_handlers derived WOS_CONFIG and the gate-cleared flag inline with duplicated logic).

There was no single source of truth. When a path needed to change, only the files someone happened to edit would get updated.

## What changed

Creates `src/orchestration/paths.py` — a new module that defines all key WOS/orchestration paths as constants, derived from `LOBSTER_WORKSPACE` env var with a sensible fallback:

- `REGISTRY_DB`, `WOS_CONFIG` — WOS data paths
- `SURFACE_QUEUE`, `META_DIR`, `HYGIENE_QUEUE_DIR` — reflective surface queue paths
- `ORACLE_DECISIONS`, `ORACLE_LEARNINGS` — oracle files in the repo root
- `SCHEDULED_JOBS_DIR`, `JOBS_JSON` — scheduled jobs paths

Three files updated to import from `paths.py` instead of re-deriving inline:

- `scheduled-tasks/auto-router.py`: hardcoded `Path.home() / "lobster-workspace" / "meta" / ...` → `SURFACE_QUEUE`
- `scheduled-tasks/surface-queue-delivery.py`: same inline derivation → `SURFACE_QUEUE`  
- `src/orchestration/dispatcher_handlers.py`: two separate inline `os.environ.get("LOBSTER_WORKSPACE", ...)` blocks for `_GATE_CLEARED_FLAG` and `_WOS_CONFIG_PATH` → imported from `paths.py`

No behavior change. Paths resolve to the same locations. The `SOURCE_WEIGHT` keys in surface-queue-delivery are left unchanged — they are string labels that match `source_file` fields in live queue items, not filesystem paths.

## Functional patterns used

Pure constants module with no side effects. All path derivations are referentially transparent — `LOBSTER_WORKSPACE` is evaluated once at import time from env var, and all other constants are derived from it compositionally.

## Out of scope

This PR does not update the dozen other files that have their own inline `_WORKSPACE = Path(os.environ.get(...))` patterns (e.g. bot/lobster_bot.py, classifiers, bisque relay). Those are all correct — they derive workspace locally and don't share paths across modules. Only the files with actual bugs or duplicated derivation of the same path are touched here.

## Tests run
- [x] `uv run pytest tests/unit/test_surface_queue_delivery.py` — 20 passed, 0 failed
- [x] Import smoke test: `python3 -c "from src.orchestration.paths import ..."` — all constants resolve to expected paths
- [ ] Full test suite — pre-existing failures in test_dispatch_job_sh.py (5 tests) and test_wos_pipeline.py (1 test) confirmed to pre-date this branch on main; no new failures introduced

## Manual test
N/A — no systemd, cron, external services, file I/O, or DB schema changes. Pure refactor replacing inline path strings with imported constants.