### PR TITLE
feat(wos-v3): schema migration — register field + corrective_traces table

### DIFF
--- a/scripts/migrate-wos-v3-schema.py
+++ b/scripts/migrate-wos-v3-schema.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+WOS V3 Schema Migration Script
+
+Applies migration 0007 (register field, uow_mode field, corrective_traces table,
+closed_at, close_reason) to the WOS registry database.
+
+This script is a thin wrapper around the existing migration runner. It validates
+that migration 0007 applied cleanly and reports what changed.
+
+Usage:
+    uv run scripts/migrate-wos-v3-schema.py [DB_PATH]
+
+    DB_PATH defaults to ~/lobster-workspace/orchestration/registry.db
+    Override with REGISTRY_DB_PATH environment variable.
+
+Exit codes:
+    0 — migration applied or already up-to-date
+    1 — migration failed
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# Ensure the repo root is on sys.path so src.orchestration imports work.
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _default_db_path() -> Path:
+    workspace = Path(os.environ.get(
+        "LOBSTER_WORKSPACE",
+        Path.home() / "lobster-workspace",
+    ))
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    return workspace / "orchestration" / "registry.db"
+
+
+def _verify_schema(db_path: Path) -> dict[str, list[str]]:
+    """Return a dict of {table_name: [column_names]} for V3-added objects."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    results: dict[str, list[str]] = {}
+    try:
+        # Check uow_registry columns
+        cols = conn.execute("PRAGMA table_info(uow_registry)").fetchall()
+        results["uow_registry"] = [c["name"] for c in cols]
+
+        # Check corrective_traces table
+        tables = {
+            r["name"]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        if "corrective_traces" in tables:
+            ct_cols = conn.execute("PRAGMA table_info(corrective_traces)").fetchall()
+            results["corrective_traces"] = [c["name"] for c in ct_cols]
+        else:
+            results["corrective_traces"] = []
+
+        # Check executor_uow_view columns
+        views = {
+            r["name"]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='view'"
+            ).fetchall()
+        }
+        if "executor_uow_view" in views:
+            view_cols = conn.execute("PRAGMA table_info(executor_uow_view)").fetchall()
+            results["executor_uow_view"] = [c["name"] for c in view_cols]
+        else:
+            results["executor_uow_view"] = []
+
+    finally:
+        conn.close()
+    return results
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        db_path = Path(sys.argv[1])
+    else:
+        db_path = _default_db_path()
+
+    print(f"WOS V3 Schema Migration")
+    print(f"DB path: {db_path}")
+    print()
+
+    try:
+        from src.orchestration.migrate import run_migrations
+    except ImportError as exc:
+        print(f"ERROR: Could not import migration runner: {exc}", file=sys.stderr)
+        print(
+            "Ensure you are running from the lobster repo root:\n"
+            "  uv run scripts/migrate-wos-v3-schema.py",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        applied = run_migrations(db_path)
+    except Exception as exc:
+        print(f"ERROR: Migration failed: {exc}", file=sys.stderr)
+        return 1
+
+    if applied:
+        print(f"Applied migrations: {applied}")
+    else:
+        print("No migrations needed (already up-to-date).")
+
+    # Verify V3 fields are present
+    schema = _verify_schema(db_path)
+
+    uow_cols = schema.get("uow_registry", [])
+    missing_uow = [c for c in ("register", "uow_mode", "closed_at", "close_reason") if c not in uow_cols]
+    if missing_uow:
+        print(f"ERROR: Missing V3 columns in uow_registry: {missing_uow}", file=sys.stderr)
+        return 1
+
+    ct_cols = schema.get("corrective_traces", [])
+    if not ct_cols:
+        print("ERROR: corrective_traces table not found", file=sys.stderr)
+        return 1
+    missing_ct = [c for c in ("uow_id", "register", "execution_summary", "gate_score") if c not in ct_cols]
+    if missing_ct:
+        print(f"ERROR: Missing columns in corrective_traces: {missing_ct}", file=sys.stderr)
+        return 1
+
+    view_cols = schema.get("executor_uow_view", [])
+    missing_view = [c for c in ("register", "uow_mode") if c not in view_cols]
+    if missing_view:
+        print(f"ERROR: Missing V3 columns in executor_uow_view: {missing_view}", file=sys.stderr)
+        return 1
+
+    print()
+    print("Schema verification PASSED:")
+    print(f"  uow_registry V3 columns present: register, uow_mode, closed_at, close_reason")
+    print(f"  corrective_traces table present: {ct_cols}")
+    print(f"  executor_uow_view V3 columns present: register, uow_mode")
+    print()
+    print("WOS V3 schema migration complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/orchestration/migrations/0007_wos_v3_register_and_corrective_traces.sql
+++ b/src/orchestration/migrations/0007_wos_v3_register_and_corrective_traces.sql
@@ -1,0 +1,70 @@
+-- Migration 0007: WOS V3 — register field, uow_mode field, corrective_traces table,
+--                 and delivery≠closure fields (closed_at, close_reason)
+--
+-- Design:
+--   register   — attentional configuration required for completion evaluation.
+--                Immutable after germination. Written at INSERT time by the Germinator.
+--                Values: operational | iterative-convergent | philosophical | human-judgment
+--                Default: 'operational' (safe default for existing rows).
+--
+--   uow_mode   — mirrors register; used for execution context selection by the Executor.
+--                Kept as a separate column to allow future divergence between routing
+--                register and execution mode without a schema change.
+--
+--   closed_at  — ISO timestamp written when the Steward declares done (loop closure).
+--                Distinct from completed_at (executor delivery). NULL until Steward closes.
+--                This enforces the delivery≠closure distinction: result.json written by
+--                the Executor marks delivery; Steward writing closed_at marks closure.
+--
+--   close_reason — Prose explaining the Steward's closure decision. Required when
+--                  transitioning to done. Enables post-hoc audit of why a loop was
+--                  declared closed.
+--
+-- corrective_traces table:
+--   Every executor return writes a structured trace capturing execution summary,
+--   surprises, prescription delta, and gate score. Traces accumulate in the garden.
+--   The Steward reads them at diagnosis time for register-aware orientation.
+--   Absence of a trace is logged as a contract violation but does not block Steward
+--   re-entry (unlike result.json absence, which blocks completion declaration).
+--
+-- Note on executor_uow_view: register and uow_mode are included in the view so that
+-- the Executor can select a register-appropriate execution context. closed_at and
+-- close_reason are excluded (Steward-private closure fields).
+
+ALTER TABLE uow_registry ADD COLUMN register TEXT NOT NULL DEFAULT 'operational';
+ALTER TABLE uow_registry ADD COLUMN uow_mode TEXT;
+ALTER TABLE uow_registry ADD COLUMN closed_at TEXT DEFAULT NULL;
+ALTER TABLE uow_registry ADD COLUMN close_reason TEXT DEFAULT NULL;
+
+-- Backfill uow_mode to match register for all existing rows.
+UPDATE uow_registry SET uow_mode = register WHERE uow_mode IS NULL;
+
+-- Drop and recreate executor_uow_view to include register and uow_mode.
+-- SQLite does not support ALTER VIEW, so we must DROP and CREATE.
+DROP VIEW IF EXISTS executor_uow_view;
+
+CREATE VIEW IF NOT EXISTS executor_uow_view AS
+SELECT
+    id, status, output_ref, started_at, completed_at,
+    source_issue_number, summary,
+    workflow_artifact, success_criteria, prescribed_skills,
+    steward_cycles, timeout_at, estimated_runtime,
+    register, uow_mode
+FROM uow_registry;
+
+-- corrective_traces: learning artifacts written by every executor return.
+-- Accumulated in the garden; read by Steward at diagnosis time.
+CREATE TABLE IF NOT EXISTS corrective_traces (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    uow_id              TEXT    NOT NULL,
+    register            TEXT    NOT NULL,
+    execution_summary   TEXT    NOT NULL,
+    surprises           TEXT,   -- JSON array of unexpected findings
+    prescription_delta  TEXT,   -- what would change the prescription on next run
+    gate_score          TEXT,   -- JSON: {"command": "...", "result": "...", "score": 0.9} or null
+    created_at          TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Index for efficient Steward lookup by uow_id at diagnosis time.
+CREATE INDEX IF NOT EXISTS idx_corrective_traces_uow_id
+    ON corrective_traces(uow_id);

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -168,6 +168,23 @@ class UoW:
     # Canonical GitHub issue URL (populated after migration 0005)
     # Eliminates hardcoded repo references in Steward and Executor.
     issue_url: str | None = None
+    # V3 register fields (populated after migration 0007)
+    # register: attentional configuration required for completion evaluation.
+    #   Values: operational | iterative-convergent | philosophical | human-judgment
+    #   Immutable after germination — written at INSERT time by the Germinator.
+    #   If the Steward detects a mismatch on diagnosis, it surfaces to Dan rather
+    #   than reclassifying autonomously.
+    # uow_mode: mirrors register; used for execution context selection by Executor.
+    #   Kept separate to allow future divergence without a schema change.
+    register: str = "operational"
+    uow_mode: str | None = None
+    # Delivery≠closure fields (populated after migration 0007)
+    # closed_at: ISO timestamp written by Steward when it declares the loop done.
+    #   Distinct from completed_at (Executor delivery). NULL until Steward closes.
+    # close_reason: prose explaining the Steward's closure decision.
+    #   Required at done transition. Enables post-hoc audit of closure rationale.
+    closed_at: str | None = None
+    close_reason: str | None = None
 
 
 def _now_iso() -> str:
@@ -297,6 +314,10 @@ class Registry:
             source_last_seen_at=d.get("source_last_seen_at"),
             source_state=d.get("source_state"),
             issue_url=d.get("issue_url"),
+            register=d.get("register") or "operational",
+            uow_mode=d.get("uow_mode"),
+            closed_at=d.get("closed_at"),
+            close_reason=d.get("close_reason"),
         )
 
     def _write_audit(
@@ -457,8 +478,8 @@ class Registry:
                     id, type, source, source_issue_number, sweep_date,
                     status, posture, created_at, updated_at, summary,
                     success_criteria, route_reason, route_evidence, trigger,
-                    issue_url
-                ) VALUES (?, ?, ?, ?, ?, 'proposed', 'solo', ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?)
+                    issue_url, register, uow_mode
+                ) VALUES (?, ?, ?, ?, ?, 'proposed', 'solo', ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?, ?, ?)
                 """,
                 (
                     uow_id,
@@ -472,6 +493,8 @@ class Registry:
                     success_criteria,
                     _LEGACY_ROUTE_REASON,
                     resolved_issue_url,
+                    "operational",   # register default — Germinator overwrites at PR1
+                    "operational",   # uow_mode mirrors register at insert time
                 ),
             )
             conn.commit()


### PR DESCRIPTION
## Summary

- **Migration 0007**: adds `register` (`TEXT NOT NULL DEFAULT 'operational'`) and `uow_mode` fields to `uow_registry` — the attentional configuration required for completion evaluation, classified at germination and immutable thereafter
- **Migration 0007**: adds `corrective_traces` table — V3's core new primitive; every executor return writes a structured trace (execution_summary, surprises, prescription_delta, gate_score) that accumulates in the garden for Steward to read at diagnosis time
- **Migration 0007**: adds `closed_at` + `close_reason` fields — enforces the delivery≠closure distinction. `completed_at` = Executor delivered result.json. `closed_at` = Steward declared loop done. The `done` transition requires explicit `close_reason` prose.
- **executor_uow_view** rebuilt to include `register` and `uow_mode` (Executor needs these for context selection); `closed_at`/`close_reason` excluded (Steward-private)
- **UoW dataclass** updated with all four new fields; `_row_to_uow` populates them; INSERT default is `'operational'` until PR1 Germinator overwrites at germination
- **scripts/migrate-wos-v3-schema.py**: standalone migration + verification script (`uv run scripts/migrate-wos-v3-schema.py [DB_PATH]`)

## Test plan

- [x] All 60 unit tests pass (`tests/unit/test_orchestration/test_registry.py`)
- [x] Migration applies cleanly to fresh DB (migrations 1–7 all applied)
- [x] Schema verification script confirms all V3 columns and corrective_traces table present
- [x] Pre-existing integration test failures are on main branch (not caused by this PR)

## Part of WOS V3 series

- PR0 (this): schema migration
- PR1 (follow-up): register classification at germination (Germinator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)