### PR TITLE
docs: add workspace CONVENTIONS.md and reference it from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,7 @@ Never use cron for user-space jobs. Never use systemd tools for system-level inf
 - `~/messages/failed/` - Failed messages (pending retry or permanently failed)
 - `~/messages/audio/` - Voice message audio files
 - `~/messages/task-outputs/` - Outputs from scheduled jobs
+- For full workspace layout and conventions, see `~/lobster-workspace/CONVENTIONS.md`
 
 ## WOS Runtime Execution Control
 


### PR DESCRIPTION
## Summary

The `~/lobster-workspace/` directory has grown to 18+ directories, but only 7 were documented in CLAUDE.md. Agents and subagents working in the workspace had no reference for where things belong, leading to loose files at the root and ambiguous placement decisions (e.g., is a retrospective an assessment? does a design doc go in `design/`, `meta/`, or `scraps/`?).

This PR adds `~/lobster-workspace/CONVENTIONS.md` — a full directory-by-directory reference covering all 18+ workspace directories — and adds a single pointer line to CLAUDE.md's Key Directories section so it is discoverable.

**What changed in CLAUDE.md:** One line added at the end of the Key Directories bullet list, pointing to the new CONVENTIONS.md. No existing content modified.

**What CONVENTIONS.md covers:** Every directory in `~/lobster-workspace/`, including the 11 that were previously undocumented: `archive/`, `deep-work/`, `design/`, `messages/`, `meta/`, `obsidian-vault/`, `oracle/`, `orchestration/`, `philosophy/`, `philosophy-explore/`, `reports/`, `retros/`, `scraps/`, `sessions/`, `signals/`, `user-model/`, `whisper.cpp/`, `wos/`. Each entry documents purpose, what belongs, and what does not (common misplacements).

CONVENTIONS.md lives in `~/lobster-workspace/` and is not committed to the repo — consistent with the workspace convention that runtime data never goes in the repo.

**Functional patterns:** Pure documentation — no code changes. The CONVENTIONS.md content was derived from auditing directory contents, existing docs, and CLAUDE.md context.

**What this does not change:** Existing CLAUDE.md content is untouched beyond the one appended line. No behavior changes.

## Tests run
- [x] Verified `~/lobster-workspace/CONVENTIONS.md` exists and covers all 18+ directories
- [x] Verified CLAUDE.md diff is exactly one line added, no existing content modified
- [ ] Live integration test — N/A: documentation change only

## Manual test
N/A — this change is entirely documentation. No external services, systemd units, file I/O, or runtime state affected.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, documentation only
- [x] Integration/manual test run (if applicable) — N/A
- [x] User-visible outcome verified — CONVENTIONS.md exists at the documented path
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — documentation only
- [x] External service calls: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)