### PR TITLE
feat(wos): queue depth monitor for starvation and toxicity observation (#681)

### DIFF
--- a/scheduled-tasks/wos-queue-monitor.py
+++ b/scheduled-tasks/wos-queue-monitor.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+WOS Queue Monitor — Asymmetric governor: backlog starvation and toxicity observation.
+
+Runs every 30 minutes. On each invocation:
+1. Queries uow_registry for count of UoWs with status in
+   ('ready-for-steward', 'ready-for-executor', 'active').
+2. Appends {"timestamp": "<ISO>", "queue_depth": N} to
+   ~/lobster-workspace/data/queue-depth-history.jsonl.
+3. Reads the rolling history to detect:
+   - STARVATION: queue depth 0 for >= 6 consecutive hours
+     (12+ consecutive 30-min readings at depth 0).
+   - TOXICITY: queue depth > 10 for >= 3 consecutive readings.
+4. Emits write_task_output observations when either condition is met.
+5. Checks jobs.json for its own `enabled` gate before running.
+
+This is a pure observation instrument. No automated action is taken.
+
+Cron schedule (every 30 minutes):
+    */30 * * * * cd ~/lobster && uv run scheduled-tasks/wos-queue-monitor.py >> ~/lobster-workspace/scheduled-jobs/logs/wos-queue-monitor.log 2>&1 # LOBSTER-WOS-QUEUE-MONITOR
+
+Type C dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+involvement). The jobs.json enabled gate is checked at the top of main() so that
+runtime enable/disable is respected without touching cron.
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/wos-queue-monitor.py
+
+Design reference: docs/mito-modeling.md Section 2, Row 4; Section 5.2
+GitHub issue: https://github.com/dcetlin/Lobster/issues/681
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("wos-queue-monitor")
+
+# ---------------------------------------------------------------------------
+# Constants — derived from the spec in issue #681 and mito-modeling.md
+# ---------------------------------------------------------------------------
+
+JOB_NAME: str = "wos-queue-monitor"
+
+# Queue depth 0 for this many consecutive readings (30-min cadence) = 6 hours
+STARVATION_CONSECUTIVE_READINGS: int = 12
+
+# Queue depth > this threshold for TOXICITY_CONSECUTIVE_READINGS = toxicity signal
+TOXICITY_DEPTH_THRESHOLD: int = 10
+TOXICITY_CONSECUTIVE_READINGS: int = 3
+
+# UoW statuses that contribute to the "active backlog" depth
+BACKLOG_STATUSES: tuple[str, ...] = (
+    "ready-for-steward",
+    "ready-for-executor",
+    "active",
+)
+
+
+# ---------------------------------------------------------------------------
+# Workspace / path helpers
+# ---------------------------------------------------------------------------
+
+def _workspace() -> Path:
+    return Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+
+
+def _registry_db_path() -> Path:
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    return _workspace() / "orchestration" / "registry.db"
+
+
+def _history_file() -> Path:
+    return _workspace() / "data" / "queue-depth-history.jsonl"
+
+
+def _task_outputs_dir() -> Path:
+    messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+    return messages_base / "task-outputs"
+
+
+def _jobs_file() -> Path:
+    return _workspace() / "scheduled-jobs" / "jobs.json"
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type C dispatch pattern
+# ---------------------------------------------------------------------------
+
+def _is_job_enabled() -> bool:
+    """
+    Return True if this job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when:
+    - jobs.json is absent
+    - the job entry is missing
+    - the file is unreadable or malformed
+    """
+    try:
+        data = json.loads(_jobs_file().read_text())
+        return bool(data.get("jobs", {}).get(JOB_NAME, {}).get("enabled", True))
+    except Exception:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Registry query — pure function, returns int
+# ---------------------------------------------------------------------------
+
+def query_queue_depth(db_path: Path) -> int:
+    """
+    Query uow_registry for count of UoWs with status in BACKLOG_STATUSES.
+
+    Returns 0 if the DB does not exist or the table is absent (safe default
+    during first-run before the registry is initialized).
+    """
+    if not db_path.exists():
+        log.warning("Registry DB not found at %s — reporting depth 0", db_path)
+        return 0
+
+    placeholders = ",".join("?" * len(BACKLOG_STATUSES))
+    sql = f"SELECT COUNT(*) FROM uow_registry WHERE status IN ({placeholders})"
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        try:
+            row = conn.execute(sql, BACKLOG_STATUSES).fetchone()
+            return int(row[0]) if row else 0
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("Failed to query registry at %s: %s — reporting depth 0", db_path, exc)
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# History file I/O — pure reads, isolated append
+# ---------------------------------------------------------------------------
+
+def _load_history(history_file: Path) -> list[dict]:
+    """Load all entries from the JSONL history file. Returns [] if absent or empty."""
+    if not history_file.exists():
+        return []
+    entries = []
+    for line in history_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            log.warning("Skipping malformed history line: %r", line)
+    return entries
+
+
+def _append_history(history_file: Path, timestamp: str, queue_depth: int) -> None:
+    """Append a new reading to the JSONL history file (side effect isolated here)."""
+    history_file.parent.mkdir(parents=True, exist_ok=True)
+    record = {"timestamp": timestamp, "queue_depth": queue_depth}
+    with history_file.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Signal detection — pure functions operating on history list
+# ---------------------------------------------------------------------------
+
+def detect_starvation(history: list[dict]) -> bool:
+    """
+    Return True if the last STARVATION_CONSECUTIVE_READINGS entries all have
+    queue_depth == 0.
+
+    At 30-minute cadence, STARVATION_CONSECUTIVE_READINGS readings = 6 hours.
+    """
+    if len(history) < STARVATION_CONSECUTIVE_READINGS:
+        return False
+    tail = history[-STARVATION_CONSECUTIVE_READINGS:]
+    return all(entry.get("queue_depth", -1) == 0 for entry in tail)
+
+
+def detect_toxicity(history: list[dict]) -> tuple[bool, int]:
+    """
+    Return (True, current_depth) if the last TOXICITY_CONSECUTIVE_READINGS
+    entries all have queue_depth > TOXICITY_DEPTH_THRESHOLD, else (False, 0).
+    """
+    if len(history) < TOXICITY_CONSECUTIVE_READINGS:
+        return False, 0
+    tail = history[-TOXICITY_CONSECUTIVE_READINGS:]
+    depths = [entry.get("queue_depth", 0) for entry in tail]
+    if all(d > TOXICITY_DEPTH_THRESHOLD for d in depths):
+        return True, depths[-1]
+    return False, 0
+
+
+# ---------------------------------------------------------------------------
+# Task output writer — side effect isolated here
+# ---------------------------------------------------------------------------
+
+def _write_task_output(output: str, status: str, timestamp: str) -> None:
+    """
+    Write a task output record to the task-outputs directory.
+    Mirrors the format expected by check_task_outputs / the MCP tool.
+    """
+    task_outputs = _task_outputs_dir()
+    task_outputs.mkdir(parents=True, exist_ok=True)
+    date_prefix = timestamp[:19].replace(":", "").replace("-", "").replace("T", "-")
+    filename = f"{date_prefix}-{JOB_NAME}.json"
+    record = {
+        "job_name": JOB_NAME,
+        "timestamp": timestamp,
+        "status": status,
+        "output": output,
+    }
+    out_path = task_outputs / filename
+    tmp_path = Path(str(out_path) + ".tmp")
+    tmp_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp_path.replace(out_path)
+    log.info("Wrote task output: %s → %s", status, output)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    if not _is_job_enabled():
+        log.info("Job %s is disabled in jobs.json — exiting.", JOB_NAME)
+        return
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    db_path = _registry_db_path()
+    history_file = _history_file()
+
+    # 1. Query current queue depth
+    depth = query_queue_depth(db_path)
+    log.info("Queue depth: %d (statuses: %s)", depth, ", ".join(BACKLOG_STATUSES))
+
+    # 2. Append to history
+    _append_history(history_file, timestamp, depth)
+
+    # 3. Load history and run signal detection
+    history = _load_history(history_file)
+
+    starvation = detect_starvation(history)
+    toxicity, toxic_depth = detect_toxicity(history)
+
+    # 4. Emit observations when signals fire
+    if starvation:
+        msg = (
+            f"STARVATION: queue depth 0 for {STARVATION_CONSECUTIVE_READINGS}+ "
+            f"consecutive readings ({STARVATION_CONSECUTIVE_READINGS * 30} minutes)"
+        )
+        log.warning(msg)
+        _write_task_output(msg, "success", timestamp)
+
+    if toxicity:
+        msg = (
+            f"TOXICITY: queue depth >{TOXICITY_DEPTH_THRESHOLD} for "
+            f"{TOXICITY_CONSECUTIVE_READINGS}+ consecutive readings, "
+            f"current depth: {toxic_depth}"
+        )
+        log.warning(msg)
+        _write_task_output(msg, "success", timestamp)
+
+    if not starvation and not toxicity:
+        log.info("No anomalies detected. Queue depth: %d", depth)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_wos_queue_monitor.py
+++ b/tests/unit/test_wos_queue_monitor.py
@@ -1,0 +1,302 @@
+"""
+Tests for scheduled-tasks/wos-queue-monitor.py
+
+Tests are derived from the spec in GitHub issue #681 and mito-modeling.md:
+- STARVATION: queue depth 0 for 6+ consecutive hours (12 readings at 30-min cadence)
+- TOXICITY: queue depth >10 for 3+ consecutive readings
+- jobs.json enabled gate checked before running
+- History JSONL append and load are correct
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Load the module from its script path (not a package)
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent
+    / "scheduled-tasks"
+    / "wos-queue-monitor.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("wos_queue_monitor", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+qm = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Constants — must match the spec, not derived from implementation
+# ---------------------------------------------------------------------------
+
+STARVATION_CONSECUTIVE_READINGS = 12    # 6 hours at 30-min cadence
+TOXICITY_DEPTH_THRESHOLD = 10
+TOXICITY_CONSECUTIVE_READINGS = 3
+
+
+# ---------------------------------------------------------------------------
+# detect_starvation
+# ---------------------------------------------------------------------------
+
+class TestDetectStarvation:
+    def _history(self, depths: list[int]) -> list[dict]:
+        return [{"timestamp": f"2026-04-08T{i:02d}:00:00+00:00", "queue_depth": d}
+                for i, d in enumerate(depths)]
+
+    def test_starvation_fires_after_12_consecutive_zero_readings(self):
+        """12 zero readings at 30-min cadence = exactly 6 hours — must fire."""
+        history = self._history([0] * STARVATION_CONSECUTIVE_READINGS)
+        assert qm.detect_starvation(history) is True
+
+    def test_starvation_does_not_fire_with_11_zero_readings(self):
+        """One reading short of the threshold — must not fire."""
+        history = self._history([0] * (STARVATION_CONSECUTIVE_READINGS - 1))
+        assert qm.detect_starvation(history) is False
+
+    def test_starvation_does_not_fire_if_tail_has_nonzero(self):
+        """12 readings but the last one is nonzero — no starvation."""
+        depths = [0] * (STARVATION_CONSECUTIVE_READINGS - 1) + [1]
+        history = self._history(depths)
+        assert qm.detect_starvation(history) is False
+
+    def test_starvation_fires_on_longer_history_when_tail_is_all_zero(self):
+        """20 readings where the last 12 are all zero — must fire."""
+        depths = [5] * 8 + [0] * STARVATION_CONSECUTIVE_READINGS
+        history = self._history(depths)
+        assert qm.detect_starvation(history) is True
+
+    def test_starvation_does_not_fire_on_empty_history(self):
+        assert qm.detect_starvation([]) is False
+
+    def test_starvation_does_not_fire_on_insufficient_history(self):
+        history = self._history([0] * 5)
+        assert qm.detect_starvation(history) is False
+
+    def test_starvation_uses_named_constant_not_magic_literal(self):
+        """Verify the module exposes the constant matching the spec."""
+        assert qm.STARVATION_CONSECUTIVE_READINGS == STARVATION_CONSECUTIVE_READINGS
+
+
+# ---------------------------------------------------------------------------
+# detect_toxicity
+# ---------------------------------------------------------------------------
+
+class TestDetectToxicity:
+    def _history(self, depths: list[int]) -> list[dict]:
+        return [{"timestamp": f"2026-04-08T{i:02d}:00:00+00:00", "queue_depth": d}
+                for i, d in enumerate(depths)]
+
+    def test_toxicity_fires_after_3_consecutive_readings_above_10(self):
+        """3 consecutive readings > 10 — must fire."""
+        history = self._history([11, 12, 13])
+        fired, depth = qm.detect_toxicity(history)
+        assert fired is True
+        assert depth == 13
+
+    def test_toxicity_depth_in_result_is_most_recent(self):
+        """The returned depth should be from the last entry in the tail."""
+        history = self._history([0] * 10 + [15, 20, 25])
+        fired, depth = qm.detect_toxicity(history)
+        assert fired is True
+        assert depth == 25
+
+    def test_toxicity_does_not_fire_with_2_consecutive_readings(self):
+        """Only 2 readings above threshold — not enough."""
+        history = self._history([15, 20])
+        fired, _ = qm.detect_toxicity(history)
+        assert fired is False
+
+    def test_toxicity_does_not_fire_if_tail_has_10_exactly(self):
+        """Threshold is strictly >10 — depth of exactly 10 must NOT fire."""
+        history = self._history([10, 10, 10])
+        fired, _ = qm.detect_toxicity(history)
+        assert fired is False
+
+    def test_toxicity_does_not_fire_if_one_reading_in_tail_is_at_threshold(self):
+        """3 readings but the middle one is exactly 10 — no toxicity."""
+        history = self._history([11, 10, 12])
+        fired, _ = qm.detect_toxicity(history)
+        assert fired is False
+
+    def test_toxicity_fires_on_longer_history_when_tail_toxic(self):
+        """Long history with a toxic tail — fires on the last 3."""
+        depths = [0] * 20 + [11, 12, 15]
+        history = self._history(depths)
+        fired, depth = qm.detect_toxicity(history)
+        assert fired is True
+        assert depth == 15
+
+    def test_toxicity_does_not_fire_on_empty_history(self):
+        fired, _ = qm.detect_toxicity([])
+        assert fired is False
+
+    def test_toxicity_uses_named_constants_matching_spec(self):
+        assert qm.TOXICITY_DEPTH_THRESHOLD == TOXICITY_DEPTH_THRESHOLD
+        assert qm.TOXICITY_CONSECUTIVE_READINGS == TOXICITY_CONSECUTIVE_READINGS
+
+
+# ---------------------------------------------------------------------------
+# History file I/O
+# ---------------------------------------------------------------------------
+
+class TestHistoryIO:
+    def test_load_history_returns_empty_for_missing_file(self, tmp_path):
+        missing = tmp_path / "nonexistent.jsonl"
+        result = qm._load_history(missing)
+        assert result == []
+
+    def test_append_and_load_round_trip(self, tmp_path):
+        f = tmp_path / "history.jsonl"
+        qm._append_history(f, "2026-04-08T12:00:00+00:00", 5)
+        qm._append_history(f, "2026-04-08T12:30:00+00:00", 0)
+        entries = qm._load_history(f)
+        assert len(entries) == 2
+        assert entries[0] == {"timestamp": "2026-04-08T12:00:00+00:00", "queue_depth": 5}
+        assert entries[1] == {"timestamp": "2026-04-08T12:30:00+00:00", "queue_depth": 0}
+
+    def test_load_history_skips_malformed_lines(self, tmp_path):
+        f = tmp_path / "history.jsonl"
+        f.write_text('{"timestamp": "T1", "queue_depth": 3}\nnot-json\n{"timestamp": "T2", "queue_depth": 7}\n')
+        entries = qm._load_history(f)
+        assert len(entries) == 2
+        assert entries[0]["queue_depth"] == 3
+        assert entries[1]["queue_depth"] == 7
+
+    def test_append_creates_parent_directories(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "history.jsonl"
+        qm._append_history(nested, "2026-04-08T00:00:00+00:00", 1)
+        assert nested.exists()
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate
+# ---------------------------------------------------------------------------
+
+class TestJobsJsonEnabledGate:
+    def test_returns_true_when_jobs_file_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        assert qm._is_job_enabled() is True
+
+    def test_returns_true_when_job_entry_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        jobs_dir = tmp_path / "scheduled-jobs"
+        jobs_dir.mkdir(parents=True)
+        (jobs_dir / "jobs.json").write_text(json.dumps({"jobs": {}}))
+        assert qm._is_job_enabled() is True
+
+    def test_returns_true_when_job_explicitly_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        jobs_dir = tmp_path / "scheduled-jobs"
+        jobs_dir.mkdir(parents=True)
+        (jobs_dir / "jobs.json").write_text(json.dumps({
+            "jobs": {"wos-queue-monitor": {"enabled": True}}
+        }))
+        assert qm._is_job_enabled() is True
+
+    def test_returns_false_when_job_explicitly_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        jobs_dir = tmp_path / "scheduled-jobs"
+        jobs_dir.mkdir(parents=True)
+        (jobs_dir / "jobs.json").write_text(json.dumps({
+            "jobs": {"wos-queue-monitor": {"enabled": False}}
+        }))
+        assert qm._is_job_enabled() is False
+
+    def test_returns_true_on_malformed_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        jobs_dir = tmp_path / "scheduled-jobs"
+        jobs_dir.mkdir(parents=True)
+        (jobs_dir / "jobs.json").write_text("not-json")
+        assert qm._is_job_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# query_queue_depth — DB interactions (using a real in-memory SQLite)
+# ---------------------------------------------------------------------------
+
+class TestQueryQueueDepth:
+    def _create_registry_db(self, path: Path, rows: list[tuple]) -> None:
+        """Create a minimal uow_registry table with the given (id, status) rows."""
+        import sqlite3
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "CREATE TABLE uow_registry (id TEXT PRIMARY KEY, status TEXT)"
+        )
+        conn.executemany("INSERT INTO uow_registry VALUES (?, ?)", rows)
+        conn.commit()
+        conn.close()
+
+    def test_counts_ready_for_steward(self, tmp_path):
+        db = tmp_path / "registry.db"
+        self._create_registry_db(db, [
+            ("u1", "ready-for-steward"),
+            ("u2", "done"),
+            ("u3", "failed"),
+        ])
+        assert qm.query_queue_depth(db) == 1
+
+    def test_counts_all_three_backlog_statuses(self, tmp_path):
+        db = tmp_path / "registry.db"
+        self._create_registry_db(db, [
+            ("u1", "ready-for-steward"),
+            ("u2", "ready-for-executor"),
+            ("u3", "active"),
+            ("u4", "done"),
+            ("u5", "failed"),
+        ])
+        assert qm.query_queue_depth(db) == 3
+
+    def test_returns_zero_when_db_absent(self, tmp_path):
+        missing = tmp_path / "nonexistent.db"
+        assert qm.query_queue_depth(missing) == 0
+
+    def test_returns_zero_when_table_absent(self, tmp_path):
+        import sqlite3
+        db = tmp_path / "empty.db"
+        conn = sqlite3.connect(str(db))
+        conn.close()
+        assert qm.query_queue_depth(db) == 0
+
+    def test_returns_zero_on_empty_registry(self, tmp_path):
+        db = tmp_path / "registry.db"
+        self._create_registry_db(db, [])
+        assert qm.query_queue_depth(db) == 0
+
+
+# ---------------------------------------------------------------------------
+# write_task_output — output file written correctly
+# ---------------------------------------------------------------------------
+
+class TestWriteTaskOutput:
+    def test_writes_json_file_with_expected_fields(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        ts = "2026-04-08T14:00:00+00:00"
+        qm._write_task_output("STARVATION: queue depth 0 for 360 minutes", "success", ts)
+        outputs = list((tmp_path / "task-outputs").glob("*.json"))
+        assert len(outputs) == 1
+        data = json.loads(outputs[0].read_text())
+        assert data["job_name"] == "wos-queue-monitor"
+        assert data["status"] == "success"
+        assert "STARVATION" in data["output"]
+        assert data["timestamp"] == ts
+
+    def test_write_is_atomic_via_tmp_rename(self, tmp_path, monkeypatch):
+        """No .tmp file should remain after a successful write."""
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        qm._write_task_output("TOXICITY: queue depth >10", "success", "2026-04-08T15:00:00+00:00")
+        tmp_files = list((tmp_path / "task-outputs").glob("*.tmp"))
+        assert tmp_files == []


### PR DESCRIPTION
## What problem does this solve?

The WOS observation layer had no signal for two distinct failure modes defined in mito-modeling.md Section 2, Row 4: **starvation** (queue empty for extended periods — not rest, but throughput death) and **toxicity** (queue growing beyond capacity, forcing exceeding dissipation). This PR adds the observation instrument for both.

## What changed

Adds `scheduled-tasks/wos-queue-monitor.py`, a Type C cron-direct script that:

- Queries `uow_registry` for count of UoWs with status `ready-for-steward`, `ready-for-executor`, or `active`
- Appends `{"timestamp": "<ISO>", "queue_depth": N}` to `~/lobster-workspace/data/queue-depth-history.jsonl` on every run
- Detects **starvation**: depth 0 for 12 consecutive readings (30-min cadence = 6 hours) → emits `STARVATION: queue depth 0 for 6+ hours`
- Detects **toxicity**: depth > 10 for 3 consecutive readings → emits `TOXICITY: queue depth >10 for 3+ consecutive readings, current depth: N`
- Checks `jobs.json` for its own `enabled` gate before running (standard Type C pattern, same as executor-heartbeat)
- Writes observations via `_write_task_output` — same atomic tmp-then-rename pattern used by steward-heartbeat and executor-heartbeat

This is a pure observation instrument. No automated action is taken; signals surface for Dan to review during engagement windows.

The runtime `jobs.json` entry and cron registration (`# LOBSTER-WOS-QUEUE-MONITOR`) have been applied to the live instance. `jobs.json` is not in the repo (it's runtime state), so the cron entry is documented in the script's docstring for use with future installs.

## Functional patterns

- **Pure functions** for both signal detectors (`detect_starvation`, `detect_toxicity`) — no side effects, fully testable in isolation
- **Side effects isolated** at boundaries: `_append_history` for the JSONL write, `_write_task_output` for the task output write
- **Named constants** for all threshold values (`STARVATION_CONSECUTIVE_READINGS = 12`, `TOXICITY_DEPTH_THRESHOLD = 10`, `TOXICITY_CONSECUTIVE_READINGS = 3`) — directly traceable to the spec

## What is NOT changed

- No changes to `steward-heartbeat.py`, `executor-heartbeat.py`, or any other orchestration file
- No changes to the dispatcher or registry schema
- `jobs.json` is not in this PR (it is runtime state; the live instance entry was applied separately)

## Tests run

- [x] `uv run pytest tests/unit/test_wos_queue_monitor.py -v` — 31 passed, 0 failed
- [ ] Live run against production registry — not executed (no registry state available in test environment; DB-absent path returns 0 safely, covered by unit tests)

## Manual test

N/A — this change is entirely internal. The script writes to `queue-depth-history.jsonl` (a local data file) and `messages/task-outputs/` (a local directory). It does not call Telegram, GitHub API, or any external service. User-visible output (task output observations) would only appear when starvation or toxicity thresholds are crossed; no such condition was induced during testing.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external services; local file I/O only)
- [x] User-visible outcome verified — N/A (signal fires only on threshold breach; not applicable to unit test run)
- [x] Side-effect audit complete: writes only to `queue-depth-history.jsonl` and `task-outputs/`; no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #681