### PR TITLE
fix(steward): handle diagnosing_orphan in _determine_reentry_posture

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -212,6 +212,7 @@ _RETURN_REASON_CLASSIFICATIONS: dict[str, str] = {
     "crashed_zero_bytes": _CLASSIFICATION_ERROR,
     "crashed_output_ref_missing": _CLASSIFICATION_ERROR,
     "executor_orphan": _CLASSIFICATION_ORPHAN,
+    "diagnosing_orphan": _CLASSIFICATION_ORPHAN,
 }
 
 
@@ -377,6 +378,8 @@ def _determine_reentry_posture(
                     return clf
                 elif clf == "executor_orphan":
                     return "executor_orphan"
+                elif clf == "diagnosing_orphan":
+                    return "diagnosing_orphan"
             elif event == "execution_failed":
                 return "execution_failed"
 
@@ -1034,6 +1037,7 @@ def _build_deterministic_prescription_instructions(
         "crashed_no_output": "Previous execution crashed without producing output. Re-execute, adding error handling.",
         "execution_failed": "Previous execution failed. Diagnose the failure and re-execute.",
         "executor_orphan": "Executor never ran on this UoW. Execute fresh.",
+        "diagnosing_orphan": "Steward crashed mid-diagnosis. Re-diagnosing from current state.",
     }
 
     posture_msg = posture_context.get(reentry_posture, "Continue from previous attempt.")


### PR DESCRIPTION
## What this fixes

When a steward crashed mid-diagnosis, the affected UoW re-entered `_determine_reentry_posture()` with `return_reason == "diagnosing_orphan"`. That string was absent from `_RETURN_REASON_CLASSIFICATIONS`, so it fell through the startup_sweep audit-event inspection branch to the `return "first_execution"` default at line 383. The resulting `[DIAG] posture=first_execution` log entry made a crash-recovery cycle visually indistinguishable from a genuine first-pass cycle, making crash loops harder to observe and diagnose.

Identified and documented in `~/lobster-workspace/assessments/audit-steward-posture-20260401.md` (Part 3).

## Changes (3 lines)

- `_RETURN_REASON_CLASSIFICATIONS`: adds `"diagnosing_orphan": _CLASSIFICATION_ORPHAN` so the dict lookup path resolves to the orphan branch
- `_determine_reentry_posture()` startup_sweep branch: adds `elif clf == "diagnosing_orphan": return "diagnosing_orphan"` (belt-and-suspenders: both entry paths now return the right label)
- `posture_context` in `_build_deterministic_prescription_instructions()`: adds the matching instruction string so re-prescription is accurate

No logic outside these three areas is touched.

## Behavioral impact

The audit confirms this is an observability gap, not a behavioral gap. The UoW was correctly re-prescribed under `first_execution` — the executor was never dispatched before the steward crashed, so the semantics are close. The fix makes the `[DIAG]` posture label accurate and gives the re-prescription a meaningful instruction string.

## Functional patterns

Pure function fix: `_determine_reentry_posture` is a pure classifier. The change adds a missing branch to an exhaustive `elif` chain and a missing key to the classification dict — consistent with the existing pattern throughout.

## Tests run

- [x] `uv run pytest tests/ -x -q` (from worktree) — 124 passed, 3 skipped, 1 pre-existing failure
  - `TestBootupCandidateGate::test_bootup_candidate_blocked_when_gate_is_open` fails on both `main` and this branch — confirmed not introduced by this change

## Manual test

N/A — no systemd, cron, external services, file I/O, or DB schema changes.