### PR TITLE
refactor(oracle): restructure learnings.md with two-layer index + archive

### DIFF
--- a/oracle/learnings.md
+++ b/oracle/learnings.md
@@ -2,9 +2,38 @@
 
 Patterns and antipatterns surfaced through oracle review. These inform future design decisions.
 
+**Structure:** Layer 1 (index) is a compact, categorized reference — one line per entry. Layer 2 (archive) contains full entries with detail. Add new entries to both layers.
+
 ---
 
-## [2026-04-04] PR #607 — Corrective trace temporal gate
+## Layer 1: Index
+
+### State Machines
+
+| Date | PR | Learning |
+|------|----|----------|
+| 2026-04-04 | #607 | Comment/code mismatch at state-machine transition causes silent state divergence — state and comment must be synchronized |
+
+### Contract & Interface Design
+
+| Date | PR | Learning |
+|------|----|----------|
+| 2026-04-04 | #607 | Recovery gate tolerating an open executor contract gap inverts principle-1 — fix the contract at the producer, not the consumer |
+
+### Classification & Detection
+
+| Date | PR | Learning |
+|------|----|----------|
+| 2026-04-04 | #602 | Boolean frozenset intersection over-eager for shared vocabulary — use weighted scoring or frequency thresholds instead of presence-only detection |
+| 2026-04-04 | #602 | Classification results should be typed frozen dataclasses with observability fields — not bare return values |
+
+---
+
+## Layer 2: Archive
+
+---
+
+### [2026-04-04] PR #607 — Corrective trace temporal gate
 
 **Learning 1: Recovery gate tolerating an open executor contract gap — principle-1 inversion**
 When a steward-side temporal gate is added to tolerate a missing executor output artifact (trace.json absent → wait one cycle, proceed on second entry), the gate makes the steward the adaptation layer for an incomplete executor contract. Vision.yaml principle-1 ("Proactive resilience over reactive recovery") identifies the correct fix layer: close the contract at the executor exit side (require trace.json before result.json is written), not at the steward re-entry side. Once the steward gracefully tolerates the gap, pressure to close the upstream contract decreases. Detection: when a steward-side gate's purpose is "wait for an artifact the executor should have written," check whether the fix should be in the executor's exit protocol instead.
@@ -14,7 +43,7 @@ When a code comment says "Transition back to X so next heartbeat picks it up" bu
 
 ---
 
-## [2026-04-04] PR #602 — Germinator register classification
+### [2026-04-04] PR #602 — Germinator register classification
 
 **Learning 1: Boolean frozenset intersection is an over-eager gate for shared vocabulary**
 `_PHILOSOPHICAL_TERMS` using a frozenset intersection means a single ambiguous term (like "register") fires Gate 3 at full confidence. When technical vocabulary overlaps with phenomenological vocabulary, weighted scoring or term-frequency thresholds are more appropriate than presence-only detection. Monitor for false positives as the term list grows.
@@ -23,3 +52,5 @@ When a code comment says "Transition back to X so next heartbeat picks it up" bu
 `RegisterClassification(register, gate_fired, evidence, confidence)` is better than returning just the register string. The observability fields (gate_fired, evidence) make the classification auditable from the result alone without log access. Apply this pattern to any future classifier returning a consequential decision.
 
 ---
+
+*To add a new entry: (1) add a one-line row to the appropriate Layer 1 category (or create a new category); (2) append the full entry to Layer 2 with date, PR, and bold learning titles.*


### PR DESCRIPTION
## What this solves

`oracle/learnings.md` was a flat list of full-text entries. As the file grows over time, the reader must scan all full entries to find a specific learning or assess coverage by category. This PR implements the design-approved two-layer structure that separates quick-scan access (Layer 1) from full detail (Layer 2).

## What changed

**Layer 1 (index)** added at the top: a set of categorized tables, one row per learning entry. Categories currently: State Machines, Contract & Interface Design, Classification & Detection. Each row gives date, PR reference, and a one-line summary — enough to recognize the pattern without reading the full entry.

**Layer 2 (archive)** is the existing content, preserved verbatim with only the section heading level changed from `##` to `###` (to sit correctly under the Layer 2 `##` header). No text deleted, no entries removed.

**Authoring instructions** added at the bottom: one sentence explaining the two-step process for adding new entries (index row first, full archive entry second).

## What this does not change

- No oracle entries were deleted or modified
- No other oracle files touched (decisions.md, golden-patterns.md)
- No code changes — documentation restructure only

## Functional patterns

Pure restructure: no logic, no side effects. The index rows are manually maintained summaries of the archive entries — deterministic, not generated.

## Tests run

- [x] Verified all 4 original learning entries are present in Layer 2 (word-for-word)
- [x] Verified Layer 1 index has one row per learning (4 entries, 4 rows)
- [x] Verified no content lost in diff review

## Manual test

N/A — documentation-only change, no external services or runtime behavior affected.

## Definition of Done

- [x] All existing content preserved — restructure only, no deletions
- [x] Design spec implemented: two-layer index + archive
- [x] Authoring instructions present so future entries follow the pattern
- [x] No code changes, no side effects