### PR TITLE
feat(ralph): add type-D long-running UoW to validate PR #555 timing fix

### DIFF
--- a/scheduled-jobs/tasks/ralph-loop.md
+++ b/scheduled-jobs/tasks/ralph-loop.md
@@ -61,7 +61,19 @@ Rotate the UoW type based on `total_runs % 3`:
 - Run 0, 3, 6... → inject one of each type (A + B + C)
 - Always inject all three types; rotation just changes which variant of each type
 
+**Additionally, on cycles where `cycle_number % 3 == 0`** (i.e., every third cycle), also inject a type-D long-running UoW. `cycle_number` is `total_runs` from the state loaded in Step 0 (before incrementing).
+
 **Type A — simple-doc-write**: Write a short markdown file.
+
+**Type D — long-running timing validation** (injected only when `cycle_number % 3 == 0`): A multi-step task that naturally takes 5–7 minutes to complete, designed to exercise the 300-second startup-sweep threshold from PR #555. The executor must complete this UoW without the startup sweep interrupting it.
+
+The type-D task must instruct the executor to:
+1. Read and summarize 20 markdown files from `/home/lobster/lobster/` (recurse into subdirectories, pick the first 20 `.md` files found)
+2. For each file, write a one-paragraph summary to `/tmp/ralph-test-{run_id}-d-summaries.txt`, appending after each read
+3. After all 20 summaries, query the WOS registry DB: for each table, read its schema and row count, and append a brief table report to the same file
+4. Write a final line "RALPH type-D complete: <timestamp>" to the file
+
+This is intentionally multi-step and IO-heavy. The executor subprocess should run for roughly 5–7 minutes. Brief pauses between file reads (1–2 seconds each) are acceptable and expected.
 
 ```python
 import sqlite3, uuid, json
@@ -71,6 +83,14 @@ db = '/home/lobster/lobster-workspace/orchestration/registry.db'
 now = datetime.now(timezone.utc).isoformat()
 date = datetime.now(timezone.utc).date().isoformat()
 run_id = uuid.uuid4().hex[:6]
+
+# Load cycle_number from state (total_runs before this cycle's increment)
+import json as _json
+from pathlib import Path as _Path
+_state_raw = _Path('/home/lobster/lobster-workspace/data/ralph-state.json').read_text() if _Path('/home/lobster/lobster-workspace/data/ralph-state.json').exists() else '{}'
+_state = _json.loads(_state_raw) if _state_raw.strip() else {}
+cycle_number = _state.get("total_runs", 0)
+inject_type_d = (cycle_number % 3 == 0)
 
 uows = [
     {
@@ -111,6 +131,32 @@ uows = [
     },
 ]
 
+if inject_type_d:
+    uows.append({
+        "id": f"uow_{date.replace('-','')}_{run_id}_d",
+        "source": "ralph-test",
+        "summary": (
+            f"RALPH type-D: read and summarize 20 markdown files from /home/lobster/lobster/, "
+            f"then query each WOS registry table schema and row count, "
+            f"appending all output to /tmp/ralph-test-{run_id}-d-summaries.txt. "
+            f"Add a 1-2 second pause between each file read. "
+            f"This task is expected to take 5-7 minutes. "
+            f"Finish by writing 'RALPH type-D complete: <ISO timestamp>' as the final line."
+        ),
+        "success_criteria": (
+            f"File /tmp/ralph-test-{run_id}-d-summaries.txt exists, "
+            f"contains at least 20 paragraph summaries, "
+            f"contains a WOS table schema report, "
+            f"and ends with 'RALPH type-D complete:'"
+        ),
+        "status": "ready-for-steward",
+        "type": "executable",
+        "posture": "solo",
+        "output_ref": f"/tmp/ralph-test-{run_id}-d-summaries.txt",
+        "route_reason": "ralph-test injection",
+        "notes": json.dumps({"ralph_run_id": run_id, "ralph_type": "long-running-timing-validation", "pr_555_validation": True}),
+    })
+
 conn = sqlite3.connect(db)
 for u in uows:
     conn.execute("BEGIN IMMEDIATE")
@@ -134,15 +180,18 @@ for u in uows:
     print(f"Injected: {u['id']} ({u['summary'][:60]})")
 
 conn.close()
+print(f"Type-D injected this cycle: {inject_type_d} (cycle_number={cycle_number})")
 ```
 
 **Important**: After injection, the steward and executor heartbeats pick up UoWs automatically (they run every 3 minutes). Do not call them manually.
 
 ---
 
-## Step 2 — Wait and Poll (10 minutes max)
+## Step 2 — Wait and Poll (10 or 15 minutes max)
 
-Poll every 60 seconds for up to 10 minutes until all injected UoWs reach terminal state (`done`, `failed`, `expired`), or timeout.
+Poll every 60 seconds until all injected UoWs reach terminal state (`done`, `failed`, `expired`), or timeout.
+
+**Timeout**: Use **15 minutes** if a type-D UoW was injected this cycle (`inject_type_d == True`); otherwise use the standard **10 minutes**. Type-D UoWs are designed to run for 5–7 minutes, so the extended window is required.
 
 ```python
 import sqlite3, time, json
@@ -150,9 +199,14 @@ from datetime import datetime, timezone
 
 db = '/home/lobster/lobster-workspace/orchestration/registry.db'
 run_id = "<run_id from Step 1>"  # substitute actual run_id
+inject_type_d = <inject_type_d from Step 1>  # True or False
 uow_ids = [f"uow_{date}_{run_id}_a", f"uow_{date}_{run_id}_b", f"uow_{date}_{run_id}_c"]
+if inject_type_d:
+    uow_ids.append(f"uow_{date}_{run_id}_d")
+
 terminal = {'done', 'failed', 'expired'}
-deadline = time.time() + 600  # 10 minutes
+timeout_seconds = 900 if inject_type_d else 600  # 15 min for type-D cycles, 10 min otherwise
+deadline = time.time() + timeout_seconds
 
 while time.time() < deadline:
     conn = sqlite3.connect(db)
@@ -173,7 +227,7 @@ while time.time() < deadline:
         break
     time.sleep(60)
 else:
-    print("TIMEOUT: not all UoWs reached terminal state within 10 minutes.")
+    print(f"TIMEOUT: not all UoWs reached terminal state within {timeout_seconds // 60} minutes.")
 ```
 
 ---
@@ -223,11 +277,12 @@ tail -30 /home/lobster/lobster-workspace/scheduled-jobs/logs/executor-heartbeat.
 ```
 
 **Anomaly checklist** — flag any of the following:
-- Any UoW in non-terminal state after 10 minutes
+- Any UoW in non-terminal state after the polling timeout (10 min standard, 15 min for type-D cycles)
 - `steward_cycles` = 0 after the wait period (steward never touched it)
 - `has_artifact = 0` for a UoW that reached `done` (executor did not produce output)
 - Errors in steward or executor logs during the window
 - `wos-config.json` `execution_enabled = false` (executor paused — note this, do not treat as anomaly)
+- **Type-D timing validation**: if a type-D UoW was injected and `steward_cycles > 2` for that UoW, flag as `pr_555_timing_fix_validation_failed` (the startup sweep re-prescribed while the subprocess was still running — see Step 4 for evaluation logic)
 
 **Deep exchange audit** — after checking terminal states, run these four additional checks. "Checking did it complete" is not sufficient; the exchange quality must also be audited.
 
@@ -238,7 +293,10 @@ import sqlite3, json
 
 db = '/home/lobster/lobster-workspace/orchestration/registry.db'
 run_id = "<run_id from Step 1>"  # substitute actual run_id
+inject_type_d = <inject_type_d from Step 1>  # True or False
 uow_ids = [f"uow_{date}_{run_id}_a", f"uow_{date}_{run_id}_b", f"uow_{date}_{run_id}_c"]
+if inject_type_d:
+    uow_ids.append(f"uow_{date}_{run_id}_d")
 
 conn = sqlite3.connect(db)
 cur = conn.cursor()
@@ -255,6 +313,8 @@ conn.close()
 
 A clean first-execution run should have `steward_cycles <= 2` (1 to prescribe, 1 to close). If any UoW has `steward_cycles >= 3`, flag as anomaly type `steward_cycle_excess` with detail including the actual cycle count.
 
+**Note for type-D**: If the type-D UoW has `steward_cycles > 2`, this specifically indicates the startup sweep re-prescribed during active execution — see Step 4 for the PR #555 validation outcome logic.
+
 **Audit 2 — PRSC reasons from steward_log:**
 
 ```python
@@ -262,7 +322,10 @@ import sqlite3, json
 
 db = '/home/lobster/lobster-workspace/orchestration/registry.db'
 run_id = "<run_id from Step 1>"  # substitute actual run_id
+inject_type_d = <inject_type_d from Step 1>  # True or False
 uow_ids = [f"uow_{date}_{run_id}_a", f"uow_{date}_{run_id}_b", f"uow_{date}_{run_id}_c"]
+if inject_type_d:
+    uow_ids.append(f"uow_{date}_{run_id}_d")
 
 conn = sqlite3.connect(db)
 cur = conn.cursor()
@@ -310,7 +373,10 @@ import sqlite3, json
 
 db = '/home/lobster/lobster-workspace/orchestration/registry.db'
 run_id = "<run_id from Step 1>"  # substitute actual run_id
+inject_type_d = <inject_type_d from Step 1>  # True or False
 uow_ids = [f"uow_{date}_{run_id}_a", f"uow_{date}_{run_id}_b", f"uow_{date}_{run_id}_c"]
+if inject_type_d:
+    uow_ids.append(f"uow_{date}_{run_id}_d")
 
 conn = sqlite3.connect(db)
 cur = conn.cursor()
@@ -338,7 +404,10 @@ import sqlite3, json
 
 db = '/home/lobster/lobster-workspace/orchestration/registry.db'
 run_id = "<run_id from Step 1>"  # substitute actual run_id
+inject_type_d = <inject_type_d from Step 1>  # True or False
 uow_ids = [f"uow_{date}_{run_id}_a", f"uow_{date}_{run_id}_b", f"uow_{date}_{run_id}_c"]
+if inject_type_d:
+    uow_ids.append(f"uow_{date}_{run_id}_d")
 
 conn = sqlite3.connect(db)
 cur = conn.cursor()
@@ -387,7 +456,7 @@ anomalies_this_run = []
 # For each anomaly found, append a dict like:
 # {
 #   "uow_id": "<id>",
-#   "anomaly_type": "stalled|steward_cycles_zero|missing_artifact|log_error|steward_cycle_excess|prsc_first_exec_conflation|duplicate_dispatch|bad_posture_transition",
+#   "anomaly_type": "stalled|steward_cycles_zero|missing_artifact|log_error|steward_cycle_excess|prsc_first_exec_conflation|duplicate_dispatch|bad_posture_transition|pr_555_timing_fix_validation_failed",
 #   "detail": "<brief description including observed values>"
 # }
 # Examples:
@@ -396,6 +465,7 @@ anomalies_this_run = []
 # anomalies_this_run.append({"uow_id": "uow_20260401_abc123_a", "anomaly_type": "prsc_first_exec_conflation", "detail": "[PRSC] output_ref is null or file does not exist for first_execution UoW"})
 # anomalies_this_run.append({"uow_id": "uow_20260401_abc123_c", "anomaly_type": "duplicate_dispatch", "detail": "dispatched 2 times"})
 # anomalies_this_run.append({"uow_id": "uow_20260401_abc123_b", "anomaly_type": "bad_posture_transition", "detail": "posture crashed_output_ref_missing observed in audit trail"})
+# anomalies_this_run.append({"uow_id": "uow_20260401_abc123_d", "anomaly_type": "pr_555_timing_fix_validation_failed", "detail": "steward_cycles=3 for type-D UoW: sweep re-prescribed during active execution"})
 # If no anomalies were found, anomalies_this_run remains [].
 ```
 
@@ -404,12 +474,42 @@ anomalies_this_run = []
 ## Step 4 — Evaluate: Clean Run or Not?
 
 A **clean run** is defined as:
-- All injected UoWs reached `done` or `failed` within 10 minutes
+- All injected UoWs reached `done` or `failed` within the polling timeout (10 min standard, 15 min for type-D cycles)
 - No posture anomalies (no stalled UoWs)
 - No errors in heartbeat logs during the window
 - All four deep exchange audits from Step 3 are clean: `steward_cycles <= 2` per UoW, no bad PRSC reasons for first-execution UoWs, no duplicate dispatches, no unexpected posture transitions
 
-**Note**: A UoW reaching `failed` is acceptable if the failure reason is expected (e.g., the executor correctly identified an unsolvable task). A `failed` outcome with a recorded `return_reason` counts as clean. A timeout or a UoW with `steward_cycles = 0` after 10 minutes is NOT clean.
+**Note**: A UoW reaching `failed` is acceptable if the failure reason is expected (e.g., the executor correctly identified an unsolvable task). A `failed` outcome with a recorded `return_reason` counts as clean. A timeout or a UoW with `steward_cycles = 0` after the polling timeout is NOT clean.
+
+**Type-D timing validation outcome** (only applies on cycles where `inject_type_d == True`):
+
+Check the type-D UoW's `steward_cycles` from the Step 3 Audit 1 query:
+
+```python
+type_d_id = f"uow_{date}_{run_id}_d"
+# Query steward_cycles for type-D from the Audit 1 results
+# (use the conn/cur established in Audit 1, or re-query)
+conn = sqlite3.connect(db)
+cur = conn.cursor()
+cur.execute("SELECT steward_cycles FROM uow_registry WHERE id = ?", (type_d_id,))
+row = cur.fetchone()
+conn.close()
+
+if row is not None:
+    type_d_steward_cycles = row[0]
+    if type_d_steward_cycles <= 2:
+        print(f"PR #555 timing fix validated for this cycle: type-D completed with steward_cycles={type_d_steward_cycles} (<= 2, sweep did not interrupt)")
+    else:
+        print(f"PR #555 timing fix validation FAILED: type-D UoW steward_cycles={type_d_steward_cycles} (> 2, sweep re-prescribed during active execution)")
+        # Add to anomalies_this_run:
+        anomalies_this_run.append({
+            "uow_id": type_d_id,
+            "anomaly_type": "pr_555_timing_fix_validation_failed",
+            "detail": f"steward_cycles={type_d_steward_cycles} for type-D UoW: startup sweep re-prescribed while subprocess was still active"
+        })
+```
+
+Log the outcome in the Step 5 report under a dedicated "PR #555 Timing Validation" section.
 
 Determine: `is_clean_run = True` or `False`.
 
@@ -431,7 +531,8 @@ Write a report to `/home/lobster/lobster-workspace/data/ralph-reports/ralph-<YYY
 ## Summary
 - Run ID: <run_id>
 - Clean run: <yes/no>
-- UoWs injected: 3 (type-A, type-B, type-C)
+- UoWs injected: <3 or 4> (type-A, type-B, type-C[, type-D])
+- Type-D injected: <yes/no> (cycle_number=<N>, cycle_number % 3 == 0: <True/False>)
 
 ## Outcomes
 | UoW ID | Type | Final Status | Steward Cycles | Has Artifact |
@@ -442,6 +543,12 @@ Write a report to `/home/lobster/lobster-workspace/data/ralph-reports/ralph-<YYY
 | UoW ID | Steward Cycles OK? | PRSC Reason OK? | Duplicate Dispatch? | Posture Sequence OK? |
 |--------|--------------------|-----------------|--------------------|-----------------------|
 | ...    | yes/no (N cycles)  | yes/no (reason) | yes/no             | yes/no (posture)     |
+
+## PR #555 Timing Validation
+<!-- Only present when type-D was injected -->
+- Type-D UoW: <uow_id>
+- Steward cycles: <N>
+- Outcome: VALIDATED (steward_cycles <= 2, sweep did not interrupt) | FAILED (steward_cycles > 2, sweep re-prescribed during active execution)
 
 ## Anomalies
 <list anomalies or "none" — include anomalies from both basic checklist and deep exchange audit>
@@ -502,11 +609,12 @@ state["last_run_ts"] = datetime.now(timezone.utc).isoformat()
 
 # Populate last_anomalies from the anomalies observed in Step 3.
 # Each entry should be a dict with at minimum: {"uow_id": ..., "anomaly_type": ..., "detail": ...}
-# Example anomaly types: "stalled" (non-terminal after 10 min), "steward_cycles_zero",
+# Example anomaly types: "stalled" (non-terminal after polling timeout), "steward_cycles_zero",
 # "missing_artifact" (done but no workflow_artifact), "log_error",
 # "steward_cycle_excess" (steward_cycles >= 3), "prsc_first_exec_conflation"
 # (steward treated first_execution UoW as crashed), "duplicate_dispatch",
-# "bad_posture_transition" (unexpected posture in audit trail)
+# "bad_posture_transition" (unexpected posture in audit trail),
+# "pr_555_timing_fix_validation_failed" (type-D UoW steward_cycles > 2, sweep interrupted active execution)
 # Use the stalled list and outcome data from Step 3 to build this.
 # If is_clean_run is True, this should be [].
 state["last_anomalies"] = anomalies_this_run  # list of anomaly dicts from Step 3


### PR DESCRIPTION
## What problem this solves

PR #555 fixed a race condition in startup-sweep.py where the sweep would misclassify a subprocess that had been running for less than 300 seconds as crashed, causing premature re-prescription. But RALPH's existing type-A/B/C UoWs all complete in under 78 seconds — well below that 300-second threshold — so the fix has never been exercised in production.

This PR closes that gap by adding a type-D UoW whose subprocess is designed to run for 5–7 minutes. On any cycle where type-D is active, the startup sweep will see an in-flight subprocess that's been running for 3+ minutes. If the fix is working, the sweep leaves it alone (steward_cycles stays at <= 2). If the fix regressed, the sweep re-prescribes (steward_cycles goes to 3+), which RALPH detects and logs as a validation failure.

## What changed

**Step 1 — Injection**: On cycles where `cycle_number % 3 == 0`, RALPH injects a fourth UoW (type-D). The task reads and summarizes 20 markdown files from the repo with 1–2 second pauses between each, then queries the WOS registry DB for table schemas and row counts, ending with a timestamped completion marker. The 1–2 second pauses between 20 file reads, plus the DB query phase, naturally produce a 5–7 minute runtime without artificial sleeps dominating.

**Step 2 — Polling**: When type-D is present, the poll deadline extends from 10 minutes to 15 minutes, giving the long-running subprocess room to complete before RALPH declares a timeout.

**Step 3 — Anomaly checklist**: Added the `pr_555_timing_fix_validation_failed` anomaly type to the checklist. The four deep-audit code blocks now include the type-D UoW ID when `inject_type_d` is True, and Audit 1 notes that steward_cycles > 2 specifically on type-D indicates a PR #555 regression.

**Step 4 — Evaluate**: Added an explicit code block that queries the type-D UoW's steward_cycles and either logs "PR #555 timing fix validated for this cycle" or appends a `pr_555_timing_fix_validation_failed` anomaly and logs the failure clearly.

**Step 5 — Report**: Added a "PR #555 Timing Validation" section to the report template, showing the UoW ID, steward_cycles count, and VALIDATED/FAILED verdict.

**Step 7 — State**: Updated the anomaly type comment to include the new type.

## Functional patterns used

Pure data construction (the type-D UoW dict is built from immutable expressions), conditional injection (type-D appended only when `cycle_number % 3 == 0`), and deterministic anomaly detection (steward_cycles threshold is a code comparison, not LLM judgment).

## Boundary

Only `scheduled-jobs/tasks/ralph-loop.md` was modified. No code in `executor.py`, `steward.py`, `startup-sweep.py`, or any other orchestration file was touched.

## Tests run
- [x] Manual review of the full modified file — all four changed sections (Step 1, 2, 3, 4) are internally consistent: the `inject_type_d` flag flows from Step 1 through Step 2's timeout logic, Step 3's audit queries, and Step 4's evaluation block
- [ ] Live RALPH cycle — not run; requires WOS execution enabled in production. The change is self-contained within a markdown prompt file; no executable code was modified.

## Manual test

N/A — only a markdown task definition file was modified. The change is observable only when RALPH next runs on a cycle where `cycle_number % 3 == 0`.