### PR TITLE
feat(wos): prescription format — front-matter + prose split

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -931,8 +931,10 @@ def _parse_workflow_artifact(raw_text: str) -> dict:
     for line in front_matter_lines:
         if ":" not in line:
             continue
-        key, _, value = line.partition(":")
-        front_matter[key.strip()] = value.strip()
+        parts = line.split(":", 1)
+        key = parts[0].strip()
+        value = parts[1].strip() if len(parts) > 1 else ""
+        front_matter[key] = value
 
     executor_type = front_matter.get("executor_type", "")
     if not executor_type:

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -3560,3 +3560,19 @@ class TestParseWorkflowArtifact:
         result = steward._parse_workflow_artifact(raw)
 
         assert result["estimated_cycles"] == 1
+
+    def test_parse_workflow_artifact_value_with_colon(self):
+        """Front-matter values containing colons are preserved in full."""
+        steward = _import_steward()
+
+        raw = (
+            "---\n"
+            "executor_type: functional-engineer\n"
+            "success_criteria_check: Check that status: done appears in output\n"
+            "---\n\n"
+            "Do the work."
+        )
+
+        result = steward._parse_workflow_artifact(raw)
+
+        assert result["success_criteria_check"] == "Check that status: done appears in output"


### PR DESCRIPTION
## What this changes

The WOS steward prescriber previously asked Claude to return a JSON object with prose instructions embedded as a JSON string value — JSON-within-JSON. This required the LLM to correctly escape multi-line prose (newlines, quotes, braces) inside a JSON string, which is fragile and produces unreadable artifact files.

This PR replaces that format with front-matter + prose:

```
---
executor_type: functional-engineer
estimated_cycles: 1
success_criteria_check: Verify PR is open and tests pass
---

<full prose instructions here>
```

The prose body is now plain text — no escaping required.

## What changed

**`_parse_workflow_artifact(raw_text: str) -> dict`** — new pure function (no external deps, line-by-line scanning). Extracts `executor_type` (required, raises `ValueError` if absent), `estimated_cycles` (int, default 1), `success_criteria_check` (str, default ""), and `instructions` (prose body). Tolerates preamble prose before the opening `---` to be as robust as the previous JSON extraction strategy.

**`_llm_prescribe`** — prompt updated to request front-matter + prose. JSON extraction (`_extract_json_from_llm_output` + `json.loads`) replaced with `_parse_workflow_artifact`. Returned dict shape is unchanged — callers are unaffected.

**`_extract_json_from_llm_output`** — untouched (used by other callers).

**`WorkflowArtifact` TypedDict, `workflow_artifact.py`, `executor.py`** — untouched.

## Backpressure test fix (exposed by this change)

`TestBackpressureSkipsRePrescription` tests were accidentally passing because LLM parse failures left UoWs in `ready-for-steward`. With a more reliable parser, the backpressure gate now reaches `is_execution_enabled()`, which returns `True` in the test environment (because `wos-config.json` has `execution_enabled: true`). When enabled, the backpressure hold is intentionally bypassed (the orphan classification is stale).

The tests now explicitly mock `is_execution_enabled` to return `False`, which is the correct precondition for the backpressure gate to fire. This is the right fix — the tests were testing the wrong precondition before.

## Functional patterns

Pure functions (`_parse_workflow_artifact`), immutable input processing, explicit error handling via `ValueError` (not exceptions for control flow), composable transformation pipeline.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -v` — 111 passed, 0 failed
- [x] `TestParseWorkflowArtifact` — 9 tests covering: valid input with all fields, only executor_type (defaults), missing executor_type (ValueError), empty input (ValueError), prose body preserved exactly, extra whitespace, missing closing delimiter, non-integer estimated_cycles, preamble tolerance
- [x] `TestLlmPrescription` — 24 tests updated: JSON mocks replaced with front-matter mocks; tests for preamble tolerance, missing executor_type, no-closing-delimiter edge cases added

## Manual test

N/A — no external service calls, no file I/O affecting runtime state, no Telegram output. The `_llm_prescribe` function calls `claude -p` subprocess but this is already exercised by the integration tests in the suite (those tests call `run_steward_cycle` without `llm_prescriber` stub and invoke the real LLM).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A for this change
- [x] User-visible outcome — not applicable (internal prescription format change)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: LLM calls mocked in unit tests; integration tests use real `claude -p` subprocess (same as pre-change behavior)