### PR TITLE
feat(attunement): add Attunement Over Assumption evaluation for subagent results

### DIFF
--- a/src/memory/attunement.py
+++ b/src/memory/attunement.py
@@ -1,0 +1,271 @@
+"""
+src/memory/attunement.py — Attunement Over Assumption evaluation for subagent results
+
+Implements the Attunement Over Assumption principle from the dan-reviewer posture:
+
+    "The presenting problem is rarely the problem. Look past surfaces — whether
+    in directives, bugs, or code — to underlying intent and cause. Find root
+    causes, not surface symptoms. State what layer the symptom is at and what
+    layer the cause is likely at — before proposing a fix."
+
+Primary operation:
+
+    evaluate_attunement(result_text, original_request?) -> AttunementResult
+
+Called by the dispatcher during the Result Evaluation hook (Epistemic Hook 3)
+before relaying a subagent_result to the user. If the result addresses only
+the surface layer, the dispatcher prepends an annotation before relay.
+
+Pure-logic function — no I/O side effects.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+DEPTH_VALUES = frozenset({"surface_only", "causal", "both", "indeterminate"})
+
+# Layers where symptoms and causes can live. Ordered from outermost to deepest.
+LAYERS = (
+    "presentation",   # UI, message formatting, user-facing text
+    "behavior",       # runtime behavior, feature logic, observable effects
+    "integration",    # how components connect, API contracts, data flow
+    "architecture",   # structural decisions, module boundaries, patterns
+    "intent",         # why the system exists, what problem it solves
+)
+
+
+@dataclass
+class AttunementResult:
+    """Result of evaluating a subagent result for causal depth."""
+
+    depth: str               # one of DEPTH_VALUES
+    symptom_layer: str       # which LAYER the addressed symptom is at
+    likely_cause_layer: str  # which LAYER the root cause likely lives at
+    reason: str              # one-sentence explanation
+    annotation: str = ""     # prepend this to relay if surface_only
+
+    def needs_annotation(self) -> bool:
+        return self.depth == "surface_only"
+
+
+# ---------------------------------------------------------------------------
+# Signal vocabulary
+#
+# These are token-level signals, not semantic analysis. They indicate whether
+# the result text *discusses* surface vs. causal layers. A result that uses
+# causal vocabulary may still be wrong about the cause — but a result with
+# zero causal vocabulary is almost certainly surface-only.
+# ---------------------------------------------------------------------------
+
+# Phrases indicating the result addresses root causes or underlying structure
+_CAUSAL_PHRASES: list[re.Pattern] = [
+    re.compile(p, re.IGNORECASE) for p in [
+        r"\broot\s+cause\b",
+        r"\bunderlying\b",
+        r"\bfundamental(?:ly)?\b",
+        r"\barchitectur(?:e|al)\b",
+        r"\bstructural(?:ly)?\b",
+        r"\bdesign\s+(?:issue|flaw|problem|decision)\b",
+        r"\bbecause\s+the\b",
+        r"\bthe\s+(?:real|actual|deeper)\s+(?:issue|problem|cause)\b",
+        r"\bthis\s+(?:happens|occurs|fails)\s+because\b",
+        r"\bthe\s+reason\b",
+        r"\bupstream\b",
+        r"\bsource\s+of\b",
+        r"\bwhy\s+(?:this|it|the)\b",
+    ]
+]
+
+# Phrases indicating the result addresses only surface symptoms
+_SURFACE_PHRASES: list[re.Pattern] = [
+    re.compile(p, re.IGNORECASE) for p in [
+        r"\bworkaround\b",
+        r"\bquick\s+fix\b",
+        r"\btemporary\s+(?:fix|patch|solution)\b",
+        r"\bband[\s-]?aid\b",
+        r"\bhotfix\b",
+        r"\bpatched?\b",
+        r"\bfor\s+now\b",
+        r"\bshort[\s-]?term\b",
+        r"\bjust\s+(?:change|update|fix|set|add|remove)\b",
+        r"\bsymptom\b",
+    ]
+]
+
+# Phrases indicating explicit layer attribution (strong causal signal)
+_LAYER_ATTRIBUTION_PHRASES: list[re.Pattern] = [
+    re.compile(p, re.IGNORECASE) for p in [
+        r"\b(?:the\s+)?(?:symptom|issue|problem)\s+(?:is\s+)?(?:at|in)\s+the\b",
+        r"\b(?:the\s+)?(?:cause|root)\s+(?:is\s+)?(?:at|in)\s+the\b",
+        r"\b(?:surface|presentation|behavior|integration|architecture|intent)\s+layer\b",
+        r"\bthis\s+is\s+a\s+(?:surface|structural|architectural|design|behavioral)\b",
+    ]
+]
+
+
+def _count_matches(text: str, patterns: list[re.Pattern]) -> int:
+    """Count how many distinct patterns match anywhere in the text."""
+    return sum(1 for p in patterns if p.search(text))
+
+
+# ---------------------------------------------------------------------------
+# Layer inference
+# ---------------------------------------------------------------------------
+
+# Keywords associated with each layer — used to infer which layer the result
+# is discussing. Not exhaustive; just enough to distinguish layers.
+_LAYER_KEYWORDS: dict[str, list[str]] = {
+    "presentation": [
+        "message", "display", "format", "text", "ui", "output", "render",
+        "label", "string", "template",
+    ],
+    "behavior": [
+        "function", "method", "logic", "condition", "branch", "return",
+        "parameter", "argument", "value", "error", "exception", "bug",
+    ],
+    "integration": [
+        "api", "endpoint", "contract", "interface", "protocol", "schema",
+        "connection", "request", "response", "handler", "route", "dispatch",
+    ],
+    "architecture": [
+        "module", "component", "pattern", "design", "structure", "abstraction",
+        "dependency", "coupling", "boundary", "layer", "system", "pipeline",
+    ],
+    "intent": [
+        "purpose", "goal", "requirement", "need", "user wants", "the point",
+        "objective", "why we", "mission", "use case",
+    ],
+}
+
+
+def _infer_layer(text: str) -> str:
+    """Infer the most-discussed layer from keyword frequency.
+
+    Returns the layer with the highest keyword hit count.
+    Defaults to 'behavior' when no strong signal.
+    """
+    text_lower = text.lower()
+    scores: dict[str, int] = {}
+    for layer, keywords in _LAYER_KEYWORDS.items():
+        scores[layer] = sum(1 for kw in keywords if kw in text_lower)
+
+    best = max(scores, key=scores.get)  # type: ignore[arg-type]
+    if scores[best] == 0:
+        return "behavior"
+    return best
+
+
+def _infer_cause_layer(symptom_layer: str, has_causal_signals: bool) -> str:
+    """Given the symptom layer and whether causal analysis is present,
+    infer where the root cause likely lives.
+
+    Heuristic: causes tend to live one or two layers deeper than symptoms.
+    If the result already provides causal analysis, trust the symptom layer
+    (the result is already looking deeper). If surface-only, the cause is
+    likely one layer deeper.
+    """
+    if has_causal_signals:
+        return symptom_layer
+
+    idx = LAYERS.index(symptom_layer) if symptom_layer in LAYERS else 1
+    deeper = min(idx + 1, len(LAYERS) - 1)
+    return LAYERS[deeper]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def evaluate_attunement(
+    result_text: str,
+    original_request: str = "",
+) -> AttunementResult:
+    """Evaluate a subagent result for causal depth before relay.
+
+    Args:
+        result_text: The text content of the subagent_result message.
+        original_request: Optional — the original user request that spawned
+            the subagent. When provided, enables detection of request/result
+            register mismatch (e.g., user asked "why" but result only says "what").
+
+    Returns:
+        AttunementResult with depth classification, layer attribution, and
+        an annotation string to prepend if the result is surface-only.
+    """
+    if not result_text or not result_text.strip():
+        return AttunementResult(
+            depth="indeterminate",
+            symptom_layer="behavior",
+            likely_cause_layer="behavior",
+            reason="Empty result text — cannot evaluate attunement.",
+        )
+
+    causal_count = _count_matches(result_text, _CAUSAL_PHRASES)
+    surface_count = _count_matches(result_text, _SURFACE_PHRASES)
+    layer_attr_count = _count_matches(result_text, _LAYER_ATTRIBUTION_PHRASES)
+
+    has_causal = causal_count > 0 or layer_attr_count > 0
+    has_surface = surface_count > 0
+
+    # Check if the original request asked "why" but the result only says "what"
+    why_requested = False
+    if original_request:
+        why_requested = bool(re.search(
+            r"\bwhy\b|\broot\s+cause\b|\bwhat\s+(?:caused|causes)\b|\breason\b",
+            original_request, re.IGNORECASE,
+        ))
+
+    symptom_layer = _infer_layer(result_text)
+    likely_cause_layer = _infer_cause_layer(symptom_layer, has_causal)
+
+    # Classify depth
+    if has_causal and has_surface:
+        depth = "both"
+        reason = (
+            f"Result addresses both surface ({surface_count} signal(s)) "
+            f"and causal ({causal_count} signal(s)) layers."
+        )
+    elif has_causal:
+        depth = "causal"
+        reason = (
+            f"Result provides causal analysis ({causal_count} signal(s), "
+            f"{layer_attr_count} layer attribution(s))."
+        )
+    elif has_surface:
+        depth = "surface_only"
+        reason = (
+            f"Result uses surface-fix vocabulary ({surface_count} signal(s)) "
+            f"with no causal analysis."
+        )
+    elif why_requested:
+        depth = "surface_only"
+        reason = (
+            "Original request asked 'why' but result provides no causal analysis."
+        )
+    else:
+        depth = "indeterminate"
+        reason = "No strong surface or causal signals detected."
+
+    # Build annotation for surface-only results
+    annotation = ""
+    if depth == "surface_only":
+        annotation = (
+            f"[Surface addressed. Causal layer may need investigation: "
+            f"symptom at {symptom_layer} layer, "
+            f"cause likely at {likely_cause_layer} layer.]"
+        )
+
+    return AttunementResult(
+        depth=depth,
+        symptom_layer=symptom_layer,
+        likely_cause_layer=likely_cause_layer,
+        reason=reason,
+        annotation=annotation,
+    )

--- a/tests/unit/test_attunement.py
+++ b/tests/unit/test_attunement.py
@@ -1,0 +1,249 @@
+"""
+Tests for the Attunement Over Assumption module (src/memory/attunement.py).
+
+Covers:
+- Causal vs. surface signal detection
+- Layer inference
+- Depth classification (surface_only, causal, both, indeterminate)
+- Annotation generation for surface-only results
+- Why-requested detection from original request
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure src/ is on the path for direct imports
+_REPO_ROOT = Path(__file__).parent.parent.parent
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from memory.attunement import (
+    DEPTH_VALUES,
+    LAYERS,
+    AttunementResult,
+    _count_matches,
+    _infer_cause_layer,
+    _infer_layer,
+    _CAUSAL_PHRASES,
+    _SURFACE_PHRASES,
+    evaluate_attunement,
+)
+
+
+# ============================================================================
+# Signal detection tests
+# ============================================================================
+
+
+class TestSignalDetection:
+    def test_causal_root_cause(self):
+        text = "The root cause is a missing null check in the parser."
+        assert _count_matches(text, _CAUSAL_PHRASES) >= 1
+
+    def test_causal_because_the(self):
+        text = "This happens because the connection pool is exhausted."
+        assert _count_matches(text, _CAUSAL_PHRASES) >= 1
+
+    def test_causal_underlying(self):
+        text = "The underlying issue is in the schema migration."
+        assert _count_matches(text, _CAUSAL_PHRASES) >= 1
+
+    def test_causal_the_reason(self):
+        text = "The reason this fails is that the timeout is too short."
+        assert _count_matches(text, _CAUSAL_PHRASES) >= 1
+
+    def test_surface_workaround(self):
+        text = "Applied a workaround by retrying the request."
+        assert _count_matches(text, _SURFACE_PHRASES) >= 1
+
+    def test_surface_quick_fix(self):
+        text = "Quick fix: set the timeout to 30 seconds."
+        assert _count_matches(text, _SURFACE_PHRASES) >= 1
+
+    def test_surface_for_now(self):
+        text = "For now I just changed the config value."
+        assert _count_matches(text, _SURFACE_PHRASES) >= 1
+
+    def test_surface_just_change(self):
+        text = "Just update the import path to fix the error."
+        assert _count_matches(text, _SURFACE_PHRASES) >= 1
+
+    def test_no_signals(self):
+        text = "Updated the README with the new API documentation."
+        assert _count_matches(text, _CAUSAL_PHRASES) == 0
+        assert _count_matches(text, _SURFACE_PHRASES) == 0
+
+
+# ============================================================================
+# Layer inference tests
+# ============================================================================
+
+
+class TestLayerInference:
+    def test_presentation_layer(self):
+        text = "Fixed the message template and display format for the UI output."
+        assert _infer_layer(text) == "presentation"
+
+    def test_behavior_layer(self):
+        text = "The function returns an error when the parameter is null."
+        assert _infer_layer(text) == "behavior"
+
+    def test_integration_layer(self):
+        text = "The API endpoint handler dispatches the request to the wrong route."
+        assert _infer_layer(text) == "integration"
+
+    def test_architecture_layer(self):
+        text = "The module boundary creates a dependency coupling between components."
+        assert _infer_layer(text) == "architecture"
+
+    def test_intent_layer(self):
+        text = "The purpose and goal of this requirement is unclear for the use case."
+        assert _infer_layer(text) == "intent"
+
+    def test_default_layer(self):
+        text = "xyz abc 123"
+        assert _infer_layer(text) == "behavior"
+
+
+class TestCauseLayerInference:
+    def test_with_causal_signals_stays_same(self):
+        assert _infer_cause_layer("behavior", has_causal_signals=True) == "behavior"
+
+    def test_without_causal_goes_deeper(self):
+        assert _infer_cause_layer("behavior", has_causal_signals=False) == "integration"
+
+    def test_presentation_without_causal(self):
+        assert _infer_cause_layer("presentation", has_causal_signals=False) == "behavior"
+
+    def test_intent_stays_at_intent(self):
+        # Can't go deeper than intent
+        assert _infer_cause_layer("intent", has_causal_signals=False) == "intent"
+
+
+# ============================================================================
+# evaluate_attunement tests
+# ============================================================================
+
+
+class TestEvaluateAttunement:
+    def test_empty_text(self):
+        result = evaluate_attunement("")
+        assert result.depth == "indeterminate"
+        assert not result.needs_annotation()
+
+    def test_whitespace_only(self):
+        result = evaluate_attunement("   \n  ")
+        assert result.depth == "indeterminate"
+
+    def test_surface_only_result(self):
+        text = (
+            "Applied a quick fix: just changed the config value to 30 seconds. "
+            "This is a temporary patch for now."
+        )
+        result = evaluate_attunement(text)
+        assert result.depth == "surface_only"
+        assert result.needs_annotation()
+        assert "Surface addressed" in result.annotation
+        assert result.symptom_layer in LAYERS
+        assert result.likely_cause_layer in LAYERS
+
+    def test_causal_result(self):
+        text = (
+            "The root cause is that the connection pool has a hard limit of 10 "
+            "connections. This happens because the database driver defaults to a "
+            "conservative pool size. The architectural decision to share a single "
+            "pool across all request handlers means the system saturates under load."
+        )
+        result = evaluate_attunement(text)
+        assert result.depth == "causal"
+        assert not result.needs_annotation()
+        assert result.annotation == ""
+
+    def test_both_layers(self):
+        text = (
+            "Applied a temporary workaround by increasing the timeout, but the "
+            "root cause is the upstream service's retry logic creating cascading "
+            "failures. The architectural issue is that there's no circuit breaker."
+        )
+        result = evaluate_attunement(text)
+        assert result.depth == "both"
+        assert not result.needs_annotation()
+
+    def test_indeterminate_result(self):
+        text = "Updated the README with new installation instructions."
+        result = evaluate_attunement(text)
+        assert result.depth == "indeterminate"
+        assert not result.needs_annotation()
+
+    def test_why_requested_but_not_answered(self):
+        text = "Updated the config file and restarted the service."
+        result = evaluate_attunement(text, original_request="Why is the service crashing?")
+        assert result.depth == "surface_only"
+        assert result.needs_annotation()
+        assert "why" in result.reason.lower()
+
+    def test_why_requested_and_answered(self):
+        text = (
+            "The service crashes because the memory limit is set too low. "
+            "The root cause is that the container spec was copied from a "
+            "smaller service template."
+        )
+        result = evaluate_attunement(text, original_request="Why is the service crashing?")
+        assert result.depth == "causal"
+        assert not result.needs_annotation()
+
+    def test_annotation_format(self):
+        text = "Quick fix: just set the environment variable."
+        result = evaluate_attunement(text)
+        assert result.depth == "surface_only"
+        assert result.annotation.startswith("[Surface addressed.")
+        assert "symptom at" in result.annotation
+        assert "cause likely at" in result.annotation
+        assert result.annotation.endswith("]")
+
+    def test_layer_attribution_counts_as_causal(self):
+        text = (
+            "This is a structural issue in the architecture layer. "
+            "The symptom is at the behavior layer but the cause is at the "
+            "integration layer."
+        )
+        result = evaluate_attunement(text)
+        assert result.depth in ("causal", "both")
+        assert not result.needs_annotation()
+
+
+# ============================================================================
+# Dataclass tests
+# ============================================================================
+
+
+class TestAttunementResult:
+    def test_needs_annotation_surface_only(self):
+        r = AttunementResult(
+            depth="surface_only",
+            symptom_layer="behavior",
+            likely_cause_layer="integration",
+            reason="test",
+            annotation="[Surface addressed.]",
+        )
+        assert r.needs_annotation() is True
+
+    def test_needs_annotation_causal(self):
+        r = AttunementResult(
+            depth="causal",
+            symptom_layer="behavior",
+            likely_cause_layer="behavior",
+            reason="test",
+        )
+        assert r.needs_annotation() is False
+
+    def test_needs_annotation_indeterminate(self):
+        r = AttunementResult(
+            depth="indeterminate",
+            symptom_layer="behavior",
+            likely_cause_layer="behavior",
+            reason="test",
+        )
+        assert r.needs_annotation() is False


### PR DESCRIPTION
## Summary

- Adds `src/memory/attunement.py` — pure-function module implementing the Attunement Over Assumption principle for subagent result evaluation before relay
- `evaluate_attunement(result_text, original_request)` classifies results by causal depth: `surface_only`, `causal`, `both`, or `indeterminate`
- Surface-only results get a layer-attributed annotation: `[Surface addressed. Causal layer may need investigation: symptom at behavior layer, cause likely at integration layer.]`
- Detects "why-requested-but-not-answered" mismatches when the original request asked "why" but the result provides no causal analysis
- 32 passing tests in `tests/unit/test_attunement.py` covering signal detection, layer inference, depth classification, and annotation format

## Test plan

- [x] `uv run pytest tests/unit/test_attunement.py -v` — 32/32 passing
- [ ] Dispatcher bootup Result Evaluation hook update (blocked — `.claude/` file is protected, needs manual edit to reference `evaluate_attunement` in the hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)