### PR TITLE
fix(wos): remove empty legacy registry DB and add startup warning

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -90,6 +90,22 @@ def _is_job_enabled(job_name: str) -> bool:
         return True
 
 
+def _warn_if_legacy_registry_exists() -> None:
+    """Log a warning if the deprecated legacy registry path exists and is non-empty."""
+    workspace = Path(os.environ.get(
+        "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
+    ))
+    legacy_path = workspace / "data" / "wos-registry.db"
+    if legacy_path.exists() and legacy_path.stat().st_size > 0:
+        log.warning(
+            "Legacy registry DB at %s exists and is non-empty (%d bytes). "
+            "Canonical path is %s. Investigate and remove the legacy file.",
+            legacy_path,
+            legacy_path.stat().st_size,
+            workspace / "orchestration" / "registry.db",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Recovery threshold — UoWs not yet dispatched after this many minutes are
 # considered missed by the primary event-driven inbox path and are eligible
@@ -423,6 +439,8 @@ def main() -> int:
     if not _is_job_enabled("executor-heartbeat"):
         log.info("Executor heartbeat: skipped (disabled in jobs.json)")
         return 0
+
+    _warn_if_legacy_registry_exists()
 
     from src.orchestration.steward import is_bootup_candidate_gate_active
     log.info("BOOTUP_CANDIDATE_GATE = %s", is_bootup_candidate_gate_active())

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -226,6 +226,22 @@ def _default_db_path() -> Path:
     return workspace / "orchestration" / "registry.db"
 
 
+def _warn_if_legacy_registry_exists() -> None:
+    """Log a warning if the deprecated legacy registry path exists and is non-empty."""
+    workspace = Path(os.environ.get(
+        "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
+    ))
+    legacy_path = workspace / "data" / "wos-registry.db"
+    if legacy_path.exists() and legacy_path.stat().st_size > 0:
+        log.warning(
+            "Legacy registry DB at %s exists and is non-empty (%d bytes). "
+            "Canonical path is %s. Investigate and remove the legacy file.",
+            legacy_path,
+            legacy_path.stat().st_size,
+            workspace / "orchestration" / "registry.db",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Agent cleanup — prevent backlog accumulation (Phase 1)
 # ---------------------------------------------------------------------------
@@ -525,6 +541,8 @@ def main() -> int:
     if not _is_job_enabled("steward-heartbeat"):
         log.info("Steward heartbeat: skipped (disabled in jobs.json)")
         return 0
+
+    _warn_if_legacy_registry_exists()
 
     gate_active = is_bootup_candidate_gate_active()
     log.info("BOOTUP_CANDIDATE_GATE = %s", gate_active)


### PR DESCRIPTION
## What and why

Two WOS registry paths existed simultaneously: the legacy `data/wos-registry.db` (empty, 0 rows, artifact of an earlier registry migration) and the active `orchestration/registry.db`. Any code or agent constructing the path naively — `LOBSTER_WORKSPACE/data/wos-registry.db` — would silently operate on an empty registry. This PR eliminates that ambiguity.

## Changes

**Runtime (workspace, not committed):** Removed `~/lobster-workspace/data/wos-registry.db` (confirmed empty) and placed a `wos-registry.db.deprecated` marker at the same path explaining the canonical location.

**Code (both heartbeats):** Added `_warn_if_legacy_registry_exists()` to `executor-heartbeat.py` and `steward-heartbeat.py`. It fires early in `main()` (after the jobs.json gate, before any registry access) and logs a WARNING if the legacy path reappears with data — providing a recovery signal if the file is inadvertently recreated. The function is a pure side-effect-isolated check: reads the filesystem, calls `log.warning`, returns `None`.

**Code audit:** Grepped the full repo for `wos-registry.db` and `data/wos-registry`. Zero production `.py` hits — all references were in `docs/` only. No code path fixes were needed.

**Functional patterns used:** Pure function (`_warn_if_legacy_registry_exists` has no state mutations), side-effect boundary isolation (the warning is issued at startup before any registry work), early exit (no-op when legacy path is absent or empty).

## Before / after

Before: Two registry paths in the workspace. Code uses `orchestration/registry.db` correctly but the orphaned `data/wos-registry.db` exists and could mislead agents or future code.

After: Only `orchestration/registry.db` exists. Any future reappearance of the legacy path with data triggers a logged WARNING on every heartbeat invocation.

No state machine transitions affected — this is purely a cleanup and guard addition.

## Tests run
- [x] `uv run -m pytest tests/unit/test_orchestration/test_executor_heartbeat.py -x -q` — 22 passed, 0 failed
- [x] `uv run -m pytest tests/unit/test_orchestration/ -x -q` — 568 passed, 1 pre-existing failure (`test_approve_idempotent_on_pending` in `test_registry_cli.py`; confirmed failing on main before this branch)
- [ ] `--timeout=60` flag — not supported by the installed pytest version; ran without it, same results

**Blocked items needing attention before merge:** none — the pre-existing test failure is unrelated to this change.

## Manual test

N/A for the code changes (pure function addition, no external service calls, no file I/O at runtime beyond reading filesystem stat).

The workspace-level change (removing the legacy DB and placing the marker file) was applied directly and verified:
- `~/lobster-workspace/data/wos-registry.db` removed (was empty)
- `~/lobster-workspace/data/wos-registry.db.deprecated` placed with deprecation text

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external services, DB removed was confirmed empty)
- [x] User-visible outcome verified — N/A (this is internal infrastructure cleanup)
- [x] Side-effect audit complete: no floods, no unscoped writes. The warning function is read-only; it only calls `log.warning` when the legacy path reappears with data.
- [x] External service calls: none

Closes #682