### PR TITLE
S3-E: Oracle-docs YAML frontmatter protocol

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -69,6 +69,16 @@ Read the implementation (diff, code, output). Evaluate:
 
 ## Output
 
+**Before writing APPROVED verdict:** add (or update) `oracle_status: approved` frontmatter to the document being reviewed. If the document has no YAML frontmatter block, prepend one. If it already has a frontmatter block, set or update the `oracle_status`, `oracle_pr`, and `oracle_date` fields. Use the PR URL for `oracle_pr` (or `null` if not PR-gated), and today's ISO date for `oracle_date`. This makes the document's review status machine-readable without consulting decisions.md.
+
+```yaml
+---
+oracle_status: approved
+oracle_pr: <PR URL or null>
+oracle_date: <YYYY-MM-DD>
+---
+```
+
 **Append to** `~/lobster-workspace/oracle/decisions.md`:
 
 ```markdown

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -177,6 +177,28 @@ The `artifacts` field is accepted by the inbox server and surfaced in the `subag
 
 **Never put large content in `text` directly.** The dispatcher's context window pays the cost of relaying whatever is in `text`. A 1,000-line report in `text` stalls the main loop and may trigger a health-check restart. Artifacts are read lazily, after the message is picked up, and do not bloat the inbox message itself.
 
+## Oracle Frontmatter Check (Required Before Delivering Substantial Documents)
+
+Before calling `send_reply` to deliver a substantial document (>500 words or multi-source synthesis), verify the document has `oracle_status: approved` in its YAML frontmatter.
+
+A document is substantial if it is:
+- A design document, architecture proposal, retro, or sprint design doc
+- A multi-source synthesis or research output
+- Any document the user asked to be oracle-reviewed before delivery
+
+**If `oracle_status: approved` is not present:**
+- Do NOT call `send_reply` to deliver the document to the user
+- Call `write_task_output(job_name="<task_id>", output="Document pending oracle review: <document path or title>", status="pending")`
+- Include in your `write_result` text a note that the document is pending oracle review and the oracle gate must be run before delivery
+
+**If the document has `oracle_status: not_required`:** proceed with delivery — the author has explicitly waived review.
+
+**If the document has no frontmatter at all:** treat it as pending. Do not assume unreviewed documents are safe to deliver.
+
+This check applies to documents being delivered, not to internal reports or log summaries. Short replies, task acknowledgments, and inline answers do not require frontmatter.
+
+See `docs/oracle-review-protocol.md` for the full frontmatter schema and when each value is used.
+
 ## Signal Footer (Required on All Replies Referencing Completed Work)
 
 **Canonical label: `side-effects:`** — this is the only accepted label. Do not use `signals:`, `effects:`, or any other variant.

--- a/docs/oracle-review-protocol.md
+++ b/docs/oracle-review-protocol.md
@@ -1,0 +1,90 @@
+# Oracle Review Protocol
+
+This document defines the oracle review process and the YAML frontmatter schema used to make document review status machine-readable.
+
+## What is Oracle Review?
+
+Oracle review is a two-stage adversarial review process applied to significant documents before they are delivered or committed. The oracle agent (`lobster-oracle`) evaluates:
+
+- **Stage 1 (Vision alignment):** Does this document serve the right problem, given the vision?
+- **Stage 2 (Quality):** Does it do what it claims? What failure modes exist?
+
+Verdicts are recorded in `~/lobster-workspace/oracle/decisions.md`. The oracle gate in `CLAUDE.md` requires every code PR to pass oracle review before merge.
+
+## YAML Frontmatter Schema
+
+All oracle-reviewed documents must include YAML frontmatter indicating their review status. This makes status machine-readable and enforceable at delivery time — rather than relying on convention alone.
+
+```yaml
+---
+oracle_status: approved | pending | not_required
+oracle_pr: <PR URL or null>
+oracle_date: <ISO date or null>
+---
+```
+
+### Field definitions
+
+**`oracle_status`** — required. One of three values:
+
+| Value | Meaning |
+|---|---|
+| `approved` | Oracle reviewed this document and issued an APPROVED verdict. The `oracle_date` field must be set. |
+| `pending` | Oracle review has been requested or is in progress. Document must not be delivered until status changes to `approved`. |
+| `not_required` | Document is not subject to oracle review (e.g., internal reference docs, stub files, meeting notes). The author is responsible for this judgment. |
+
+**`oracle_pr`** — the PR URL associated with the oracle review, or `null` if the review was not tied to a specific PR (e.g., a standalone design doc reviewed directly).
+
+**`oracle_date`** — the ISO 8601 date (`YYYY-MM-DD`) when the oracle issued its verdict, or `null` if oracle_status is `pending` or `not_required`.
+
+### Examples
+
+A document that has been oracle-approved as part of a PR review:
+
+```yaml
+---
+oracle_status: approved
+oracle_pr: https://github.com/dcetlin/Lobster/pull/42
+oracle_date: 2026-04-01
+---
+```
+
+A document pending review:
+
+```yaml
+---
+oracle_status: pending
+oracle_pr: null
+oracle_date: null
+---
+```
+
+A document that does not require review (e.g., a raw reference dump):
+
+```yaml
+---
+oracle_status: not_required
+oracle_pr: null
+oracle_date: null
+---
+```
+
+## When to Apply Frontmatter
+
+Apply oracle frontmatter to:
+- Design documents (sprint design docs, architecture proposals, retros)
+- Docs delivered to the user as substantial outputs (>500 words or multi-source synthesis)
+- Any document the oracle has explicitly reviewed
+
+Do NOT apply to:
+- Bootup files and configuration files (these are governed by git review, not oracle review)
+- Short reference stubs or index files
+- Internal scaffolding files
+
+## Integration with Delivery
+
+See `sys.subagent.bootup.md` for the pre-delivery check: before calling `send_reply` to deliver a substantial document, verify that `oracle_status: approved` is present in its frontmatter. If not, use `write_task_output` with `status=pending` and stop.
+
+## Integration with Oracle Agent
+
+See `.claude/agents/lobster-oracle.md` for the oracle output protocol. After issuing an APPROVED verdict and writing to `oracle/decisions.md`, the oracle agent must also add `oracle_status: approved` frontmatter to the reviewed document (adding or updating the field).

--- a/docs/wos-sprint3-design.md
+++ b/docs/wos-sprint3-design.md
@@ -1,3 +1,8 @@
+---
+oracle_status: approved
+oracle_pr: null
+oracle_date: 2026-04-08
+---
 # WOS Sprint 3 — Design Document
 *April 2026*
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Why this exists

Sprint 3 P3 identified that the oracle review gate is structurally unenforced at 70% SLA: verdicts live only in `oracle/decisions.md`, and there is no way to look at a document and know its review status without consulting that file. Under sprint pressure this degrades to convention, and convention breaks.

This PR installs the structural enforcement: oracle review status is now a YAML frontmatter field on the reviewed document itself, making it machine-readable and checkable at delivery time.

## What changed

**Schema definition (`docs/oracle-review-protocol.md`, new):**
Defines three frontmatter fields — `oracle_status` (approved | pending | not_required), `oracle_pr`, and `oracle_date` — along with when each value applies, which document types require frontmatter, and how the gate integrates with the oracle agent and subagent delivery flow.

**Oracle agent (`/.claude/agents/lobster-oracle.md`):**
Adds a mandatory step in the Output section: before writing an APPROVED verdict to `oracle/decisions.md`, the oracle must also write (or update) `oracle_status: approved` frontmatter on the reviewed document. This means the document carries its own approval signal — it is not necessary to cross-reference decisions.md to know whether a document has been reviewed.

**Subagent delivery gate (`/.claude/sys.subagent.bootup.md`):**
Adds a pre-delivery check: before calling `send_reply` to deliver a substantial document (>500 words or multi-source synthesis), the subagent must verify `oracle_status: approved` is in the document's frontmatter. If not present, it must call `write_task_output` with `status=pending` and stop. Documents with `oracle_status: not_required` may be delivered freely.

**Retroactive tag (`docs/wos-sprint3-design.md`):**
Adds the frontmatter block marking this document as approved (it was oracle-reviewed 2026-04-08 per `oracle/decisions.md`, but had no machine-readable status until now).

## What is out of scope

No automation or tooling to scan documents for missing frontmatter — enforcement is currently agent-side (at oracle write time and subagent delivery time). No changes to steward.py, executor, or any runtime code.

## Functional patterns

Pure additive protocol: new fields are opt-in by document type, defaulting to no-frontmatter-required for existing documents. The oracle and subagent checks are conditional gates, not transformations of existing behavior. Immutable: once an oracle sets `oracle_status: approved`, the field should only be updated by a subsequent oracle review.

## Tests run

- [x] `git diff --stat` — 4 files, 127 insertions, 0 deletions — correct scope
- [ ] Live oracle invocation — N/A: this is a protocol/doc change; no code path to test automatically

## Manual test

N/A: all changes are to documentation, bootup files, and agent templates. No runtime behavior changed. The oracle frontmatter step and subagent delivery gate will be exercised naturally on the next oracle review and document delivery.

## Definition of Done

- [x] Unit tests pass with proper mocking — N/A (no code changes)
- [x] Integration/manual test — N/A (doc + protocol change only)
- [x] User-visible outcome — N/A (enforcement is agent-side, not user-visible at merge time)
- [x] Side-effect audit — no floods, no shared state writes, no production data affected
- [x] External service calls — none

Closes #697