### PR TITLE
cleanup: route corrective_traces reads through Registry method (#656)

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -946,6 +946,32 @@ class Registry:
         finally:
             conn.close()
 
+    def get_corrective_trace_history(self, uow_id: str, limit: int = 3) -> list[str]:
+        """
+        Return the most recent ``prescription_delta`` values from
+        ``corrective_traces`` for *uow_id*, newest first.
+
+        Returns an empty list if no rows exist or if the table is absent
+        (e.g. running against a pre-migration DB in tests). Callers should
+        treat an empty list as "no history available" and proceed without
+        bounding.
+
+        This is the canonical read path for corrective-trace history —
+        callers must not open a raw sqlite3 connection to query this table.
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT prescription_delta FROM corrective_traces WHERE uow_id = ? "
+                "ORDER BY created_at DESC LIMIT ?",
+                (uow_id, limit),
+            ).fetchall()
+            return [row["prescription_delta"] for row in rows if row["prescription_delta"]]
+        except Exception:
+            return []
+        finally:
+            conn.close()
+
     def record_startup_sweep_active(
         self,
         uow_id: str,

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2541,21 +2541,10 @@ def _process_uow(
         if _trace_data is not None:
             _trace_surprises = _trace_data.get("surprises") or []
             _raw_prescription_delta = _trace_data.get("prescription_delta") or ""
-            # Read historical prescription_deltas from corrective_traces for bounding
-            _prior_deltas: list[str] = []
-            try:
-                _conn_ro = sqlite3.connect(str(registry.db_path))
-                _prior_deltas = [
-                    row[0] for row in _conn_ro.execute(
-                        "SELECT prescription_delta FROM corrective_traces WHERE uow_id = ? "
-                        "ORDER BY created_at DESC LIMIT 3",
-                        (uow_id,),
-                    ).fetchall()
-                    if row[0]
-                ]
-                _conn_ro.close()
-            except Exception:
-                pass
+            # Read historical prescription_deltas from corrective_traces for bounding.
+            # Routed through Registry to keep all corrective_traces reads behind the
+            # abstraction layer — no raw sqlite3 connections at call sites.
+            _prior_deltas: list[str] = registry.get_corrective_trace_history(uow_id)
             _trace_prescription_delta = _bound_prescription_delta(
                 _raw_prescription_delta, history=_prior_deltas
             )


### PR DESCRIPTION
The Steward's `_process_uow` opened a raw `sqlite3.connect()` to read `prescription_delta` from `corrective_traces`. Every other DB read in the Steward goes through the Registry abstraction — this was the one exception, noted as a seam violation in the PR #653 oracle verdict.

## What changed

Added `Registry.get_corrective_trace_history(uow_id, limit=3) -> list[str]` to `registry.py`. The method:
- Returns prescription_delta values for the given UoW, newest first
- Is exception-safe: returns `[]` on any DB error, preserving the best-effort semantics of the original `try/except` block
- Follows the same `_connect() / try / finally conn.close()` pattern used by `get_started_at` and other Registry reads

The call site in `_process_uow` (steward.py ~line 2544) replaces the 10-line raw-connection block with a single `registry.get_corrective_trace_history(uow_id)` call.

`sqlite3` import in steward.py is retained — `validate_steward_schema` uses it directly and is out of scope for this PR.

## Before / after

```
Before:
  _prior_deltas = []
  try:
      _conn_ro = sqlite3.connect(str(registry.db_path))
      _prior_deltas = [row[0] for row in _conn_ro.execute(
          "SELECT prescription_delta FROM corrective_traces WHERE uow_id = ? ...",
          (uow_id,),
      ).fetchall() if row[0]]
      _conn_ro.close()
  except Exception:
      pass

After:
  _prior_deltas = registry.get_corrective_trace_history(uow_id)
```

## Functional patterns
Pure function extraction — `get_corrective_trace_history` is a read-only query with no side effects. The callers' exception-handling semantics are preserved inside the method.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_steward_register_aware_diagnosis.py tests/unit/test_orchestration/test_executor_register_routing.py -q` — 118 passed
- Pre-existing failures on main (`test_approve_idempotent_on_pending`, `test_philosophical_no_surface_on_first_execution`) are present before this branch and unrelated.

## Manual test
N/A — internal refactor with identical observable behavior. The corrective_traces table query is unchanged; only the connection ownership moves from the call site to the Registry.

## Definition of Done
- [x] Unit tests pass with no regressions introduced
- [x] User-visible outcome: N/A (internal refactor)
- [x] Side-effect audit: N/A — read-only query, no writes

Closes #656