### PR TITLE
fix: remove stale mirror_inbound import that blocked test collection

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -98,10 +98,12 @@ from reliability import (
 from update_manager import UpdateManager
 
 # Bot-talk mirroring — fire-and-forget relay to the shared SaharLobster/AlbertLobster channel
+# mirror_inbound was removed from bot_talk_mirror (cross-Lobster messages only; owner messages
+# are never logged here). Only mirror_outbound is used in this module.
 try:
-    from bot_talk.mirror import mirror_outbound as _mirror_outbound, mirror_inbound as _mirror_inbound
+    from bot_talk.mirror import mirror_outbound as _mirror_outbound
 except ImportError:
-    from bot_talk_mirror import mirror_outbound as _mirror_outbound, mirror_inbound as _mirror_inbound
+    from bot_talk_mirror import mirror_outbound as _mirror_outbound
 
 
 # Pending agent tracker (thin adapter over session_store)


### PR DESCRIPTION
## What was broken and why

`bot_talk_mirror.py` previously removed `mirror_inbound()` — a function that incorrectly logged owner Telegram messages as bot-talk entries. That removal was intentional and documented in the module's docstring. However, `inbox_server.py` still imported `mirror_inbound` from both `bot_talk.mirror` and `bot_talk_mirror` in its two-clause try/except import block.

Because `mirror_inbound` no longer exists in `bot_talk_mirror.py`, the fallback import raised `ImportError: cannot import name 'mirror_inbound'`. This is NOT caught by the outer `try/except ImportError` (which only catches `ModuleNotFoundError` on `bot_talk.mirror`) — the inner `from bot_talk_mirror import` gets a name-level `ImportError` that propagates at module import time.

## Effect on tests

Any test file that imported `inbox_server` (directly or via `src.mcp.inbox_server`) triggered this error during pytest collection, not execution. The result was 13+ `ERROR collecting` failures that caused `Interrupted: 13 errors during collection` — preventing `TestBackpressureSkipsRePrescription` and hundreds of other tests from running at all.

The 4 tests in `TestBackpressureSkipsRePrescription` themselves are correct and pass cleanly once collection succeeds. This fix unblocks them and the full `tests/unit/` run.

## What the fix does

Removes `mirror_inbound` from both import lines. `mirror_inbound` was imported but never referenced anywhere in `inbox_server.py` — grep finds zero uses of `_mirror_inbound` in the module body. The import was purely residual.

## S3-B interaction verdict: NO

`TestBackpressureSkipsRePrescription` tests the `executor_orphan` backpressure gate (skips re-prescription when the executor queue is saturated). It has no reference to `trace_gate_waited`, no trace gate imports, and does not touch the steward log path that S3-B will extend. S3-B and S3-G are fully independent.

## Remaining pre-existing issues (out of scope)

After this fix, `tests/unit/test_mcp_server/` goes from uncollectable to collected-but-failing — 82 test failures that were previously hidden behind the collection error (in `test_write_observation.py`, `test_debug_alerts.py`, and others). These are pre-existing failures uncovered by this fix, not introduced by it.

Additionally, `tests/unit/test_attunement.py` fails when collected alongside `tests/test_vps_integration.py` in a full `tests/` run. Root cause: multiple test files add `src/mcp/` to `sys.path`, causing Python to cache `src/mcp/memory/` as `sys.modules['memory']`, shadowing `src/memory/attunement.py`. This is a separate pre-existing namespace collision issue.

Both are outside the S3-G scope boundary.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -k "TestBackpressureSkipsRePrescription" -v` — 4 passed
- [x] `uv run pytest tests/unit/ -k "TestBackpressureSkipsRePrescription" -v` — 4 passed (previously interrupted by collection errors on main)
- [x] Confirmed `_mirror_inbound` has zero uses in `inbox_server.py` body — import was dead code

## Manual test
N/A — pure import cleanup; no runtime behavior changes. The removed symbol was never called.