### PR TITLE
steward: bump hard cap from 5 to 9 (pre-Sprint 3)

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -202,7 +202,7 @@ _ACTOR_STEWARD = "steward"
 # Hard cap: surface to Dan unconditionally if lifetime_cycles >= this value.
 # lifetime_cycles accumulates across all decide-retry resets, so this is a true
 # per-UoW-lifetime circuit breaker. steward_cycles (per-attempt) is NOT used here.
-_HARD_CAP_CYCLES = 5
+_HARD_CAP_CYCLES = 9
 
 # Early warning threshold: notify Dan when lifetime_cycles + steward_cycles reaches this value.
 # Uses cumulative lifetime_cycles + new_cycles (post-prescription) so the warning fires based


### PR DESCRIPTION
Sprint 2 showed complex UoWs hitting the 5-cycle cap and requiring manual resets. Bumping to 9 restores appropriate runway without changing semantics, as a pre-Sprint 3 commit independent of S3-A.

## What changed

`_HARD_CAP_CYCLES` in `src/orchestration/steward.py` bumped from 5 to 9. This is the per-UoW-lifetime circuit breaker: when `lifetime_cycles >= _HARD_CAP_CYCLES`, the steward surfaces the UoW to the operator unconditionally. No other constants or logic changed.

The design doc (`docs/wos-sprint3-design.md`) does not reference the literal value 5 for the hard cap, so no doc update was needed.

## Why

Sprint 2 UoWs with diagnosis + prescription + re-prescription rounds routinely reached 5 lifetime cycles on legitimate multi-step work, triggering the cap and requiring manual operator resets. 9 provides headroom for complex UoWs while preserving the circuit-breaker guarantee.

## Scope

Single constant change. `_EARLY_WARNING_CYCLES` (4) and `_CRASH_SURFACE_CYCLES` (2) are unchanged. The cleanup arc behavior at cap (S3-A) is unchanged — this PR only adjusts when the cap fires, not what happens when it does.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -q` — 7 tests passed before hitting a pre-existing hang in the test suite (unrelated to this change)
- [ ] Full steward test suite — blocked by pre-existing test infrastructure hang (asyncio tests block indefinitely); not introduced by this change

**Blocked items needing attention before merge:** none — the test hang is pre-existing.

## Manual test
N/A — pure constant change; no external services, file I/O, or systemd touched.