### PR TITLE
cleanup: fix stale docstring and misleading test name (#655, #657)

### DIFF
--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -888,8 +888,8 @@ class TestDispatchViaInbox:
         """
         When no dispatcher is injected, Executor._dispatcher_override must be None
         so that _run_execution uses the dispatch table (_resolve_dispatcher).
-        Callers that need a specific dispatcher (e.g. heartbeat with _dispatch_via_inbox)
-        pass it explicitly — the injected dispatcher takes precedence over the table.
+        Callers that need a specific dispatcher pass it explicitly via the constructor
+        (e.g. tests inject a no-op); the injected dispatcher takes precedence over the table.
         """
         executor = Executor(registry)
         assert executor._dispatcher_override is None, (

--- a/tests/unit/test_orchestration/test_steward_register_mismatch.py
+++ b/tests/unit/test_orchestration/test_steward_register_mismatch.py
@@ -136,8 +136,8 @@ class TestCheckRegisterExecutorCompatibility:
         ok, reason = _check_register_executor_compatibility("iterative-convergent", "general")
         assert ok is False
 
-    def test_iterative_convergent_philosophical_mismatch(self):
-        """philosophical→iterative-convergent: philosophical not compatible with iterative executors."""
+    def test_philosophical_register_lobster_ops_mismatch(self):
+        """philosophical register is incompatible with lobster-ops executor."""
         ok, reason = _check_register_executor_compatibility("philosophical", "lobster-ops")
         assert ok is False
 


### PR DESCRIPTION
Two oracle follow-up items from PRs #649 and #651 — both are documentation-only with no behavior change.

## What changed

**#655 — Stale docstring in test_executor.py line 891**
The docstring referenced `_dispatch_via_inbox` as an example of a caller-injected dispatcher. That function was removed in PR #649 when the dispatch table was introduced. Updated to describe the actual pattern: callers (typically tests) inject any dispatcher they need via the constructor.

**#657 — Misleading test name in test_steward_register_mismatch.py**
`test_iterative_convergent_philosophical_mismatch` tested `("philosophical", "lobster-ops")`, not any iterative-convergent pairing. Renamed to `test_philosophical_register_lobster_ops_mismatch` to match what the test actually validates.

Neither change affects runtime behavior.

## Functional patterns
Pure documentation — no logic changes.

## Tests run
- [x] `uv run pytest tests/unit/test_executor.py -k "defaults_to_dispatch_table"` — 1 passed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_register_mismatch.py` — 20 passed
- Pre-existing failures on main (`test_registry_cli::test_approve_idempotent_on_pending`, `bot_talk` import error) are unrelated and present before this branch.

## Manual test
N/A — documentation-only changes, no runtime paths affected.

## Definition of Done
- [x] Unit tests pass
- [x] User-visible outcome: N/A (test/doc-only)
- [x] Side-effect audit: N/A

Closes #655, Closes #657