### PR TITLE
fix: expand decide-retry to allow recovery from ready-for-steward status

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1255,17 +1255,25 @@ class Registry:
         finally:
             conn.close()
 
+    # Statuses from which decide-retry may recover a UoW.
+    # 'blocked' covers the normal hard-cap / stuck-steward case.
+    # 'ready-for-steward' covers UoWs that false-completed at executor dispatch
+    # time (issue #669) and are looping in the steward queue without advancing.
+    RETRYABLE_STATUSES: frozenset[str] = frozenset({"blocked", "ready-for-steward"})
+
     def decide_retry(self, uow_id: str) -> int:
         """
         Reset a stuck UoW so it re-enters the Steward queue.
 
         Intended for use when Dan selects "Retry" after the Steward surfaces a
-        UoW that has hit the 5-cycle hard cap or another stuck condition.
+        UoW that has hit the 5-cycle hard cap, or when a UoW has false-completed
+        at executor dispatch time (issue #669) and is looping in ready-for-steward.
 
-        Transitions: blocked → ready-for-steward (optimistic lock on blocked).
+        Transitions: blocked → ready-for-steward
+                     ready-for-steward → ready-for-steward (with cycle reset)
         Also resets steward_cycles to 0 so the Steward treats it as a fresh start.
 
-        Returns rows_affected (1 on success, 0 if UoW is not in blocked status).
+        Returns rows_affected (1 on success, 0 if UoW is not in a retryable status).
         Writes audit entry atomically in the same transaction as the UPDATE.
         """
         conn = self._connect()
@@ -1273,31 +1281,40 @@ class Registry:
             now = _now_iso()
             conn.execute("BEGIN IMMEDIATE")
 
+            # Read current status so the audit log records the actual from_status.
+            row = conn.execute(
+                "SELECT status FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+            from_status = row["status"] if row else None
+
             note_json = json.dumps({
                 "event": "decide_retry",
                 "actor": "user",
                 "uow_id": uow_id,
                 "timestamp": now,
+                "from_status": from_status,
                 "note": "user requested retry — steward_cycles reset to 0",
             })
 
             conn.execute(
                 """
                 INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
-                VALUES (?, ?, 'decide_retry', 'blocked', 'ready-for-steward', 'user', ?)
+                VALUES (?, ?, 'decide_retry', ?, 'ready-for-steward', 'user', ?)
                 """,
-                (now, uow_id, note_json),
+                (now, uow_id, from_status, note_json),
             )
 
+            placeholders = ",".join("?" * len(self.RETRYABLE_STATUSES))
             cursor = conn.execute(
-                """
+                f"""
                 UPDATE uow_registry
                 SET status = 'ready-for-steward',
                     steward_cycles = 0,
                     updated_at = ?
-                WHERE id = ? AND status = 'blocked'
+                WHERE id = ? AND status IN ({placeholders})
                 """,
-                (now, uow_id),
+                (now, uow_id, *self.RETRYABLE_STATUSES),
             )
             rows_affected = cursor.rowcount
 

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -156,17 +156,21 @@ def cmd_decide_retry(registry: Registry, args: argparse.Namespace) -> None:
     """Handle decide-retry: reset a stuck UoW for a new Steward cycle."""
     uow_id = args.id
     rows = registry.decide_retry(uow_id)
+    retryable = ", ".join(sorted(registry.RETRYABLE_STATUSES))
     if rows == 1:
         _output({
             "status": "ok",
             "id": uow_id,
-            "message": f"UoW `{uow_id}` reset for retry — blocked \u2192 ready-for-steward (steward_cycles reset to 0)",
+            "message": f"UoW `{uow_id}` reset for retry \u2192 ready-for-steward (steward_cycles reset to 0)",
         })
     else:
         _output({
-            "status": "not_blocked",
+            "status": "not_retryable",
             "id": uow_id,
-            "message": f"UoW `{uow_id}` could not be retried — it is not currently in `blocked` status",
+            "message": (
+                f"UoW `{uow_id}` could not be retried — "
+                f"it is not in a retryable status ({retryable})"
+            ),
         })
 
 

--- a/tests/unit/test_orchestration/test_registry_cli.py
+++ b/tests/unit/test_orchestration/test_registry_cli.py
@@ -233,3 +233,107 @@ class TestGateReadinessCommand:
         assert "days_running" in result
         assert "proposed_to_confirmed_ratio_7d" in result
         assert "reason" in result
+
+
+# ---------------------------------------------------------------------------
+# decide-retry command
+# ---------------------------------------------------------------------------
+
+def _force_status(db_path: Path, uow_id: str, status: str) -> None:
+    """Directly set a UoW's status in the DB, bypassing Registry transitions."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "UPDATE uow_registry SET status = ? WHERE id = ?",
+        (status, uow_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestDecideRetryCommand:
+    def test_retry_from_blocked_resets_to_ready_for_steward(self, db_path):
+        """A UoW in blocked status is retried successfully."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "80", "--title", "Issue 80", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "blocked")
+
+        result = run_cli(db_path, "decide-retry", "--id", uow_id)
+
+        assert result["status"] == "ok"
+        assert result["id"] == uow_id
+        # Confirm DB status was updated
+        record = run_cli(db_path, "get", "--id", uow_id)
+        assert record["status"] == "ready-for-steward"
+        assert record["steward_cycles"] == 0
+
+    def test_retry_from_ready_for_steward_resets_cycles(self, db_path):
+        """
+        A UoW stuck in ready-for-steward (false-complete via issue #669) can be
+        retried — decide-retry must not silently no-op when status is not blocked.
+        """
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "81", "--title", "Issue 81", "--sweep-date", today)
+        uow_id = inserted["id"]
+        # Force into ready-for-steward with non-zero steward_cycles to simulate false-complete
+        _force_status(db_path, uow_id, "ready-for-steward")
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET steward_cycles = 3 WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        result = run_cli(db_path, "decide-retry", "--id", uow_id)
+
+        assert result["status"] == "ok"
+        assert result["id"] == uow_id
+        record = run_cli(db_path, "get", "--id", uow_id)
+        assert record["status"] == "ready-for-steward"
+        assert record["steward_cycles"] == 0
+
+    def test_retry_from_non_retryable_status_returns_not_retryable(self, db_path):
+        """A UoW in active status (not retryable) returns a clear error, not silent no-op."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "82", "--title", "Issue 82", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "active")
+
+        result = run_cli(db_path, "decide-retry", "--id", uow_id)
+
+        assert result["status"] == "not_retryable"
+        assert result["id"] == uow_id
+        assert "retryable" in result["message"].lower()
+        # Status unchanged
+        record = run_cli(db_path, "get", "--id", uow_id)
+        assert record["status"] == "active"
+
+    def test_retry_from_done_status_returns_not_retryable(self, db_path):
+        """A done UoW cannot be retried — done is terminal and intentional."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "83", "--title", "Issue 83", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "done")
+
+        result = run_cli(db_path, "decide-retry", "--id", uow_id)
+
+        assert result["status"] == "not_retryable"
+
+    def test_retry_audit_log_records_actual_from_status(self, db_path):
+        """Audit log must record the actual source status, not a hardcoded 'blocked'."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "84", "--title", "Issue 84", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "ready-for-steward")
+
+        run_cli(db_path, "decide-retry", "--id", uow_id)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT from_status FROM audit_log WHERE uow_id = ? AND event = 'decide_retry' ORDER BY ts DESC LIMIT 1",
+            (uow_id,),
+        ).fetchone()
+        conn.close()
+        assert row is not None, "audit_log must have a decide_retry entry"
+        assert row["from_status"] == "ready-for-steward", (
+            "audit log from_status must reflect actual source status, not hardcoded 'blocked'"
+        )


### PR DESCRIPTION
## Summary

`decide-retry` silently did nothing when a UoW was stuck in `ready-for-steward` after a false-complete at executor dispatch time (issue #669). The WHERE clause was locked to `status = 'blocked'`, so any operator call to `decide-retry` on a false-completed UoW returned `not_blocked` and left the UoW unchanged — with no indication that the retry was rejected.

This affected Sprint 2: two UoWs that false-completed appeared to retry successfully but actually did nothing, requiring manual SQL to recover.

## What changed

**`registry.py`:**
- Added `Registry.RETRYABLE_STATUSES = frozenset({"blocked", "ready-for-steward"})` as a named constant — the single source of truth for which statuses allow retry
- `decide_retry` WHERE clause now uses `IN (retryable statuses)` instead of `= 'blocked'`
- Audit log `from_status` is read from the actual DB row before the update, eliminating the hardcoded `'blocked'` that was always wrong for the `ready-for-steward` case

**`registry_cli.py`:**
- Error response key changed from `not_blocked` → `not_retryable`
- Error message now lists the retryable statuses so the operator knows exactly why the retry was rejected

## What is not changed

- `decide-close` is unchanged: closing from `ready-for-steward` would be unsafe (the UoW may still be running a subagent). Only retry is expanded.
- `decide-proceed` is unchanged: it reuses the blocked → ready-for-steward path without resetting cycles.
- No schema changes.

## State transition diagram

Before this fix:

```
blocked           --[decide-retry]--> ready-for-steward  (OK)
ready-for-steward --[decide-retry]--> (silent no-op)     (BUG)
active            --[decide-retry]--> (silent no-op)
```

After this fix:

```
blocked           --[decide-retry]--> ready-for-steward  (OK)
ready-for-steward --[decide-retry]--> ready-for-steward  (OK, cycles reset)
active            --[decide-retry]--> not_retryable error (explicit rejection)
done/failed       --[decide-retry]--> not_retryable error (explicit rejection)
```

## Functional patterns used

Pure function for status set membership (`RETRYABLE_STATUSES` frozenset). Parameterized SQL built from the set to avoid hardcoded literal lists. Audit log `from_status` derived from a read before the write rather than hardcoded.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry_cli.py -v` — 21 passed, 1 failed (pre-existing: `test_approve_idempotent_on_pending` fails on main too, unrelated to this fix)
- New tests added: retry from blocked, retry from ready-for-steward (the regression case), reject from active, reject from done, audit log records actual from_status

## Manual test

N/A — this change is entirely internal (pure DB reads/writes with no external service calls, no Telegram output, no file I/O beyond the registry DB which is exercised by tests).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, no external services touched
- [x] User-visible outcome verified OR not applicable — N/A, this is an operator CLI tool
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #670