### PR TITLE
feat(wos): per-cycle steward trace logging in UoW loop

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -262,6 +262,60 @@ def _classify_return_reason(return_reason: str | None) -> str:
     return _RETURN_REASON_CLASSIFICATIONS.get(return_reason, _CLASSIFICATION_ERROR)
 
 
+# ---------------------------------------------------------------------------
+# Per-cycle steward trace logging
+# ---------------------------------------------------------------------------
+
+_CYCLE_TRACE_EXCERPT_MAX = 200
+_DEFAULT_CYCLE_TRACE_DIR = Path(
+    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+) / "orchestration" / "artifacts"
+
+
+def _append_cycle_trace(
+    uow_id: str,
+    cycle_num: int,
+    subagent_excerpt: str,
+    return_reason: str,
+    next_action: str,
+    artifact_dir: Path | None = None,
+) -> None:
+    """Append one JSONL entry to <artifact_dir>/<uow_id>.cycles.jsonl.
+
+    Each entry records the outcome of a single steward cycle, enabling
+    post-hoc debugging of multi-cycle UoW lifecycles.
+
+    Args:
+        uow_id: The UoW identifier.
+        cycle_num: The current steward_cycles value (pre-increment).
+        subagent_excerpt: Text from the executor output (output_ref), truncated
+            to _CYCLE_TRACE_EXCERPT_MAX chars with a trailing ellipsis if longer.
+        return_reason: The return_reason from diagnosis, or empty string.
+        next_action: One of 'prescribed', 'done', 'surfaced', 'stuck'.
+        artifact_dir: Override for the artifact directory. Defaults to
+            ~/lobster-workspace/orchestration/artifacts.
+    """
+    resolved_dir = Path(artifact_dir) if artifact_dir is not None else _DEFAULT_CYCLE_TRACE_DIR
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+
+    # Truncate excerpt with ellipsis if it exceeds the max length
+    excerpt = subagent_excerpt
+    if len(excerpt) > _CYCLE_TRACE_EXCERPT_MAX:
+        excerpt = excerpt[:_CYCLE_TRACE_EXCERPT_MAX] + "\u2026"
+
+    entry = {
+        "cycle_num": cycle_num,
+        "subagent_excerpt": excerpt,
+        "return_reason": return_reason,
+        "next_action": next_action,
+        "timestamp": _now_iso(),
+    }
+
+    trace_path = resolved_dir / f"{uow_id}.cycles.jsonl"
+    with trace_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
 def _parse_audit_log(audit_entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     Extract structured entries from the audit_log rows passed in.
@@ -2400,6 +2454,14 @@ def _process_uow(
         if not dry_run:
             registry.transition(uow_id, _STATUS_BLOCKED, _STATUS_DIAGNOSING)
 
+        _append_cycle_trace(
+            uow_id=uow_id,
+            cycle_num=cycles,
+            subagent_excerpt=_read_output_ref(uow.output_ref),
+            return_reason=return_reason or "",
+            next_action="stuck",
+            artifact_dir=artifact_dir,
+        )
         return Surfaced(uow_id=uow_id, condition=stuck_condition)
 
     # 4b: Declare done
@@ -2432,6 +2494,14 @@ def _process_uow(
             })
             registry.transition(uow_id, _STATUS_DONE, _STATUS_DIAGNOSING)
 
+        _append_cycle_trace(
+            uow_id=uow_id,
+            cycle_num=cycles,
+            subagent_excerpt=_read_output_ref(uow.output_ref),
+            return_reason=return_reason or "",
+            next_action="done",
+            artifact_dir=artifact_dir,
+        )
         return Done(uow_id=uow_id)
 
     # 4c: Prescribe another Executor pass
@@ -2499,6 +2569,14 @@ def _process_uow(
                     })
                     registry.transition(uow_id, _STATUS_READY_FOR_STEWARD, _STATUS_DIAGNOSING)
                 # Return a special Prescribed outcome with cycles unchanged to signal skip
+                _append_cycle_trace(
+                    uow_id=uow_id,
+                    cycle_num=cycles,
+                    subagent_excerpt=_read_output_ref(uow.output_ref),
+                    return_reason=return_reason or "",
+                    next_action="prescribed",
+                    artifact_dir=artifact_dir,
+                )
                 return Prescribed(uow_id=uow_id, cycles=cycles)
             else:
                 # Already waited one cycle — proceed with prescription, log contract violation
@@ -2865,6 +2943,14 @@ def _process_uow(
         _notify_early = notify_dan_early_warning or _default_notify_dan_early_warning
         _notify_early(uow, return_reason, new_cycles)
 
+    _append_cycle_trace(
+        uow_id=uow_id,
+        cycle_num=cycles,
+        subagent_excerpt=_read_output_ref(uow.output_ref),
+        return_reason=return_reason or "",
+        next_action="prescribed",
+        artifact_dir=artifact_dir,
+    )
     return Prescribed(uow_id=uow_id, cycles=new_cycles)
 
 

--- a/tests/unit/test_orchestration/test_steward_cycle_trace.py
+++ b/tests/unit/test_orchestration/test_steward_cycle_trace.py
@@ -1,0 +1,453 @@
+"""
+Unit tests for per-cycle steward trace logging (_append_cycle_trace).
+
+Tests verify that:
+- A .cycles.jsonl file is written when a UoW is prescribed
+- Two JSONL entries are written over two cycles with correct cycle_num values
+- subagent_excerpt is truncated to 200 chars with a trailing ellipsis
+- Each JSONL entry has the required schema fields
+- Appending to an existing file does not overwrite prior entries
+
+All tests use tmp_path for artifact_dir so no production paths are touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Named constants (mirror the spec to keep tests coupled to requirements)
+# ---------------------------------------------------------------------------
+
+EXCERPT_MAX_CHARS = 200
+ELLIPSIS_CHAR = "\u2026"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (shared with test_steward.py pattern)
+# ---------------------------------------------------------------------------
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def _apply_phase2_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS uow_registry (
+            id                  TEXT    PRIMARY KEY,
+            type                TEXT    NOT NULL DEFAULT 'executable',
+            source              TEXT    NOT NULL,
+            source_issue_number INTEGER,
+            sweep_date          TEXT,
+            status              TEXT    NOT NULL DEFAULT 'proposed',
+            posture             TEXT    NOT NULL DEFAULT 'solo',
+            agent               TEXT,
+            children            TEXT    DEFAULT '[]',
+            parent              TEXT,
+            created_at          TEXT    NOT NULL,
+            updated_at          TEXT    NOT NULL,
+            started_at          TEXT,
+            completed_at        TEXT,
+            summary             TEXT    NOT NULL,
+            output_ref          TEXT,
+            hooks_applied       TEXT    DEFAULT '[]',
+            route_reason        TEXT,
+            route_evidence      TEXT    DEFAULT '{}',
+            trigger             TEXT    DEFAULT '{"type": "immediate"}',
+            vision_ref          TEXT    DEFAULT NULL,
+            workflow_artifact   TEXT    NULL,
+            success_criteria    TEXT    NULL,
+            prescribed_skills   TEXT    NULL,
+            steward_cycles      INTEGER NOT NULL DEFAULT 0,
+            timeout_at          TEXT    NULL,
+            estimated_runtime   INTEGER NULL,
+            steward_agenda      TEXT    NULL,
+            steward_log         TEXT    NULL,
+            UNIQUE(source_issue_number, sweep_date)
+        );
+
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts          TEXT    NOT NULL,
+            uow_id      TEXT    NOT NULL,
+            event       TEXT    NOT NULL,
+            from_status TEXT,
+            to_status   TEXT,
+            agent       TEXT,
+            note        TEXT
+        );
+
+        CREATE VIEW IF NOT EXISTS executor_uow_view AS
+        SELECT id, type, source, source_issue_number, sweep_date,
+               status, posture, agent, children, parent,
+               created_at, updated_at, started_at, completed_at,
+               summary, output_ref, hooks_applied,
+               route_reason, route_evidence, trigger, vision_ref,
+               workflow_artifact, success_criteria, prescribed_skills,
+               steward_cycles, timeout_at, estimated_runtime
+        FROM uow_registry;
+    """)
+    conn.commit()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_uow_row(
+    conn: sqlite3.Connection,
+    uow_id: str | None = None,
+    status: str = "ready-for-steward",
+    steward_cycles: int = 0,
+    output_ref: str | None = None,
+    audit_log_entries: list[dict] | None = None,
+    steward_agenda: str | None = None,
+    steward_log: str | None = None,
+    source_issue_number: int = 42,
+    summary: str = "Test UoW",
+    success_criteria: str | None = "Output file exists with non-empty content",
+) -> str:
+    if uow_id is None:
+        uow_id = f"uow_test_{uuid.uuid4().hex[:6]}"
+    now = _now_iso()
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+            (id, type, source, source_issue_number, sweep_date, status, posture,
+             created_at, updated_at, summary, output_ref, steward_cycles,
+             steward_agenda, steward_log, success_criteria,
+             route_evidence, trigger)
+        VALUES (?, 'executable', 'github:issue/42', ?, '2026-01-01', ?, 'solo',
+                ?, ?, ?, ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}')
+        """,
+        (uow_id, source_issue_number, status, now, now, summary,
+         output_ref, steward_cycles, steward_agenda, steward_log,
+         success_criteria),
+    )
+    if audit_log_entries:
+        for entry in audit_log_entries:
+            conn.execute(
+                """
+                INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (_now_iso(), uow_id,
+                 entry.get("event", "unknown"),
+                 entry.get("from_status"),
+                 entry.get("to_status"),
+                 entry.get("agent"),
+                 json.dumps(entry)),
+            )
+    conn.commit()
+    return uow_id
+
+
+def _get_uow(db_path: Path, uow_id: str) -> dict:
+    conn = _open_db(db_path)
+    row = conn.execute("SELECT * FROM uow_registry WHERE id = ?", (uow_id,)).fetchone()
+    conn.close()
+    return dict(row) if row else {}
+
+
+def _ensure_registry_has_phase2_methods(registry) -> None:
+    """Patch registry with Phase 2 methods when not yet on main (pre-merge)."""
+    import types
+
+    if not hasattr(registry, "transition"):
+        def transition(self, uow_id: str, to_status: str, where_status: str) -> int:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                now = _now_iso()
+                cursor = conn.execute(
+                    "UPDATE uow_registry SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+                    (to_status, now, uow_id, where_status),
+                )
+                rows = cursor.rowcount
+                conn.commit()
+                return rows
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+        registry.transition = types.MethodType(transition, registry)
+
+    if not hasattr(registry, "append_audit_log"):
+        def append_audit_log(self, uow_id: str, entry: dict) -> None:
+            conn = self._connect()
+            note_json = json.dumps(entry)
+            try:
+                conn.execute(
+                    "INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note) VALUES (?, ?, ?, NULL, NULL, NULL, ?)",
+                    (_now_iso(), uow_id, entry.get("event", "unknown"), note_json),
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+        registry.append_audit_log = types.MethodType(append_audit_log, registry)
+
+
+def _mock_github_client_open(issue_number: int) -> dict:
+    return {
+        "status_code": 200,
+        "state": "open",
+        "labels": [],
+        "body": f"Issue #{issue_number}: implement this feature.\n\nAcceptance criteria:\n- Feature works",
+        "title": f"Test issue {issue_number}",
+    }
+
+
+def _import_steward():
+    from src.orchestration import steward
+    return steward
+
+
+def _read_cycles_jsonl(trace_path: Path) -> list[dict]:
+    """Read all JSONL entries from a .cycles.jsonl file."""
+    lines = trace_path.read_text(encoding="utf-8").strip().splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "registry.db"
+    conn = _open_db(path)
+    _apply_phase2_schema(conn)
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def registry(db_path: Path):
+    from src.orchestration.registry import Registry
+    return Registry(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStewardCycleTrace:
+    """Per-cycle steward trace logging written to <artifact_dir>/<uow_id>.cycles.jsonl."""
+
+    def test_cycle_trace_written_on_prescribe(self, db_path, registry, tmp_path):
+        """A .cycles.jsonl file is created after a UoW is prescribed."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=0,
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=artifact_dir,
+            llm_prescriber=None,
+        )
+
+        trace_path = artifact_dir / f"{uow_id}.cycles.jsonl"
+        assert trace_path.exists(), (
+            f".cycles.jsonl file must be written after prescription; "
+            f"expected {trace_path}"
+        )
+        entries = _read_cycles_jsonl(trace_path)
+        assert len(entries) >= 1, "At least one cycle trace entry must be written"
+        assert entries[0]["next_action"] == "prescribed"
+
+    def test_cycle_trace_two_cycles(self, db_path, registry, tmp_path):
+        """Two steward cycles produce two JSONL entries with cycle_num 0 and 1."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=0,
+        )
+        conn.close()
+
+        # First cycle: cycle_num 0
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=artifact_dir,
+            llm_prescriber=None,
+        )
+
+        # Reset to ready-for-steward for second cycle
+        conn = _open_db(db_path)
+        conn.execute(
+            "UPDATE uow_registry SET status = 'ready-for-steward' WHERE id = ?",
+            (uow_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        # Second cycle: cycle_num 1
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=artifact_dir,
+            llm_prescriber=None,
+        )
+
+        trace_path = artifact_dir / f"{uow_id}.cycles.jsonl"
+        assert trace_path.exists()
+        entries = _read_cycles_jsonl(trace_path)
+        assert len(entries) == 2, f"Expected 2 entries, got {len(entries)}: {entries}"
+
+        cycle_nums = [e["cycle_num"] for e in entries]
+        assert 0 in cycle_nums, f"Expected cycle_num=0 in entries: {entries}"
+        assert 1 in cycle_nums, f"Expected cycle_num=1 in entries: {entries}"
+
+    def test_subagent_excerpt_truncated(self, tmp_path):
+        """subagent_excerpt is truncated to 200 chars with trailing ellipsis."""
+        steward = _import_steward()
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+
+        uow_id = f"uow_test_{uuid.uuid4().hex[:6]}"
+        long_text = "x" * 300  # 300 chars, exceeds the 200-char limit
+
+        steward._append_cycle_trace(
+            uow_id=uow_id,
+            cycle_num=0,
+            subagent_excerpt=long_text,
+            return_reason="observation_complete",
+            next_action="prescribed",
+            artifact_dir=artifact_dir,
+        )
+
+        trace_path = artifact_dir / f"{uow_id}.cycles.jsonl"
+        assert trace_path.exists()
+        entries = _read_cycles_jsonl(trace_path)
+        assert len(entries) == 1
+        excerpt = entries[0]["subagent_excerpt"]
+
+        assert len(excerpt) == EXCERPT_MAX_CHARS + len(ELLIPSIS_CHAR), (
+            f"Truncated excerpt must be {EXCERPT_MAX_CHARS} content chars + ellipsis; "
+            f"got length {len(excerpt)}"
+        )
+        assert excerpt.endswith(ELLIPSIS_CHAR), (
+            f"Truncated excerpt must end with ellipsis (U+2026); got: {excerpt[-5:]!r}"
+        )
+        assert excerpt[:EXCERPT_MAX_CHARS] == "x" * EXCERPT_MAX_CHARS
+
+    def test_cycle_trace_fields_schema(self, tmp_path):
+        """Each cycle trace entry contains exactly the required fields."""
+        steward = _import_steward()
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+
+        uow_id = f"uow_test_{uuid.uuid4().hex[:6]}"
+
+        steward._append_cycle_trace(
+            uow_id=uow_id,
+            cycle_num=2,
+            subagent_excerpt="output snippet",
+            return_reason="needs_steward_review",
+            next_action="prescribed",
+            artifact_dir=artifact_dir,
+        )
+
+        trace_path = artifact_dir / f"{uow_id}.cycles.jsonl"
+        entries = _read_cycles_jsonl(trace_path)
+        assert len(entries) == 1
+        entry = entries[0]
+
+        required_fields = {"cycle_num", "subagent_excerpt", "return_reason", "next_action", "timestamp"}
+        assert required_fields == set(entry.keys()), (
+            f"Entry must have exactly {required_fields}; got {set(entry.keys())}"
+        )
+
+        assert entry["cycle_num"] == 2
+        assert entry["subagent_excerpt"] == "output snippet"
+        assert entry["return_reason"] == "needs_steward_review"
+        assert entry["next_action"] == "prescribed"
+
+        # Timestamp must be parseable as ISO 8601 UTC
+        ts = datetime.fromisoformat(entry["timestamp"])
+        assert ts.tzinfo is not None, "timestamp must include timezone info"
+
+    def test_cycle_trace_appends_not_overwrites(self, tmp_path):
+        """Calling _append_cycle_trace twice accumulates both entries (append semantics)."""
+        steward = _import_steward()
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+
+        uow_id = f"uow_test_{uuid.uuid4().hex[:6]}"
+
+        steward._append_cycle_trace(
+            uow_id=uow_id,
+            cycle_num=0,
+            subagent_excerpt="first output",
+            return_reason="",
+            next_action="prescribed",
+            artifact_dir=artifact_dir,
+        )
+        steward._append_cycle_trace(
+            uow_id=uow_id,
+            cycle_num=1,
+            subagent_excerpt="second output",
+            return_reason="observation_complete",
+            next_action="done",
+            artifact_dir=artifact_dir,
+        )
+
+        trace_path = artifact_dir / f"{uow_id}.cycles.jsonl"
+        entries = _read_cycles_jsonl(trace_path)
+
+        assert len(entries) == 2, (
+            f"Both entries must be present (append, not overwrite); got {len(entries)}: {entries}"
+        )
+        assert entries[0]["cycle_num"] == 0
+        assert entries[0]["subagent_excerpt"] == "first output"
+        assert entries[1]["cycle_num"] == 1
+        assert entries[1]["subagent_excerpt"] == "second output"


### PR DESCRIPTION
## What this solves

Multi-cycle UoW lifecycles are currently opaque after the fact. When a UoW passes through several steward cycles before completing or surfacing, there is no lightweight record of what happened at each cycle — what the executor returned, what the steward diagnosed, and what it decided to do next. Debugging requires reconstructing the sequence from audit_log rows and steward_log entries, which is tedious and doesn't give a chronological per-cycle view.

This PR adds a `.cycles.jsonl` sidecar file that records one entry per steward cycle in a directly-inspectable format.

## What changed

`_append_cycle_trace(uow_id, cycle_num, subagent_excerpt, return_reason, next_action, artifact_dir)` is a new pure function in `steward.py` that appends one JSON line to `<artifact_dir>/<uow_id>.cycles.jsonl`. Each entry has exactly five fields:

- `cycle_num` — the pre-increment steward_cycles value (int)
- `subagent_excerpt` — first 200 chars of the executor output_ref file, truncated with `…` if longer (str)
- `return_reason` — from diagnosis, or empty string (str)
- `next_action` — one of `prescribed`, `done`, `surfaced`, `stuck` (str)
- `timestamp` — ISO 8601 UTC (str)

The function is called at all four `_process_uow` exit branches:
- After the `stuck_condition` surface path → `next_action='stuck'`
- After the `is_complete` done path → `next_action='done'`
- After the trace-gate-wait early `Prescribed` return → `next_action='prescribed'`
- At the normal prescription return → `next_action='prescribed'`

The file is pure append — each call opens with mode `"a"` — so multi-cycle UoWs accumulate a full trace in one file without overwriting prior entries.

## What is not changed

- `_build_trace_entry` is untouched
- `steward_agenda` logic is untouched
- No new DB columns, no schema migration
- No changes to the audit_log structure
- `run_steward_cycle` signature is unchanged — `artifact_dir` is passed through to `_append_cycle_trace` as before

## Functional patterns

Pure function: `_append_cycle_trace` has no side effects beyond the file write; all inputs are explicit. The excerpt truncation is a pure transform. The four call sites are isolated at branch exits, not woven into the prescription logic.

## Flow (unchanged — trace is additive)

```
ready-for-steward
  → diagnosing
    → stuck?        → .cycles.jsonl (next_action=stuck)   → blocked
    → is_complete?  → .cycles.jsonl (next_action=done)    → done
    → trace gate?   → .cycles.jsonl (next_action=prescribed) → ready-for-steward
    → prescribe     → .cycles.jsonl (next_action=prescribed) → ready-for-executor
```

## Tests run

- [x] `uv run -m pytest tests/unit/test_orchestration/test_steward_cycle_trace.py -v` — 5 passed, 0 failed
- [x] `uv run -m pytest tests/unit/test_orchestration/test_steward.py::TestCompletionPath tests/unit/test_orchestration/test_steward.py::TestInitializationRitual tests/unit/test_orchestration/test_steward.py::TestStewardQueryScope -v` — 6 passed, 0 failed
- [x] `uv run -m pytest tests/unit/test_orchestration/test_steward.py::TestHardCap -v` — 3 passed, 0 failed (covers the Surfaced path)
- [ ] Full `test_steward.py` suite — skipped: suite takes >4 min per run; core paths (completion, initialization, hard cap, query scope) verified above

## Manual test

N/A — this change is entirely internal file I/O to the artifact directory. No external services, no systemd, no Telegram output. The .cycles.jsonl sidecar is written alongside existing workflow artifacts in `~/lobster-workspace/orchestration/artifacts/`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, internal file I/O only
- [x] User-visible outcome verified OR not applicable — not applicable, debugging artifact only
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — single append per cycle exit, bounded by UoW lifecycle
- [x] External service calls: none

Closes #c128a4 (steward trace logging)