### PR TITLE
fix: skip re-prescription for UoWs already in ready-for-executor (#617)

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2567,6 +2567,37 @@ def run_steward_cycle(
         evaluated += 1
         audit_entries = _fetch_audit_entries(registry, uow_id)
 
+        # Backpressure gate (#617): skip re-prescription when the UoW was
+        # returned from ready-for-executor via startup_sweep executor_orphan.
+        # This happens when the executor queue is saturated — the startup sweep
+        # transitions the UoW back to ready-for-steward, but prescribing again
+        # consumes an LLM call without making progress.  Instead, log a
+        # backpressure event and leave the UoW in ready-for-steward so it will
+        # be re-evaluated on the next heartbeat after the queue drains.
+        #
+        # Note: _most_recent_classification scans for startup_sweep events only,
+        # so executor_orphan return_reasons from execution_complete events (a
+        # different scenario) are not intercepted here.
+        _sweep_classification = _most_recent_classification(audit_entries)
+        if _sweep_classification == "executor_orphan":
+            log.info(
+                "backpressure: uow_id=%s already in ready-for-executor, "
+                "skipping re-prescription (cycle %d)",
+                uow_id,
+                uow.steward_cycles,
+            )
+            if not dry_run:
+                registry.append_audit_log(uow_id, {
+                    "event": "backpressure",
+                    "actor": _ACTOR_STEWARD,
+                    "uow_id": uow_id,
+                    "steward_cycles": uow.steward_cycles,
+                    "note": "executor_orphan: skipping re-prescription, queue may be saturated",
+                    "timestamp": _now_iso(),
+                })
+            skipped += 1
+            continue
+
         try:
             result = _process_uow(
                 uow=uow,

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -1772,6 +1772,166 @@ class TestFeedbackLoopIntegration:
 
 
 # ---------------------------------------------------------------------------
+# Test: Backpressure — skip re-prescription when executor queue is saturated (#617)
+# ---------------------------------------------------------------------------
+
+class TestBackpressureSkipsRePrescription:
+    """
+    When the startup sweep returns a UoW from ready-for-executor to
+    ready-for-steward with classification=executor_orphan, the steward
+    must NOT re-prescribe. Instead it skips the UoW and logs a backpressure
+    event. This prevents LLM call waste when the executor queue is saturated.
+    """
+
+    EXECUTOR_ORPHAN_AUDIT_ENTRY = {
+        "event": "startup_sweep",
+        "classification": "executor_orphan",
+        "prior_status": "ready-for-executor",
+    }
+
+    def test_skip_represcription_when_executor_orphan(self, db_path, registry, tmp_path):
+        """UoW returned as executor_orphan must be skipped, not prescribed."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            output_ref=None,
+            audit_log_entries=[self.EXECUTOR_ORPHAN_AUDIT_ENTRY],
+        )
+        conn.close()
+
+        result = steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+        )
+
+        # UoW must not be prescribed: status stays ready-for-steward
+        uow = _get_uow(db_path, uow_id)
+        assert uow["status"] == "ready-for-steward", (
+            "UoW with executor_orphan return reason must remain ready-for-steward, "
+            f"not be re-prescribed. Got status: {uow['status']}"
+        )
+        assert result["skipped"] >= 1, (
+            "run_steward_cycle must count the backpressure skip in skipped counter"
+        )
+
+    def test_no_llm_call_when_executor_orphan(self, db_path, registry, tmp_path):
+        """No LLM prescription call is made when return reason is executor_orphan."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        llm_calls = []
+
+        def capturing_llm_prescriber(uow, posture, gap, issue_body=""):
+            llm_calls.append(uow.id)
+            return None
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            output_ref=None,
+            audit_log_entries=[self.EXECUTOR_ORPHAN_AUDIT_ENTRY],
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            llm_prescriber=capturing_llm_prescriber,
+        )
+
+        assert uow_id not in llm_calls, (
+            "LLM prescriber must not be called for a UoW with executor_orphan return reason"
+        )
+
+    def test_normal_uow_still_prescribed_alongside_orphan(self, db_path, registry, tmp_path):
+        """A normal UoW is prescribed even when another UoW is an executor_orphan."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        orphan_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            output_ref=None,
+            audit_log_entries=[self.EXECUTOR_ORPHAN_AUDIT_ENTRY],
+            source_issue_number=101,
+        )
+        normal_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=0,
+            output_ref=None,
+            source_issue_number=102,
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+        )
+
+        orphan_uow = _get_uow(db_path, orphan_id)
+        normal_uow = _get_uow(db_path, normal_id)
+
+        assert orphan_uow["status"] == "ready-for-steward", (
+            "executor_orphan UoW must stay ready-for-steward (backpressure skip)"
+        )
+        assert normal_uow["status"] == "ready-for-executor", (
+            f"Normal UoW must be prescribed (ready-for-executor). Got: {normal_uow['status']}"
+        )
+
+    def test_backpressure_event_written_to_audit_log(self, db_path, registry, tmp_path):
+        """A backpressure audit event is written when re-prescription is skipped."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            output_ref=None,
+            audit_log_entries=[self.EXECUTOR_ORPHAN_AUDIT_ENTRY],
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+        )
+
+        entries = _audit_entries(db_path, uow_id)
+        backpressure_entries = [
+            e for e in entries
+            if e.get("event") == "backpressure"
+        ]
+        assert backpressure_entries, (
+            "A backpressure audit entry must be written when re-prescription is skipped"
+        )
+        # The note must contain the uow_id and cycle count
+        import json as _json
+        note_data = _json.loads(backpressure_entries[0]["note"])
+        assert note_data.get("uow_id") == uow_id
+        assert "steward_cycles" in note_data
+
+
+# ---------------------------------------------------------------------------
 # Mock helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this fixes

When the executor queue is saturated, UoWs accumulate in `ready-for-executor`. The startup sweep transitions them back to `ready-for-steward` after 1 hour (the orphan threshold), classifying them as `executor_orphan`. Before this fix, the steward would unconditionally re-prescribe each such UoW — consuming an LLM call per heartbeat without making progress, repeating until the 5-cycle hard cap surface.

In a saturated queue, this compounds: N stalled UoWs × up to 5 prescription calls each before surfacing, with none of them actually advancing.

## What changed

A backpressure gate was added at the top of the `run_steward_cycle` main loop. Before calling `_process_uow`, the gate checks whether the most recent `startup_sweep` audit entry has `classification=executor_orphan`. If so, it:

1. Skips `_process_uow` entirely (no LLM call, no state transition)
2. Writes a structured `backpressure` audit event with `uow_id` and `steward_cycles`
3. Increments the `skipped` counter in the cycle result dict
4. Logs: `backpressure: uow_id=<id> already in ready-for-executor, skipping re-prescription (cycle N)`

The UoW stays in `ready-for-steward` and is re-evaluated on the next heartbeat. Once the queue drains and the executor claims the UoW, the audit trail will show an `execution_complete` event, and the backpressure gate will no longer fire.

## Why _most_recent_classification, not _most_recent_return_reason

`_most_recent_return_reason` would also return `"executor_orphan"` when an `execution_complete` event carries that return_reason in its note — a distinct scenario where the executor itself reports the orphan outcome. Using `_most_recent_classification` (which scans `startup_sweep` events only) confines the gate precisely to the startup-sweep-driven saturation case.

## Before / after flow

```
Before (saturated queue):
  heartbeat N  : startup_sweep → ready-for-executor UoW → ready-for-steward (executor_orphan)
  heartbeat N  : steward prescribes → LLM call → ready-for-executor (still no executor slot)
  heartbeat N+1: startup_sweep → ready-for-executor UoW → ready-for-steward again
  heartbeat N+1: steward prescribes → LLM call (wasted) → ready-for-executor again
  ... repeats until steward_cycles hits 5, then surfaces to Dan

After:
  heartbeat N  : startup_sweep → ready-for-executor UoW → ready-for-steward (executor_orphan)
  heartbeat N  : backpressure gate fires → skipped, audit event written, no LLM call
  heartbeat N+1: backpressure gate fires → skipped
  (executor queue drains)
  executor claims UoW → execution_complete in audit log
  heartbeat M  : backpressure gate does NOT fire (no startup_sweep executor_orphan) → normal cycle
```

## Scope

Only `src/orchestration/steward.py` and `tests/unit/test_orchestration/test_steward.py` are modified. No schema changes, no heartbeat script changes, no other files.

## Functional patterns

- Pure function composition: `_most_recent_classification` is a pure read over audit entries with no side effects
- Early-return guard before the side-effectful `_process_uow` call
- Immutable audit log append for the backpressure event
- Named constant reuse: `_ACTOR_STEWARD` and `_now_iso()` follow existing patterns

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestBackpressureSkipsRePrescription -v` — 4 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -k "Backpressure or ExecutorOrphan or TestHardCap or TestCrash or TestDone or TestFirstCycle or TestBootup" -v` — 15 passed, 0 failed (includes regression for TestExecutorOrphan)
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_execution_gate.py -v` — 4 passed
- [ ] Full `test_steward.py` suite (101 tests) — timed out at 3+ min; several tests invoke `claude -p` subprocess. The 29 non-LLM-calling tests that ran all passed. The LLM-calling tests exercise paths untouched by this change.

**Blocked items:** none for merge.

## Manual test

N/A — entirely internal to `run_steward_cycle`. No external services, no Telegram output, no file system state changes outside the SQLite audit log. The audit log write is covered by `test_backpressure_event_written_to_audit_log`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, internal state machine change only
- [x] User-visible outcome — N/A (no user-facing output)
- [x] Side-effect audit: gate only skips + writes one audit row; no floods, no volume changes
- [x] External service calls: none introduced

Closes #617