### PR TITLE
feat(steward): enrich steward_agenda with per-cycle execution trace entries

### DIFF
--- a/scheduled-jobs/tasks/ralph-loop.md
+++ b/scheduled-jobs/tasks/ralph-loop.md
@@ -454,6 +454,15 @@ conn.close()
 
 Expected posture sequence for a healthy first-execution UoW: `first_execution → [dispatch] → execution_complete`. Any unexpected posture (`crashed_output_ref_missing`, `steward_cycle_cap`, `executor_orphan`) appearing in the audit trail or as the final posture is a `bad_posture_transition` anomaly.
 
+**Audit 5 — Steward agenda trace completeness**
+
+For each RALPH test UoW that reached done or failed:
+- Parse `steward_agenda` JSON
+- Assert: count of entries with `"cycle"` key == `steward_cycles` for that UoW
+- Assert: each trace entry has `posture` (non-empty string), `posture_rationale` (non-empty string), `success_criteria_checked` (list), `anomalies` (list), `prediction` (string or None), `timestamp` (non-empty string)
+- Flag anomaly type `agenda_trace_missing` if trace count < `steward_cycles`
+- Flag anomaly type `agenda_trace_malformed` if any entry fails field validation
+
 **Build `anomalies_this_run`** — construct a list of anomaly dicts from both the basic checklist above AND the four deep audit checks. This list is written to `last_anomalies` in Step 7 and is used by the next cycle's reproducibility gate in Step 6. Each entry should be a dict:
 
 ```python
@@ -482,7 +491,7 @@ A **clean run** is defined as:
 - All injected UoWs reached `done` or `failed` within the polling timeout (10 min standard, 15 min for type-D cycles)
 - No posture anomalies (no stalled UoWs)
 - No errors in heartbeat logs during the window
-- All four deep exchange audits from Step 3 are clean: `steward_cycles <= 2` per UoW, no bad PRSC reasons for first-execution UoWs, no duplicate dispatches, no unexpected posture transitions
+- All five deep exchange audits from Step 3 are clean: `steward_cycles <= 2` per UoW, no bad PRSC reasons for first-execution UoWs, no duplicate dispatches, no unexpected posture transitions, and steward_agenda trace count equals steward_cycles with all entries passing field validation
 
 **Note**: A UoW reaching `failed` is acceptable if the failure reason is expected (e.g., the executor correctly identified an unsolvable task). A `failed` outcome with a recorded `return_reason` counts as clean. A timeout or a UoW with `steward_cycles = 0` after the polling timeout is NOT clean.
 

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -500,6 +500,130 @@ def _assess_completion(
         return True, f"success_criteria is NULL — output_ref present with execution_complete posture: {uow.summary[:80]}", None
 
 
+# ---------------------------------------------------------------------------
+# Per-cycle trace entry builder (pure functions — no DB writes)
+# ---------------------------------------------------------------------------
+
+def _posture_rationale(diagnosis: dict) -> str:
+    """
+    Return a 1-sentence rationale for the current posture.
+
+    Pure function: derives the string deterministically from diagnosis fields.
+    No LLM, no DB reads. Called by _build_trace_entry().
+    """
+    posture = diagnosis.get("reentry_posture", "unknown")
+    cycles = diagnosis.get("_cycles", 0)
+
+    if posture == "first_execution":
+        return "No prior audit entries — first steward contact, dispatching executor."
+    elif posture == "execution_complete":
+        return "Executor result file present and valid — assessing completion."
+    elif posture == "crashed_output_ref_missing":
+        return "Startup sweep detected missing output_ref — executor may have crashed."
+    elif posture == "executor_orphan":
+        return "UoW stuck in ready-for-executor beyond threshold — executor never claimed."
+    elif posture == "diagnosing_orphan":
+        return "Steward crashed mid-diagnosis — re-diagnosing from current state."
+    elif posture == "steward_cycle_cap":
+        return f"Steward cycle cap reached ({cycles} cycles) — surfacing to Dan."
+    else:
+        return f"Posture: {posture}."
+
+
+def _extract_criteria_checks(diagnosis: dict) -> list[dict]:
+    """
+    Extract success criteria check results from the diagnosis dict.
+
+    Pure function: maps is_complete + completion_rationale to a list of
+    check dicts with {name, passed, evidence}. Always returns a list.
+    """
+    is_complete = diagnosis.get("is_complete", False)
+    completion_rationale = diagnosis.get("completion_rationale", "")
+    return [
+        {
+            "name": "completion_check",
+            "passed": bool(is_complete),
+            "evidence": completion_rationale,
+        }
+    ]
+
+
+def _posture_prediction(diagnosis: dict) -> str | None:
+    """
+    Return a forward prediction string based on the diagnosis.
+
+    Pure function: deterministic based on posture and completion state.
+    Returns None only when there is genuinely nothing to predict (done).
+    """
+    posture = diagnosis.get("reentry_posture", "unknown")
+    is_complete = diagnosis.get("is_complete", False)
+    stuck_condition = diagnosis.get("stuck_condition")
+
+    if stuck_condition:
+        return "Will be surfaced to Dan — stuck condition detected."
+    if is_complete:
+        return "Closure will be declared — completion criteria satisfied."
+    if posture == "first_execution":
+        return "Executor will be dispatched for first execution pass."
+    if posture == "execution_complete":
+        return "Completion check will determine next action (prescribe or close)."
+    if posture in ("crashed_no_output", "execution_failed"):
+        return "Re-prescription will be issued after failure analysis."
+    if posture == "executor_orphan":
+        return "Re-prescription will be issued — executor never claimed UoW."
+    return "Next prescription will be determined from diagnosis output."
+
+
+def _build_trace_entry(diagnosis: dict, cycles: int) -> dict:
+    """
+    Build a single steward_agenda trace entry from a completed diagnosis.
+
+    Pure function — no side effects, no DB writes. Called pre-branch in
+    _process_uow() after diagnosis and before the stuck/done/prescribe split.
+
+    Args:
+        diagnosis: dict returned by _diagnose_uow().
+        cycles: current uow.steward_cycles (pre-increment).
+
+    Returns:
+        Trace entry dict conforming to the v2 cycle trace entry schema.
+    """
+    # Inject cycles so _posture_rationale can access it for the cycle-cap case
+    diagnosis_with_cycles = {**diagnosis, "_cycles": cycles}
+
+    return {
+        "cycle": cycles,
+        "posture": diagnosis.get("reentry_posture", "unknown"),
+        "posture_rationale": _posture_rationale(diagnosis_with_cycles),
+        "success_criteria_checked": _extract_criteria_checks(diagnosis),
+        "anomalies": (
+            [diagnosis["stuck_condition"]]
+            if diagnosis.get("stuck_condition")
+            else []
+        ),
+        "prediction": _posture_prediction(diagnosis),
+        "dispatch_instruction": None,  # filled in by prescribe branch if applicable
+        "external_dependency": None,
+        "discoveries": [],
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+
+
+def _parse_steward_agenda(steward_agenda_str: str | None) -> list[dict]:
+    """
+    Parse steward_agenda JSON string into a list of dicts.
+
+    Pure function. Returns [] on None, empty string, or parse failure.
+    """
+    if not steward_agenda_str:
+        return []
+    try:
+        result = json.loads(steward_agenda_str)
+        return result if isinstance(result, list) else []
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
 def _build_initial_agenda(uow: "UoW", issue_body: str) -> list[dict[str, Any]]:
     """
     Build the initial steward_agenda for a new UoW (steward_cycles == 0).
@@ -1797,6 +1921,23 @@ def _process_uow(
             audit_note["note"] = "evaluating against summary field as fallback"
         registry.append_audit_log(uow_id, audit_note)
 
+    # Pre-branch trace write — unconditional, fires before stuck/done/prescribe split.
+    # The agenda list at this point contains the initial agenda nodes (from the
+    # initialization ritual above). We append one trace entry per cycle so
+    # steward_agenda accumulates a full cycle history. Branch-level writes that
+    # follow (done: mark nodes complete; prescribe: mark node prescribed) will
+    # overwrite steward_agenda with the trace entry already present in the list.
+    trace_entry = _build_trace_entry(diagnosis, cycles)
+    trace_agenda = _parse_steward_agenda(uow.steward_agenda)
+    # On cycle 0, the initial agenda was already written in the initialization
+    # ritual above; re-read it from the in-memory `agenda` variable to avoid
+    # an extra DB round-trip and to pick up that write's content.
+    if cycles == 0:
+        trace_agenda = list(agenda)
+    trace_agenda.append(trace_entry)
+    if not dry_run:
+        _write_steward_fields(registry, uow_id, steward_agenda=json.dumps(trace_agenda))
+
     # Step 4: Convergence or prescription
 
     # 4a: Stuck condition check (fires before completion/prescription)
@@ -1835,8 +1976,8 @@ def _process_uow(
 
     # 4b: Declare done
     if is_complete:
-        # Mark all agenda nodes complete
-        completed_agenda = _update_agenda_node_status(agenda, "complete")
+        # Mark all agenda nodes complete (including the trace entry just appended)
+        completed_agenda = _update_agenda_node_status(trace_agenda, "complete")
 
         closure_entry = {
             "event": "steward_closure",
@@ -1945,7 +2086,9 @@ def _process_uow(
     prescription_path = "llm" if _llm_path_taken[0] else "fallback"
 
     # Update agenda: mark current pending node as prescribed
-    updated_agenda = _mark_current_agenda_node_prescribed(agenda)
+    # Use trace_agenda (which includes the trace entry we just wrote) as the base
+    # so the prescription status update is applied on top of the full trace.
+    updated_agenda = _mark_current_agenda_node_prescribed(trace_agenda)
 
     prescription_log_entry = {
         "event": "reentry_prescription" if cycles > 0 else "prescription",

--- a/tests/integration/test_wos_caretaker_wiring.py
+++ b/tests/integration/test_wos_caretaker_wiring.py
@@ -344,3 +344,330 @@ def test_steward_picks_up_ready_for_steward_uow(registry: Registry, tmp_path: Pa
     assert cycle_result.get("evaluated", 0) >= 1, (
         f"Steward cycle reported 0 UoWs evaluated. Result: {cycle_result}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Helper shared by steward trace tests
+# ---------------------------------------------------------------------------
+
+def _seed_ready_for_steward_uow(
+    registry: Registry,
+    issue_number: int,
+    title: str,
+    success_criteria: str = "Test completion.",
+) -> str:
+    """Create a UoW and advance it to ready-for-steward. Returns uow_id."""
+    from orchestration.registry import UpsertInserted, ApproveConfirmed
+
+    result = registry.upsert(
+        issue_number=issue_number,
+        title=title,
+        success_criteria=success_criteria,
+    )
+    assert isinstance(result, UpsertInserted)
+    uow_id = result.id
+    approve = registry.approve(uow_id)
+    assert isinstance(approve, ApproveConfirmed), f"Approve failed: {approve!r}"
+    return uow_id
+
+
+def _null_notify(*_args, **_kwargs) -> None:
+    """No-op notification stub — tests must not send Telegram messages."""
+    pass
+
+
+def _stub_github_open(issue_number: int) -> dict:
+    """Stub GitHub client: open issue, no labels."""
+    return {
+        "status_code": 200,
+        "state": "open",
+        "labels": [],
+        "body": "Test UoW.",
+        "title": "Test",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Steward writes a trace entry on first execution
+# ---------------------------------------------------------------------------
+
+def test_steward_trace_entry_written_on_first_execution(registry: Registry, tmp_path: Path) -> None:
+    """run_steward_cycle() must append a trace entry to steward_agenda on first contact.
+
+    The trace entry must have cycle=0, posture="first_execution",
+    success_criteria_checked as a list, anomalies==[], and a non-empty
+    posture_rationale.
+    """
+    from src.orchestration.steward import run_steward_cycle
+
+    uow_id = _seed_ready_for_steward_uow(
+        registry,
+        issue_number=8001,
+        title="Trace entry first execution test",
+    )
+
+    run_steward_cycle(
+        registry=registry,
+        dry_run=False,
+        github_client=_stub_github_open,
+        artifact_dir=tmp_path / "artifacts",
+        notify_dan=_null_notify,
+        notify_dan_early_warning=_null_notify,
+        bootup_candidate_gate=False,
+        llm_prescriber=None,
+    )
+
+    uow_after = registry.get(uow_id)
+    assert uow_after is not None
+    assert uow_after.steward_agenda is not None, "steward_agenda is None after cycle"
+
+    agenda = json.loads(uow_after.steward_agenda)
+    assert isinstance(agenda, list), f"steward_agenda is not a list: {agenda!r}"
+
+    # Find the trace entry (has "cycle" key)
+    trace_entries = [e for e in agenda if "cycle" in e]
+    assert len(trace_entries) >= 1, (
+        f"No trace entries found in agenda. Full agenda: {agenda}"
+    )
+
+    entry = trace_entries[0]
+    assert entry["cycle"] == 0, f"Expected cycle=0, got {entry['cycle']!r}"
+    assert entry["posture"] == "first_execution", (
+        f"Expected posture='first_execution', got {entry['posture']!r}"
+    )
+    assert isinstance(entry["success_criteria_checked"], list), (
+        f"success_criteria_checked is not a list: {entry['success_criteria_checked']!r}"
+    )
+    assert entry["anomalies"] == [], (
+        f"Expected anomalies=[], got {entry['anomalies']!r}"
+    )
+    assert isinstance(entry.get("posture_rationale"), str) and entry["posture_rationale"], (
+        f"posture_rationale is empty or missing: {entry.get('posture_rationale')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Steward trace entries accumulate across cycles
+# ---------------------------------------------------------------------------
+
+def test_steward_trace_entry_accumulates_per_cycle(registry: Registry, tmp_path: Path) -> None:
+    """steward_agenda must accumulate one trace entry per steward cycle.
+
+    After the first cycle the agenda has 1 trace entry; after a second cycle
+    (simulated by advancing UoW back to ready-for-steward) it has 2.
+    """
+    from src.orchestration.steward import run_steward_cycle
+
+    uow_id = _seed_ready_for_steward_uow(
+        registry,
+        issue_number=8002,
+        title="Trace accumulation test",
+    )
+
+    # Cycle 1
+    run_steward_cycle(
+        registry=registry,
+        dry_run=False,
+        github_client=_stub_github_open,
+        artifact_dir=tmp_path / "artifacts",
+        notify_dan=_null_notify,
+        notify_dan_early_warning=_null_notify,
+        bootup_candidate_gate=False,
+        llm_prescriber=None,
+    )
+
+    uow_after_1 = registry.get(uow_id)
+    assert uow_after_1 is not None
+    agenda_1 = json.loads(uow_after_1.steward_agenda or "[]")
+    trace_entries_1 = [e for e in agenda_1 if "cycle" in e]
+    assert len(trace_entries_1) == 1, (
+        f"Expected 1 trace entry after cycle 1, got {len(trace_entries_1)}: {agenda_1}"
+    )
+
+    # Advance UoW back to ready-for-steward to simulate executor return
+    # (set status directly so we can run a second Steward pass)
+    registry.set_status_direct(uow_id, "ready-for-steward")
+
+    # Cycle 2
+    run_steward_cycle(
+        registry=registry,
+        dry_run=False,
+        github_client=_stub_github_open,
+        artifact_dir=tmp_path / "artifacts",
+        notify_dan=_null_notify,
+        notify_dan_early_warning=_null_notify,
+        bootup_candidate_gate=False,
+        llm_prescriber=None,
+    )
+
+    uow_after_2 = registry.get(uow_id)
+    assert uow_after_2 is not None
+    agenda_2 = json.loads(uow_after_2.steward_agenda or "[]")
+    trace_entries_2 = [e for e in agenda_2 if "cycle" in e]
+    assert len(trace_entries_2) == 2, (
+        f"Expected 2 trace entries after cycle 2, got {len(trace_entries_2)}: {agenda_2}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Trace entry shows completion_check passed on a done UoW
+# ---------------------------------------------------------------------------
+
+def test_steward_trace_completion_check_passes_on_done(registry: Registry, tmp_path: Path) -> None:
+    """When the executor signals completion, the trace entry must show passed=True.
+
+    Simulated by writing a result file with outcome=complete and advancing the
+    UoW through an execution cycle before the steward re-enters.
+    """
+    import uuid
+    from src.orchestration.steward import run_steward_cycle
+    from orchestration.registry import UpsertInserted, ApproveConfirmed
+
+    # Seed and advance UoW
+    result = registry.upsert(
+        issue_number=8003,
+        title="Completion check trace test",
+        success_criteria="Output must report outcome=complete.",
+    )
+    assert isinstance(result, UpsertInserted)
+    uow_id = result.id
+    approve = registry.approve(uow_id)
+    assert isinstance(approve, ApproveConfirmed)
+
+    # Cycle 1: first_execution — steward dispatches executor
+    run_steward_cycle(
+        registry=registry,
+        dry_run=False,
+        github_client=_stub_github_open,
+        artifact_dir=tmp_path / "artifacts",
+        notify_dan=_null_notify,
+        notify_dan_early_warning=_null_notify,
+        bootup_candidate_gate=False,
+        llm_prescriber=None,
+    )
+
+    # Simulate executor completing: set output_ref + result file + audit entry
+    output_ref = str(tmp_path / f"{uow_id}.output.md")
+    Path(output_ref).write_text("Execution output — complete.", encoding="utf-8")
+
+    result_file = Path(output_ref + ".result.json")
+    result_file.write_text(
+        json.dumps({"uow_id": uow_id, "outcome": "complete", "reason": "all steps done"}),
+        encoding="utf-8",
+    )
+
+    # Write output_ref to the UoW record and write an execution_complete audit entry
+    conn = sqlite3.connect(str(registry.db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        "UPDATE uow_registry SET output_ref = ?, status = 'ready-for-steward' WHERE id = ?",
+        (output_ref, uow_id),
+    )
+    conn.commit()
+    conn.close()
+    registry.append_audit_log(uow_id, {
+        "event": "execution_complete",
+        "actor": "executor",
+        "uow_id": uow_id,
+        "timestamp": _now_iso(),
+    })
+
+    # Cycle 2: steward re-enters and should find execution_complete posture
+    run_steward_cycle(
+        registry=registry,
+        dry_run=False,
+        github_client=_stub_github_open,
+        artifact_dir=tmp_path / "artifacts",
+        notify_dan=_null_notify,
+        notify_dan_early_warning=_null_notify,
+        bootup_candidate_gate=False,
+        llm_prescriber=None,
+    )
+
+    uow_after = registry.get(uow_id)
+    assert uow_after is not None
+    agenda = json.loads(uow_after.steward_agenda or "[]")
+    trace_entries = [e for e in agenda if "cycle" in e]
+    assert len(trace_entries) >= 2, (
+        f"Expected at least 2 trace entries, got {len(trace_entries)}: {agenda}"
+    )
+
+    # The cycle 1 trace entry (index depends on initial agenda nodes before traces)
+    # Find the trace entry with cycle==1 (second pass)
+    cycle_1_entry = next((e for e in trace_entries if e["cycle"] == 1), None)
+    assert cycle_1_entry is not None, (
+        f"No trace entry with cycle=1 found. Trace entries: {trace_entries}"
+    )
+    checks = cycle_1_entry.get("success_criteria_checked", [])
+    assert len(checks) >= 1, (
+        f"success_criteria_checked is empty in cycle 1 trace entry: {cycle_1_entry}"
+    )
+    assert checks[0]["passed"] is True, (
+        f"Expected passed=True for execution_complete posture, got {checks[0]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Trace entry captures anomaly on stuck condition
+# ---------------------------------------------------------------------------
+
+def test_steward_trace_anomaly_captured_on_stuck(registry: Registry, tmp_path: Path) -> None:
+    """When a stuck condition fires, the trace entry anomalies list must be non-empty.
+
+    Simulated by forcing the hard-cap condition (steward_cycles >= _HARD_CAP_CYCLES)
+    via direct SQL — the Steward will diagnose hard_cap as stuck_condition and
+    write a trace entry with anomalies=[hard_cap].
+    """
+    from src.orchestration.steward import run_steward_cycle, _HARD_CAP_CYCLES
+
+    uow_id = _seed_ready_for_steward_uow(
+        registry,
+        issue_number=8004,
+        title="Anomaly trace capture test",
+    )
+
+    # Directly set steward_cycles to _HARD_CAP_CYCLES so the Steward
+    # immediately hits the hard_cap stuck condition on next diagnosis.
+    conn = sqlite3.connect(str(registry.db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        "UPDATE uow_registry SET steward_cycles = ? WHERE id = ?",
+        (_HARD_CAP_CYCLES, uow_id),
+    )
+    conn.commit()
+    conn.close()
+
+    captured_notifications: list[tuple] = []
+
+    def _capturing_notify(uow, condition, **_kwargs) -> None:
+        captured_notifications.append((uow.id, condition))
+
+    run_steward_cycle(
+        registry=registry,
+        dry_run=False,
+        github_client=_stub_github_open,
+        artifact_dir=tmp_path / "artifacts",
+        notify_dan=_capturing_notify,
+        notify_dan_early_warning=_null_notify,
+        bootup_candidate_gate=False,
+        llm_prescriber=None,
+    )
+
+    uow_after = registry.get(uow_id)
+    assert uow_after is not None
+    agenda = json.loads(uow_after.steward_agenda or "[]")
+    trace_entries = [e for e in agenda if "cycle" in e]
+    assert len(trace_entries) >= 1, (
+        f"No trace entries found in agenda after stuck cycle: {agenda}"
+    )
+
+    # Find the trace entry for this cycle (cycle == _HARD_CAP_CYCLES)
+    stuck_entry = next((e for e in trace_entries if e["cycle"] == _HARD_CAP_CYCLES), None)
+    assert stuck_entry is not None, (
+        f"No trace entry with cycle={_HARD_CAP_CYCLES} found. Entries: {trace_entries}"
+    )
+    assert len(stuck_entry.get("anomalies", [])) > 0, (
+        f"Expected non-empty anomalies for hard_cap stuck condition, got: {stuck_entry!r}"
+    )
+    # Also verify the notification was fired (confirms the stuck branch was hit)
+    assert len(captured_notifications) >= 1, "Stuck condition did not fire a Dan notification"


### PR DESCRIPTION
## What this solves

The `steward_agenda` field was a skeleton: initialized with forecast nodes at UoW creation (cycle 0) and never updated. After every Executor return, the Steward diagnosed the UoW and prescribed or closed it — but left no trace of that reasoning in `steward_agenda`. The design spec (wos-v2-design.md) defines `steward_agenda` as a per-cycle trace array, one entry per Steward pass. This PR closes that gap.

## What changed

**`steward.py` — four pure functions, one pre-branch write.**

`_build_trace_entry(diagnosis, cycles)` assembles a v2-schema trace entry from a completed `_diagnose_uow()` result. It delegates to three helper pure functions:
- `_posture_rationale(diagnosis)` — 1-sentence string from posture, deterministic by code path
- `_extract_criteria_checks(diagnosis)` — maps `is_complete` + `completion_rationale` to a `[{name, passed, evidence}]` list
- `_posture_prediction(diagnosis)` — forward-looking string based on stuck condition and posture

`_parse_steward_agenda(steward_agenda_str)` — safe JSON parser with empty-list fallback.

The pre-branch write in `_process_uow()` fires after `registry.append_audit_log(... "steward_diagnosis" ...)` and before the stuck/done/prescribe branch split. It builds the trace entry, appends it to the current agenda list (using the in-memory `agenda` on cycle 0, the DB-resident list on subsequent cycles), and writes `steward_agenda` unconditionally. The done and prescribe branches then update node statuses on top of the trace-enriched list — no trace entry is lost.

**Functional patterns used:** pure functions throughout the trace building stack; immutable dict construction via `{**diagnosis, "_cycles": cycles}` rather than mutation; composition (`_build_trace_entry` delegates to three single-responsibility helpers).

## Before / after

Before: `steward_agenda` at closure contained only the initial forecast nodes from cycle 0, with statuses marked complete. No per-cycle reasoning visible.

After: `steward_agenda` at closure is a list of `initial_nodes + [trace_entry_cycle_0, trace_entry_cycle_1, ...]`. Each trace entry carries `cycle`, `posture`, `posture_rationale`, `success_criteria_checked`, `anomalies`, `prediction`, `timestamp`. RALPH Audit 5 validates this invariant (trace count == steward_cycles).

## Out of scope

No schema changes — `steward_agenda` is already `TEXT NULL (JSON)`. No changes to the Executor, UoW Registrar, Garden Caretaker, or any other file. No changes to the initial agenda nodes written by `_build_initial_agenda()`.

## Tests run

- [x] `uv run pytest tests/integration/test_wos_caretaker_wiring.py -v` — 8 passed, 0 failed
  - 4 existing tests (caretaker wiring) all still pass
  - 4 new trace tests: first_execution entry, per-cycle accumulation, completion_check passed on done, anomaly captured on stuck

## Manual test

N/A — no systemd, cron, external service calls, or file I/O that affects runtime state. All changes are in-process logic and SQLite writes covered by integration tests.

## Areas to review closely

1. The `trace_agenda` vs `agenda` variable handoff in `_process_uow()` — on cycle 0, uses the in-memory `agenda` (already written by the initialization ritual); on subsequent cycles, parses from `uow.steward_agenda` (the DB-resident value). The two paths must not diverge.
2. The done branch now calls `_update_agenda_node_status(trace_agenda, "complete")` instead of `agenda`. This marks `status` on all list entries including trace entries — confirm acceptable since trace entries have no `status` key and the function uses `.get("status")`.
3. `_posture_rationale` uses `diagnosis_with_cycles` (a shallow copy with `_cycles` injected) — no mutation risk to the original diagnosis dict.

Closes no issue directly — implements the spec enrichment described in wos-v2-design.md §Cycle trace entry schema (v2).