### PR TITLE
feat(oracle): document review protocol with named-gap accountability

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -38,6 +38,15 @@ Your task prompt specifies one of:
 
 **Premise-review:** You receive a pattern of observations accumulated by lobster-meta + vision.yaml. Evaluate whether a founding premise is generating systematic tension. Output goes to `meta/premise-review.md` only.
 
+**Document review (non-code artifact):** You receive the document path + vision.yaml + the question or purpose the document serves. Same two-stage structure as Standard, but Stage 2 evaluates interpretation rather than implementation quality:
+- What is this document making invisible?
+- What position would a reader need to hold to find this document sufficient?
+- What specific gaps exist between what the document claims to address and what it actually addresses?
+
+Use the document review format in decisions.md (see "Named gaps" structure in the Output section). Each gap must be specific enough that "addressed vs not addressed" is decidable by a subsequent reviewer without re-reading the full document.
+
+When reviewing a document that has prior entries in `decisions.md`, enumerate each previously named gap and state its current status (addressed/disputed/deferred/open) before issuing a new verdict.
+
 ---
 
 ## Stage 1: Vision alignment
@@ -85,11 +94,31 @@ oracle_date: <YYYY-MM-DD>
 ### [YYYY-MM-DD] [PR/task reference]
 **Vision alignment:** [Stage 1 finding — one paragraph. Does not change after seeing implementation.]
 **Alignment verdict:** Confirmed | Questioned | Misaligned
-**Quality finding:** [Stage 2 key observations — 2–4 bullet points]
+**Quality finding:** [Stage 2 key observations -- 2-4 bullet points]
 **Patterns introduced:** [What this adds to the system's character]
 **What this forecloses:** [Directions that become harder]
 **Opportunity cost note:** [What wasn't built instead, if relevant]
 ```
+
+**For document reviews, use this extended format instead:**
+
+```markdown
+### [YYYY-MM-DD] Doc review: [document name/path]
+**Vision alignment:** [Stage 1 finding -- one paragraph. Does not change after seeing document.]
+**Alignment verdict:** Confirmed | Questioned | Misaligned
+**Interpretation finding:** [What does this document make invisible? What position is the oracle taking about the gap? State in terms the author can cite and dispute.]
+**Named gaps:**
+- **Gap 1: [specific gap name]** -- [What is missing or obscured, why it matters, what the document would need to show to close this gap. Must be specific enough that "addressed" vs "not addressed" is decidable.]
+- **Gap 2: ...** (if applicable)
+**Patterns introduced:** [What structural or rhetorical patterns this document introduces]
+**What this forecloses:** [Directions or questions that become harder to raise after this document exists]
+
+**VERDICT: APPROVED | NEEDS_CHANGES**
+**If NEEDS_CHANGES -- revision contract:**
+Each named gap must be resolved in one of three ways: (a) addressed -- the revision shows the thing the gap named, (b) disputed -- the author states why the gap does not apply, with specific reason, (c) deferred -- the author acknowledges the gap and states why it is not addressed now. Generic "improvement" without tracing to a named gap does not count as resolution.
+```
+
+**Prior gap tracking (document reviews only):** When reviewing a document that has prior entries in `decisions.md`, begin the Stage 2 section by enumerating each previously named gap with its current status: addressed / disputed (with stated reason) / deferred (with stated reason) / open. A gap is "open" only if the revision made no change to the area it named. Do not issue a new verdict until all prior gaps are accounted for.
 
 **Append to** `~/lobster/oracle/learnings.md` any:
 - Recurring patterns (same issue appearing across multiple tasks)
@@ -110,7 +139,7 @@ Append to `~/lobster-workspace/meta/premise-review.md`:
 ---
 id: pr-[YYYYMMDDHHMMSS]
 status: open
-observation: [the raw observation — what was noticed, no synthesis, no question, no recommendation]
+observation: [the raw observation -- what was noticed, no synthesis, no question, no recommendation]
 ---
 ```
 
@@ -126,7 +155,7 @@ Also append to `~/lobster-workspace/meta/reflective-surface-queue.json`:
   "observation": "[verbatim from the observation field above]",
   "source_file": "meta/premise-review.md",
   "source_id": "[pr-id]",
-  "surface_reason": "[which criterion triggered and why this specific observation meets it — not 'seems important']",
+  "surface_reason": "[which criterion triggered and why this specific observation meets it -- not 'seems important']",
   "delivered": false,
   "delivered_at": null
 }
@@ -136,4 +165,4 @@ Also append to `~/lobster-workspace/meta/reflective-surface-queue.json`:
 
 ## Completion
 
-Call `write_result`. If alignment verdict is `Questioned` or `Misaligned`, or if a premise-review item was written, set `forward=true` so the dispatcher surfaces it to the user. Otherwise `forward=false` — findings are in the oracle files.
+Call `write_result`. If alignment verdict is `Questioned` or `Misaligned`, or if a premise-review item was written, set `forward=true` so the dispatcher surfaces it to the user. Otherwise `forward=false` -- findings are in the oracle files.

--- a/oracle/decisions.md
+++ b/oracle/decisions.md
@@ -969,3 +969,26 @@ PR #727 is approved for merge. Three path references correctly updated. One rema
 
 **Opportunity cost note:** No production features deferred. The only marginal cost is the stale docstring not being corrected alongside the assertion fix — a one-line change that was not made.
 
+
+
+---
+
+### [2026-04-14] Design decision: oracle document review protocol
+
+**Vision alignment:** The system's stated phase intent is to build a substrate that lets every agent make intent-anchored decisions. The oracle's existing code-review protocol operationalizes this for code PRs: it names the failure mode before seeing the implementation, then adjudicates whether the implementation forecloses better paths. Document artifacts -- bootup docs, agent definitions, protocol specs, context files -- are at least as load-bearing as code in this substrate. They encode the behavioral contracts that all agents operate under. A code PR that ships a wrong algorithm is wrong in one place; a document that encodes a wrong premise propagates that premise into every agent session that reads it. Yet documents have no external adjudicator: unlike code, there are no tests to run. The adversarial prior does not transfer cleanly -- "this document is solving the wrong problem" must be cashed out as "this document makes something invisible that matters." The vision alignment for this protocol extension: principle-5 ("when a behavioral rule isn't followed, improve the discriminator") is a document-governance principle as much as a gate-table principle. This protocol gives the oracle a decision-procedural discriminator for document review rather than an open-ended "is this good?" question.
+
+**Alignment verdict:** Confirmed
+
+**Quality finding:**
+- The key structural transfer from code review is not the gate (APPROVED/NEEDS_CHANGES) but the requirement that NEEDS_CHANGES names a specific thing that must change. For code, this is a failing behavior. For documents, this is a named gap -- something the document makes invisible that a reader would need to know. The three-path resolution contract (addressed / disputed / deferred) replaces the binary "fixed it" that works for code bugs but fails for documents, where a gap may be intentionally out of scope.
+- The revision contract's three paths are necessary because documents have legitimate reasons not to address every gap: scope constraints, deliberate deferral, or genuine disagreement with the oracle's interpretation. The "disputed" path is the accountability mechanism -- it requires the author to state a specific reason for disagreement rather than silently omitting the gap. Without it, "I didn't fix gap 2" is indistinguishable from "I disagree that gap 2 is a gap."
+- Prior gap tracking (enumerating previous named gaps and their status before issuing a new verdict) closes the cycle that code re-review relies on test-rerun to close. Without this, a document can be re-reviewed on the second pass without the oracle knowing whether the first pass's gaps were addressed, creating the appearance of resolution without the substance.
+- The "interpretation finding" field forces the oracle to take a position in disputable terms -- not "this document is incomplete" but "this document treats X as settled when a reader would need to know Y to evaluate that claim." This is the minimum requirement for accountable review of interpretation.
+
+**Patterns introduced:** Named-gap citation structure as the document analog of failing-test citation. Three-path gap resolution (addressed/disputed/deferred) as the accountability mechanism for document revision cycles. Prior gap tracking as the document analog of test-rerun for code re-review.
+
+**What this forecloses:** Open-ended "improve it" review cycles where a document can be revised without tracing revisions to named gaps. This is the primary failure mode the protocol exists to prevent -- generic improvement that satisfies the form of revision without closing the specific interpretive gap the oracle identified.
+
+**Opportunity cost note:** No tooling, automation, or new files were built. The protocol is entirely expressed in the oracle agent definition and this decisions.md entry. The cost of not having this: document artifacts in the system accumulate without accountable review, and the oracle has no decision-procedural basis for document verdicts. This has been true since the oracle was introduced. The cost was diffuse (every document reviewed without the named-gap structure) rather than acute.
+
+**VERDICT: APPROVED**


### PR DESCRIPTION
## What this solves

The oracle review system could review code PRs but had no protocol for document artifacts — bootup docs, agent definitions, protocol specs. Documents are at least as load-bearing as code in this system: they encode the behavioral contracts all agents operate under. A wrong algorithm is wrong in one place; a wrong premise in a document propagates into every agent session that reads it.

The gap: documents have no external adjudicator (no tests to run). The existing oracle posture — "this is solving the wrong problem" — doesn't transfer directly. For documents, that translates to "this document makes something invisible that matters." Without a decision-procedural form for that, the oracle has no basis for a citable verdict.

## What changed

**`.claude/agents/lobster-oracle.md`** — adds a "Document review" invocation mode under the existing modes section. The mode:
- Specifies the Stage 2 questions for documents (what is invisible? what position does sufficiency require? what gaps exist between claimed and actual coverage?)
- Directs the oracle to use the named-gap format in decisions.md
- Requires prior gap tracking: when reviewing a document with prior decisions.md entries, enumerate each previous gap and its current status before issuing a new verdict

Also adds, in the Output section:
- The document review format block (distinct from code review format)
- The revision contract: each named gap must be resolved as addressed / disputed (with reason) / deferred (with reason) — generic improvement without gap tracing does not count
- Prior gap tracking instruction as the document analog of test-rerun for re-review

**`oracle/decisions.md`** — records the design decision using the existing code-review format (this is a decision about the oracle, not a document review itself). Covers:
- Why named gaps rather than open-ended feedback (the document analog of failing-test citation)
- Why three resolution paths are necessary (legitimate scope constraints and genuine disagreement must be expressible)
- Why prior gap tracking is required (closes the cycle that test-rerun closes for code)
- What this forecloses: open-ended "improve it" cycles where revision can satisfy the form without closing the named gap

## Functional patterns used

Pure declarative extension — no new state, no new control flow. The document review mode composes with the existing two-stage structure; Stage 1 is unchanged (vision alignment), Stage 2 is extended with document-specific questions. The named-gap format is a structural constraint applied to the output, not a new process.

## Tests run

- [x] Manual diff review — oracle agent file has correct structure, document review mode is properly placed under Invocation modes, output section has both code and document format blocks
- [x] decisions.md entry appended correctly, no formatting errors, VERDICT field present

## Manual test

N/A — this change is entirely internal to document format and agent instruction text. No external services, no runtime state, no user-visible output.

## Definition of Done

- [x] Unit tests pass with proper mocking — not applicable (no code)
- [x] Integration/manual test — see above
- [x] User-visible outcome verified — not applicable (internal protocol document)
- [x] Side-effect audit — no floods, no writes to shared state, no volume impact
- [x] External service calls — none