### PR TITLE
fix(wos): eliminate polling hop and hard-gate legacy done fallback (#648)

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -539,19 +539,25 @@ def _assess_completion(
                 log.warning("Could not parse result file %s: %s", result_file, e)
 
     # No structured result file found (or result file was invalid/misrouted).
+    # Require a result file regardless of whether success_criteria is set.
+    # A missing result.json means the Executor has not confirmed completion —
+    # the subagent may have exited 0 without opening a PR or calling write_result.
+    # Declaring done without evidence is the bug described in issue #648 Part B.
     success_criteria = uow.success_criteria
     if success_criteria:
-        # Conservative fallback: without a valid result file we cannot
-        # deterministically verify completion against success_criteria.
-        # Do not declare done — require the Executor to write a result file.
         return False, (
             f"no structured result file ({output_ref}.result.json) found — "
             f"cannot verify success_criteria without Executor confirmation: {success_criteria[:80]}"
         ), None
     else:
-        # Legacy fallback: no success_criteria and no result file.
-        # Trust the output_ref + execution_complete posture.
-        return True, f"success_criteria is NULL — output_ref present with execution_complete posture: {uow.summary[:80]}", None
+        # Hard gate: require result.json even when success_criteria is NULL.
+        # The legacy fallback (trust output_ref presence alone) is removed —
+        # it could declare done when the subagent exited 0 without producing
+        # any artifact (PR, write_result call, etc.). See issue #648 Part B.
+        return False, (
+            f"no structured result file ({output_ref}.result.json) found — "
+            f"Executor confirmation required even when success_criteria is NULL: {uow.summary[:80]}"
+        ), None
 
 
 # ---------------------------------------------------------------------------
@@ -2235,11 +2241,21 @@ def _process_uow(
     notify_dan: Callable | None,
     notify_dan_early_warning: Callable | None = None,
     llm_prescriber: Callable[..., dict[str, Any] | None] | None = _llm_prescribe,
+    inline_executor: Callable[[str], Any] | None = None,
 ) -> StewardOutcome:
     """
     Process a single UoW through the full diagnosis + prescribe/close/surface cycle.
 
     Returns a StewardOutcome: Prescribed | Done | Surfaced | RaceSkipped.
+
+    Args:
+        inline_executor: Optional callable(uow_id) that is invoked immediately after
+            the READY_FOR_EXECUTOR transition, collapsing the polling hop described in
+            issue #648 Part A.  When provided, the Steward dispatches the Executor
+            synchronously rather than waiting for the next heartbeat cycle (0–3 min).
+            The Executor's optimistic lock protects against double-execution if a
+            concurrent heartbeat fires between the transition and the inline call.
+            Defaults to None (no inline dispatch — heartbeat remains the dispatch path).
     """
     uow_id = uow.id
     cycles = uow.steward_cycles
@@ -2821,6 +2837,28 @@ def _process_uow(
         # Transition status to ready-for-executor
         registry.transition(uow_id, _STATUS_READY_FOR_EXECUTOR, _STATUS_DIAGNOSING)
 
+        # Issue #648 Part A — collapse the polling hop.
+        # When inline_executor is provided, invoke the Executor immediately after
+        # the READY_FOR_EXECUTOR transition rather than waiting for the next
+        # heartbeat cycle (which would add 0–3 min of unnecessary latency).
+        # The Executor's optimistic lock (step 2 in _claim) guards against
+        # double-execution if a concurrent heartbeat fires between transition
+        # and inline call — ClaimRejected is logged and re-raised, which the
+        # caller's exception handler surfaces.
+        if inline_executor is not None:
+            try:
+                inline_executor(uow_id)
+                log.info(
+                    "Steward: inline executor dispatch complete for UoW %s",
+                    uow_id,
+                )
+            except Exception as exc:
+                log.warning(
+                    "Steward: inline executor dispatch failed for UoW %s — %s: %s. "
+                    "UoW remains in ready-for-executor; heartbeat will retry.",
+                    uow_id, type(exc).__name__, exc,
+                )
+
     # Early warning: fire when new_cycles reaches the early-warning threshold.
     # Fires regardless of dry_run so tests can capture the notification.
     if new_cycles == _EARLY_WARNING_CYCLES:
@@ -2844,6 +2882,7 @@ def run_steward_cycle(
     bootup_candidate_gate: bool | None = None,
     db_path: Path | None = None,
     llm_prescriber: Callable[..., dict[str, Any] | None] | None = _llm_prescribe,
+    inline_executor: Callable[[str], Any] | None = None,
 ) -> dict[str, Any]:
     """
     Execute one full Steward heartbeat cycle.
@@ -2877,6 +2916,10 @@ def run_steward_cycle(
         Called during prescription to generate LLM-quality instructions.
         Inject None to bypass LLM (tests), or a stub to capture calls.
         Defaults to _llm_prescribe (production path).
+    inline_executor:
+        Optional callable(uow_id) invoked immediately after the READY_FOR_EXECUTOR
+        transition, collapsing the 0–3 min polling hop (issue #648 Part A).
+        Defaults to None — heartbeat remains the sole dispatch path.
 
     Returns
     -------
@@ -3035,6 +3078,7 @@ def run_steward_cycle(
                 notify_dan=notify_dan,
                 notify_dan_early_warning=notify_dan_early_warning,
                 llm_prescriber=llm_prescriber,
+                inline_executor=inline_executor,
             )
         except Exception:
             log.exception("Steward: unhandled error processing UoW %s — skipping", uow_id)

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -3176,3 +3176,269 @@ class TestCorrectiveTraceGate:
         assert "trace_gate_waited" not in steward_log, (
             "trace_gate_waited must NOT appear in steward_log when trace.json is present"
         )
+
+# ---------------------------------------------------------------------------
+# Tests: Issue #648 Part B — _assess_completion legacy fallback hard-gated
+# (NULL success_criteria must not declare done without a result.json)
+# ---------------------------------------------------------------------------
+
+class TestAssessCompletionLegacyFallbackRemoved:
+    """
+    Verify that _assess_completion no longer declares 'done' based solely on
+    output_ref presence when success_criteria is NULL and no result.json exists.
+
+    Issue #648 Part B: the legacy fallback (trust output_ref + execution_complete
+    posture when success_criteria is NULL) is removed. A result.json with
+    outcome=complete is required regardless of whether success_criteria is set.
+    """
+
+    def _make_uow(self, tmp_path, uow_id=None, success_criteria=None):
+        """Build a minimal UoW with output_ref pointing to a tmp file."""
+        from src.orchestration.registry import UoW, UoWStatus
+        if uow_id is None:
+            import uuid
+            uow_id = f"uow_{uuid.uuid4().hex[:8]}"
+        output_file = tmp_path / f"{uow_id}.json"
+        output_file.write_text("execution complete: task dispatched as run-123")
+        return UoW(
+            id=uow_id,
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="Fix the login bug",
+            source="github:issue/99",
+            source_issue_number=99,
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            type="executable",
+            success_criteria=success_criteria,
+            steward_cycles=1,
+            output_ref=str(output_file),
+        ), output_file
+
+    def test_null_success_criteria_no_result_json_is_not_done(self, tmp_path):
+        """
+        NULL success_criteria + no result.json must not declare done.
+
+        The legacy fallback trusted output_ref presence alone when
+        success_criteria was NULL. A subagent that exits 0 without opening a
+        PR or calling write_result would trigger this path — false done.
+        The fix: require result.json regardless of success_criteria.
+        """
+        steward = _import_steward()
+        uow, output_file = self._make_uow(tmp_path, success_criteria=None)
+        # No result.json written — subagent exited without confirming work.
+
+        is_complete, rationale, executor_outcome = steward._assess_completion(
+            uow=uow,
+            output_content=output_file.read_text(),
+            reentry_posture="execution_complete",
+        )
+
+        assert not is_complete, (
+            "_assess_completion must return is_complete=False when no result.json "
+            "is present, even when success_criteria is NULL. "
+            "The legacy fallback must not silently declare done."
+        )
+        assert executor_outcome is None
+        assert "result file" in rationale.lower() or "result.json" in rationale.lower(), (
+            "Rationale must explain that a result file is required"
+        )
+
+    def test_null_success_criteria_with_complete_result_json_is_done(self, tmp_path):
+        """
+        NULL success_criteria + result.json with outcome=complete must declare done.
+
+        Removing the legacy fallback must not prevent legitimate completions:
+        when the Executor writes a result.json with outcome=complete, the
+        Steward should close the UoW even without explicit success_criteria.
+        """
+        steward = _import_steward()
+        uow, output_file = self._make_uow(tmp_path, success_criteria=None)
+        result_file = output_file.with_suffix(".result.json")
+        result_file.write_text(json.dumps({
+            "uow_id": uow.id,
+            "outcome": "complete",
+            "success": True,
+        }))
+
+        is_complete, rationale, executor_outcome = steward._assess_completion(
+            uow=uow,
+            output_content=output_file.read_text(),
+            reentry_posture="execution_complete",
+        )
+
+        assert is_complete, (
+            "_assess_completion must return is_complete=True when result.json "
+            "reports outcome=complete, even when success_criteria is NULL."
+        )
+        assert executor_outcome == "complete"
+
+    def test_null_success_criteria_with_failed_result_json_is_not_done(self, tmp_path):
+        """
+        NULL success_criteria + result.json with outcome=failed must not declare done.
+
+        Confirms the full routing path: result.json outcome is authoritative
+        even when success_criteria is NULL.
+        """
+        steward = _import_steward()
+        uow, output_file = self._make_uow(tmp_path, success_criteria=None)
+        result_file = output_file.with_suffix(".result.json")
+        result_file.write_text(json.dumps({
+            "uow_id": uow.id,
+            "outcome": "failed",
+            "success": False,
+            "reason": "subagent exited without opening PR",
+        }))
+
+        is_complete, rationale, executor_outcome = steward._assess_completion(
+            uow=uow,
+            output_content=output_file.read_text(),
+            reentry_posture="execution_complete",
+        )
+
+        assert not is_complete
+        assert executor_outcome == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Issue #648 Part A — inline_executor collapses the polling hop
+# ---------------------------------------------------------------------------
+
+class TestInlineExecutorDispatch:
+    """
+    Verify that when inline_executor is provided to _process_uow / run_steward_cycle,
+    the Executor is invoked immediately after the READY_FOR_EXECUTOR transition,
+    eliminating the 0-3 min polling hop described in issue #648 Part A.
+    """
+
+    def _setup_db(self, tmp_path):
+        """Return (db_path, registry, uow_id) for a fresh DB with one ready-for-steward UoW."""
+        from src.orchestration.registry import Registry
+        db_path = tmp_path / "registry.db"
+        conn = _open_db(db_path)
+        _apply_phase2_schema(conn)
+        uow_id = _make_uow_row(conn, status="ready-for-steward", source_issue_number=42)
+        conn.close()
+        registry = Registry(db_path)
+        return db_path, registry, uow_id
+
+    def test_inline_executor_called_after_prescription(self, tmp_path):
+        """
+        When inline_executor is provided and a UoW is prescribed, the callable
+        is invoked with the UoW ID immediately after the READY_FOR_EXECUTOR
+        transition — not on the next heartbeat cycle.
+        """
+        steward = _import_steward()
+        db_path, registry, uow_id = self._setup_db(tmp_path)
+
+        dispatched_uow_ids: list[str] = []
+
+        def fake_executor(uid: str) -> None:
+            dispatched_uow_ids.append(uid)
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            notify_dan=lambda *a, **kw: None,
+            llm_prescriber=None,
+            inline_executor=fake_executor,
+        )
+
+        assert dispatched_uow_ids == [uow_id], (
+            f"inline_executor must be called once with the UoW ID after prescription. "
+            f"Got: {dispatched_uow_ids!r}"
+        )
+
+    def test_no_inline_executor_by_default(self, tmp_path):
+        """
+        When inline_executor is not provided (default None), the Executor is
+        not called inline — the heartbeat remains the sole dispatch path.
+
+        This verifies backward compatibility: existing callers that do not
+        pass inline_executor continue to work unchanged.
+        """
+        steward = _import_steward()
+        db_path, registry, uow_id = self._setup_db(tmp_path)
+
+        executor_called: list[str] = []
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            notify_dan=lambda *a, **kw: None,
+            llm_prescriber=None,
+            # inline_executor intentionally omitted
+        )
+
+        assert executor_called == [], (
+            "With no inline_executor, the executor must not be called inline"
+        )
+
+    def test_inline_executor_failure_is_non_fatal(self, tmp_path):
+        """
+        When inline_executor raises, the error is logged but the UoW stays
+        in ready-for-executor — the heartbeat will retry on the next cycle.
+
+        The Steward must not propagate the executor exception; _process_uow
+        must return Prescribed normally even if inline dispatch fails.
+        """
+        steward = _import_steward()
+        db_path, registry, uow_id = self._setup_db(tmp_path)
+
+        def failing_executor(uid: str) -> None:
+            raise RuntimeError("Executor claim rejected — optimistic lock race")
+
+        # Must not raise even though inline_executor raises
+        result = steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            notify_dan=lambda *a, **kw: None,
+            llm_prescriber=None,
+            inline_executor=failing_executor,
+        )
+
+        # The prescription still completes — Prescribed is counted
+        assert result["prescribed"] >= 1, (
+            "Steward must count the prescription as successful even when "
+            "inline_executor raises — the UoW is in ready-for-executor for retry"
+        )
+
+        # UoW is in ready-for-executor (heartbeat will pick it up)
+        uow = _get_uow(db_path, uow_id)
+        assert uow["status"] == "ready-for-executor", (
+            f"UoW must remain in ready-for-executor when inline_executor fails. "
+            f"Got: {uow['status']!r}"
+        )
+
+    def test_inline_executor_not_called_in_dry_run(self, tmp_path):
+        """
+        In dry-run mode the READY_FOR_EXECUTOR transition is suppressed, so
+        inline_executor must NOT be called (it would have nothing to claim).
+        """
+        steward = _import_steward()
+        db_path, registry, uow_id = self._setup_db(tmp_path)
+
+        dispatched: list[str] = []
+
+        def fake_executor(uid: str) -> None:
+            dispatched.append(uid)
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=True,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            notify_dan=lambda *a, **kw: None,
+            llm_prescriber=None,
+            inline_executor=fake_executor,
+        )
+
+        assert dispatched == [], (
+            "inline_executor must not be called in dry-run mode — "
+            "the READY_FOR_EXECUTOR transition is suppressed in dry_run"
+        )


### PR DESCRIPTION
## Problem

Two architectural bugs identified in issue #648:

**Part A — 0–3 min unnecessary latency:** After prescribing, the Steward wrote a UoW to `ready-for-executor` and did nothing else. The executor-heartbeat cron (every 3 min) had to fire before dispatch happened. This is pure wait time with no benefit — the Steward has everything it needs to dispatch inline.

**Part B — Silent false-done declarations:** `_assess_completion` had a legacy fallback (steward.py:551–554) that declared a UoW complete when `success_criteria` was NULL and no `result.json` was present. The condition was: output_ref exists + posture is `execution_complete`. A subagent that exits 0 without opening a PR or calling `write_result` satisfies this condition — the UoW closes with no evidence of real work.

## What changed

### Part A — Inline executor dispatch
Added `inline_executor: Callable[[str], Any] | None = None` to `_process_uow()` and `run_steward_cycle()`. When provided, it is called immediately after `registry.transition(uow_id, READY_FOR_EXECUTOR, DIAGNOSING)`, eliminating the polling hop.

Flow before: Steward prescribes → waits up to 3 min → heartbeat fires → Executor dispatches
Flow after:  Steward prescribes → Executor dispatches inline → heartbeat is a no-op fallback

The Executor's existing optimistic lock (step 2 of the 6-step claim sequence) prevents double-execution if a concurrent heartbeat races. If inline dispatch fails (e.g. race lost), the exception is caught and logged — the UoW stays in `ready-for-executor` for the heartbeat to retry. `dry_run=True` suppresses both the transition and the inline call. All callers that do not pass `inline_executor` are unaffected.

### Part B — Hard gate on legacy done fallback
Removed the `else` branch at steward.py:551–554 that declared done when `success_criteria is NULL`. Both code paths now require a `result.json` with `outcome=complete`:

```
Before (NULL success_criteria + no result.json): is_complete=True  ← bug
After  (NULL success_criteria + no result.json): is_complete=False ← safe
Before (NULL success_criteria + result.json outcome=complete): is_complete=True
After  (NULL success_criteria + result.json outcome=complete): is_complete=True (unchanged)
```

## Files affected
- `src/orchestration/steward.py` — `_assess_completion` (Part B) and `_process_uow` / `run_steward_cycle` (Part A)
- `tests/unit/test_orchestration/test_steward.py` — 7 new tests

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestAssessCompletionLegacyFallbackRemoved` — 3 passed (new Part B tests)
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestInlineExecutorDispatch` — 4 passed (new Part A tests)
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestAssessCompletionStructuralProxy` — 4 passed (existing regression tests for `_assess_completion`)
- [x] Full orchestration unit suite — 737 passed, 9 pre-existing failures confirmed on `main` before this branch

Pre-existing failures (not caused by this PR, confirmed on main):
- `test_registry_cli.py::TestApproveCommand::test_approve_idempotent_on_pending`
- `test_steward.py::TestBackpressureSkipsRePrescription` (4 tests)
- `test_steward_register_aware_diagnosis.py::TestTraceInjectionIntegration::test_philosophical_no_surface_on_first_execution`
- `test_executor.py::TestOptimisticLock` (3 tests)

## Manual test
N/A — this change is entirely internal. No systemd, cron, external services, file I/O (beyond existing output_ref mechanics), or DB schema changes. The `inline_executor` API is in place for caller-side integration; no production callers are wired in this PR.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, internal logic only
- [x] User-visible outcome — not applicable (no user-visible surface changed)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #648