### PR TITLE
fix: gate execution_complete on write_result, not inbox dispatch (#669)

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -142,7 +142,7 @@ def run_ttl_recovery(registry, dry_run: bool = False) -> list[str]:
                 rows = conn.execute(
                     """
                     SELECT id FROM uow_registry
-                    WHERE status = 'active'
+                    WHERE status IN ('active', 'executing')
                       AND started_at IS NOT NULL
                       AND started_at < ?
                     """,

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -6937,6 +6937,35 @@ async def handle_write_task_output(args: dict) -> list[TextContent]:
 
 
 # =============================================================================
+# WOS registry completion helper (issue #669)
+# =============================================================================
+
+def _maybe_complete_wos_uow(task_id: str, status: str) -> None:
+    """
+    Transition a WOS UoW from 'executing' to 'ready-for-steward' when its subagent
+    calls write_result with status='success'.
+
+    Delegates to orchestration.wos_completion.maybe_complete_wos_uow — see that
+    module for full documentation. Imported lazily so inbox_server's heavy import
+    chain does not block if the orchestration package is unavailable.
+
+    Errors are logged but never raised — write_result delivery must not be blocked
+    by registry update failures.
+    """
+    try:
+        import sys as _sys
+        import os
+        from pathlib import Path as _Path
+        _src = str(_Path(__file__).resolve().parent.parent)
+        if _src not in _sys.path:
+            _sys.path.insert(0, _src)
+        from orchestration.wos_completion import maybe_complete_wos_uow
+        maybe_complete_wos_uow(task_id, status)
+    except Exception as exc:
+        log.warning("_maybe_complete_wos_uow: unexpected error — %s: %s", type(exc).__name__, exc)
+
+
+# =============================================================================
 # Subagent Result Relay Handler
 # =============================================================================
 
@@ -7051,6 +7080,16 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         )
     except Exception as exc:
         log.warning(f"write_result auto-unregister failed for task_id={task_id!r}: {exc}")
+
+    # WOS registry completion (issue #669): when a subagent writes its result for a
+    # wos_execute task, transition the UoW from 'executing' → 'ready-for-steward'.
+    # The executor transitions active → executing at dispatch time (fire-and-forget inbox
+    # dispatch). The execution_complete audit entry and status transition happen here —
+    # only after the subagent confirms completion via write_result — preventing the
+    # false-complete bug where UoWs appeared done before any work was done.
+    #
+    # task_id convention: "wos-{uow_id}" (set by route_wos_message in dispatcher_handlers.py)
+    _maybe_complete_wos_uow(task_id, status)
 
     # Notify wire server so SSE clients update within 40ms
     asyncio.create_task(_notify_wire_server())

--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -705,7 +705,7 @@ class Executor:
             executor_id = dispatcher(instructions, uow_id)
 
         # Step 3: Write output_ref content (signal that execution produced output)
-        _write_output_ref_content(output_ref, f"execution complete: task dispatched as {executor_id}")
+        _write_output_ref_content(output_ref, f"execution dispatched: task_id={executor_id}")
 
         # Step 4: Build result
         result = ExecutorResult(
@@ -732,8 +732,23 @@ class Executor:
         _write_trace_json(output_ref, trace)
         _insert_corrective_trace(self.registry.db_path, trace)
 
-        # Step 6: Transition to ready-for-steward (audit before status update, single transaction)
-        self.registry.complete_uow(uow_id, output_ref)
+        # Step 6: Status transition — depends on dispatch path.
+        #
+        # Async (inbox) dispatchers: write wos_execute to inbox and return immediately.
+        # The subagent has NOT yet done any work — calling complete_uow here would produce
+        # a false execution_complete before the subagent confirms. Instead, transition to
+        # 'executing' (active → executing). The write_result MCP handler transitions
+        # executing → ready-for-steward (with execution_complete audit) when the subagent
+        # reports back. (issue #669)
+        #
+        # Synchronous (subprocess) dispatchers: block until the subprocess exits. By the
+        # time we reach this point, the subagent has finished its work. Call complete_uow
+        # directly (active → ready-for-steward) as before.
+        executor_type = artifact.get("executor_type", "functional-engineer")
+        if _dispatcher_is_async(self._dispatcher_override, executor_type):
+            self.registry.transition_to_executing(uow_id, executor_id or "")
+        else:
+            self.registry.complete_uow(uow_id, output_ref)
 
         return result
 
@@ -1111,6 +1126,36 @@ _EXECUTOR_TYPE_TO_DISPATCHER: dict[str, str] = {
     "design-review": "_dispatch_via_design_review",
 }
 
+#: Executor types that use the async inbox dispatch path (_dispatch_via_inbox).
+#: For these types, the executor transitions to 'executing' at dispatch time;
+#: complete_uow (execution_complete) fires only when write_result arrives.
+#: Types absent from this set use synchronous subprocess dispatch — complete_uow
+#: is called immediately after the subprocess exits (issue #669).
+_ASYNC_EXECUTOR_TYPES: frozenset[str] = frozenset({
+    "functional-engineer",
+    "lobster-ops",
+    "general",
+})
+
+
+def _dispatcher_is_async(dispatcher_override: "SubagentDispatcher | None", executor_type: str) -> bool:
+    """
+    Return True when the dispatch path is asynchronous (inbox fire-and-forget).
+
+    When a dispatcher_override is injected (tests, CI), it is treated as
+    synchronous — the override may be _noop_dispatcher or a test stub, and
+    callers that inject overrides expect the legacy complete_uow-immediately
+    behavior. Only the production dispatch table uses the async path.
+
+    For production dispatch (dispatcher_override is None), the executor_type
+    determines the path: types in _ASYNC_EXECUTOR_TYPES use _dispatch_via_inbox
+    (async); all others use synchronous subprocess dispatchers.
+    """
+    if dispatcher_override is not None:
+        # Injected dispatcher — assume synchronous (test/CI path).
+        return False
+    return executor_type in _ASYNC_EXECUTOR_TYPES
+
 
 def _resolve_dispatcher(executor_type: str) -> SubagentDispatcher:
     """
@@ -1196,18 +1241,23 @@ def _dispatch_via_inbox(instructions: str, uow_id: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# TTL recovery — mark stuck 'active' UoWs as failed
+# TTL recovery — mark stuck 'active' and 'executing' UoWs as failed
 # ---------------------------------------------------------------------------
-# TTL recovery catches UoWs that transition to 'active' but never complete —
-# e.g. if the subagent crashes before writing its result file, or the inbox
-# message was lost. With inbox dispatch, UoWs have natural heartbeat presence
-# via the dispatcher cycle, but TTL recovery remains as a safety net for any
-# subagent that stalls beyond TTL_EXCEEDED_HOURS without writing a result.
+# TTL recovery catches UoWs that transition to 'active' or 'executing' but
+# never complete — e.g. if the subagent crashes before writing its result file,
+# or the inbox message was lost. With inbox dispatch, UoWs have natural heartbeat
+# presence via the dispatcher cycle, but TTL recovery remains as a safety net for
+# any subagent that stalls beyond TTL_EXCEEDED_HOURS without writing a result.
+#
+# 'executing' UoWs are included alongside 'active': an 'executing' UoW whose
+# subagent never calls write_result (orphan, crash, context loss) must be
+# recovered so the Steward can re-diagnose it. Without this, orphaned 'executing'
+# UoWs would be invisible to standard recovery paths (issue #669).
 
 def recover_ttl_exceeded_uows(registry: "Registry") -> list[str]:
     """
-    Scan for UoWs in 'active' state that have exceeded TTL_EXCEEDED_HOURS and
-    transition them to 'failed' with return_reason='ttl_exceeded'.
+    Scan for UoWs in 'active' or 'executing' state that have exceeded
+    TTL_EXCEEDED_HOURS and transition them to 'failed'.
 
     Call this at executor-heartbeat startup, before the dispatch cycle, so
     the Steward can re-diagnose stalled UoWs on its next pass.
@@ -1230,7 +1280,7 @@ def recover_ttl_exceeded_uows(registry: "Registry") -> list[str]:
         rows = conn.execute(
             """
             SELECT id FROM uow_registry
-            WHERE status = 'active'
+            WHERE status IN ('active', 'executing')
               AND started_at IS NOT NULL
               AND started_at < ?
             """,

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -47,6 +47,11 @@ class UoWStatus(StrEnum):
     READY_FOR_STEWARD = "ready-for-steward"
     READY_FOR_EXECUTOR = "ready-for-executor"
     ACTIVE = "active"
+    # EXECUTING: inbox message written, subagent dispatched but write_result not yet received.
+    # Transitions: active → executing (at inbox dispatch) → ready-for-steward (at write_result).
+    # This intermediate state prevents false-complete UoWs: execution_complete is only written
+    # when the subagent confirms completion via write_result (issue #669).
+    EXECUTING = "executing"
     DIAGNOSING = "diagnosing"
     BLOCKED = "blocked"
     DONE = "done"
@@ -58,9 +63,10 @@ class UoWStatus(StrEnum):
         return self in {UoWStatus.DONE, UoWStatus.FAILED, UoWStatus.EXPIRED}
 
     def is_in_flight(self) -> bool:
-        """True for statuses that block re-proposal (active, pending, ready-for-steward, ready-for-executor, diagnosing)."""
+        """True for statuses that block re-proposal (active, executing, pending, ready-for-steward, ready-for-executor, diagnosing)."""
         return self in {
             UoWStatus.ACTIVE,
+            UoWStatus.EXECUTING,
             UoWStatus.PENDING,
             UoWStatus.READY_FOR_STEWARD,
             UoWStatus.READY_FOR_EXECUTOR,
@@ -1195,9 +1201,56 @@ class Registry:
         finally:
             conn.close()
 
+    def transition_to_executing(self, uow_id: str, executor_id: str) -> None:
+        """
+        Transition a UoW from 'active' to 'executing' after inbox dispatch.
+
+        Called by the Executor immediately after writing the wos_execute inbox
+        message (fire-and-forget async dispatch). The UoW remains in 'executing'
+        until write_result is received from the subagent, at which point
+        complete_uow transitions it to 'ready-for-steward'.
+
+        This prevents false-complete UoWs: execution_complete is only written
+        when the subagent confirms completion via write_result (issue #669).
+
+        Single transaction: audit INSERT before status UPDATE
+        (audit-before-transition invariant).
+        """
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+                VALUES (?, ?, 'executor_dispatch', 'active', 'executing', 'executor', ?)
+                """,
+                (now, uow_id, json.dumps({"actor": "executor", "executor_id": executor_id, "timestamp": now})),
+            )
+            conn.execute(
+                "UPDATE uow_registry SET status = 'executing', updated_at = ? WHERE id = ?",
+                (now, uow_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
     def complete_uow(self, uow_id: str, output_ref: str) -> None:
         """
-        Transition a UoW from 'active' to 'ready-for-steward'.
+        Transition a UoW to 'ready-for-steward' with an execution_complete audit entry.
+
+        For async inbox dispatch: transitions 'executing' → 'ready-for-steward'.
+        Called by the write_result MCP handler when the subagent reports completion.
+
+        For synchronous subprocess dispatch (frontier-writer, design-review):
+        transitions 'active' → 'ready-for-steward'. Called by the Executor after
+        the subprocess exits.
+
+        The from_status is derived from the current DB state so the audit entry
+        is accurate regardless of which dispatch path was used.
 
         Single transaction: audit INSERT before status UPDATE
         (audit-before-transition invariant).
@@ -1208,12 +1261,17 @@ class Registry:
         try:
             now = _now_iso()
             conn.execute("BEGIN IMMEDIATE")
+            # Derive current status for accurate audit log from_status.
+            row = conn.execute(
+                "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+            ).fetchone()
+            current_status = row["status"] if row else "active"
             conn.execute(
                 """
                 INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
-                VALUES (?, ?, 'execution_complete', 'active', 'ready-for-steward', 'executor', ?)
+                VALUES (?, ?, 'execution_complete', ?, 'ready-for-steward', 'executor', ?)
                 """,
-                (now, uow_id, json.dumps({"actor": "executor", "output_ref": output_ref, "timestamp": now})),
+                (now, uow_id, current_status, json.dumps({"actor": "executor", "output_ref": output_ref, "timestamp": now})),
             )
             conn.execute(
                 "UPDATE uow_registry SET status = 'ready-for-steward', updated_at = ? WHERE id = ?",
@@ -1228,7 +1286,10 @@ class Registry:
 
     def fail_uow(self, uow_id: str, reason: str) -> None:
         """
-        Transition a UoW from 'active' to 'failed'.
+        Transition a UoW to 'failed'.
+
+        Handles UoWs in 'active' or 'executing' status. The from_status in the
+        audit entry reflects the actual current status for accurate history.
 
         Single transaction: audit INSERT before status UPDATE
         (audit-before-transition invariant).
@@ -1237,12 +1298,17 @@ class Registry:
         try:
             now = _now_iso()
             conn.execute("BEGIN IMMEDIATE")
+            # Derive current status for accurate audit log from_status.
+            row = conn.execute(
+                "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+            ).fetchone()
+            current_status = row["status"] if row else "active"
             conn.execute(
                 """
                 INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
-                VALUES (?, ?, 'execution_failed', 'active', 'failed', 'executor', ?)
+                VALUES (?, ?, 'execution_failed', ?, 'failed', 'executor', ?)
                 """,
-                (now, uow_id, json.dumps({"actor": "executor", "reason": reason, "timestamp": now})),
+                (now, uow_id, current_status, json.dumps({"actor": "executor", "reason": reason, "timestamp": now})),
             )
             conn.execute(
                 "UPDATE uow_registry SET status = 'failed', updated_at = ? WHERE id = ?",

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -1,0 +1,118 @@
+"""
+WOS execution completion helper (issue #669).
+
+Provides maybe_complete_wos_uow — the deferred execution_complete transition
+for the async inbox dispatch path.
+
+Background: when the Executor writes a wos_execute message to the inbox (fire-
+and-forget), it transitions the UoW to 'executing' rather than 'ready-for-
+steward'. The execution_complete audit entry and the final executing →
+ready-for-steward transition happen here, only after the subagent confirms
+completion by calling write_result.
+
+This module is imported by both inbox_server.py (production) and test code.
+It has no dependency on inbox_server's heavy MCP server stack — only on the
+orchestration.registry module.
+
+Naming convention: task_id for WOS dispatches is "wos-{uow_id}", set by
+route_wos_message in dispatcher_handlers.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger("wos_completion")
+
+#: Prefix used by route_wos_message to form the task_id for wos_execute dispatches.
+WOS_TASK_ID_PREFIX = "wos-"
+
+#: write_result status value that signals successful subagent completion.
+WRITE_RESULT_SUCCESS_STATUS = "success"
+
+
+def maybe_complete_wos_uow(task_id: str, status: str) -> None:
+    """
+    Transition a WOS UoW from 'executing' to 'ready-for-steward' when its
+    subagent calls write_result with status='success'.
+
+    This is the deferred execution_complete transition for the async inbox
+    dispatch path (issue #669). The Executor transitions active → executing at
+    dispatch time; this function fires the execution_complete audit entry and
+    the executing → ready-for-steward transition only after the subagent
+    confirms completion via write_result.
+
+    Conditions required to fire:
+    - task_id starts with WOS_TASK_ID_PREFIX ("wos-")
+    - status == "success" (only successful completions advance the UoW)
+    - UoW exists in the registry with status == "executing"
+
+    A UoW not in 'executing' status is skipped silently — this handles the
+    case where TTL recovery already failed the UoW, or where a duplicate
+    write_result arrives after the first has already completed it.
+
+    Errors are logged but never raised — write_result delivery must not be
+    blocked by registry update failures.
+
+    Args:
+        task_id: The task_id string from the write_result call.
+                 Expected format: "wos-{uow_id}".
+        status:  The status from the write_result call ("success" or "error").
+    """
+    if not task_id.startswith(WOS_TASK_ID_PREFIX):
+        return
+    if status != WRITE_RESULT_SUCCESS_STATUS:
+        # Only advance to ready-for-steward on success. Failed write_results
+        # leave the UoW in 'executing' for TTL recovery to handle.
+        return
+
+    uow_id = task_id[len(WOS_TASK_ID_PREFIX):]
+    try:
+        from orchestration.registry import Registry, UoWStatus
+
+        workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+        env_override = os.environ.get("REGISTRY_DB_PATH")
+        db_path = Path(env_override) if env_override else workspace / "orchestration" / "registry.db"
+
+        if not db_path.exists():
+            log.debug(
+                "maybe_complete_wos_uow: registry DB not found at %s — "
+                "skipping (no WOS install or test env)",
+                db_path,
+            )
+            return
+
+        registry = Registry(db_path)
+        uow = registry.get(uow_id)
+        if uow is None:
+            log.debug(
+                "maybe_complete_wos_uow: UoW %r not found in registry — skipping",
+                uow_id,
+            )
+            return
+
+        if uow.status != UoWStatus.EXECUTING:
+            log.debug(
+                "maybe_complete_wos_uow: UoW %r is in status %r (expected 'executing') — "
+                "skipping (already recovered or duplicate write_result)",
+                uow_id,
+                uow.status,
+            )
+            return
+
+        output_ref = uow.output_ref or ""
+        registry.complete_uow(uow_id, output_ref)
+        log.info(
+            "maybe_complete_wos_uow: UoW %r transitioned executing → ready-for-steward "
+            "(execution_complete written on write_result confirmation)",
+            uow_id,
+        )
+    except Exception as exc:
+        log.warning(
+            "maybe_complete_wos_uow: failed to complete UoW %r — %s: %s",
+            uow_id,
+            type(exc).__name__,
+            exc,
+        )

--- a/tests/unit/test_orchestration/test_executor_false_complete_fix.py
+++ b/tests/unit/test_orchestration/test_executor_false_complete_fix.py
@@ -1,0 +1,558 @@
+"""
+Tests for the executor false-complete fix (issue #669).
+
+Spec: executor marks `execution_complete` at dispatch time instead of when
+`write_result` is received.
+
+Expected behavior per issue #669:
+- For async inbox dispatch (functional-engineer, lobster-ops, general executor types):
+  UoW transitions active → executing at dispatch time.
+  execution_complete and executing → ready-for-steward happen only when the
+  subagent calls write_result (i.e. Registry.complete_uow called from write_result handler).
+- For synchronous subprocess dispatch (frontier-writer, design-review, injected overrides):
+  Behavior unchanged — complete_uow is called after the subprocess exits.
+- UoWStatus.EXECUTING is in-flight (blocks re-proposal).
+- TTL recovery covers 'executing' UoWs alongside 'active'.
+- Registry.transition_to_executing writes executor_dispatch audit entry.
+- Registry.complete_uow on an 'executing' UoW writes execution_complete audit entry.
+- _maybe_complete_wos_uow transitions executing → ready-for-steward on write_result.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from orchestration.registry import Registry, UoWStatus
+from orchestration.workflow_artifact import WorkflowArtifact, to_json
+from orchestration.executor import (
+    Executor,
+    ExecutorOutcome,
+    _dispatch_via_inbox,
+    _noop_dispatcher,
+    _dispatcher_is_async,
+    _ASYNC_EXECUTOR_TYPES,
+    recover_ttl_exceeded_uows,
+    TTL_EXCEEDED_HOURS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Named constants derived from the spec (issue #669)
+# ---------------------------------------------------------------------------
+
+#: Executor types that must use async inbox dispatch and the executing intermediate status.
+INBOX_EXECUTOR_TYPES = frozenset({"functional-engineer", "lobster-ops", "general"})
+
+#: Executor types that must use synchronous subprocess dispatch (no executing intermediate).
+SUBPROCESS_EXECUTOR_TYPES = frozenset({"frontier-writer", "design-review"})
+
+#: Status set by async inbox dispatch before subagent confirms.
+STATUS_EXECUTING = "executing"
+
+#: Status after subagent confirms via write_result.
+STATUS_READY_FOR_STEWARD = "ready-for-steward"
+
+#: Audit event written at inbox dispatch time.
+AUDIT_EXECUTOR_DISPATCH = "executor_dispatch"
+
+#: Audit event that must only appear after write_result confirms.
+AUDIT_EXECUTION_COMPLETE = "execution_complete"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "test_registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path) -> Registry:
+    return Registry(db_path)
+
+
+def _make_artifact(uow_id: str, executor_type: str = "general") -> str:
+    """Return JSON-encoded WorkflowArtifact for the given executor_type."""
+    artifact: WorkflowArtifact = {
+        "uow_id": uow_id,
+        "executor_type": executor_type,
+        "constraints": [],
+        "prescribed_skills": [],
+        "instructions": "Do the thing",
+    }
+    return to_json(artifact)
+
+
+def _insert_uow(db_path: Path, uow_id: str, workflow_artifact: str | None = None) -> None:
+    """Directly insert a UoW into the registry for test setup."""
+    import sqlite3
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute(
+            """
+            INSERT INTO uow_registry (
+                id, type, source, status, posture, created_at, updated_at,
+                summary, success_criteria, workflow_artifact
+            ) VALUES (?, 'executable', 'test', ?, 'solo', ?, ?, 'Test UoW', 'test done', ?)
+            """,
+            (uow_id, "ready-for-executor", now, now, workflow_artifact),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _get_uow_status(db_path: Path, uow_id: str) -> str:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute("SELECT status FROM uow_registry WHERE id = ?", (uow_id,)).fetchone()
+        return row["status"] if row else ""
+    finally:
+        conn.close()
+
+
+def _get_audit_events(db_path: Path, uow_id: str) -> list[str]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT event FROM audit_log WHERE uow_id = ? ORDER BY id", (uow_id,)
+        ).fetchall()
+        return [r["event"] for r in rows]
+    finally:
+        conn.close()
+
+
+def _insert_uow_with_status(db_path: Path, uow_id: str, status: str, started_at: str | None = None) -> None:
+    """Insert a UoW with a specific status for TTL recovery testing."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute(
+            """
+            INSERT INTO uow_registry (
+                id, type, source, status, posture, created_at, updated_at,
+                summary, success_criteria, started_at
+            ) VALUES (?, 'executable', 'test', ?, 'solo', ?, ?, 'Test UoW', 'done', ?)
+            """,
+            (uow_id, status, now, now, started_at or now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: UoWStatus.EXECUTING is a valid in-flight status
+# ---------------------------------------------------------------------------
+
+class TestExecutingStatus:
+    def test_executing_is_in_flight(self) -> None:
+        """EXECUTING status blocks re-proposal — it is an in-flight state."""
+        assert UoWStatus.EXECUTING.is_in_flight() is True
+
+    def test_executing_is_not_terminal(self) -> None:
+        """EXECUTING status is not terminal — the UoW is not done or failed."""
+        assert UoWStatus.EXECUTING.is_terminal() is False
+
+    def test_executing_string_value(self) -> None:
+        """UoWStatus.EXECUTING must serialize to the string 'executing'."""
+        assert str(UoWStatus.EXECUTING) == STATUS_EXECUTING
+        assert UoWStatus("executing") == UoWStatus.EXECUTING
+
+
+# ---------------------------------------------------------------------------
+# Tests: _dispatcher_is_async correctly identifies async vs sync paths
+# ---------------------------------------------------------------------------
+
+class TestDispatcherIsAsync:
+    def test_inbox_executor_types_are_async(self) -> None:
+        """All inbox executor types must be identified as async dispatch."""
+        for executor_type in INBOX_EXECUTOR_TYPES:
+            assert _dispatcher_is_async(None, executor_type) is True, (
+                f"executor_type={executor_type!r} must be async (inbox dispatch)"
+            )
+
+    def test_subprocess_executor_types_are_sync(self) -> None:
+        """Subprocess executor types must NOT be identified as async dispatch."""
+        for executor_type in SUBPROCESS_EXECUTOR_TYPES:
+            assert _dispatcher_is_async(None, executor_type) is False, (
+                f"executor_type={executor_type!r} must be sync (subprocess dispatch)"
+            )
+
+    def test_injected_dispatcher_is_always_sync(self) -> None:
+        """Any injected dispatcher override is treated as synchronous."""
+        # Even if executor_type would normally be async, override → sync
+        for executor_type in INBOX_EXECUTOR_TYPES:
+            assert _dispatcher_is_async(_noop_dispatcher, executor_type) is False, (
+                f"Injected dispatcher must always be treated as sync "
+                f"(executor_type={executor_type!r})"
+            )
+
+    def test_unknown_executor_type_is_sync_without_override(self) -> None:
+        """An unknown executor_type with no override defaults to sync (safe default)."""
+        assert _dispatcher_is_async(None, "unknown-type") is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: Async dispatch (inbox path) — status transitions
+# ---------------------------------------------------------------------------
+
+class TestAsyncDispatchStatusTransitions:
+    def test_inbox_dispatch_transitions_to_executing_not_ready_for_steward(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Async inbox dispatch must leave UoW in 'executing', not 'ready-for-steward'.
+
+        The UoW status must not jump to ready-for-steward at dispatch time —
+        that would produce a false execution_complete before any work is done.
+        """
+        uow_id = "uow_async_001"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id, "functional-engineer"))
+
+        dispatched: list[str] = []
+
+        def fake_inbox_dispatcher(instructions: str, uid: str) -> str:
+            dispatched.append(uid)
+            return f"msg-{uid}"
+
+        # Simulate async inbox dispatch: no dispatcher_override, executor_type is async.
+        # We inject a fake that behaves like _dispatch_via_inbox (fire-and-forget).
+        # To trigger the async path, we patch the dispatch table lookup.
+        import orchestration.executor as executor_mod
+        original = executor_mod._dispatch_via_inbox
+        try:
+            executor_mod._dispatch_via_inbox = fake_inbox_dispatcher  # type: ignore[attr-defined]
+            executor = Executor(registry)  # dispatcher=None → uses dispatch table
+            executor.execute_uow(uow_id)
+        finally:
+            executor_mod._dispatch_via_inbox = original
+
+        status = _get_uow_status(db_path, uow_id)
+        assert status == STATUS_EXECUTING, (
+            f"Async inbox dispatch must leave UoW in 'executing', got {status!r}. "
+            "execution_complete must not fire at dispatch time (issue #669)."
+        )
+
+    def test_inbox_dispatch_does_not_write_execution_complete_audit_entry(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """execution_complete must NOT appear in audit_log at dispatch time for async path."""
+        uow_id = "uow_async_002"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id, "lobster-ops"))
+
+        def fake_inbox_dispatcher(instructions: str, uid: str) -> str:
+            return f"msg-{uid}"
+
+        import orchestration.executor as executor_mod
+        original = executor_mod._dispatch_via_inbox
+        try:
+            executor_mod._dispatch_via_inbox = fake_inbox_dispatcher  # type: ignore[attr-defined]
+            executor = Executor(registry)
+            executor.execute_uow(uow_id)
+        finally:
+            executor_mod._dispatch_via_inbox = original
+
+        events = _get_audit_events(db_path, uow_id)
+        assert AUDIT_EXECUTION_COMPLETE not in events, (
+            f"execution_complete must not appear at dispatch time for async path. "
+            f"Audit events: {events}"
+        )
+
+    def test_inbox_dispatch_writes_executor_dispatch_audit_entry(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """executor_dispatch audit entry must appear after async inbox dispatch."""
+        uow_id = "uow_async_003"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id, "general"))
+
+        def fake_inbox_dispatcher(instructions: str, uid: str) -> str:
+            return f"msg-{uid}"
+
+        import orchestration.executor as executor_mod
+        original = executor_mod._dispatch_via_inbox
+        try:
+            executor_mod._dispatch_via_inbox = fake_inbox_dispatcher  # type: ignore[attr-defined]
+            executor = Executor(registry)
+            executor.execute_uow(uow_id)
+        finally:
+            executor_mod._dispatch_via_inbox = original
+
+        events = _get_audit_events(db_path, uow_id)
+        assert AUDIT_EXECUTOR_DISPATCH in events, (
+            f"executor_dispatch audit entry must appear after async inbox dispatch. "
+            f"Audit events: {events}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Synchronous dispatch (injected override / subprocess) — unchanged behavior
+# ---------------------------------------------------------------------------
+
+class TestSyncDispatchStatusTransitions:
+    def test_sync_dispatch_transitions_to_ready_for_steward(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Synchronous dispatch (injected override) must still transition to ready-for-steward."""
+        uow_id = "uow_sync_001"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id))
+
+        executor = Executor(registry, dispatcher=_noop_dispatcher)
+        executor.execute_uow(uow_id)
+
+        status = _get_uow_status(db_path, uow_id)
+        assert status == STATUS_READY_FOR_STEWARD, (
+            f"Sync dispatch must transition to ready-for-steward. Got {status!r}."
+        )
+
+    def test_sync_dispatch_writes_execution_complete_audit_entry(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Synchronous dispatch must write execution_complete audit entry immediately."""
+        uow_id = "uow_sync_002"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id))
+
+        executor = Executor(registry, dispatcher=_noop_dispatcher)
+        executor.execute_uow(uow_id)
+
+        events = _get_audit_events(db_path, uow_id)
+        assert AUDIT_EXECUTION_COMPLETE in events, (
+            f"Sync dispatch must write execution_complete audit entry. "
+            f"Audit events: {events}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Registry.transition_to_executing
+# ---------------------------------------------------------------------------
+
+class TestTransitionToExecuting:
+    def test_transition_to_executing_sets_status(self, registry: Registry, db_path: Path) -> None:
+        """transition_to_executing must set status to 'executing'."""
+        uow_id = "uow_te_001"
+        _insert_uow(db_path, uow_id)
+        # Manually put it in 'active' state (as the claim sequence would)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'active' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        registry.transition_to_executing(uow_id, "executor-id-abc")
+
+        assert _get_uow_status(db_path, uow_id) == STATUS_EXECUTING
+
+    def test_transition_to_executing_writes_audit_entry(self, registry: Registry, db_path: Path) -> None:
+        """transition_to_executing must write an executor_dispatch audit entry."""
+        uow_id = "uow_te_002"
+        _insert_uow(db_path, uow_id)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'active' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        registry.transition_to_executing(uow_id, "executor-id-xyz")
+
+        events = _get_audit_events(db_path, uow_id)
+        assert AUDIT_EXECUTOR_DISPATCH in events
+
+
+# ---------------------------------------------------------------------------
+# Tests: Registry.complete_uow from executing state
+# ---------------------------------------------------------------------------
+
+class TestCompleteUowFromExecuting:
+    def test_complete_uow_from_executing_sets_ready_for_steward(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """complete_uow on an 'executing' UoW must transition to ready-for-steward."""
+        uow_id = "uow_cu_001"
+        _insert_uow(db_path, uow_id)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'executing' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        registry.complete_uow(uow_id, "/tmp/output_ref.json")
+
+        assert _get_uow_status(db_path, uow_id) == STATUS_READY_FOR_STEWARD
+
+    def test_complete_uow_from_executing_writes_execution_complete_audit(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """complete_uow on 'executing' UoW must write execution_complete audit entry."""
+        uow_id = "uow_cu_002"
+        _insert_uow(db_path, uow_id)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'executing' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        registry.complete_uow(uow_id, "/tmp/output_ref.json")
+
+        events = _get_audit_events(db_path, uow_id)
+        assert AUDIT_EXECUTION_COMPLETE in events
+
+    def test_complete_uow_from_active_still_works(self, registry: Registry, db_path: Path) -> None:
+        """complete_uow on 'active' UoW (sync dispatch path) must still work."""
+        uow_id = "uow_cu_003"
+        _insert_uow(db_path, uow_id)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'active' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        registry.complete_uow(uow_id, "/tmp/output_ref.json")
+
+        assert _get_uow_status(db_path, uow_id) == STATUS_READY_FOR_STEWARD
+        events = _get_audit_events(db_path, uow_id)
+        assert AUDIT_EXECUTION_COMPLETE in events
+
+
+# ---------------------------------------------------------------------------
+# Tests: TTL recovery covers 'executing' UoWs
+# ---------------------------------------------------------------------------
+
+class TestTtlRecoveryCoversExecuting:
+    def test_ttl_recovery_fails_executing_uow_past_ttl(self, registry: Registry, db_path: Path) -> None:
+        """TTL recovery must include 'executing' UoWs that have exceeded TTL_EXCEEDED_HOURS."""
+        from datetime import datetime, timezone, timedelta
+
+        uow_id = "uow_ttl_exec_001"
+        # started_at is well past the TTL cutoff
+        stale_started_at = (
+            datetime.now(timezone.utc) - timedelta(hours=TTL_EXCEEDED_HOURS + 1)
+        ).isoformat()
+        _insert_uow_with_status(db_path, uow_id, "executing", started_at=stale_started_at)
+
+        recovered = recover_ttl_exceeded_uows(registry)
+
+        assert uow_id in recovered, (
+            f"TTL recovery must recover 'executing' UoWs past TTL. "
+            f"Recovered: {recovered}"
+        )
+        assert _get_uow_status(db_path, uow_id) == "failed"
+
+    def test_ttl_recovery_does_not_fail_fresh_executing_uow(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """TTL recovery must NOT fail 'executing' UoWs that are still within TTL."""
+        from datetime import datetime, timezone, timedelta
+
+        uow_id = "uow_ttl_exec_002"
+        # started_at is recent — well within TTL
+        fresh_started_at = (
+            datetime.now(timezone.utc) - timedelta(minutes=30)
+        ).isoformat()
+        _insert_uow_with_status(db_path, uow_id, "executing", started_at=fresh_started_at)
+
+        recovered = recover_ttl_exceeded_uows(registry)
+
+        assert uow_id not in recovered, (
+            f"TTL recovery must not touch 'executing' UoWs within TTL. "
+            f"Recovered: {recovered}"
+        )
+        assert _get_uow_status(db_path, uow_id) == "executing"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _maybe_complete_wos_uow (inbox_server integration)
+# ---------------------------------------------------------------------------
+
+class TestMaybeCompleteWosUow:
+    """Tests for _maybe_complete_wos_uow.
+
+    This function is defined in src/mcp/inbox_server.py but tested here via the
+    wos_completion module (same logic, importable without inbox_server's heavy deps).
+    """
+
+    def test_completes_executing_uow_on_success_write_result(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_maybe_complete_wos_uow must transition executing → ready-for-steward on success."""
+        uow_id = "uow_mcwu_001"
+        _insert_uow(db_path, uow_id)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'executing' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setenv("REGISTRY_DB_PATH", str(db_path))
+
+        from orchestration.wos_completion import maybe_complete_wos_uow
+        maybe_complete_wos_uow(f"wos-{uow_id}", "success")
+
+        assert _get_uow_status(db_path, uow_id) == STATUS_READY_FOR_STEWARD
+
+    def test_does_not_complete_for_non_wos_task_id(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """maybe_complete_wos_uow must be a no-op for task_ids that don't start with 'wos-'."""
+        uow_id = "uow_mcwu_002"
+        _insert_uow(db_path, uow_id)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'executing' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setenv("REGISTRY_DB_PATH", str(db_path))
+
+        from orchestration.wos_completion import maybe_complete_wos_uow
+        maybe_complete_wos_uow("issue-42-pr-review", "success")  # not a wos- task_id
+
+        # Status must remain unchanged
+        assert _get_uow_status(db_path, uow_id) == "executing"
+
+    def test_does_not_complete_on_failed_write_result(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """maybe_complete_wos_uow must NOT complete UoW when status='error'."""
+        uow_id = "uow_mcwu_003"
+        _insert_uow(db_path, uow_id)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET status = 'executing' WHERE id = ?", (uow_id,))
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setenv("REGISTRY_DB_PATH", str(db_path))
+
+        from orchestration.wos_completion import maybe_complete_wos_uow
+        maybe_complete_wos_uow(f"wos-{uow_id}", "error")  # failed write_result
+
+        # Status must remain in executing — TTL recovery handles this
+        assert _get_uow_status(db_path, uow_id) == "executing"
+
+    def test_does_not_complete_uow_not_in_executing_status(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """maybe_complete_wos_uow must skip UoWs already past 'executing' (idempotency)."""
+        uow_id = "uow_mcwu_004"
+        _insert_uow(db_path, uow_id)
+        # Already in ready-for-steward (e.g. from TTL recovery or duplicate write_result)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE uow_registry SET status = 'ready-for-steward' WHERE id = ?", (uow_id,)
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setenv("REGISTRY_DB_PATH", str(db_path))
+
+        from orchestration.wos_completion import maybe_complete_wos_uow
+        # Must not raise; must be a no-op
+        maybe_complete_wos_uow(f"wos-{uow_id}", "success")
+
+        assert _get_uow_status(db_path, uow_id) == "ready-for-steward"


### PR DESCRIPTION
## Problem

The executor was calling `complete_uow()` immediately after writing a `wos_execute` message to the inbox — before any subagent had done any work. Since `_dispatch_via_inbox()` is fire-and-forget, this produced a false `execution_complete` audit entry and prematurely advanced the UoW to `ready-for-steward`. The steward would then re-diagnose a UoW whose subagent was still running, causing duplicate work or lost results.

## Solution

Introduce an `executing` intermediate status that the executor writes at dispatch time. The `execution_complete` audit entry and the `executing → ready-for-steward` transition are deferred until the subagent confirms completion by calling `write_result(status="success")`.

The dispatch path distinction that drives this:
- **Async executor types** (`functional-engineer`, `lobster-ops`, `general`): use `_dispatch_via_inbox()` (fire-and-forget). At dispatch time, transition `active → executing`. The `write_result` handler fires `complete_uow()`.
- **Sync executor types** (`frontier-writer`, `design-review`) and injected test dispatchers: use blocking `claude -p`. At dispatch time, call `complete_uow()` immediately (no behavior change — the subprocess has already returned).

## State machine change

```
Before:
  active → ready-for-steward   (at inbox write time, before subagent runs)

After:
  active → executing           (at inbox write time)
  executing → ready-for-steward  (when write_result status=success received)
  executing → failed           (TTL recovery after 4h, or write_result status=error leaves it for TTL)
```

## Changes

**`src/orchestration/registry.py`**
- Added `UoWStatus.EXECUTING = "executing"` with explaining comment
- Added `transition_to_executing(uow_id, executor_id)` — atomic audit+update, same invariant as all other transitions
- Updated `complete_uow()` and `fail_uow()` to derive `from_status` dynamically (handles both `active` and `executing` as the prior state)
- Updated `is_in_flight()` to include `EXECUTING`

**`src/orchestration/executor.py`**
- Added `_ASYNC_EXECUTOR_TYPES` constant (named, traceable to spec)
- Added `_dispatcher_is_async()` pure function: injected override → sync; executor_type in async set → async
- Modified `_run_execution()` Step 6: async path calls `transition_to_executing`; sync path calls `complete_uow` (unchanged)
- Updated `recover_ttl_exceeded_uows()` query to cover `status IN ('active', 'executing')`

**`src/orchestration/wos_completion.py`** (new)
- Standalone module: `maybe_complete_wos_uow(task_id, status)` — fires `complete_uow` when a `wos-{uow_id}` write_result arrives with `status=success` and the UoW is in `executing` state. Errors are logged and swallowed — write_result delivery is never blocked by registry failures. Extracted from `inbox_server.py` to avoid importing its heavy dependency chain in tests.

**`src/mcp/inbox_server.py`**
- Added thin `_maybe_complete_wos_uow()` wrapper imported from `wos_completion`
- Called after the auto-unregister block in `handle_write_result()`

**`scheduled-tasks/executor-heartbeat.py`**
- Updated dry-run TTL query from `WHERE status = 'active'` to `WHERE status IN ('active', 'executing')`

## Functional patterns used

Pure functions (`_dispatcher_is_async`), named constants (`_ASYNC_EXECUTOR_TYPES`, `WOS_TASK_ID_PREFIX`, `WRITE_RESULT_SUCCESS_STATUS`), explicit error boundaries (errors logged, never raised from `maybe_complete_wos_uow`), immutable audit-before-transition invariant preserved across all new transitions.

## Tests run

- [x] `cd ~/lobster-workspace/projects/fix-issue-669-executor-false-complete && uv run pytest tests/unit/test_orchestration/test_executor_false_complete_fix.py -v` — 23 passed, 0 failed
- [x] `uv run pytest tests/unit/ -x --ignore=tests/unit/test_orchestration/test_executor_false_complete_fix.py` — same pre-existing failures on main and fix branch (3 `TestOptimisticLock` tests, 1 `test_approve_idempotent_on_pending`) — confirmed not regressions
- [ ] Live Telegram / write_result integration test — blocked: requires production dispatcher running with a live WOS UoW. The `maybe_complete_wos_uow` path is isolated and covered by unit tests with a real SQLite DB.

## Manual test

N/A — this change is entirely internal to the registry state machine and the write_result handler. No Telegram output, no external service calls, no file I/O affecting runtime state beyond the registry DB (covered by unit tests using real SQLite fixtures).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal state machine change, no external services)
- [x] User-visible outcome verified — N/A (no direct user-visible output; steward behavior correctness verified by state transition tests)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change

Closes #669