### PR TITLE
fix(steward): clean PRSC reason for first-execution UoWs

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -411,6 +411,9 @@ def _assess_completion(
     if cycles >= _HARD_CAP_CYCLES:
         return False, f"hard_cap: steward_cycles={cycles} >= {_HARD_CAP_CYCLES}", None
 
+    if reentry_posture == "first_execution":
+        return False, "first_execution: awaiting executor dispatch", None
+
     output_ref = uow.output_ref
     if not _output_ref_is_valid(output_ref):
         return False, "output_ref is null or file does not exist or is empty", None


### PR DESCRIPTION
## Summary

When a brand-new UoW enters the steward for the first time (no prior audit entries, `steward_cycles=0`), the PRSC reason logged was:

```
first_execution — output_ref is null or file does not exist or is empty
```

The trailing clause is an output_ref error message bleeding into the success path. The `_assess_completion` function ran the `_output_ref_is_valid` guard before it could short-circuit on posture. For a `first_execution` UoW, the absence of an output_ref is expected — the executor hasn't run yet.

The fix checks for `first_execution` posture before the output_ref guard and returns the clean reason:

```
first_execution: awaiting executor dispatch
```

Prescription behavior (UoW is sent to the executor) is entirely unchanged. Only the human-readable reason string in the PRSC log entry is different.

No other cases are affected: all other postures continue through the existing `_output_ref_is_valid` check as before.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestAssessCompletionStructuralProxy -v` — 4 passed, 0 failed
- [ ] Full `test_steward.py` suite — timed out at 90s; 31 tests passed before cutoff, 1 pre-existing failure (`test_bootup_candidate_gate_constant_exists` — dynamic file-flag gate, not related to this change)

**Blocked items needing attention before merge:** none

## Manual test
N/A — no systemd, cron, external services, file I/O at runtime, or DB schema changes.