### PR TITLE
fix(wos): use updated_at as age anchor for ready-for-executor orphan detection

### DIFF
--- a/scheduled-tasks/startup-sweep.py
+++ b/scheduled-tasks/startup-sweep.py
@@ -318,19 +318,30 @@ def run_startup_sweep(
             )
             continue
 
-        proposed_at = uow.created_at  # proposed_at proxy: conservative lower bound
+        proposed_at = uow.created_at
+
+        # Age anchor: use updated_at (the time the UoW entered ready-for-executor)
+        # rather than created_at (when the issue was first proposed). The steward
+        # sets updated_at atomically on the ready-for-executor transition, so it
+        # accurately reflects how long the executor has had the UoW available.
+        #
+        # Using created_at caused Sprint 2 UoWs (created days ago) to be swept
+        # as executor_orphans on every heartbeat even seconds after prescription,
+        # because created_at always exceeded the 1-hour threshold.
+        _age_anchor = getattr(uow, "updated_at", None) or uow.created_at
+        _age_anchor_label = "updated_at" if getattr(uow, "updated_at", None) else "created_at"
 
         try:
-            proposed_dt = datetime.fromisoformat(
-                proposed_at.replace("Z", "+00:00")
+            age_anchor_dt = datetime.fromisoformat(
+                _age_anchor.replace("Z", "+00:00")
             )
-            if proposed_dt.tzinfo is None:
-                proposed_dt = proposed_dt.replace(tzinfo=timezone.utc)
-            age_seconds = (now - proposed_dt).total_seconds()
+            if age_anchor_dt.tzinfo is None:
+                age_anchor_dt = age_anchor_dt.replace(tzinfo=timezone.utc)
+            age_seconds = (now - age_anchor_dt).total_seconds()
         except (ValueError, TypeError, AttributeError):
             log.warning(
-                "Startup sweep: UoW %s has unparseable created_at=%r — skipping",
-                uow_id, proposed_at,
+                "Startup sweep: UoW %s has unparseable %s=%r — skipping",
+                uow_id, _age_anchor_label, _age_anchor,
             )
             continue
 

--- a/tests/unit/test_orchestration/test_startup_sweep.py
+++ b/tests/unit/test_orchestration/test_startup_sweep.py
@@ -548,6 +548,58 @@ class TestExecutorOrphan:
         assert result.executor_orphans_swept == 0
         assert _get_status(tmp_db, uow_id) == "ready-for-executor"
 
+    def test_updated_at_is_age_anchor_for_rfe_uow_not_created_at(self, registry, tmp_db):
+        """
+        The orphan threshold must use updated_at (when the UoW entered
+        ready-for-executor) — not created_at (when the issue was first proposed).
+
+        Sprint 2 blocker: UoWs created days ago but prescribed minutes ago were
+        being swept as executor_orphans on every heartbeat because created_at
+        exceeded the 1-hour threshold. updated_at is reset atomically when the
+        steward transitions to ready-for-executor, so it accurately reflects
+        how long the executor has had the UoW available.
+        """
+        conn = _open_conn(tmp_db)
+        uow_id = _make_uow(
+            conn,
+            status="ready-for-executor",
+            created_at=_iso_ago(7 * 24 * 3600),  # created 7 days ago (old issue)
+            updated_at=_iso_ago(120),             # entered ready-for-executor 2 min ago
+        )
+        conn.close()
+
+        # With the fix: updated_at (2 min) < threshold (1 hour) → should NOT be swept.
+        result = run_startup_sweep(registry, orphan_threshold_seconds=3600)
+
+        assert result.executor_orphans_swept == 0, (
+            "UoW with old created_at but recent updated_at must not be swept — "
+            "the executor has only had it for 2 minutes"
+        )
+        assert _get_status(tmp_db, uow_id) == "ready-for-executor"
+        assert len(_audit_entries(tmp_db, uow_id)) == 0
+
+    def test_rfe_uow_old_updated_at_is_swept_as_executor_orphan(self, registry, tmp_db):
+        """
+        A UoW whose updated_at (ready-for-executor entry time) exceeds the
+        orphan threshold should still be swept — executor genuinely never ran.
+        """
+        conn = _open_conn(tmp_db)
+        uow_id = _make_uow(
+            conn,
+            status="ready-for-executor",
+            created_at=_iso_ago(7 * 24 * 3600),  # created 7 days ago
+            updated_at=_iso_ago(7200),            # entered ready-for-executor 2 hours ago
+        )
+        conn.close()
+
+        result = run_startup_sweep(registry, orphan_threshold_seconds=3600)
+
+        assert result.executor_orphans_swept == 1
+        assert _get_status(tmp_db, uow_id) == "ready-for-steward"
+        note = json.loads(_audit_entries(tmp_db, uow_id)[0]["note"])
+        assert note["classification"] == "executor_orphan"
+        assert note["age_seconds"] > 3600
+
 
 class TestDiagnosingUow:
     def test_diagnosing_uow_is_transitioned_to_ready_for_steward(self, registry, tmp_db):


### PR DESCRIPTION
## What broke and why

The startup sweep classifies `ready-for-executor` UoWs as executor_orphans when their age exceeds 1 hour — intended for cases where the executor never claimed the UoW. But it was measuring age from `created_at` (when the source issue was first proposed), not `updated_at` (when the steward transitioned to `ready-for-executor`).

Sprint 2 UoWs (S2-A, S2-B) were created days ago. Even though the steward correctly prescribed them, within 3 minutes the startup sweep would look at `created_at` (days old >> 1-hour threshold), classify them as executor_orphans, and transition them back to `ready-for-steward`. This reset `updated_at` every ~3 minutes, defeating the executor's 5-minute staleness gate from PR #667 — the executor never saw a UoW sit still long enough to claim it.

## The fix

In `startup-sweep.py` Population 2, replace the `created_at` age anchor with `updated_at`. The registry updates `updated_at` atomically on every status transition, so `updated_at` for a `ready-for-executor` UoW accurately reflects when the steward finished prescribing — which is exactly the duration the executor has had to claim it.

Falls back to `created_at` if `updated_at` is absent (pre-migration rows).

**Flow before vs. after:**

```
Before:
  steward prescribes → status=ready-for-executor, updated_at=now
  3 min later: startup sweep checks age using created_at (days old >> 1h threshold)
  → executor_orphan → transition to ready-for-steward → updated_at reset
  → executor never sees it stable → staleness gate from #667 cannot fire
  → repeat indefinitely

After:
  steward prescribes → status=ready-for-executor, updated_at=now
  3 min later: startup sweep checks age using updated_at (3 min < 1h threshold)
  → not swept → UoW stays in ready-for-executor
  → executor staleness gate (#667) fires after 5 min
  → executor claims and runs
```

## Functional patterns

Pure function composition throughout — the fix is a single variable reassignment in the age computation, isolated to Population 2 of the startup sweep. No state machine changes, no new side effects, no cross-component coupling.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_startup_sweep.py -v` — 35 passed, 0 failed (includes 2 new tests for this fix)
- [x] Pre-existing failures on main confirmed pre-existing (6 unrelated failures in `TestBackpressureSkipsRePrescription`, `TestTraceInjectionIntegration`, `TestApproveCommand` — all present on main before this change)
- [ ] Full orchestration suite (`tests/unit/test_orchestration/`) — ran to completion (717 passed, 6 pre-existing failures), terminated at 6m09s by timeout; no new failures introduced by this change

**Pre-existing failures (not introduced by this PR):**
- `TestBackpressureSkipsRePrescription` (4 tests) — executor_orphan backpressure logic
- `TestTraceInjectionIntegration::test_philosophical_no_surface_on_first_execution`
- `TestApproveCommand::test_approve_idempotent_on_pending`

## Manual test

N/A for this change — it is entirely internal registry state logic with no external service calls, Telegram output, or file I/O beyond what the existing startup sweep already does.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure internal logic change)
- [x] User-visible outcome — N/A (infrastructure fix; executor can now claim UoWs)
- [x] Side-effect audit: no floods, no mass writes, no unintended volume — this reduces writes (stops the every-3-minute re-prescription cycle)
- [x] External service calls: none