### PR TITLE
fix(wos): early-warning threshold uses lifetime_cycles not steward_cycles

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -204,7 +204,9 @@ _ACTOR_STEWARD = "steward"
 # per-UoW-lifetime circuit breaker. steward_cycles (per-attempt) is NOT used here.
 _HARD_CAP_CYCLES = 5
 
-# Early warning threshold: notify Dan when steward_cycles reaches this value
+# Early warning threshold: notify Dan when lifetime_cycles + steward_cycles reaches this value.
+# Uses cumulative lifetime_cycles + new_cycles (post-prescription) so the warning fires based
+# on total cycles across all decide-retry rounds, not just the current attempt.
 _EARLY_WARNING_CYCLES = 4
 
 # Crash surface threshold: surface if crashed_no_output and steward_cycles >= this value.
@@ -3042,9 +3044,11 @@ def _process_uow(
                     uow_id, type(exc).__name__, exc,
                 )
 
-    # Early warning: fire when new_cycles reaches the early-warning threshold.
+    # Early warning: fire when lifetime_cycles + new_cycles reaches the early-warning threshold.
+    # Uses cumulative count (lifetime_cycles from previous attempts + new_cycles this attempt)
+    # so the warning fires correctly even after decide-retry resets steward_cycles to 0.
     # Fires regardless of dry_run so tests can capture the notification.
-    if new_cycles == _EARLY_WARNING_CYCLES:
+    if uow.lifetime_cycles + new_cycles == _EARLY_WARNING_CYCLES:
         _notify_early = notify_dan_early_warning or _default_notify_dan_early_warning
         _notify_early(uow, return_reason, new_cycles)
 

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -1698,8 +1698,12 @@ class TestModuleConstants:
 # ---------------------------------------------------------------------------
 
 class TestEarlyWarningAt4:
-    def test_early_warning_fires_when_prescription_reaches_cycle_4(self, db_path, registry, tmp_path):
-        """When a prescription results in new steward_cycles == 4, an early warning is sent."""
+    def test_early_warning_fires_when_cumulative_cycles_reaches_4(self, db_path, registry, tmp_path):
+        """Early warning fires when lifetime_cycles + new steward_cycles reaches 4.
+
+        First-attempt case: lifetime_cycles=0, steward_cycles=3.
+        After prescription: 0 + 4 = 4 → early warning fires.
+        """
         _ensure_registry_has_phase2_methods(registry)
         steward = _import_steward()
 
@@ -1715,11 +1719,12 @@ class TestEarlyWarningAt4:
         ]
 
         conn = _open_db(db_path)
-        # steward_cycles=3: after prescription it becomes 4 → early warning
+        # lifetime_cycles=0 (first attempt), steward_cycles=3: after prescription 0+4=4 → early warning
         uow_id = _make_uow_row(
             conn,
             status="ready-for-steward",
             steward_cycles=3,
+            lifetime_cycles=0,
             output_ref=None,
             audit_log_entries=audit_entries,
             success_criteria="Must produce artifact",
@@ -1741,7 +1746,7 @@ class TestEarlyWarningAt4:
         )
         assert uow["steward_cycles"] == 4, "steward_cycles must be 4 after prescription"
         assert len(early_warnings) == 1, (
-            f"Early warning must fire exactly once when new_cycles == 4, got: {early_warnings}"
+            f"Early warning must fire exactly once when lifetime_cycles+new_cycles == 4, got: {early_warnings}"
         )
         assert early_warnings[0]["uow_id"] == uow_id
         assert early_warnings[0]["new_cycles"] == 4, (
@@ -1749,8 +1754,60 @@ class TestEarlyWarningAt4:
             f"got: {early_warnings[0]['new_cycles']}"
         )
 
-    def test_early_warning_not_fired_at_cycle_3(self, db_path, registry, tmp_path):
-        """No early warning when new steward_cycles is 3 (only fires at exactly 4)."""
+    def test_early_warning_fires_after_retry_when_cumulative_reaches_4(self, db_path, registry, tmp_path):
+        """Early warning fires based on cumulative lifetime_cycles, not per-attempt steward_cycles.
+
+        Cross-retry case: lifetime_cycles=2 (from previous attempt), steward_cycles=1.
+        After prescription: 2 + 2 = 4 → early warning fires despite steward_cycles being low.
+        Without the fix (using steward_cycles only), this would produce new_cycles=2 and not fire.
+        """
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        early_warnings = []
+
+        def capture_early_warning(uow, return_reason, new_cycles=None):
+            uow_id = uow.id if hasattr(uow, "id") else uow["id"]
+            early_warnings.append({"uow_id": uow_id, "return_reason": return_reason, "new_cycles": new_cycles})
+
+        audit_entries = [
+            {"event": "execution_complete", "actor": "executor",
+             "return_reason": "needs_steward_review", "timestamp": _now_iso()},
+        ]
+
+        conn = _open_db(db_path)
+        # lifetime_cycles=2 (accumulated from previous attempt), steward_cycles=1:
+        # after prescription: 2 + 2 = 4 → early warning must fire
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            lifetime_cycles=2,
+            output_ref=None,
+            audit_log_entries=audit_entries,
+            success_criteria="Must produce artifact",
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            notify_dan_early_warning=capture_early_warning,
+        )
+
+        uow = _get_uow(db_path, uow_id)
+        assert uow["status"] == "ready-for-executor", (
+            "UoW should be prescribed (status=ready-for-executor)"
+        )
+        assert len(early_warnings) == 1, (
+            f"Early warning must fire when lifetime_cycles(2) + new_cycles(2) == 4, got: {early_warnings}"
+        )
+        assert early_warnings[0]["uow_id"] == uow_id
+
+    def test_early_warning_not_fired_at_cumulative_cycle_3(self, db_path, registry, tmp_path):
+        """No early warning when lifetime_cycles + new steward_cycles is 3 (only fires at exactly 4)."""
         _ensure_registry_has_phase2_methods(registry)
         steward = _import_steward()
 
@@ -1765,11 +1822,12 @@ class TestEarlyWarningAt4:
         ]
 
         conn = _open_db(db_path)
-        # steward_cycles=2: after prescription it becomes 3 → no early warning
+        # lifetime_cycles=0 (first attempt), steward_cycles=2: after prescription 0+3=3 → no early warning
         uow_id = _make_uow_row(
             conn,
             status="ready-for-steward",
             steward_cycles=2,
+            lifetime_cycles=0,
             output_ref=None,
             audit_log_entries=audit_entries,
             success_criteria="Must produce artifact",
@@ -1785,7 +1843,7 @@ class TestEarlyWarningAt4:
         )
 
         assert len(early_warnings) == 0, (
-            f"Early warning must not fire at new_cycles=3, got: {early_warnings}"
+            f"Early warning must not fire at cumulative new_cycles=3, got: {early_warnings}"
         )
 
     def test_early_warning_not_fired_at_hard_cap(self, db_path, registry, tmp_path):


### PR DESCRIPTION
## What this fixes

The WOS steward's early-warning notification was checking the wrong cycle counter. The threshold comparison at prescription time used `new_cycles` (which is `steward_cycles + 1`, a per-attempt counter that resets to 0 on decide-retry) instead of the cumulative `lifetime_cycles + new_cycles`.

The practical failure: a UoW that has gone through a decide-retry starts a new attempt with `steward_cycles = 0` while `lifetime_cycles` carries the effort from the prior round. The warning would never fire at the intended cumulative threshold — it would only fire if the new attempt independently reached cycle 4, treating a retried UoW as if it were brand new.

This was flagged as an advisory in the oracle review of PR #687 (which introduced `lifetime_cycles`).

## The fix

One-line change in `_process_uow`:

Before: `if new_cycles == _EARLY_WARNING_CYCLES:`
After: `if uow.lifetime_cycles + new_cycles == _EARLY_WARNING_CYCLES:`

`uow.lifetime_cycles` is the cumulative count from all prior attempts (set by `decide_retry` in the registry: `lifetime_cycles = old_lifetime + old_steward_cycles`, then `steward_cycles = 0`). Adding `new_cycles` (the post-prescription per-attempt count) gives the true total effort expended.

The constant `_EARLY_WARNING_CYCLES` and the `_default_notify_dan_early_warning` callback are unchanged. The hard-cap check (`lifetime_cycles >= _HARD_CAP_CYCLES`) and the crash-surface check (`steward_cycles >= _CRASH_SURFACE_CYCLES`) are intentionally untouched — the hard cap already uses `lifetime_cycles` correctly, and crash detection is explicitly per-attempt by design.

## Functional patterns

Pure function: the comparison is a local predicate with no side effects. The fix preserves the existing immutable data flow — `uow.lifetime_cycles` is read-only at this point and never mutated by the steward.

## Tests

Updated two existing tests to set `lifetime_cycles=0` explicitly (first-attempt case; the default had been to mirror `steward_cycles`, which inadvertently passed the old broken check). Added one new test:

- `test_early_warning_fires_after_retry_when_cumulative_reaches_4`: `lifetime_cycles=2`, `steward_cycles=1` -> post-prescription `2 + 2 = 4` -> warning fires. Without the fix, `new_cycles = 2 != 4` and the warning silently skips.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -q` -- 118 passed, 0 failed (9m 15s)
- [ ] Full test suite -- not run; unrelated pre-existing failures in `test_vps_integration.py` (missing `bot_talk` module) and `test_registry_cli.py` (unrelated approve idempotency test) prevent clean collection. Steward-specific tests are the complete relevant scope for this change.

## Manual test

N/A -- this is a pure in-process logic fix with no external service calls, file I/O, or systemd involvement. Behavior verified by unit tests.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run -- N/A (internal logic only)
- [x] User-visible outcome -- N/A (early warning is an internal threshold; the notification mechanism itself is unchanged)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change

Closes advisory from PR #687 oracle review.