### PR TITLE
feat(wos-report): redesign into summary PDF + full markdown investigation report

### DIFF
--- a/scheduled-jobs/tasks/ralph-loop.md
+++ b/scheduled-jobs/tasks/ralph-loop.md
@@ -542,7 +542,30 @@ Create the reports directory and write a markdown report:
 mkdir -p /home/lobster/lobster-workspace/data/ralph-reports/
 ```
 
-Write a report to `/home/lobster/lobster-workspace/data/ralph-reports/ralph-<YYYY-MM-DD-HHMMSS>.md`:
+**Generate WOS reports** — after the RALPH markdown report is written, run wos_report.py on the injected UoW IDs to generate:
+1. A summary PDF (sent to Dan via Telegram)
+2. A full markdown investigation report (saved locally for deep debugging)
+
+```bash
+# Substitute actual UoW IDs from Step 1 (comma-separated, no spaces)
+UOW_IDS="uow_<date>_<run_id>_a,uow_<date>_<run_id>_b,uow_<date>_<run_id>_c"
+# If type-D was injected, add it: UOW_IDS="${UOW_IDS},uow_<date>_<run_id>_d"
+
+REPORT_TS=$(date +%Y%m%d-%H%M%S)
+SUMMARY_PDF="/home/lobster/messages/documents/wos-ralph-${REPORT_TS}.pdf"
+FULL_MD="/home/lobster/lobster-workspace/data/ralph-reports/wos-full-${REPORT_TS}.md"
+
+cd /home/lobster/lobster && uv run src/wos_report.py \
+  --ids "${UOW_IDS}" \
+  --output "${SUMMARY_PDF}" \
+  --full-output "${FULL_MD}"
+```
+
+The summary PDF is automatically sent to Dan (chat_id 8075091586) with caption "WOS Registry (N UoWs, ids=N) -- timestamp". The full markdown report is saved to `ralph-reports/` for investigation.
+
+If `wos_report.py` fails (e.g., DB not found), log the error and continue — report failure is not a pipeline anomaly.
+
+Write a RALPH cycle report to `/home/lobster/lobster-workspace/data/ralph-reports/ralph-<YYYY-MM-DD-HHMMSS>.md`:
 
 ```markdown
 # RALPH Cycle Report — <timestamp ET>

--- a/src/wos_report.py
+++ b/src/wos_report.py
@@ -1,19 +1,24 @@
 #!/usr/bin/env python3
 """
-wos_report.py — Generate a PDF of the WOS Registry and send it to Telegram.
+wos_report.py — Generate WOS Registry reports in two formats.
+
+Summary PDF (Dan's report): clean card layout, key signals prominent, no verbose logs.
+Full markdown report: all fields, full JSON logs, for deep investigation.
 
 Usage:
     uv run ~/lobster/src/wos_report.py [OPTIONS]
 
 Options:
     --chat-id           Telegram chat ID to send to (default: 8075091586)
-    --output PATH       Output PDF path (default: ~/messages/documents/wos-report-<timestamp>.pdf)
-    --no-send           Generate PDF but do not send to Telegram (default: send directly via Bot API)
+    --output PATH       Output PDF path (generates summary PDF)
+    --full-output PATH  Output markdown path (generates full investigation report)
+    --no-send           Generate reports but do not send PDF to Telegram
     --status STATUS     Filter by status (e.g. active, done, proposed; default: all)
     --since YYYY-MM-DD  Include only UoWs created on or after this date
     --ids id1,id2,...   Include only the specified UoW IDs (comma-separated)
 
 Filters combine: --since and --ids are applied after --status.
+Both --output and --full-output can be used together.
 """
 
 from __future__ import annotations
@@ -46,6 +51,7 @@ OUTBOX_DIR = Path(os.environ.get(
     "LOBSTER_OUTBOX",
     Path.home() / "messages" / "outbox"
 ))
+FULL_REPORTS_DIR = Path.home() / "lobster-workspace" / "data" / "ralph-reports"
 DEFAULT_CHAT_ID = 8075091586
 GITHUB_REPO = "dcetlin/Lobster"
 
@@ -64,50 +70,46 @@ STATUS_COLORS: dict[str, tuple[int, int, int]] = {
 }
 DEFAULT_STATUS_COLOR = (120, 120, 120)
 
-# Canonical lifecycle state ordering for timeline display
-LIFECYCLE_STATES = [
-    "proposed", "pending", "ready-for-steward", "diagnosing",
-    "ready-for-executor", "active", "done", "failed", "expired", "blocked",
-]
+# Terminal statuses — used for anomaly detection
+TERMINAL_STATUSES = {"done", "failed", "expired"}
 
 PAGE_W = 210          # A4 mm
 MARGIN = 14           # mm left/right/top
 CONTENT_W = PAGE_W - MARGIN * 2
-CARD_PAD = 5          # mm inner padding
-LABEL_W = 34          # mm for field labels
 
 # ── colour palette ─────────────────────────────────────────────────────────────
-C_HEADING_BG   = (235, 240, 250)   # light blue for section headings
-C_HEADING_TEXT = (50,  80, 140)    # dark blue for section heading text
-C_GRID_LINE    = (210, 215, 225)   # subtle grid line
-C_MUTED        = (120, 120, 130)   # muted labels
-C_DARK         = (25,  25,  35)    # near-black body text
-C_LINK         = (30,  80, 180)    # hyperlink blue
-C_STEWARD_BG   = (235, 245, 255)   # steward section tint
-C_EXECUTOR_BG  = (235, 250, 240)   # executor section tint
-C_DONE_NODE    = ( 70, 160,  90)   # completed lifecycle node
-C_PENDING_NODE = (190, 195, 210)   # future/unreached lifecycle node
-C_ACTIVE_NODE  = ( 40, 140, 200)   # current-status lifecycle node
+C_HEADING_BG   = (235, 240, 250)
+C_HEADING_TEXT = (50,  80, 140)
+C_GRID_LINE    = (210, 215, 225)
+C_MUTED        = (120, 120, 130)
+C_DARK         = (25,  25,  35)
+C_LINK         = (30,  80, 180)
+C_DONE         = ( 70, 160,  90)
+C_ANOMALY_BG   = (255, 235, 235)
+C_ANOMALY_TEXT = (180,  40,  40)
+C_WARN_TEXT    = (160,  90,  20)
+C_CYCLE_OK     = ( 70, 160,  90)   # 1 steward cycle = healthy
+C_CYCLE_WARN   = (180,  90,  20)   # 2+ cycles = investigate
 
 
 # ── text helpers ──────────────────────────────────────────────────────────────
 
 _UNICODE_MAP = str.maketrans({
-    "\u2014": "--",   # em dash
-    "\u2013": "-",    # en dash
-    "\u2019": "'",    # right single quote
-    "\u2018": "'",    # left single quote
-    "\u201c": '"',    # left double quote
-    "\u201d": '"',    # right double quote
-    "\u2022": "*",    # bullet
-    "\u2026": "...",  # ellipsis
-    "\u00e9": "e",    # e acute
-    "\u00e8": "e",    # e grave
-    "\u00e0": "a",    # a grave
-    "\u00fc": "u",    # u umlaut
-    "\u00f6": "o",    # o umlaut
-    "\u00e4": "a",    # a umlaut
-    "\u00df": "ss",   # sharp s
+    "\u2014": "--",
+    "\u2013": "-",
+    "\u2019": "'",
+    "\u2018": "'",
+    "\u201c": '"',
+    "\u201d": '"',
+    "\u2022": "*",
+    "\u2026": "...",
+    "\u00e9": "e",
+    "\u00e8": "e",
+    "\u00e0": "a",
+    "\u00fc": "u",
+    "\u00f6": "o",
+    "\u00e4": "a",
+    "\u00df": "ss",
 })
 
 
@@ -119,18 +121,6 @@ def _safe(text: str) -> str:
         for c in unicodedata.normalize("NFKD", text)
         if ord(c) < 256 or unicodedata.category(c) not in ("Mn",)
     )
-
-
-# ── data layer ────────────────────────────────────────────────────────────────
-
-def _source_url(source: str | None, issue_number: int | None) -> str:
-    """Derive a GitHub URL from the source field."""
-    if issue_number:
-        return f"https://github.com/{GITHUB_REPO}/issues/{issue_number}"
-    if source and source.startswith("github:issue/"):
-        num = source.split("/")[-1]
-        return f"https://github.com/{GITHUB_REPO}/issues/{num}"
-    return source or ""
 
 
 def _fmt_ts(ts: str | None, short: bool = False) -> str:
@@ -152,6 +142,43 @@ def _fmt_ts(ts: str | None, short: bool = False) -> str:
         return ts[:16] if ts else ""
 
 
+def _duration_str(start_ts: str | None, end_ts: str | None) -> str:
+    """Return human-readable duration between two timestamps."""
+    if not start_ts or not end_ts:
+        return ""
+    try:
+        def _parse(ts: str) -> datetime:
+            ts = ts.replace(" ", "T")
+            if "+" in ts:
+                return datetime.fromisoformat(ts)
+            if ts.endswith("Z"):
+                return datetime.fromisoformat(ts[:-1]).replace(tzinfo=timezone.utc)
+            return datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
+
+        delta = _parse(end_ts) - _parse(start_ts)
+        secs = int(delta.total_seconds())
+        if secs < 0:
+            return ""
+        if secs < 60:
+            return f"{secs}s"
+        if secs < 3600:
+            return f"{secs // 60}m {secs % 60}s"
+        return f"{secs // 3600}h {(secs % 3600) // 60}m"
+    except Exception:
+        return ""
+
+
+# ── data layer ────────────────────────────────────────────────────────────────
+
+def _source_url(source: str | None, issue_number: int | None) -> str:
+    if issue_number:
+        return f"https://github.com/{GITHUB_REPO}/issues/{issue_number}"
+    if source and source.startswith("github:issue/"):
+        num = source.split("/")[-1]
+        return f"https://github.com/{GITHUB_REPO}/issues/{num}"
+    return source or ""
+
+
 def _parse_steward_log(raw: str | None) -> list[dict]:
     """Parse newline-delimited JSON steward_log into a list of event dicts."""
     if not raw:
@@ -168,64 +195,76 @@ def _parse_steward_log(raw: str | None) -> list[dict]:
     return events
 
 
-def _parse_steward_agenda(raw: str | None) -> list[dict]:
-    """Parse steward_agenda JSON array."""
-    if not raw:
-        return []
-    try:
-        val = json.loads(raw)
-        return val if isinstance(val, list) else []
-    except Exception:
-        return []
-
-
-def _extract_lifecycle_from_audit(audit_events: list[dict]) -> list[dict]:
-    """
-    Build an ordered list of {status, ts} pairs from audit log events,
-    deduplicated so each status appears only once (first occurrence).
-    """
-    transitions = []
-    seen: set[str] = set()
-
-    for ev in audit_events:
-        event_type = ev.get("event", "")
-        to_s = ev.get("to_status") or ""
-        ts = ev.get("ts", "")
-
-        if event_type == "created" and to_s and to_s not in seen:
-            transitions.append({"status": to_s, "ts": ts})
-            seen.add(to_s)
-        elif event_type == "status_change" and to_s and to_s not in seen:
-            transitions.append({"status": to_s, "ts": ts})
-            seen.add(to_s)
-
-    return transitions
-
-
-def _build_steward_exchange(log_events: list[dict]) -> list[dict]:
-    """
-    Extract the steward-executor back-and-forth from steward_log events.
-    Returns list of {event, cycle, ts, posture, assessment, return_reason, ...}.
-    """
-    exchange = []
+def _extract_first_prsc_reason(log_events: list[dict]) -> str:
+    """Extract the first prescription reason (what sent UoW to executor)."""
     for ev in log_events:
-        event_type = ev.get("event", "")
-        if event_type in ("diagnosis", "prescription", "reentry_prescription",
-                          "steward_closure", "agenda_update"):
-            exchange.append({
-                "event": event_type,
-                "cycle": ev.get("steward_cycles", 0),
-                "ts": ev.get("timestamp", ""),
-                "posture": ev.get("re_entry_posture") or "",
-                "assessment": (ev.get("completion_rationale")
-                               or ev.get("completion_assessment")
-                               or ev.get("assessment")
-                               or ""),
-                "rationale": ev.get("next_posture_rationale") or "",
-                "is_complete": ev.get("is_complete", False),
-                "return_reason": ev.get("return_reason") or "",
-            })
-    return exchange
+        if ev.get("event") in ("prescription", "reentry_prescription"):
+            # Try several fields where this surfaces
+            reason = (
+                ev.get("return_reason")
+                or ev.get("re_entry_posture")
+                or ev.get("next_posture_rationale")
+                or ""
+            )
+            if reason:
+                return reason
+            # Fall back to posture from agenda
+            posture = ev.get("re_entry_posture") or ""
+            if posture:
+                return posture
+    return ""
+
+
+def _extract_outcome_summary(log_events: list[dict], uow: dict) -> str:
+    """Extract outcome / completion summary from steward closure or audit notes."""
+    # Try steward_closure event first
+    for ev in reversed(log_events):
+        if ev.get("event") == "steward_closure":
+            assessment = (
+                ev.get("completion_rationale")
+                or ev.get("completion_assessment")
+                or ev.get("assessment")
+                or ""
+            )
+            if assessment:
+                return assessment
+
+    # Fall back to last audit note
+    for audit in reversed(uow.get("_audit_events", [])):
+        note = audit.get("note", "")
+        if note and len(note) > 10:
+            return note
+
+    return ""
+
+
+def _detect_anomalies(uow: dict) -> list[str]:
+    """
+    Return list of anomaly strings for a UoW.
+    Empty list = no anomalies.
+    """
+    anomalies = []
+    status = uow.get("status", "")
+    steward_cycles = uow.get("steward_cycles", 0) or 0
+
+    if status == "failed":
+        anomalies.append("Status: FAILED")
+
+    if status not in TERMINAL_STATUSES and status not in ("proposed", "pending"):
+        anomalies.append(f"Non-terminal status: {status}")
+
+    # Steward never touched it but it's past pending
+    if steward_cycles == 0 and status not in ("proposed", "pending", "ready-for-steward"):
+        anomalies.append("Steward cycles = 0 (steward may not have processed this)")
+
+    # Done but no workflow artifact (executor produced no output artifact)
+    if status == "done" and not uow.get("workflow_artifact"):
+        log_events = uow.get("_steward_log_events", [])
+        # Only flag if there were steward cycles (not a trivially-completed UoW)
+        if steward_cycles > 0:
+            anomalies.append("Done but no workflow artifact recorded")
+
+    return anomalies
 
 
 def fetch_uows(
@@ -233,15 +272,7 @@ def fetch_uows(
     since: str | None = None,
     ids: list[str] | None = None,
 ) -> list[dict]:
-    """Load UoWs from the registry DB, sorted by created_at descending.
-
-    Args:
-        status_filter: If given, only UoWs with this exact status are returned.
-        since:         If given (ISO date string YYYY-MM-DD), only UoWs whose
-                       created_at is >= this date are returned.
-        ids:           If given, only UoWs whose id is in this list are returned.
-                       Applied after status_filter and since.
-    """
+    """Load UoWs from the registry DB, sorted by created_at descending."""
     if not REGISTRY_DB.exists():
         raise FileNotFoundError(f"Registry DB not found: {REGISTRY_DB}")
     conn = sqlite3.connect(str(REGISTRY_DB))
@@ -254,8 +285,6 @@ def fetch_uows(
             conditions.append("status = ?")
             params.append(status_filter)
         if since:
-            # Normalize to ISO datetime so string comparison works regardless of
-            # whether the DB stores timestamps with or without the time component.
             conditions.append("created_at >= ?")
             params.append(since)
 
@@ -268,23 +297,17 @@ def fetch_uows(
         uows = []
         for row in rows:
             d = dict(row)
-            # Apply --ids filter in Python (simpler than a parameterised IN clause)
             if ids is not None and d["id"] not in ids:
                 continue
 
-            # All audit events (chronological) for lifecycle reconstruction
             audits = conn.execute(
                 "SELECT ts, event, from_status, to_status, note "
                 "FROM audit_log WHERE uow_id=? ORDER BY ts ASC",
                 (d["id"],)
             ).fetchall()
             d["_audit_events"] = [dict(a) for a in audits]
-
-            # Parse steward data
             d["_steward_log_events"] = _parse_steward_log(d.get("steward_log"))
-            d["_steward_agenda_list"] = _parse_steward_agenda(d.get("steward_agenda"))
 
-            # Parse prescribed skills
             try:
                 d["_prescribed_skills"] = json.loads(d.get("prescribed_skills") or "[]")
             except Exception:
@@ -296,26 +319,32 @@ def fetch_uows(
         conn.close()
 
 
-# ── PDF builder ───────────────────────────────────────────────────────────────
+# ── Summary PDF builder ────────────────────────────────────────────────────────
 
-class WoSReport(FPDF):
-    """A4 PDF report of WOS Registry UoWs — rich visual layout."""
+class SummaryReport(FPDF):
+    """
+    Clean summary PDF for Dan.
+    One card per UoW: status prominent, steward cycle health signal,
+    timing block, PRSC reason, outcome. Anomalies highlighted in red.
+    No verbose log dumps.
+    """
 
-    def __init__(self, total: int, generated_at: str):
+    def __init__(self, total: int, generated_at: str, status_counts: dict[str, int]):
         super().__init__()
         self._total = total
         self._generated_at = generated_at
+        self._status_counts = status_counts
 
     def header(self):
-        self.set_font("Helvetica", "B", 14)
+        self.set_font("Helvetica", "B", 15)
         self.set_text_color(*C_DARK)
-        self.cell(0, 10, "WOS Registry",
+        self.cell(0, 10, "WOS Registry -- Summary",
                   new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="L")
-        self.set_font("Helvetica", "", 9)
+        self.set_font("Helvetica", "", 8.5)
         self.set_text_color(*C_MUTED)
         self.cell(0, 5, f"Generated {self._generated_at}  |  {self._total} unit(s)",
                   new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="L")
-        self.ln(3)
+        self.ln(2)
         self.set_draw_color(*C_GRID_LINE)
         self.set_line_width(0.3)
         self.line(MARGIN, self.get_y(), PAGE_W - MARGIN, self.get_y())
@@ -325,710 +354,338 @@ class WoSReport(FPDF):
         self.set_y(-12)
         self.set_font("Helvetica", "", 8)
         self.set_text_color(*C_MUTED)
-        self.cell(0, 5, f"WOS Registry  |  {self._generated_at}  |  Page {self.page_no()}",
+        self.cell(0, 5, f"WOS Registry Summary  |  {self._generated_at}  |  Page {self.page_no()}",
                   align="C")
 
-    # ── section heading ────────────────────────────────────────────────────────
-
-    def _section_heading(self, card_x: float, label: str,
-                         bg_color: tuple = C_HEADING_BG):
-        """Render a tinted full-width section heading bar."""
-        x = card_x + CARD_PAD
-        w = CONTENT_W - CARD_PAD * 2
-        y = self.get_y() + 2
-        self.set_fill_color(*bg_color)
-        self.rect(x, y, w, 5.5, style="F")
-        self.set_xy(x + 2, y + 0.5)
-        self.set_font("Helvetica", "B", 7.5)
+    def _render_registry_snapshot(self) -> None:
+        """Render the registry snapshot header block on the first page."""
+        # Status pills row
+        self.set_font("Helvetica", "B", 9)
         self.set_text_color(*C_HEADING_TEXT)
-        self.cell(w - 4, 4.5, label.upper(),
+        self.cell(0, 6, "Registry Snapshot",
                   new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-        self.set_text_color(*C_DARK)
         self.ln(1)
 
-    # ── field row ──────────────────────────────────────────────────────────────
-
-    def _label_value(self, card_x: float, label: str, value: str, url: str = ""):
-        """Render a label + value row."""
-        self.set_x(card_x + CARD_PAD)
-        self.set_font("Helvetica", "B", 8)
-        self.set_text_color(*C_MUTED)
-        self.cell(LABEL_W, 5, label + ":",
-                  new_x=XPos.RIGHT, new_y=YPos.TOP)
-        self.set_font("Helvetica", "", 8)
-        val_w = CONTENT_W - CARD_PAD * 2 - LABEL_W
-        if url:
-            self.set_text_color(*C_LINK)
-            disp = _safe(value)
-            while disp and self.get_string_width(disp) > val_w - 4:
-                disp = disp[:-4] + "..."
-            self.cell(val_w, 5, disp, link=url,
-                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-            self.set_text_color(*C_DARK)
-        else:
-            self.set_text_color(*C_DARK)
-            self.multi_cell(val_w, 5, _safe(value),
-                            new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-
-    # ── lifecycle timeline ─────────────────────────────────────────────────────
-
-    def _render_lifecycle_timeline(self, card_x: float, uow: dict):
-        """
-        Render a visual timeline of status transitions as a row of labelled nodes.
-        Reached states are coloured; unreached states are greyed out.
-        Current status node uses the status badge colour.
-        """
-        audit_events = uow.get("_audit_events", [])
-        transitions = _extract_lifecycle_from_audit(audit_events)
-        current_status = uow.get("status", "")
-
-        # Build reached set (status -> ts)
-        reached: dict[str, str] = {t["status"]: t["ts"] for t in transitions}
-        if current_status and current_status not in reached:
-            reached[current_status] = uow.get("updated_at", "")
-
-        # Determine node sequence: canonical order, then any extra states
-        node_states = [s for s in LIFECYCLE_STATES
-                       if s in reached or s == current_status]
-        for s in reached:
-            if s not in node_states:
-                node_states.append(s)
-
-        if not node_states:
-            return
-
-        self._section_heading(card_x, "Lifecycle Timeline")
-
-        x_start = card_x + CARD_PAD + 4
-        avail_w = CONTENT_W - CARD_PAD * 2 - 8
-        y_base = self.get_y()
-
-        n = len(node_states)
-        spacing = min(avail_w / max(n, 1), 22)
-        node_r = 2.0
-
-        # Connecting line
-        if n > 1:
-            line_y = y_base + node_r + 0.5
-            self.set_draw_color(*C_PENDING_NODE)
-            self.set_line_width(0.5)
-            self.line(x_start + node_r,
-                      line_y,
-                      x_start + (n - 1) * spacing + node_r,
-                      line_y)
-
-        for i, state in enumerate(node_states):
-            nx = x_start + i * spacing
-            ny = y_base
-
-            is_current = (state == current_status)
-            is_terminal_current = is_current and state in ("done", "failed", "expired")
-            is_reached = state in reached
-
-            if is_terminal_current:
-                r, g, b = STATUS_COLORS.get(state, C_DONE_NODE)
-            elif is_current:
-                r, g, b = C_ACTIVE_NODE
-            elif is_reached:
-                r, g, b = C_DONE_NODE
-            else:
-                r, g, b = C_PENDING_NODE
-
-            self.set_fill_color(r, g, b)
-            self.set_draw_color(r, g, b)
-            self.ellipse(nx, ny, node_r * 2, node_r * 2, style="F")
-
-            # Abbreviated label (max 5 chars)
-            abbrev = {
-                "proposed": "prop",
-                "pending": "pend",
-                "ready-for-steward": "rfs",
-                "ready-for-executor": "rfe",
-                "active": "actv",
-                "diagnosing": "diag",
-                "blocked": "blkd",
-                "done": "done",
-                "failed": "fail",
-                "expired": "expd",
-            }.get(state, state[:4])
-
-            self.set_font("Helvetica", "", 5.5)
-            if is_reached or is_current:
-                self.set_text_color(*C_DARK)
-            else:
-                self.set_text_color(*C_PENDING_NODE)
-
-            lw = self.get_string_width(abbrev)
-            self.set_xy(nx + node_r - lw / 2, ny + node_r * 2 + 0.5)
-            self.cell(lw + 1, 3.5, abbrev)
-
-            # Timestamp under label for reached states
-            if is_reached and reached.get(state):
-                ts_short = _fmt_ts(reached[state], short=True)
-                self.set_font("Helvetica", "", 4.5)
-                self.set_text_color(*C_MUTED)
-                tsw = self.get_string_width(ts_short)
-                self.set_xy(nx + node_r - tsw / 2, ny + node_r * 2 + 4.2)
-                self.cell(tsw + 1, 3, ts_short)
-
-        self.set_y(y_base + node_r * 2 + 10)
-        self.set_text_color(*C_DARK)
-
-    # ── prescription ──────────────────────────────────────────────────────────
-
-    def _render_prescription(self, card_x: float, uow: dict):
-        """
-        Render what the steward prescribed to the executor:
-        agenda posture entries and the instructions written to the workflow artifact.
-        """
-        agenda_list = uow.get("_steward_agenda_list", [])
-        workflow_artifact_path = uow.get("workflow_artifact")
-        instructions = ""
-
-        if workflow_artifact_path:
-            try:
-                artifact = json.loads(Path(workflow_artifact_path).read_text())
-                instructions = artifact.get("instructions", "")
-            except Exception:
-                pass
-
-        agenda_lines = []
-        for i, entry in enumerate(agenda_list):
-            posture = entry.get("posture", "")
-            context = entry.get("context", "")
-            entry_status = entry.get("status", "")
-            if posture and context:
-                agenda_lines.append(
-                    f"Step {i + 1} [{posture}]: {context[:120]}"
-                    + (f" ({entry_status})" if entry_status else "")
-                )
-
-        if not instructions and not agenda_lines:
-            return
-
-        self._section_heading(card_x, "Steward Prescription", bg_color=C_STEWARD_BG)
-
-        inner_x = card_x + CARD_PAD + 2
-        inner_w = CONTENT_W - CARD_PAD * 2 - 4
-
-        if agenda_lines:
-            self.set_x(inner_x)
-            self.set_font("Helvetica", "B", 7)
-            self.set_text_color(*C_MUTED)
-            self.cell(inner_w, 4, "Agenda:",
-                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-            for line in agenda_lines:
-                self.set_x(inner_x + 2)
-                self.set_font("Helvetica", "", 7.5)
-                self.set_text_color(*C_DARK)
-                self.multi_cell(inner_w - 2, 4.5, _safe(line),
-                                new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-
-        if instructions:
-            self.ln(1)
-            self.set_x(inner_x)
-            self.set_font("Helvetica", "B", 7)
-            self.set_text_color(*C_MUTED)
-            self.cell(inner_w, 4, "Instructions to executor:",
-                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-            instr_display = (instructions[:400]
-                             + ("..." if len(instructions) > 400 else ""))
-            self.set_x(inner_x + 2)
-            self.set_font("Courier", "", 7)
-            self.set_text_color(55, 65, 90)
-            self.multi_cell(inner_w - 2, 4.2, _safe(instr_display),
-                            new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-
-        self.set_text_color(*C_DARK)
-        self.ln(1)
-
-    # ── steward-executor exchange ──────────────────────────────────────────────
-
-    def _render_exchange(self, card_x: float, uow: dict):
-        """
-        Render the steward-executor back-and-forth per steward_cycles:
-        diagnosis -> prescription -> executor -> re-diagnosis.
-        """
-        log_events = uow.get("_steward_log_events", [])
-        exchange = _build_steward_exchange(log_events)
-
-        if not exchange:
-            return
-
-        self._section_heading(card_x, "Steward <-> Executor Exchange")
-
-        inner_x = card_x + CARD_PAD + 2
-        inner_w = CONTENT_W - CARD_PAD * 2 - 4
-
-        # Group by cycle number
-        cycles: dict[int, list[dict]] = {}
-        for ev in exchange:
-            c = ev.get("cycle", 0)
-            cycles.setdefault(c, []).append(ev)
-
-        for cycle_num in sorted(cycles.keys()):
-            events = cycles[cycle_num]
-
-            self.set_x(inner_x)
-            self.set_font("Helvetica", "B", 7.5)
-            self.set_text_color(*C_HEADING_TEXT)
-            self.cell(inner_w, 4.5, f"Cycle {cycle_num + 1}",
-                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-            self.set_text_color(*C_DARK)
-
-            for ev in events:
-                etype = ev.get("event", "")
-                ts_short = _fmt_ts(ev.get("ts"), short=True)
-                posture = ev.get("posture", "")
-                assessment = ev.get("assessment", "")
-                return_reason = ev.get("return_reason", "")
-
-                if etype == "diagnosis":
-                    prefix = "[DIAG]"
-                    color = (75, 100, 165)
-                elif etype in ("prescription", "reentry_prescription"):
-                    prefix = "[PRSC]"
-                    color = (75, 140, 75)
-                elif etype == "steward_closure":
-                    prefix = "[CLOS]"
-                    color = (55, 145, 75)
-                elif etype == "agenda_update":
-                    prefix = "[AGND]"
-                    color = (130, 85, 160)
-                else:
-                    prefix = f"[{etype[:4].upper()}]"
-                    color = C_MUTED
-
-                parts = []
-                if posture:
-                    parts.append(f"posture={posture[:35]}")
-                if return_reason and return_reason != posture:
-                    parts.append(f"reason={return_reason[:30]}")
-                if assessment:
-                    parts.append(assessment[:65])
-
-                detail = "  ".join(parts)[:110]
-                line = f"{prefix} {ts_short}  {detail}"
-
-                self.set_x(inner_x + 3)
-                self.set_font("Courier", "", 6.5)
-                self.set_text_color(*color)
-                self.multi_cell(inner_w - 3, 4, _safe(line),
-                                new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-
-            self.ln(0.5)
-
-        self.set_text_color(*C_DARK)
-        self.ln(1)
-
-    # ── agenda stability & executor posture ────────────────────────────────────
-
-    def _render_agenda_stability(self, card_x: float, uow: dict):
-        """
-        Show steward cycle count, agenda posture evolution, prescribed skills,
-        and inferred executor posture.
-        """
-        steward_cycles = uow.get("steward_cycles", 0)
-        prescribed_skills = uow.get("_prescribed_skills", [])
-        agenda_list = uow.get("_steward_agenda_list", [])
-
-        postures_seen = [a.get("posture", "") for a in agenda_list if a.get("posture")]
-        unique_postures = list(dict.fromkeys(postures_seen))  # ordered dedup
-
-        if len(unique_postures) <= 1:
-            stability = "stable"
-        elif len(unique_postures) <= 2:
-            stability = "evolved"
-        else:
-            stability = "highly evolved"
-
-        # Executor posture from workflow artifact first, then agenda inference
-        executor_posture = ""
-        workflow_artifact_path = uow.get("workflow_artifact")
-        if workflow_artifact_path:
-            try:
-                artifact = json.loads(Path(workflow_artifact_path).read_text())
-                executor_posture = artifact.get("executor_type", "")
-            except Exception:
-                pass
-        if not executor_posture:
-            for p in unique_postures:
-                if p not in ("pending_evaluation",):
-                    executor_posture = p
-                    break
-
-        # Skip section if no meaningful data beyond the default
-        has_data = (steward_cycles > 0 or prescribed_skills or
-                    executor_posture or len(unique_postures) > 1)
-        if not has_data:
-            # Still show skills if present even on cycle-0 UoWs
-            if not prescribed_skills:
-                return
-
-        self._section_heading(card_x, "Executor Posture & Agenda", bg_color=C_EXECUTOR_BG)
-
-        inner_x = card_x + CARD_PAD + 2
-        inner_w = CONTENT_W - CARD_PAD * 2 - 4
-
-        def _row(label: str, value: str, value_color: tuple = C_DARK):
-            self.set_x(inner_x)
-            self.set_font("Helvetica", "B", 7.5)
-            self.set_text_color(*C_MUTED)
-            self.cell(32, 4.5, label,
-                      new_x=XPos.RIGHT, new_y=YPos.TOP)
-            self.set_font("Helvetica", "", 7.5)
-            self.set_text_color(*value_color)
-            self.cell(inner_w - 32, 4.5, _safe(value),
-                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-            self.set_text_color(*C_DARK)
-
-        _row("Steward cycles:", str(steward_cycles))
-
-        if unique_postures:
-            stab_color = C_DONE_NODE if stability == "stable" else (180, 100, 40)
-            posture_display = f"{stability}  ({' -> '.join(unique_postures[:5])})"
-            _row("Agenda stability:", posture_display, value_color=stab_color)
-
-        if executor_posture:
-            _row("Executor posture:", executor_posture)
-
-        if prescribed_skills:
-            _row("Skills loaded:", ", ".join(prescribed_skills))
-
-        self.ln(1)
-
-    # ── card ───────────────────────────────────────────────────────────────────
-
-    def add_uow_card(self, uow: dict):
-        """Render one UoW on its own page with all rich sections."""
-        self.add_page()
-
-        card_x = MARGIN
-
-        # ── Title + badge ─────────────────────────────────────────────────────
-        summary = _safe(uow.get("summary") or uow.get("id", ""))
-        title_w = CONTENT_W - 46  # leave room for badge
-
-        self.set_font("Helvetica", "B", 11)
-        self.set_text_color(*C_DARK)
-        self.set_x(card_x)
-        while summary and self.get_string_width(summary) > title_w:
-            summary = summary[:-4] + "..."
-        self.cell(title_w, 8, summary,
-                  new_x=XPos.RIGHT, new_y=YPos.TOP)
-
-        status = uow.get("status", "unknown")
-        r, g, b = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
-        self.set_fill_color(r, g, b)
-        self.set_text_color(255, 255, 255)
-        self.set_font("Helvetica", "B", 7.5)
-        badge_text = status.upper()
-        badge_w = max(self.get_string_width(badge_text) + 8, 28)
-        self.cell(badge_w, 8, badge_text, fill=True, align="C",
-                  new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-        self.set_text_color(*C_DARK)
-        self.ln(2)
-
-        # Separator under title
+        x = MARGIN
+        y = self.get_y()
+        for status_name, count in sorted(self._status_counts.items()):
+            sr, sg, sb = STATUS_COLORS.get(status_name, DEFAULT_STATUS_COLOR)
+            label = f"{status_name}: {count}"
+            self.set_font("Helvetica", "B", 8)
+            pill_w = self.get_string_width(label) + 10
+            if x + pill_w > PAGE_W - MARGIN:
+                x = MARGIN
+                y += 7
+            self.set_fill_color(sr, sg, sb)
+            self.set_text_color(255, 255, 255)
+            self.set_xy(x, y)
+            self.cell(pill_w, 6, label, fill=True, align="C")
+            x += pill_w + 4
+
+        self.set_y(y + 9)
         self.set_draw_color(*C_GRID_LINE)
         self.set_line_width(0.2)
-        self.line(card_x, self.get_y(), card_x + CONTENT_W, self.get_y())
-        self.ln(3)
+        self.line(MARGIN, self.get_y(), PAGE_W - MARGIN, self.get_y())
+        self.ln(5)
 
-        # ── Identity fields ────────────────────────────────────────────────────
-        self._label_value(card_x, "ID", uow.get("id", ""))
+    def _field(self, label: str, value: str, label_w: float = 40,
+               value_color: tuple = C_DARK, bold_value: bool = False) -> None:
+        """Render a label + value row, wrapping value if needed."""
+        self.set_font("Helvetica", "B", 8)
+        self.set_text_color(*C_MUTED)
+        self.cell(label_w, 5.5, label + ":", new_x=XPos.RIGHT, new_y=YPos.TOP)
+        self.set_font("Helvetica", "B" if bold_value else "", 8)
+        self.set_text_color(*value_color)
+        val_w = CONTENT_W - label_w
+        self.multi_cell(val_w, 5.5, _safe(value),
+                        new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.set_text_color(*C_DARK)
+
+    def add_uow_card(self, uow: dict) -> None:
+        """Render one UoW summary card. Each card gets its own page."""
+        self.add_page()
+
+        status = uow.get("status", "unknown")
+        sr, sg, sb = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
+        anomalies = _detect_anomalies(uow)
+        has_anomaly = bool(anomalies)
+
+        # ── Anomaly banner (if any) ────────────────────────────────────────────
+        if has_anomaly:
+            self.set_fill_color(*C_ANOMALY_BG)
+            self.set_draw_color(*C_ANOMALY_TEXT)
+            self.set_line_width(0.5)
+            self.rect(MARGIN, self.get_y(), CONTENT_W, 7, style="FD")
+            self.set_x(MARGIN + 3)
+            self.set_font("Helvetica", "B", 8.5)
+            self.set_text_color(*C_ANOMALY_TEXT)
+            anomaly_text = "ANOMALY: " + "  |  ".join(anomalies)
+            self.cell(CONTENT_W - 6, 7, _safe(anomaly_text[:120]),
+                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+            self.set_line_width(0.2)
+            self.ln(3)
+
+        # ── Title + status badge ────────────────────────────────────────────────
+        summary = _safe(uow.get("summary") or uow.get("id", ""))
+        badge_text = status.upper()
+        badge_w = max(self.get_string_width(badge_text) + 10, 32)
+        title_w = CONTENT_W - badge_w - 4
+
+        self.set_font("Helvetica", "B", 12)
+        self.set_text_color(*C_DARK)
+        self.set_x(MARGIN)
+
+        # Truncate title to fit available width
+        while summary and self.get_string_width(summary) > title_w - 2:
+            summary = summary[:-4] + "..."
+
+        y_title = self.get_y()
+        self.set_xy(MARGIN, y_title)
+        self.cell(title_w, 9, summary, new_x=XPos.RIGHT, new_y=YPos.TOP)
+
+        # Status badge — filled pill
+        self.set_fill_color(sr, sg, sb)
+        self.set_text_color(255, 255, 255)
+        self.set_font("Helvetica", "B", 8.5)
+        self.cell(badge_w, 9, badge_text, fill=True, align="C",
+                  new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.set_text_color(*C_DARK)
+        self.ln(1)
+
+        # Separator
+        self.set_draw_color(*C_GRID_LINE)
+        self.set_line_width(0.2)
+        self.line(MARGIN, self.get_y(), MARGIN + CONTENT_W, self.get_y())
+        self.ln(4)
+
+        # ── Identity block ──────────────────────────────────────────────────────
+        self._field("ID", uow.get("id", ""))
+        self._field("Type", uow.get("type") or "executable")
 
         source_url = _source_url(uow.get("source"), uow.get("source_issue_number"))
-        source_display = uow.get("source") or source_url
-        self._label_value(card_x, "Source", source_display or "(none)", url=source_url)
-
-        self._label_value(card_x, "Created", _fmt_ts(uow.get("created_at")))
-        if uow.get("started_at"):
-            self._label_value(card_x, "Started", _fmt_ts(uow.get("started_at")))
-        if uow.get("completed_at"):
-            self._label_value(card_x, "Completed", _fmt_ts(uow.get("completed_at")))
+        source_display = uow.get("source") or source_url or "(none)"
+        self.set_font("Helvetica", "B", 8)
+        self.set_text_color(*C_MUTED)
+        self.cell(40, 5.5, "Source:", new_x=XPos.RIGHT, new_y=YPos.TOP)
+        self.set_font("Helvetica", "", 8)
+        val_w = CONTENT_W - 40
+        if source_url:
+            self.set_text_color(*C_LINK)
+            disp = _safe(source_display)
+            while disp and self.get_string_width(disp) > val_w - 4:
+                disp = disp[:-4] + "..."
+            self.cell(val_w, 5.5, disp, link=source_url,
+                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
         else:
-            self._label_value(card_x, "Updated", _fmt_ts(uow.get("updated_at")))
+            self.set_text_color(*C_DARK)
+            self.multi_cell(val_w, 5.5, _safe(source_display),
+                            new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.set_text_color(*C_DARK)
 
+        self.ln(3)
+
+        # ── Timing block ────────────────────────────────────────────────────────
+        self.set_fill_color(*C_HEADING_BG)
+        self.set_x(MARGIN)
+        self.set_font("Helvetica", "B", 7.5)
+        self.set_text_color(*C_HEADING_TEXT)
+        self.cell(CONTENT_W, 5.5, "  EXECUTION TIME",
+                  fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.ln(1.5)
+
+        created_ts = uow.get("created_at", "")
+        started_ts = uow.get("started_at", "")
+        completed_ts = uow.get("completed_at", "")
+        updated_ts = uow.get("updated_at", "")
+
+        self._field("Created", _fmt_ts(created_ts))
+        if started_ts:
+            self._field("Started", _fmt_ts(started_ts))
+        if completed_ts:
+            self._field("Completed", _fmt_ts(completed_ts))
+            duration = _duration_str(started_ts or created_ts, completed_ts)
+            if duration:
+                self._field("Total duration", duration, bold_value=True)
+        else:
+            self._field("Last updated", _fmt_ts(updated_ts))
+            if started_ts:
+                duration = _duration_str(started_ts, updated_ts)
+                if duration:
+                    self._field("Elapsed (so far)", duration)
+
+        self.ln(3)
+
+        # ── Steward cycles health signal ────────────────────────────────────────
+        steward_cycles = uow.get("steward_cycles", 0) or 0
+        self.set_fill_color(*C_HEADING_BG)
+        self.set_x(MARGIN)
+        self.set_font("Helvetica", "B", 7.5)
+        self.set_text_color(*C_HEADING_TEXT)
+        self.cell(CONTENT_W, 5.5, "  STEWARD HEALTH",
+                  fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.ln(1.5)
+
+        if steward_cycles == 0:
+            cycle_color = C_MUTED
+            cycle_signal = "0 — not yet processed"
+        elif steward_cycles == 1:
+            cycle_color = C_CYCLE_OK
+            cycle_signal = "1 — healthy (single-pass)"
+        else:
+            cycle_color = C_CYCLE_WARN
+            cycle_signal = f"{steward_cycles} — investigate (multiple cycles)"
+
+        self._field("Steward cycles", cycle_signal, value_color=cycle_color, bold_value=True)
+
+        skills = uow.get("_prescribed_skills", [])
+        if skills:
+            self._field("Skills loaded", ", ".join(skills))
+
+        self.ln(3)
+
+        # ── PRSC reason ─────────────────────────────────────────────────────────
+        log_events = uow.get("_steward_log_events", [])
+        prsc_reason = _extract_first_prsc_reason(log_events)
         success_criteria = (uow.get("success_criteria") or "").strip()
+
+        self.set_fill_color(*C_HEADING_BG)
+        self.set_x(MARGIN)
+        self.set_font("Helvetica", "B", 7.5)
+        self.set_text_color(*C_HEADING_TEXT)
+        self.cell(CONTENT_W, 5.5, "  PRESCRIPTION & CRITERIA",
+                  fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.ln(1.5)
+
+        if prsc_reason:
+            self._field("PRSC reason", prsc_reason)
+        else:
+            self.set_font("Helvetica", "I", 8)
+            self.set_text_color(*C_MUTED)
+            self.set_x(MARGIN)
+            self.cell(CONTENT_W, 5.5, "No prescription recorded yet",
+                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+            self.set_text_color(*C_DARK)
+
         if success_criteria:
-            self._label_value(card_x, "Success criteria", success_criteria)
+            self._field("Success criteria", success_criteria)
 
-        self.ln(2)
+        self.ln(3)
 
-        # ── Rich sections ──────────────────────────────────────────────────────
-        self._render_lifecycle_timeline(card_x, uow)
-        self._render_agenda_stability(card_x, uow)
-        self._render_prescription(card_x, uow)
-        self._render_exchange(card_x, uow)
+        # ── Outcome ─────────────────────────────────────────────────────────────
+        outcome = _extract_outcome_summary(log_events, uow)
+
+        self.set_fill_color(*C_HEADING_BG)
+        self.set_x(MARGIN)
+        self.set_font("Helvetica", "B", 7.5)
+        self.set_text_color(*C_HEADING_TEXT)
+        self.cell(CONTENT_W, 5.5, "  OUTCOME",
+                  fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+        self.ln(1.5)
+
+        if status in TERMINAL_STATUSES:
+            status_display = status.upper()
+            outcome_color = C_DONE if status == "done" else C_ANOMALY_TEXT
+            self._field("Final status", status_display,
+                        value_color=outcome_color, bold_value=True)
+
+        if outcome:
+            self._field("Summary", outcome)
+        else:
+            self.set_font("Helvetica", "I", 8)
+            self.set_text_color(*C_MUTED)
+            self.set_x(MARGIN)
+            self.cell(CONTENT_W, 5.5, "No outcome recorded",
+                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+            self.set_text_color(*C_DARK)
+
+        # Output ref (if any)
+        output_ref = uow.get("output_ref")
+        if output_ref:
+            self._field("Output ref", output_ref)
+
+        if has_anomaly:
+            self.ln(3)
+            self.set_font("Helvetica", "B", 8)
+            self.set_text_color(*C_ANOMALY_TEXT)
+            self.set_x(MARGIN)
+            self.cell(CONTENT_W, 5, "See full report for complete logs and audit trail.",
+                      new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+            self.set_text_color(*C_DARK)
 
 
-# ── summary index page ─────────────────────────────────────────────────────────
+def _render_index_page(pdf: SummaryReport, uows: list[dict]) -> None:
+    """Render the registry snapshot + index table on the first page."""
+    pdf._render_registry_snapshot()
 
-def _render_index_page(pdf: WoSReport, uows: list[dict]) -> None:
-    """Render a status-summary bar and index table on the first page."""
-    # Status pill summary
+    # Index table
+    col_widths = [14, 70, 22, 28, 14, 14]
+    col_headers = ["#", "Summary", "Status", "Created", "Cycles", "Anomaly"]
+
+    pdf.set_fill_color(*C_HEADING_BG)
+    pdf.set_font("Helvetica", "B", 7.5)
+    pdf.set_text_color(*C_HEADING_TEXT)
+    hx = MARGIN
+    hy = pdf.get_y()
+    for w, h in zip(col_widths, col_headers):
+        pdf.set_xy(hx, hy)
+        pdf.cell(w, 5.5, h, border=0, fill=True, align="L")
+        hx += w
+    pdf.ln(6)
+
+    for i, uow in enumerate(uows):
+        row_y = pdf.get_y()
+        row_bg = (250, 250, 252) if i % 2 == 0 else (255, 255, 255)
+        pdf.set_fill_color(*row_bg)
+        pdf.rect(MARGIN, row_y, sum(col_widths), 5.5, style="F")
+
+        status = uow.get("status", "")
+        sr, sg, sb = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
+        anomalies = _detect_anomalies(uow)
+
+        values = [
+            str(i + 1),
+            _safe((uow.get("summary") or "")[:65]),
+            status.upper()[:14],
+            _fmt_ts(uow.get("created_at"), short=True),
+            str(uow.get("steward_cycles", 0) or 0),
+            "YES" if anomalies else "-",
+        ]
+        aligns = ["C", "L", "L", "L", "C", "C"]
+
+        rx = MARGIN
+        for j, (w, val, align) in enumerate(zip(col_widths, values, aligns)):
+            pdf.set_xy(rx, row_y)
+            if j == 2:
+                pdf.set_text_color(sr, sg, sb)
+                pdf.set_font("Helvetica", "B", 7)
+            elif j == 5 and anomalies:
+                pdf.set_text_color(*C_ANOMALY_TEXT)
+                pdf.set_font("Helvetica", "B", 7)
+            else:
+                pdf.set_text_color(*C_DARK)
+                pdf.set_font("Helvetica", "", 7)
+            pdf.cell(w, 5.5, val, border=0, align=align)
+            rx += w
+        pdf.ln(5.5)
+
+    pdf.set_text_color(*C_DARK)
+    pdf.ln(3)
+
+
+def generate_pdf(uows: list[dict], output_path: Path) -> Path:
+    """Render the summary PDF and save to output_path."""
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
     status_counts: dict[str, int] = {}
     for u in uows:
         s = u.get("status", "unknown")
         status_counts[s] = status_counts.get(s, 0) + 1
 
-    pdf.set_font("Helvetica", "B", 9)
-    pdf.set_text_color(*C_HEADING_TEXT)
-    pdf.cell(0, 6, "Status Summary",
-             new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-    pdf.ln(1)
-
-    x = MARGIN
-    y = pdf.get_y()
-    for status_name, count in sorted(status_counts.items()):
-        sr, sg, sb = STATUS_COLORS.get(status_name, DEFAULT_STATUS_COLOR)
-        label = f"{status_name}: {count}"
-        pdf.set_font("Helvetica", "B", 7.5)
-        pill_w = pdf.get_string_width(label) + 8
-        if x + pill_w > PAGE_W - MARGIN:
-            x = MARGIN
-            y += 7
-        pdf.set_fill_color(sr, sg, sb)
-        pdf.set_text_color(255, 255, 255)
-        pdf.set_xy(x, y)
-        pdf.cell(pill_w, 5.5, label, fill=True, align="C")
-        x += pill_w + 3
-
-    pdf.ln(10)
-
-    # Column layout
-    col_widths = [12, 66, 22, 22, 14, 20]
-    col_headers = ["ID", "Summary", "Status", "Created", "Cyles", "Skills"]
-
-    # Header row
-    pdf.set_fill_color(*C_HEADING_BG)
-    pdf.set_font("Helvetica", "B", 7.5)
-    pdf.set_text_color(*C_HEADING_TEXT)
-    hx = MARGIN
-    hy = pdf.get_y() + 2
-    for w, h in zip(col_widths, col_headers):
-        pdf.set_xy(hx, hy)
-        pdf.cell(w, 5.5, h, border=0, fill=True, align="L")
-        hx += w
-    pdf.ln(7)
-
-    # Data rows
-    for i, uow in enumerate(uows):
-        row_y = pdf.get_y()
-        row_bg = (250, 250, 252) if i % 2 == 0 else (255, 255, 255)
-        pdf.set_fill_color(*row_bg)
-        pdf.rect(MARGIN, row_y, sum(col_widths), 5, style="F")
-
-        status = uow.get("status", "")
-        sr, sg, sb = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
-        skills = uow.get("_prescribed_skills", [])
-
-        values = [
-            _safe(uow.get("id", "")[-6:]),
-            _safe((uow.get("summary") or "")[:62]),
-            status.upper()[:12],
-            _fmt_ts(uow.get("created_at"), short=True),
-            str(uow.get("steward_cycles", 0)),
-            ",".join(skills)[:18] or "-",
-        ]
-        aligns = ["L", "L", "L", "L", "C", "L"]
-
-        rx = MARGIN
-        for j, (w, val, align) in enumerate(zip(col_widths, values, aligns)):
-            pdf.set_xy(rx, row_y)
-            if j == 2:
-                pdf.set_text_color(sr, sg, sb)
-                pdf.set_font("Helvetica", "B", 7)
-            else:
-                pdf.set_text_color(*C_DARK)
-                pdf.set_font("Helvetica", "", 7)
-            pdf.cell(w, 5, val, border=0, align=align)
-            rx += w
-        pdf.ln(5)
-
-    pdf.ln(3)
-    pdf.set_draw_color(*C_GRID_LINE)
-    pdf.set_line_width(0.3)
-    pdf.line(MARGIN, pdf.get_y(), PAGE_W - MARGIN, pdf.get_y())
-
-
-# ── prescription quality page ─────────────────────────────────────────────────
-
-def _render_prescription_quality_page(pdf: WoSReport) -> None:
-    """
-    Render a Prescription Quality summary page using analytics.prescription_quality_summary().
-
-    Reads directly from the registry DB (same path REGISTRY_DB points to).
-    If data is sparse, renders the data_gap note instead of an empty table.
-    """
-    try:
-        summary = prescription_quality_summary(registry_path=REGISTRY_DB)
-    except Exception as exc:  # noqa: BLE001
-        # Don't let an analytics failure break the whole report
-        summary = {
-            "per_uow": [],
-            "aggregate": {
-                "total_uows": 0, "uows_with_data": 0,
-                "avg_cycles_to_done": None,
-                "pct_llm": None, "pct_fallback": None,
-                "total_prescriptions": 0,
-                "llm_prescriptions": 0, "fallback_prescriptions": 0,
-            },
-            "data_gap": f"analytics error: {exc}",
-        }
-
-    pdf.add_page()
-
-    # Section title
-    pdf.set_font("Helvetica", "B", 12)
-    pdf.set_text_color(*C_HEADING_TEXT)
-    pdf.cell(0, 8, "Prescription Quality",
-             new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="L")
-    pdf.set_draw_color(*C_GRID_LINE)
-    pdf.set_line_width(0.3)
-    pdf.line(MARGIN, pdf.get_y(), PAGE_W - MARGIN, pdf.get_y())
-    pdf.ln(4)
-    pdf.set_text_color(*C_DARK)
-
-    agg = summary["aggregate"]
-    data_gap = summary.get("data_gap")
-
-    # ── Aggregate metrics ──────────────────────────────────────────────────────
-    pdf.set_font("Helvetica", "B", 9)
-    pdf.set_text_color(*C_HEADING_TEXT)
-    pdf.set_fill_color(*C_HEADING_BG)
-    pdf.cell(CONTENT_W, 5.5, "  AGGREGATE METRICS",
-             fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-    pdf.ln(2)
-    pdf.set_text_color(*C_DARK)
-
-    def _metric_row(label: str, value: str) -> None:
-        pdf.set_font("Helvetica", "B", 8)
-        pdf.set_text_color(*C_MUTED)
-        pdf.cell(60, 5, label + ":", new_x=XPos.RIGHT, new_y=YPos.TOP)
-        pdf.set_font("Helvetica", "", 8)
-        pdf.set_text_color(*C_DARK)
-        pdf.cell(CONTENT_W - 60, 5, value, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-
-    _metric_row("Total UoWs", str(agg["total_uows"]))
-    _metric_row("UoWs with prescription data", str(agg["uows_with_data"]))
-    _metric_row("Total prescriptions", str(agg["total_prescriptions"]))
-
-    if agg["pct_llm"] is not None:
-        _metric_row(
-            "LLM prescriptions",
-            f"{agg['llm_prescriptions']}  ({agg['pct_llm']}%)",
-        )
-        _metric_row(
-            "Fallback prescriptions",
-            f"{agg['fallback_prescriptions']}  ({agg['pct_fallback']}%)",
-        )
-    else:
-        _metric_row("LLM / Fallback split", "no prescription data yet")
-
-    if agg["avg_cycles_to_done"] is not None:
-        _metric_row(
-            "Avg cycles to done",
-            f"{agg['avg_cycles_to_done']:.1f}",
-        )
-    else:
-        _metric_row("Avg cycles to done", "no completed UoWs yet")
-
-    pdf.ln(4)
-
-    # ── Data gap note ──────────────────────────────────────────────────────────
-    if data_gap:
-        pdf.set_font("Helvetica", "I", 8)
-        pdf.set_text_color(140, 100, 40)
-        pdf.multi_cell(CONTENT_W, 5, _safe(f"Note: {data_gap}"),
-                       new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-        pdf.ln(3)
-        pdf.set_text_color(*C_DARK)
-
-    # ── Per-UoW table ──────────────────────────────────────────────────────────
-    per_uow = summary["per_uow"]
-    uows_with_data = [r for r in per_uow if r["prescription_paths"]]
-
-    if not uows_with_data:
-        pdf.set_font("Helvetica", "I", 8)
-        pdf.set_text_color(*C_MUTED)
-        pdf.cell(0, 5, "No per-UoW prescription data to display.",
-                 new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-        return
-
-    pdf.set_font("Helvetica", "B", 9)
-    pdf.set_text_color(*C_HEADING_TEXT)
-    pdf.set_fill_color(*C_HEADING_BG)
-    pdf.cell(CONTENT_W, 5.5, "  PER-UOW BREAKDOWN",
-             fill=True, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-    pdf.ln(2)
-
-    # Table headers
-    col_widths = [12, 58, 22, 14, 16, 16, 44]
-    col_headers = ["ID", "Summary", "Status", "Cycles", "LLM", "Fallback", "Path sequence"]
-
-    pdf.set_fill_color(*C_HEADING_BG)
-    pdf.set_font("Helvetica", "B", 7.5)
-    pdf.set_text_color(*C_HEADING_TEXT)
-    hx = MARGIN
-    hy = pdf.get_y() + 1
-    for w, h in zip(col_widths, col_headers):
-        pdf.set_xy(hx, hy)
-        pdf.cell(w, 5, h, border=0, fill=True, align="L")
-        hx += w
-    pdf.ln(6)
-
-    # Table rows
-    for i, rec in enumerate(uows_with_data):
-        row_y = pdf.get_y()
-        row_bg = (250, 250, 252) if i % 2 == 0 else (255, 255, 255)
-        pdf.set_fill_color(*row_bg)
-        pdf.rect(MARGIN, row_y, sum(col_widths), 5, style="F")
-
-        status = rec.get("status", "")
-        sr, sg, sb = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
-
-        # Compact path display: e.g. "llm llm fallback" → "L L F"
-        path_abbrev = " ".join(
-            "L" if p == "llm" else "F" for p in rec["prescription_paths"][:10]
-        )
-        if len(rec["prescription_paths"]) > 10:
-            path_abbrev += "..."
-
-        values = [
-            _safe(rec["id"][-6:]),
-            _safe((rec["summary"] or "")[:55]),
-            status.upper()[:12],
-            str(rec["steward_cycles"]),
-            str(rec["llm_count"]),
-            str(rec["fallback_count"]),
-            _safe(path_abbrev),
-        ]
-        aligns = ["L", "L", "L", "C", "C", "C", "L"]
-
-        rx = MARGIN
-        for j, (w, val, align) in enumerate(zip(col_widths, values, aligns)):
-            pdf.set_xy(rx, row_y)
-            if j == 2:
-                pdf.set_text_color(sr, sg, sb)
-                pdf.set_font("Helvetica", "B", 7)
-            else:
-                pdf.set_text_color(*C_DARK)
-                pdf.set_font("Helvetica", "", 7)
-            pdf.cell(w, 5, val, border=0, align=align)
-            rx += w
-        pdf.ln(5)
-
-    pdf.set_text_color(*C_DARK)
-
-
-# ── PDF generation ────────────────────────────────────────────────────────────
-
-def generate_pdf(uows: list[dict], output_path: Path) -> Path:
-    """Render the WOS report PDF and save it to output_path."""
-    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    pdf = WoSReport(total=len(uows), generated_at=generated_at)
+    pdf = SummaryReport(
+        total=len(uows),
+        generated_at=generated_at,
+        status_counts=status_counts,
+    )
     pdf.set_margins(MARGIN, MARGIN, MARGIN)
     pdf.set_auto_page_break(auto=True, margin=18)
     pdf.add_page()
@@ -1040,12 +697,213 @@ def generate_pdf(uows: list[dict], output_path: Path) -> Path:
                  new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="C")
     else:
         _render_index_page(pdf, uows)
-        _render_prescription_quality_page(pdf)
         for uow in uows:
             pdf.add_uow_card(uow)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     pdf.output(str(output_path))
+    return output_path
+
+
+# ── Full markdown report ───────────────────────────────────────────────────────
+
+def generate_full_report(uows: list[dict], output_path: Path) -> Path:
+    """
+    Write a full investigation-grade markdown report.
+    All DB fields, full JSON logs, audit trail, output_ref content.
+    No truncation of any field.
+    """
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines: list[str] = []
+
+    lines.append(f"# WOS Full Investigation Report")
+    lines.append(f"")
+    lines.append(f"Generated: {generated_at}")
+    lines.append(f"UoWs included: {len(uows)}")
+    lines.append(f"")
+
+    # Registry snapshot
+    status_counts: dict[str, int] = {}
+    for u in uows:
+        s = u.get("status", "unknown")
+        status_counts[s] = status_counts.get(s, 0) + 1
+
+    lines.append("## Registry Snapshot")
+    lines.append("")
+    for status, count in sorted(status_counts.items()):
+        lines.append(f"- **{status}**: {count}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # Per-UoW sections
+    for uow in uows:
+        uow_id = uow.get("id", "unknown")
+        status = uow.get("status", "unknown")
+        anomalies = _detect_anomalies(uow)
+
+        lines.append(f"## {uow_id}")
+        lines.append("")
+
+        if anomalies:
+            lines.append("> **ANOMALY DETECTED**")
+            for a in anomalies:
+                lines.append(f"> - {a}")
+            lines.append("")
+
+        # ── Core fields ────────────────────────────────────────────────────────
+        lines.append("### Core Fields")
+        lines.append("")
+
+        core_fields = [
+            ("id", "ID"),
+            ("status", "Status"),
+            ("type", "Type"),
+            ("posture", "Posture"),
+            ("source", "Source"),
+            ("summary", "Summary"),
+            ("success_criteria", "Success Criteria"),
+            ("route_reason", "Route Reason"),
+            ("output_ref", "Output Ref"),
+            ("workflow_artifact", "Workflow Artifact"),
+            ("steward_cycles", "Steward Cycles"),
+            ("created_at", "Created"),
+            ("started_at", "Started"),
+            ("completed_at", "Completed"),
+            ("updated_at", "Updated"),
+        ]
+        for db_key, label in core_fields:
+            val = uow.get(db_key)
+            if val is not None and str(val).strip():
+                lines.append(f"**{label}**: {val}")
+        lines.append("")
+
+        # Timing summary
+        started_ts = uow.get("started_at", "")
+        completed_ts = uow.get("completed_at", "")
+        created_ts = uow.get("created_at", "")
+        duration = _duration_str(started_ts or created_ts, completed_ts or uow.get("updated_at", ""))
+        if duration:
+            lines.append(f"**Total duration**: {duration}")
+            lines.append("")
+
+        # ── Notes ──────────────────────────────────────────────────────────────
+        notes_raw = uow.get("notes")
+        if notes_raw:
+            lines.append("### Notes")
+            lines.append("")
+            lines.append("```json")
+            try:
+                lines.append(json.dumps(json.loads(notes_raw), indent=2))
+            except Exception:
+                lines.append(str(notes_raw))
+            lines.append("```")
+            lines.append("")
+
+        # ── Steward log ────────────────────────────────────────────────────────
+        steward_log_raw = uow.get("steward_log")
+        if steward_log_raw:
+            lines.append("### Steward Log (full)")
+            lines.append("")
+            for ev in uow.get("_steward_log_events", []):
+                lines.append("```json")
+                lines.append(json.dumps(ev, indent=2))
+                lines.append("```")
+                lines.append("")
+        else:
+            lines.append("### Steward Log")
+            lines.append("")
+            lines.append("_(no steward log recorded)_")
+            lines.append("")
+
+        # ── Audit log ─────────────────────────────────────────────────────────
+        audit_events = uow.get("_audit_events", [])
+        lines.append("### Audit Log (full)")
+        lines.append("")
+        if audit_events:
+            lines.append("| Timestamp | Event | From | To | Note |")
+            lines.append("|-----------|-------|------|----|------|")
+            for ev in audit_events:
+                ts = ev.get("ts", "")
+                event = ev.get("event", "")
+                from_s = ev.get("from_status", "") or ""
+                to_s = ev.get("to_status", "") or ""
+                note = (ev.get("note") or "").replace("|", "\\|").replace("\n", " ")
+                lines.append(f"| {ts} | {event} | {from_s} | {to_s} | {note} |")
+        else:
+            lines.append("_(no audit events)_")
+        lines.append("")
+
+        # ── Steward agenda ─────────────────────────────────────────────────────
+        steward_agenda_raw = uow.get("steward_agenda")
+        if steward_agenda_raw:
+            lines.append("### Steward Agenda (full)")
+            lines.append("")
+            lines.append("```json")
+            try:
+                lines.append(json.dumps(json.loads(steward_agenda_raw), indent=2))
+            except Exception:
+                lines.append(steward_agenda_raw)
+            lines.append("```")
+            lines.append("")
+
+        # ── Prescribed skills ──────────────────────────────────────────────────
+        skills = uow.get("_prescribed_skills", [])
+        if skills:
+            lines.append("### Prescribed Skills")
+            lines.append("")
+            for sk in skills:
+                lines.append(f"- {sk}")
+            lines.append("")
+
+        # ── Output ref content ─────────────────────────────────────────────────
+        output_ref = uow.get("output_ref")
+        if output_ref:
+            lines.append("### Output Ref Content")
+            lines.append("")
+            output_path_ref = Path(output_ref)
+            if output_path_ref.exists():
+                try:
+                    content = output_path_ref.read_text(errors="replace")
+                    lines.append(f"_Path: `{output_ref}`_")
+                    lines.append("")
+                    lines.append("```")
+                    lines.append(content)
+                    lines.append("```")
+                except Exception as exc:
+                    lines.append(f"_Could not read output_ref: {exc}_")
+            else:
+                lines.append(f"_Path: `{output_ref}` — file does not exist_")
+            lines.append("")
+
+        # ── Workflow artifact content ──────────────────────────────────────────
+        workflow_artifact = uow.get("workflow_artifact")
+        if workflow_artifact:
+            lines.append("### Workflow Artifact Content")
+            lines.append("")
+            artifact_path = Path(workflow_artifact)
+            if artifact_path.exists():
+                try:
+                    content = artifact_path.read_text(errors="replace")
+                    lines.append(f"_Path: `{workflow_artifact}`_")
+                    lines.append("")
+                    lines.append("```json")
+                    try:
+                        lines.append(json.dumps(json.loads(content), indent=2))
+                    except Exception:
+                        lines.append(content)
+                    lines.append("```")
+                except Exception as exc:
+                    lines.append(f"_Could not read workflow artifact: {exc}_")
+            else:
+                lines.append(f"_Path: `{workflow_artifact}` — file does not exist_")
+            lines.append("")
+
+        lines.append("---")
+        lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines), encoding="utf-8")
     return output_path
 
 
@@ -1068,11 +926,7 @@ def _load_bot_token() -> str:
 
 
 def send_document_direct(pdf_path: Path, chat_id: int, caption: str = "") -> None:
-    """Send the PDF directly to Telegram via the Bot API (sendDocument).
-
-    Uses urllib multipart/form-data upload — no subprocess or external binary required.
-    The bot token stays in-process and is never exposed in command arguments.
-    """
+    """Send the PDF directly to Telegram via the Bot API (sendDocument)."""
     import mimetypes
     import urllib.request
 
@@ -1122,13 +976,15 @@ def send_document_direct(pdf_path: Path, chat_id: int, caption: str = "") -> Non
 
 def main(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(
-        description="Generate WOS Registry PDF report",
+        description="Generate WOS Registry reports (summary PDF and/or full markdown)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--chat-id", type=int, default=DEFAULT_CHAT_ID,
-                        help="Telegram chat ID to send to (default: %(default)s)")
+                        help="Telegram chat ID to send PDF to (default: %(default)s)")
     parser.add_argument("--output", type=Path,
-                        help="Output PDF path (default: auto-named in ~/messages/documents/)")
+                        help="Output PDF path — generates summary PDF (default: auto-named in ~/messages/documents/)")
+    parser.add_argument("--full-output", type=Path,
+                        help="Output markdown path — generates full investigation report")
     parser.add_argument("--no-send", action="store_true",
                         help="Generate PDF but do not send to Telegram")
     parser.add_argument("--status", type=str, default=None,
@@ -1141,22 +997,17 @@ def main(argv: list[str] | None = None):
                         help="Include only the specified UoW IDs (comma-separated)")
     args = parser.parse_args(argv)
 
-    # Resolve output path
-    if args.output:
-        output_path = Path(args.output)
-    else:
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        # Use ~/messages/documents/ visible to lobster-router.
-        # /tmp is private to the systemd service (PrivateTmp=true), so PDFs
-        # written there are invisible to the bot process.
-        pdf_dir = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages")) / "documents"
-        pdf_dir.mkdir(parents=True, exist_ok=True)
-        output_path = pdf_dir / f"wos-report-{ts}.pdf"
-
     # Parse --ids into a list (None means no ID filter)
     ids_filter: list[str] | None = None
     if args.ids:
         ids_filter = [i.strip() for i in args.ids.split(",") if i.strip()]
+
+    # Require at least one output flag
+    if not args.output and not args.full_output:
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        pdf_dir = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages")) / "documents"
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        args.output = pdf_dir / f"wos-report-{ts}.pdf"
 
     print(f"Loading registry from {REGISTRY_DB}...")
     uows = fetch_uows(
@@ -1166,12 +1017,22 @@ def main(argv: list[str] | None = None):
     )
     print(f"Found {len(uows)} unit(s) of work")
 
-    print(f"Generating PDF: {output_path}")
-    generate_pdf(uows, output_path)
-    print(f"PDF written: {output_path} ({output_path.stat().st_size:,} bytes)")
+    output_pdf: Path | None = None
+    output_md: Path | None = None
 
-    if not args.no_send:
-        # Build a descriptive caption
+    if args.output:
+        output_pdf = Path(args.output)
+        print(f"Generating summary PDF: {output_pdf}")
+        generate_pdf(uows, output_pdf)
+        print(f"Summary PDF written: {output_pdf} ({output_pdf.stat().st_size:,} bytes)")
+
+    if args.full_output:
+        output_md = Path(args.full_output)
+        print(f"Generating full report: {output_md}")
+        generate_full_report(uows, output_md)
+        print(f"Full report written: {output_md} ({output_md.stat().st_size:,} bytes)")
+
+    if output_pdf and not args.no_send:
         filters: list[str] = []
         if args.status:
             filters.append(f"status={args.status}")
@@ -1184,12 +1045,17 @@ def main(argv: list[str] | None = None):
         if filter_str:
             caption += f", {filter_str}"
         caption += f") -- {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
-        send_document_direct(output_path, args.chat_id, caption)
-        print(f"Sent PDF directly to Telegram chat {args.chat_id}")
-    else:
+        send_document_direct(output_pdf, args.chat_id, caption)
+        print(f"Sent summary PDF to Telegram chat {args.chat_id}")
+    elif output_pdf:
         print("--no-send: skipping Telegram delivery")
 
-    return str(output_path)
+    results = []
+    if output_pdf:
+        results.append(str(output_pdf))
+    if output_md:
+        results.append(str(output_md))
+    return results[0] if len(results) == 1 else results
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this solves

The current WOS report is a single PDF that tries to do two things at once and does neither well: it shows verbose steward-executor log dumps (the [AGND]/[DIAG]/[PRSC]/[CLOS] exchange) at tiny font alongside truncated key fields, making it hard to read as a summary and inadequate for debugging. Dan flagged this: confusing layout, fields cut off.

## Two formats, two audiences

**Summary PDF** (Dan's report -- `--output`) replaces the verbose per-UoW card:
- Registry snapshot header: total UoWs + status pills
- Index table with anomaly flag column
- Per-UoW cards: status badge prominent at top-right, anomaly banner in red if anything is wrong, then clean sections: Execution Time (start/end/total duration), Steward Health (cycle count with explicit health signal: 1 = healthy, 2+ = investigate), Prescription & Criteria (PRSC reason = the first prescription reason that sent the UoW to executor), Outcome (final status + completion summary + output ref)
- No verbose log dumps, no truncated fields, no decoder-ring label prefixes
- Anomalies surface immediately at the top of the card

**Full markdown report** (internal -- `--full-output`) for investigation:
- All DB fields, untruncated
- Full steward_log JSON per event
- Full audit_log table
- Notes, steward_agenda, prescribed skills
- output_ref file content (reads and embeds)
- Workflow artifact content (reads and embeds)

## CLI changes

`--full-output PATH` added. Both flags can be used together:
```
wos_report.py --ids ... --output summary.pdf --full-output full.md
```
When neither flag is given, defaults to auto-named summary PDF (same as before).

## RALPH loop updated

Step 5 now generates both reports automatically after each cycle and sends the summary PDF to Dan. The full markdown goes to `ralph-reports/wos-full-{timestamp}.md`.

## Functional patterns used

Pure functions for all data extraction (`_extract_first_prsc_reason`, `_extract_outcome_summary`, `_detect_anomalies`, `_duration_str`) -- each takes a UoW dict and returns a value with no side effects. Composition: `generate_pdf` and `generate_full_report` call the same `fetch_uows` and data-extraction functions. The PDF renderer and markdown writer are separate classes/functions that share no mutable state.

## Tests run

- [x] `uv run python3 -c "from src.wos_report import main; main([...])"` with cycle 3 UoW IDs, `--output /tmp/test-summary.pdf --full-output /tmp/test-full.md --no-send` -- both files written, 7,917 bytes PDF, 30,580 bytes markdown, 4 UoWs rendered, exit 0
- [x] Summary PDF sent to Dan with caption "Redesigned summary report -- cycle 3" for visual comparison
- [x] Full report verified: all 4 UoWs present, full steward_log JSON per event, full audit_log table, output_ref content embedded

## Manual test

Summary PDF sent to Dan (Telegram chat 8075091586) during this run -- confirmed delivery via Telegram API `ok: true` response. Dan can compare directly against the previous report.

## Areas to review closely

- `_detect_anomalies`: the "done but no workflow artifact" check may be too broad for trivially-complete UoWs that genuinely don't produce artifacts. Currently gated on `steward_cycles > 0` to avoid false positives, but worth verifying the threshold is right.
- The summary PDF removes the lifecycle timeline, prescription agenda detail, and steward-executor exchange entirely. These are available in the full report. If any of those were load-bearing for Dan, that's a gap.
- RALPH loop Step 5 now calls `wos_report.py` with `--output` pointing to `~/messages/documents/` (Telegram-visible path) and `--full-output` to `ralph-reports/`. The send-to-Telegram happens automatically (no `--no-send`).

## Concerns / known gaps

None. The `--output` default behavior (auto-named PDF in `~/messages/documents/`) is unchanged for callers that don't pass `--full-output`.