### PR TITLE
S3-F: Restore github-issue-cultivator (Filing Cultivator)

### DIFF
--- a/scheduled-jobs/tasks/github-issue-cultivator.md
+++ b/scheduled-jobs/tasks/github-issue-cultivator.md
@@ -1,0 +1,72 @@
+# GitHub Issue Cultivator (Filing Cultivator)
+
+**Job**: github-issue-cultivator
+**Schedule**: Weekly on Mondays at 9:00 UTC (`0 9 * * 1`)
+**Created**: 2026-04-08
+
+## Context
+
+You are running as a scheduled task. The main Lobster instance created this job.
+
+This is the **Filing Cultivator** — the upstream supply actor in the V3 WOS pipeline. It reads a manually-maintained confirmed seed list and files GitHub issues with the `wos` label on `dcetlin/Lobster`.
+
+**Scope boundary:** This job reads a pre-approved seed list and files issues. It does NOT generate new seeds autonomously. Seeds are manually added to the seed file by Dan.
+
+## Instructions
+
+### Step 1: Load the seed list
+
+Read all seeds from `~/lobster-workspace/data/cultivator-seeds.jsonl`. Each line is a JSON object:
+
+```json
+{"title": "Issue title", "body": "Issue body text", "labels": ["wos"]}
+```
+
+If the file does not exist or is empty (no non-comment lines), write task output with `"No seeds to file"` and exit successfully.
+
+### Step 2: Fetch existing wos issues
+
+Get all open and closed issues on `dcetlin/Lobster` that have the `wos` label, to avoid filing duplicates:
+
+```bash
+gh issue list --repo dcetlin/Lobster --label wos --state all --limit 500 --json title
+```
+
+Collect the set of existing issue titles (case-insensitive comparison).
+
+### Step 3: File new issues
+
+For each seed in the seed list:
+
+1. Check if the title already exists in the set of existing issue titles (case-insensitive). If it does, skip it and note it as a duplicate.
+
+2. If it does not exist, file the issue:
+   ```bash
+   gh issue create --repo dcetlin/Lobster \
+     --title "<seed title>" \
+     --body "<seed body>" \
+     --label "<each label from seed labels array>"
+   ```
+   Note the created issue URL.
+
+3. After filing, add the title to the known-titles set (prevents duplicates within a single run if the seed list has near-duplicates).
+
+### Step 4: Write output
+
+Call `write_task_output` with:
+- `job_name`: `"github-issue-cultivator"`
+- `output`: Summary including:
+  - Total seeds loaded
+  - Issues filed (count + URLs)
+  - Issues skipped as duplicates (count + titles)
+  - Any errors encountered
+- `status`: `"success"` if no fatal errors, `"failed"` if the seed file could not be read or more than half the filings failed
+
+Then call `write_result` with:
+- `chat_id`: 0
+- `sent_reply_to_user`: True
+- `text`: Brief summary, e.g. `"github-issue-cultivator: filed=N, skipped=N duplicates"`
+
+## Output
+
+Keep output concise. The main Lobster instance will review this later.


### PR DESCRIPTION
## What this solves

The WOS V3 pipeline has no upstream supply actor — the Filing Cultivator task file and jobs.json entry were absent. Without this job, the seed-to-issue pipeline cannot operate: Dan has no automated mechanism to convert approved seeds into `wos`-labeled GitHub issues.

## What changed

This PR adds the task file that defines the Filing Cultivator's behavior as an LLM-agent scheduled job.

**Scope boundary (explicit):** This is the *Filing* Cultivator only. It reads a pre-approved, manually-maintained seed list (`cultivator-seeds.jsonl`) and files issues. It does not generate seeds autonomously and does not do orientation-register work. Seeds are added manually by Dan.

**What is NOT in this PR (runtime-only, not committed):**
- `~/lobster-workspace/scheduled-jobs/jobs.json` — updated in place with `enabled: true`, schedule `0 9 * * 1`
- `~/lobster-workspace/data/cultivator-seeds.jsonl` — created as an empty file with format documentation

The task .md file is the agent's instruction set. The jobs.json entry and seed file are instance-specific runtime data that live outside the repo.

## How the job works

1. Reads seeds from `cultivator-seeds.jsonl` (one JSON object per line: `{"title": "...", "body": "...", "labels": ["wos"]}`)
2. Fetches all existing `wos`-labeled issues from `dcetlin/Lobster` (open + closed) to deduplicate by title
3. Files each unseen seed via `gh issue create`
4. Writes `write_task_output` with filed/skipped counts and issue URLs
5. Calls `write_result` with a brief summary

## Functional patterns

Pure data transformation: seeds-in → issues-out with deduplication via set membership. No shared mutable state. The job is idempotent — re-running it against the same seed list will skip all already-filed issues.

## Tests run

- [x] Task file reviewed for format conformance against existing task files (`upstream-sync.md`, `steward-heartbeat.md`) — structure matches
- [x] jobs.json validated after update: `python3 -m json.tool` — valid JSON, entry present with correct fields
- [ ] Live execution against `dcetlin/Lobster` — skipped: seed file is intentionally empty; a live run with an empty file is a no-op. Full execution path requires Dan to add seeds first.

**Blocked items needing attention before merge:** none

## Manual test

N/A — this change is entirely internal (task file + jobs.json registration). No external service calls are made during registration. The first live execution will occur Monday 2026-04-13 at 9:00 UTC, or whenever Dan adds seeds and triggers a manual run.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, LLM task file
- [x] Integration/manual test run — N/A at registration time; first run gated on seed list content
- [x] User-visible outcome verified — N/A (no user-visible output until seeds are added)
- [x] Side-effect audit complete: no floods, no unscoped writes — job is gated by seed list size; Dan controls what gets filed
- [x] External service calls: scoped to `gh issue create` per seed, deduplicated by title

Closes #698