### PR TITLE
fix(wos): scope staleness gate to executor_orphan recovery path only

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -177,54 +177,84 @@ def run_ttl_recovery(registry, dry_run: bool = False) -> list[str]:
     return recovered
 
 
-def _filter_stale_uows(ready_uows: list, stale_minutes: int) -> list:
+def _filter_stale_uows(
+    ready_uows: list,
+    stale_minutes: int,
+    is_orphan_fn=None,
+) -> list:
     """
-    Return only UoWs that have been in ready-for-executor state for longer than
-    stale_minutes, measured by their updated_at timestamp.
+    Return UoWs eligible for heartbeat dispatch.
 
-    UoWs written recently are skipped — the primary event-driven inbox dispatch
-    should pick them up within seconds. Only UoWs that have been waiting longer
-    than the recovery threshold are candidates for heartbeat re-dispatch.
+    Two dispatch paths are distinguished:
+
+    1. Fresh UoWs (never been executor_orphan): pass through immediately.
+       The primary event-driven inbox dispatch may have been missed entirely
+       (e.g. dispatcher was down when the UoW was prescribed). The heartbeat
+       should pick these up without waiting — the steward re-prescribes every
+       ~2 min, so a time-based staleness gate would never open for a fresh UoW.
+
+    2. Previously-orphaned UoWs (prior executor_orphan audit entry): apply
+       the stale_minutes gate. These UoWs had a dispatch attempt that the
+       primary path missed; the heartbeat is the recovery path and we wait
+       to confirm the primary path is truly blocked.
 
     Args:
-        ready_uows: List of UoW objects with an updated_at attribute (ISO 8601 str).
-        stale_minutes: Minimum age in minutes before a UoW is eligible for recovery.
+        ready_uows: List of UoW objects with an id and updated_at attribute.
+        stale_minutes: Minimum age in minutes before an orphaned UoW is
+            eligible for recovery dispatch. Not applied to fresh UoWs.
+        is_orphan_fn: Optional callable(uow_id: str) -> bool. Returns True
+            if the UoW has prior executor_orphan history. When None, all UoWs
+            are treated as fresh (immediate dispatch).
 
     Returns:
-        Filtered list of stale UoW objects (may be empty).
+        Filtered list of UoW objects eligible for dispatch (may be empty).
     """
     from datetime import datetime, timezone, timedelta
 
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=stale_minutes)
-    stale = []
+    eligible = []
     for uow in ready_uows:
+        # Determine whether this UoW has prior executor_orphan history.
+        # If is_orphan_fn is None or raises, treat as fresh (safe default).
+        try:
+            previously_orphaned = is_orphan_fn(uow.id) if is_orphan_fn is not None else False
+        except Exception:
+            previously_orphaned = False
+
+        if not previously_orphaned:
+            # Fresh UoW — pass through immediately for dispatch.
+            eligible.append(uow)
+            continue
+
+        # Previously-orphaned — apply the staleness gate.
         try:
             updated = datetime.fromisoformat(uow.updated_at)
             # Ensure timezone-aware comparison
             if updated.tzinfo is None:
                 updated = updated.replace(tzinfo=timezone.utc)
             if updated < cutoff:
-                stale.append(uow)
+                eligible.append(uow)
         except (ValueError, TypeError, AttributeError):
-            # If updated_at is missing, non-string, or unparseable, treat as stale (safe default)
-            stale.append(uow)
-    return stale
+            # If updated_at is missing or unparseable, treat as stale (safe default)
+            eligible.append(uow)
+    return eligible
 
 
 def run_executor_cycle(registry, dry_run: bool = False) -> dict:
     """
-    Recovery-dispatch UoWs in `ready-for-executor` state that are older than
-    RECOVERY_STALE_MINUTES.
+    Dispatch UoWs in `ready-for-executor` state that were not picked up by the
+    primary event-driven inbox path.
 
-    This is a recovery poller, not the primary dispatch path. The primary path
-    is the event-driven inbox dispatch in _dispatch_via_inbox: when the Steward
-    prescribes a UoW, the Executor writes a wos_execute message to ~/messages/inbox/
-    and the Lobster dispatcher picks it up within seconds.
+    Two eligibility rules are applied by _filter_stale_uows:
 
-    The heartbeat dispatches UoWs that were NOT picked up by the primary path —
-    e.g. due to dispatcher downtime, restart races, or any other gap. UoWs younger
-    than RECOVERY_STALE_MINUTES are skipped (they are expected to be picked up by
-    the primary path imminently).
+    - Fresh UoWs (no prior executor_orphan audit entry): dispatched immediately.
+      These were never attempted — the primary inbox dispatch may have been missed
+      entirely (e.g. dispatcher downtime when the UoW was prescribed).
+
+    - Previously-orphaned UoWs (prior executor_orphan audit entry): dispatched
+      only after RECOVERY_STALE_MINUTES have elapsed since updated_at. These had
+      a missed dispatch attempt and need the staleness gate to confirm the primary
+      path is truly blocked before re-dispatching.
 
     Each UoW is processed independently. Errors on individual UoWs are
     caught, logged, and skipped — the cycle continues for remaining UoWs.
@@ -243,15 +273,19 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
         return {"evaluated": 0, "ready": 0, "stale": 0, "dispatched": 0, "skipped": 0, "errors": 0}
 
     ready_count = len(ready_uows)
-    stale_uows = _filter_stale_uows(ready_uows, RECOVERY_STALE_MINUTES)
-    stale_count = len(stale_uows)
-    recent_count = ready_count - stale_count
+    eligible_uows = _filter_stale_uows(
+        ready_uows,
+        RECOVERY_STALE_MINUTES,
+        is_orphan_fn=registry.has_executor_orphan_history,
+    )
+    eligible_count = len(eligible_uows)
+    ineligible_count = ready_count - eligible_count
 
-    if recent_count > 0:
+    if ineligible_count > 0:
         log.debug(
-            "Executor cycle: %d ready-for-executor UoW(s) younger than %d min — "
-            "skipping (primary inbox dispatch expected)",
-            recent_count, RECOVERY_STALE_MINUTES,
+            "Executor cycle: %d ready-for-executor UoW(s) not yet eligible "
+            "(orphaned but <=%d min old) — skipping (primary inbox dispatch expected)",
+            ineligible_count, RECOVERY_STALE_MINUTES,
         )
 
     dispatched = 0
@@ -261,20 +295,20 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
     if dry_run:
         log.info(
             "Executor cycle (DRY RUN): %d ready-for-executor UoWs found, "
-            "%d stale (>%d min) — skipping all (dry-run mode)",
-            ready_count, stale_count, RECOVERY_STALE_MINUTES,
+            "%d eligible — skipping all (dry-run mode)",
+            ready_count, eligible_count,
         )
         return {
             "evaluated": ready_count,
             "ready": ready_count,
-            "stale": stale_count,
+            "stale": eligible_count,
             "dispatched": 0,
             "skipped": ready_count,
             "errors": 0,
         }
 
-    if stale_count == 0:
-        log.debug("Executor cycle: no stale UoWs to recover")
+    if eligible_count == 0:
+        log.debug("Executor cycle: no eligible UoWs to dispatch")
         return {
             "evaluated": ready_count,
             "ready": ready_count,
@@ -285,8 +319,8 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
         }
 
     log.info(
-        "Executor cycle (recovery): %d stale UoW(s) found (ready >%d min) — dispatching",
-        stale_count, RECOVERY_STALE_MINUTES,
+        "Executor cycle: %d eligible UoW(s) found — dispatching",
+        eligible_count,
     )
 
     from src.orchestration.executor import Executor
@@ -296,7 +330,7 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
     # functional-engineer, lobster-ops, and general executor types.
     executor = Executor(registry, dispatcher=None)
 
-    for uow in stale_uows:
+    for uow in eligible_uows:
         uow_id = uow.id
         try:
             result = executor.execute_uow(uow_id)
@@ -352,7 +386,7 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
     return {
         "evaluated": ready_count,
         "ready": ready_count,
-        "stale": stale_count,
+        "stale": eligible_count,
         "dispatched": dispatched,
         "skipped": skipped,
         "errors": errors,

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1103,6 +1103,41 @@ class Registry:
         finally:
             conn.close()
 
+    def has_executor_orphan_history(self, uow_id: str) -> bool:
+        """
+        Return True if this UoW has ever been classified as executor_orphan
+        in the audit_log.
+
+        Used by the executor-heartbeat staleness filter to distinguish:
+        - Fresh UoWs (never orphaned): pass through immediately for dispatch
+        - Previously-orphaned UoWs: apply the RECOVERY_STALE_MINUTES gate
+
+        The executor_orphan classification is written by
+        record_startup_sweep_executor_orphan when the Steward detects a UoW
+        stuck in ready-for-executor. Its presence means the primary inbox
+        dispatch path already had a chance and missed this UoW — the heartbeat
+        is now the correct dispatch path.
+
+        Returns False on any query error (safe default: treat as fresh UoW,
+        allow immediate dispatch).
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) as c FROM audit_log
+                WHERE uow_id = ?
+                  AND event = 'startup_sweep'
+                  AND note LIKE '%"classification": "executor_orphan"%'
+                """,
+                (uow_id,),
+            ).fetchone()
+            return (row["c"] > 0) if row else False
+        except Exception:
+            return False
+        finally:
+            conn.close()
+
     def record_startup_sweep_diagnosing(
         self,
         uow_id: str,

--- a/tests/unit/test_orchestration/test_executor_heartbeat.py
+++ b/tests/unit/test_orchestration/test_executor_heartbeat.py
@@ -1,29 +1,44 @@
 """
-Tests for executor-heartbeat.py recovery-mode dispatch (issue #664).
+Tests for executor-heartbeat.py dispatch eligibility filter.
 
-The heartbeat is a recovery poller after issue #664 — not the primary dispatch
-path. The primary path is _dispatch_via_inbox (event-driven), which the Steward
-triggers immediately when a UoW transitions to ready-for-executor.
+Background: The heartbeat is both a first-dispatch path (for UoWs missed entirely
+by the primary inbox dispatch) and a recovery path (for UoWs the primary path
+tried and missed due to orphaning). The staleness gate must only apply to the
+recovery path, not the first-dispatch path.
+
+Root cause of the bug fixed here: the original _filter_stale_uows applied a
+5-minute staleness gate to ALL ready-for-executor UoWs. The steward re-prescribes
+every ~2 minutes and resets updated_at each time, so a fresh UoW never ages past
+2 minutes — the gate never opened and no UoW was ever dispatched.
+
+The fix: apply the staleness gate only to UoWs that have a prior executor_orphan
+audit entry. Fresh UoWs (never orphaned) pass through immediately.
 
 Coverage:
 - RECOVERY_STALE_MINUTES constant is a positive integer
-- _filter_stale_uows returns only UoWs older than the threshold
-- _filter_stale_uows skips recently-written UoWs (primary dispatch expected)
-- _filter_stale_uows treats missing/unparseable/non-string updated_at as stale (safe default)
-- run_executor_cycle skips UoWs younger than RECOVERY_STALE_MINUTES
-- run_executor_cycle dispatches UoWs older than RECOVERY_STALE_MINUTES
-- run_executor_cycle returns correct result dict keys (evaluated, ready, stale, dispatched, ...)
+- _filter_stale_uows: fresh UoW (no orphan history) passes through immediately
+- _filter_stale_uows: orphaned UoW passes staleness gate when old enough
+- _filter_stale_uows: orphaned UoW is blocked when too recent
+- _filter_stale_uows: mixed fresh + orphaned UoWs handled correctly
+- _filter_stale_uows: missing/unparseable updated_at on orphaned UoW treated as stale
+- _filter_stale_uows: is_orphan_fn error treated as fresh (safe default)
+- run_executor_cycle: fresh UoW dispatched immediately (no staleness gate)
+- run_executor_cycle: orphaned recent UoW not dispatched (staleness gate active)
+- run_executor_cycle: orphaned stale UoW dispatched (staleness gate clears)
+- run_executor_cycle: result dict has required keys
+- run_executor_cycle: mixed fresh + orphaned UoWs — correct dispatch set
 """
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import sqlite3
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -66,6 +81,11 @@ def _uow_age(minutes: float) -> str:
     return ts.isoformat()
 
 
+# Canonical orphan/non-orphan callables for test clarity
+_always_orphaned = lambda uow_id: True
+_never_orphaned = lambda uow_id: False
+
+
 # ---------------------------------------------------------------------------
 # RECOVERY_STALE_MINUTES — sanity check
 # ---------------------------------------------------------------------------
@@ -81,77 +101,147 @@ class TestRecoveryStaleMintuesConstant:
 
 
 # ---------------------------------------------------------------------------
-# _filter_stale_uows — pure function tests
+# _filter_stale_uows — fresh UoW path (no orphan history)
 # ---------------------------------------------------------------------------
 
-class TestFilterStaleUoWs:
-    """_filter_stale_uows correctly splits recent vs stale UoWs."""
+class TestFilterStaleUoWsFreshPath:
+    """Fresh UoWs (no prior executor_orphan entry) pass through immediately."""
 
     def test_empty_list_returns_empty(self) -> None:
         result = _filter_stale_uows([], stale_minutes=5)
         assert result == []
 
-    def test_old_uow_is_returned(self) -> None:
-        """A UoW older than the threshold must be included in the stale list."""
-        uow = _StubUoW(id="old-001", updated_at=_uow_age(minutes=10))
+    def test_fresh_uow_passes_immediately_regardless_of_age(self) -> None:
+        """A UoW with no orphan history passes through even if written just now."""
+        uow = _StubUoW(id="fresh-001", updated_at=_uow_age(minutes=0.1))
+        result = _filter_stale_uows([uow], stale_minutes=5, is_orphan_fn=_never_orphaned)
+        assert len(result) == 1
+        assert result[0].id == "fresh-001"
+
+    def test_fresh_uow_passes_when_is_orphan_fn_is_none(self) -> None:
+        """Default (no is_orphan_fn) treats all UoWs as fresh — all pass through."""
+        uow = _StubUoW(id="fresh-002", updated_at=_uow_age(minutes=0.1))
         result = _filter_stale_uows([uow], stale_minutes=5)
         assert len(result) == 1
-        assert result[0].id == "old-001"
 
-    def test_recent_uow_is_excluded(self) -> None:
-        """A UoW younger than the threshold must be excluded (primary dispatch expected)."""
-        uow = _StubUoW(id="new-001", updated_at=_uow_age(minutes=1))
-        result = _filter_stale_uows([uow], stale_minutes=5)
-        assert result == []
-
-    def test_mixed_uows_returns_only_stale(self) -> None:
-        """Only stale UoWs are returned; recent ones are skipped."""
-        stale = _StubUoW(id="stale-001", updated_at=_uow_age(minutes=20))
-        recent = _StubUoW(id="recent-001", updated_at=_uow_age(minutes=2))
-        result = _filter_stale_uows([stale, recent], stale_minutes=5)
-        assert len(result) == 1
-        assert result[0].id == "stale-001"
-
-    def test_multiple_stale_uows_all_returned(self) -> None:
-        uows = [
-            _StubUoW(id=f"stale-{i}", updated_at=_uow_age(minutes=10 + i))
-            for i in range(3)
-        ]
-        result = _filter_stale_uows(uows, stale_minutes=5)
+    def test_multiple_fresh_uows_all_pass(self) -> None:
+        uows = [_StubUoW(id=f"fresh-{i}", updated_at=_uow_age(minutes=i)) for i in range(3)]
+        result = _filter_stale_uows(uows, stale_minutes=5, is_orphan_fn=_never_orphaned)
         assert len(result) == 3
 
-    def test_unparseable_updated_at_treated_as_stale(self) -> None:
-        """If updated_at cannot be parsed as ISO 8601, treat as stale (safe default)."""
-        uow = _StubUoW(id="bad-ts-001", updated_at="not-a-timestamp")
-        result = _filter_stale_uows([uow], stale_minutes=5)
-        assert len(result) == 1
-        assert result[0].id == "bad-ts-001"
+    def test_is_orphan_fn_error_treated_as_fresh(self) -> None:
+        """If is_orphan_fn raises, the UoW is treated as fresh and passes immediately."""
+        def _raises(uow_id: str) -> bool:
+            raise RuntimeError("db error")
 
-    def test_non_string_updated_at_treated_as_stale(self) -> None:
-        """If updated_at is not a string (e.g. Mock object), treat as stale (safe default)."""
+        uow = _StubUoW(id="err-001", updated_at=_uow_age(minutes=0.1))
+        result = _filter_stale_uows([uow], stale_minutes=5, is_orphan_fn=_raises)
+        assert len(result) == 1
+        assert result[0].id == "err-001"
+
+
+# ---------------------------------------------------------------------------
+# _filter_stale_uows — orphaned UoW path (prior executor_orphan entry)
+# ---------------------------------------------------------------------------
+
+class TestFilterStaleUoWsOrphanPath:
+    """Orphaned UoWs (prior executor_orphan audit entry) require the staleness gate."""
+
+    def test_orphaned_old_uow_is_returned(self) -> None:
+        """An orphaned UoW older than the threshold must be included."""
+        uow = _StubUoW(id="orphan-old-001", updated_at=_uow_age(minutes=10))
+        result = _filter_stale_uows([uow], stale_minutes=5, is_orphan_fn=_always_orphaned)
+        assert len(result) == 1
+        assert result[0].id == "orphan-old-001"
+
+    def test_orphaned_recent_uow_is_excluded(self) -> None:
+        """An orphaned UoW younger than the threshold must be excluded."""
+        uow = _StubUoW(id="orphan-new-001", updated_at=_uow_age(minutes=1))
+        result = _filter_stale_uows([uow], stale_minutes=5, is_orphan_fn=_always_orphaned)
+        assert result == []
+
+    def test_orphaned_mixed_uows_returns_only_stale(self) -> None:
+        """Only stale orphaned UoWs are returned; recent orphaned ones are skipped."""
+        stale = _StubUoW(id="orphan-stale-001", updated_at=_uow_age(minutes=20))
+        recent = _StubUoW(id="orphan-recent-001", updated_at=_uow_age(minutes=2))
+        result = _filter_stale_uows([stale, recent], stale_minutes=5, is_orphan_fn=_always_orphaned)
+        assert len(result) == 1
+        assert result[0].id == "orphan-stale-001"
+
+    def test_orphaned_multiple_stale_uows_all_returned(self) -> None:
+        uows = [
+            _StubUoW(id=f"orphan-{i}", updated_at=_uow_age(minutes=10 + i))
+            for i in range(3)
+        ]
+        result = _filter_stale_uows(uows, stale_minutes=5, is_orphan_fn=_always_orphaned)
+        assert len(result) == 3
+
+    def test_orphaned_unparseable_updated_at_treated_as_stale(self) -> None:
+        """If updated_at cannot be parsed on an orphaned UoW, treat as stale (safe default)."""
+        uow = _StubUoW(id="orphan-bad-ts-001", updated_at="not-a-timestamp")
+        result = _filter_stale_uows([uow], stale_minutes=5, is_orphan_fn=_always_orphaned)
+        assert len(result) == 1
+        assert result[0].id == "orphan-bad-ts-001"
+
+    def test_orphaned_non_string_updated_at_treated_as_stale(self) -> None:
+        """If updated_at is not a string on an orphaned UoW, treat as stale (safe default)."""
         uow = MagicMock()
-        uow.id = "mock-ts-001"
+        uow.id = "orphan-mock-ts-001"
         uow.updated_at = MagicMock()  # Not a string — fromisoformat will raise TypeError
-        result = _filter_stale_uows([uow], stale_minutes=5)
+        result = _filter_stale_uows([uow], stale_minutes=5, is_orphan_fn=_always_orphaned)
         assert len(result) == 1
 
     def test_preserves_order(self) -> None:
-        """Stale UoWs are returned in the same order as the input list."""
+        """Eligible UoWs are returned in the same order as the input list."""
         uows = [
-            _StubUoW(id="stale-b", updated_at=_uow_age(minutes=15)),
-            _StubUoW(id="stale-a", updated_at=_uow_age(minutes=20)),
+            _StubUoW(id="orphan-b", updated_at=_uow_age(minutes=15)),
+            _StubUoW(id="orphan-a", updated_at=_uow_age(minutes=20)),
         ]
-        result = _filter_stale_uows(uows, stale_minutes=5)
-        assert [u.id for u in result] == ["stale-b", "stale-a"]
+        result = _filter_stale_uows(uows, stale_minutes=5, is_orphan_fn=_always_orphaned)
+        assert [u.id for u in result] == ["orphan-b", "orphan-a"]
 
 
 # ---------------------------------------------------------------------------
-# run_executor_cycle — recovery scope (via SQLite-backed Registry)
+# _filter_stale_uows — mixed fresh + orphaned UoWs
 # ---------------------------------------------------------------------------
 
-class TestRunExecutorCycleRecoveryScope:
+class TestFilterStaleUoWsMixed:
+    """Fresh and orphaned UoWs in the same list are handled per their respective rules."""
+
+    def test_fresh_and_orphaned_recent_mixed(self) -> None:
+        """Fresh UoW passes immediately; recent orphaned UoW is blocked."""
+        fresh = _StubUoW(id="fresh-mix-001", updated_at=_uow_age(minutes=0.5))
+        orphan_recent = _StubUoW(id="orphan-mix-recent-001", updated_at=_uow_age(minutes=1))
+
+        orphan_ids = {"orphan-mix-recent-001"}
+        is_orphan = lambda uow_id: uow_id in orphan_ids
+
+        result = _filter_stale_uows([fresh, orphan_recent], stale_minutes=5, is_orphan_fn=is_orphan)
+        assert [u.id for u in result] == ["fresh-mix-001"]
+
+    def test_fresh_and_orphaned_stale_mixed(self) -> None:
+        """Fresh UoW passes immediately; stale orphaned UoW also passes."""
+        fresh = _StubUoW(id="fresh-mix-002", updated_at=_uow_age(minutes=0.5))
+        orphan_stale = _StubUoW(id="orphan-mix-stale-001", updated_at=_uow_age(minutes=10))
+
+        orphan_ids = {"orphan-mix-stale-001"}
+        is_orphan = lambda uow_id: uow_id in orphan_ids
+
+        result = _filter_stale_uows([fresh, orphan_stale], stale_minutes=5, is_orphan_fn=is_orphan)
+        assert len(result) == 2
+        ids = {u.id for u in result}
+        assert "fresh-mix-002" in ids
+        assert "orphan-mix-stale-001" in ids
+
+
+# ---------------------------------------------------------------------------
+# run_executor_cycle — dispatch eligibility (via SQLite-backed Registry)
+# ---------------------------------------------------------------------------
+
+class TestRunExecutorCycleDispatchEligibility:
     """
-    run_executor_cycle only dispatches stale UoWs, not recently-written ones.
+    run_executor_cycle dispatches fresh UoWs immediately and applies the
+    staleness gate only to previously-orphaned UoWs.
 
     Uses a SQLite-backed Registry so the full claim sequence runs correctly.
     """
@@ -195,6 +285,33 @@ class TestRunExecutorCycleRecoveryScope:
         finally:
             conn.close()
 
+    def _insert_executor_orphan_audit(self, db_path: Path, uow_id: str) -> None:
+        """Write an executor_orphan startup_sweep audit entry for a UoW."""
+        now = datetime.now(timezone.utc).isoformat()
+        note_json = json.dumps({
+            "event": "startup_sweep",
+            "actor": "steward",
+            "classification": "executor_orphan",
+            "uow_id": uow_id,
+            "timestamp": now,
+            "prior_status": "ready-for-executor",
+            "proposed_at": now,
+            "age_seconds": 3700,
+            "threshold_seconds": 3600,
+        })
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        try:
+            conn.execute(
+                """
+                INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+                VALUES (?, ?, 'startup_sweep', 'ready-for-executor', 'ready-for-steward', 'steward', ?)
+                """,
+                (now, uow_id, note_json),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
     def _patch_inbox(self, monkeypatch: pytest.MonkeyPatch, inbox_called: list) -> None:
         """
         Patch _dispatch_via_inbox in the module the heartbeat actually uses.
@@ -212,11 +329,39 @@ class TestRunExecutorCycleRecoveryScope:
             lambda i, u: inbox_called.append(u) or "msg-id",
         )
 
-    def test_recent_uow_not_dispatched(
+    def test_fresh_uow_dispatched_immediately(
         self, registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A UoW younger than RECOVERY_STALE_MINUTES must NOT be dispatched by the heartbeat."""
-        self._insert_uow(db_path, "recent-uow-001", age_minutes=1)
+        """
+        A fresh UoW (no prior executor_orphan entry) must be dispatched immediately,
+        even if it was written just seconds ago.
+
+        This is the primary fix: the original code blocked all dispatch because the
+        steward keeps re-prescribing and resetting updated_at, so a fresh UoW never
+        aged past 2 minutes and the 5-minute gate never opened.
+        """
+        self._insert_uow(db_path, "fresh-uow-001", age_minutes=0.1)
+        # No audit entry — this UoW has never been orphaned
+
+        inbox_called: list[str] = []
+        self._patch_inbox(monkeypatch, inbox_called)
+
+        result = _hb.run_executor_cycle(registry)
+
+        assert "fresh-uow-001" in inbox_called, (
+            "Fresh UoW (no prior orphan) must be dispatched immediately"
+        )
+        assert result["dispatched"] == 1
+
+    def test_orphaned_recent_uow_not_dispatched(
+        self, registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        A UoW with prior executor_orphan history that is too recent must NOT be
+        dispatched — the staleness gate applies to the recovery path.
+        """
+        self._insert_uow(db_path, "orphan-recent-001", age_minutes=1)
+        self._insert_executor_orphan_audit(db_path, "orphan-recent-001")
 
         inbox_called: list[str] = []
         self._patch_inbox(monkeypatch, inbox_called)
@@ -224,25 +369,29 @@ class TestRunExecutorCycleRecoveryScope:
         result = _hb.run_executor_cycle(registry)
 
         assert inbox_called == [], (
-            "No dispatch should occur for UoWs younger than RECOVERY_STALE_MINUTES"
+            "No dispatch should occur for orphaned UoWs younger than RECOVERY_STALE_MINUTES"
         )
         assert result["stale"] == 0
         assert result["dispatched"] == 0
 
-    def test_stale_uow_is_dispatched(
+    def test_orphaned_stale_uow_is_dispatched(
         self, registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A UoW older than RECOVERY_STALE_MINUTES must be dispatched by the heartbeat."""
+        """
+        A UoW with prior executor_orphan history that has aged past RECOVERY_STALE_MINUTES
+        must be dispatched by the heartbeat (recovery path).
+        """
         stale_minutes = RECOVERY_STALE_MINUTES + 10
-        self._insert_uow(db_path, "stale-uow-001", age_minutes=stale_minutes)
+        self._insert_uow(db_path, "orphan-stale-001", age_minutes=stale_minutes)
+        self._insert_executor_orphan_audit(db_path, "orphan-stale-001")
 
         inbox_called: list[str] = []
         self._patch_inbox(monkeypatch, inbox_called)
 
         result = _hb.run_executor_cycle(registry)
 
-        assert "stale-uow-001" in inbox_called, (
-            "Stale UoW must be dispatched via inbox"
+        assert "orphan-stale-001" in inbox_called, (
+            "Stale orphaned UoW must be dispatched via inbox"
         )
         assert result["stale"] == 1
         assert result["dispatched"] == 1
@@ -259,22 +408,49 @@ class TestRunExecutorCycleRecoveryScope:
         for key in ("evaluated", "ready", "stale", "dispatched", "skipped", "errors"):
             assert key in result, f"Expected key '{key}' in result dict"
 
-    def test_mixed_uows_only_stale_dispatched(
+    def test_mixed_fresh_and_orphaned_stale(
         self, registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """With one stale and one recent UoW, only the stale one is dispatched."""
+        """
+        With one fresh UoW and one stale orphaned UoW:
+        - fresh UoW: dispatched immediately
+        - stale orphaned UoW: dispatched (staleness gate cleared)
+        """
         stale_minutes = RECOVERY_STALE_MINUTES + 10
-        self._insert_uow(db_path, "stale-uow-002", age_minutes=stale_minutes)
-        self._insert_uow(db_path, "recent-uow-002", age_minutes=1)
+        self._insert_uow(db_path, "fresh-mix-001", age_minutes=0.1)
+        self._insert_uow(db_path, "orphan-stale-mix-001", age_minutes=stale_minutes)
+        self._insert_executor_orphan_audit(db_path, "orphan-stale-mix-001")
 
         inbox_called: list[str] = []
         self._patch_inbox(monkeypatch, inbox_called)
 
         result = _hb.run_executor_cycle(registry)
 
-        assert inbox_called == ["stale-uow-002"], (
-            "Only the stale UoW must be dispatched"
+        assert set(inbox_called) == {"fresh-mix-001", "orphan-stale-mix-001"}, (
+            "Both the fresh UoW and the stale orphaned UoW must be dispatched"
         )
         assert result["ready"] == 2
-        assert result["stale"] == 1
+        assert result["dispatched"] == 2
+
+    def test_mixed_fresh_and_orphaned_recent(
+        self, registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        With one fresh UoW and one recent orphaned UoW:
+        - fresh UoW: dispatched immediately
+        - recent orphaned UoW: blocked (staleness gate active)
+        """
+        self._insert_uow(db_path, "fresh-mix-002", age_minutes=0.1)
+        self._insert_uow(db_path, "orphan-recent-mix-001", age_minutes=1)
+        self._insert_executor_orphan_audit(db_path, "orphan-recent-mix-001")
+
+        inbox_called: list[str] = []
+        self._patch_inbox(monkeypatch, inbox_called)
+
+        result = _hb.run_executor_cycle(registry)
+
+        assert inbox_called == ["fresh-mix-002"], (
+            "Only the fresh UoW must be dispatched; recent orphaned UoW must be blocked"
+        )
+        assert result["ready"] == 2
         assert result["dispatched"] == 1


### PR DESCRIPTION
## Problem

The executor-heartbeat was permanently blocked from dispatching any UoW. The root cause was a mismatch between the staleness gate threshold (5 minutes) and the steward's re-prescription cadence (~2 minutes). The steward resets `updated_at` on every prescription, so a `ready-for-executor` UoW never ages past ~2 minutes. The heartbeat's 5-minute gate never opened and no UoW was ever dispatched.

This was introduced in #665, which correctly added the staleness gate as a recovery filter (so the heartbeat wouldn't race with the primary inbox dispatch path). The gate's intent was right but it was applied unconditionally — including to fresh UoWs that had never been dispatched at all.

## Fix

The staleness gate now only applies to UoWs that have a prior `executor_orphan` audit entry. The `executor_orphan` classification is written by `record_startup_sweep_executor_orphan` when the Steward detects a UoW has been stuck in `ready-for-executor` too long. Its presence means the primary inbox dispatch path already had a chance and missed this UoW — the heartbeat is in recovery mode and the staleness gate is appropriate.

Fresh UoWs (no `executor_orphan` history) pass through immediately.

**Before/after flow:**

```
Before (broken):
  UoW enters ready-for-executor
  heartbeat: updated_at < 5min? → skip (steward re-prescribes in 2min → repeat forever)
  Result: no dispatch ever

After (fixed):
  UoW enters ready-for-executor
  heartbeat: has executor_orphan history?
    No (fresh) → dispatch immediately
    Yes (orphaned) → updated_at < 5min? → skip (wait for staleness)
                   → updated_at >= 5min? → dispatch (recovery path)
```

## Implementation

Three files changed:

**`src/orchestration/registry.py`** — adds `has_executor_orphan_history(uow_id)`, which queries `audit_log` for a `startup_sweep` entry with `"classification": "executor_orphan"`. Returns `False` on any query error (safe default: treat as fresh, allow immediate dispatch).

**`scheduled-tasks/executor-heartbeat.py`** — `_filter_stale_uows` gains an `is_orphan_fn` parameter (callable). Fresh UoWs (orphan fn returns False or raises) pass through unconditionally. Orphaned UoWs go through the existing staleness gate. `run_executor_cycle` wires `registry.has_executor_orphan_history` as the callable. The functional pattern (injected callable) keeps the filter pure and testable without a DB.

**`tests/unit/test_orchestration/test_executor_heartbeat.py`** — full rewrite. Old tests covered only the time-based staleness gate. New tests cover: fresh UoW passes immediately, orphaned recent UoW blocked, orphaned stale UoW dispatched, mixed populations, error in is_orphan_fn treated as fresh (safe default).

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_executor_heartbeat.py -v` — 22 passed, 0 failed

## Manual test

N/A — this change is entirely internal to the heartbeat's dispatch eligibility filter. The audit_log query is read-only. No external services, no Telegram output, no file I/O beyond DB reads.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, pure logic change
- [x] User-visible outcome verified — N/A (internal dispatch gate)
- [x] Side-effect audit complete: read-only audit_log query, no writes, no volume risk
- [x] External service calls: none