### PR TITLE
test: add D6 smoke tests for quota-exhaustion suppression (PR #724 follow-up)

### DIFF
--- a/tests/smoke/test_health_check.py
+++ b/tests/smoke/test_health_check.py
@@ -516,3 +516,255 @@ def test_wfm_freshness_green_when_last_processed_absent_heartbeat_recent(
         "state files that predate issue #694.\n"
         f"stderr: {result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# D6 — quota exhaustion: check_usage_limit and is_limit_wait (issue #724)
+# ---------------------------------------------------------------------------
+#
+# When Claude's API quota is exhausted the session log contains a phrase like
+# "out of extra usage" or "you've hit your limit".  The health check must NOT
+# restart the dispatcher in this case — restarting is useless because Claude
+# will immediately hit the same wall.  Instead:
+#   check_usage_limit() detects the phrase, writes LIMIT_WAIT_STATE_FILE with
+#     a midnight-UTC target epoch, and returns 0 (= "suppress restart").
+#   is_limit_wait() reads the state file and returns 0 (= "still waiting")
+#     until midnight UTC, then cleans up the file and returns 1.
+#
+# These tests verify:
+#   D6a  check_usage_limit returns 0 when quota phrase present in a fresh log
+#   D6b  check_usage_limit returns 1 when log is absent
+#   D6c  check_usage_limit returns 1 when log is stale (> 10 min old)
+#   D6d  is_limit_wait returns 0 when state file present and midnight not passed
+#   D6e  is_limit_wait returns 1 when state file absent
+#   D6f  is_limit_wait returns 1 and removes stale file when midnight has passed
+
+# Recency guard constant from health-check-v3.sh (600 seconds).
+LIMIT_LOG_RECENCY_SECONDS = 600
+
+
+def _check_usage_limit_script(
+    session_log: Path,
+    limit_state_file: Path,
+    tmp_path: Path,
+) -> str:
+    """
+    Build a self-contained bash fragment that stubs all external dependencies
+    of check_usage_limit() and calls it.  Returns the function's exit code.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "health-check.log"
+    alert_dedup_dir = tmp_path / "alert-dedup"
+    alert_dedup_dir.mkdir(parents=True, exist_ok=True)
+
+    fn_body = _extract_function("check_usage_limit")
+
+    return f"""
+#!/bin/bash
+CLAUDE_SESSION_LOG="{session_log}"
+LIMIT_WAIT_STATE_FILE="{limit_state_file}"
+ALERT_DEDUP_DIR="{alert_dedup_dir}"
+ALERT_DEDUP_COOLDOWN_SECONDS=3600
+LOG_FILE="{log_file}"
+mkdir -p "$(dirname "$LOG_FILE")"
+log()       {{ echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE"; }}
+log_info()  {{ log "INFO"  "$1"; }}
+log_warn()  {{ log "WARN"  "$1"; }}
+log_error() {{ log "ERROR" "$1"; }}
+send_telegram_alert()         {{ : ; }}
+send_telegram_alert_deduped() {{ : ; }}
+
+{fn_body}
+
+check_usage_limit
+exit $?
+"""
+
+
+def _is_limit_wait_script(
+    limit_state_file: Path,
+    tmp_path: Path,
+) -> str:
+    """
+    Build a self-contained bash fragment that stubs dependencies of
+    is_limit_wait() and calls it.  Returns the function's exit code.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "health-check.log"
+
+    fn_body = _extract_function("is_limit_wait")
+
+    return f"""
+#!/bin/bash
+LIMIT_WAIT_STATE_FILE="{limit_state_file}"
+LOG_FILE="{log_file}"
+mkdir -p "$(dirname "$LOG_FILE")"
+log()      {{ echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE"; }}
+log_info() {{ log "INFO" "$1"; }}
+
+{fn_body}
+
+is_limit_wait
+exit $?
+"""
+
+
+def test_check_usage_limit_detects_quota_phrase_in_fresh_log(tmp_path: Path) -> None:
+    """
+    D6a: check_usage_limit() must return 0 when the session log was modified
+    recently and contains a quota-exhaustion phrase.
+
+    Failure mode: if this returns 1 the RED handler proceeds to do_restart(),
+    which immediately hits the same quota wall — crash-looping until midnight.
+    This was the root cause of the 2026-04-08 outage.
+    """
+    session_log = tmp_path / "claude-session.log"
+    limit_state_file = tmp_path / "health-limit-wait-state"
+
+    session_log.write_text("Claude: out of extra usage for this billing period\n")
+    # mtime defaults to now — within recency guard
+
+    fragment = _check_usage_limit_script(session_log, limit_state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 0, (
+        "check_usage_limit() returned 1 (not detected) for a fresh session log "
+        "containing 'out of extra usage'. The RED handler will proceed to restart "
+        "Claude into the same quota wall.\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert limit_state_file.exists(), (
+        "check_usage_limit() returned 0 but did not write LIMIT_WAIT_STATE_FILE. "
+        "is_limit_wait() will not suppress subsequent health-check runs.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_check_usage_limit_returns_false_when_log_absent(tmp_path: Path) -> None:
+    """
+    D6b: check_usage_limit() must return 1 when the session log does not exist.
+
+    Failure mode: if this returns 0, normal crashes (no session log) are
+    incorrectly treated as quota exhaustion and restarts are suppressed
+    indefinitely.
+    """
+    session_log = tmp_path / "claude-session.log"  # deliberately not created
+    limit_state_file = tmp_path / "health-limit-wait-state"
+
+    fragment = _check_usage_limit_script(session_log, limit_state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "check_usage_limit() returned 0 (limit detected) when session log does "
+        "not exist. This would suppress restarts for ordinary crashes.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_check_usage_limit_returns_false_when_log_stale(tmp_path: Path) -> None:
+    """
+    D6c: check_usage_limit() must return 1 when the session log is older than
+    the 10-minute recency guard, even if it contains a quota phrase.
+
+    Failure mode: if this returns 0 for a stale log, a quota event from a
+    prior session permanently suppresses restart logic for future crashes.
+    """
+    session_log = tmp_path / "claude-session.log"
+    limit_state_file = tmp_path / "health-limit-wait-state"
+
+    session_log.write_text("Claude: out of extra usage for this billing period\n")
+    # Back-date mtime to past the recency guard
+    stale_mtime = time.time() - (LIMIT_LOG_RECENCY_SECONDS + 120)
+    os.utime(session_log, (stale_mtime, stale_mtime))
+
+    fragment = _check_usage_limit_script(session_log, limit_state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "check_usage_limit() returned 0 (limit detected) for a session log that "
+        f"is more than {LIMIT_LOG_RECENCY_SECONDS}s old. Stale quota phrases from "
+        "prior sessions must not suppress restart logic for current crashes.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_is_limit_wait_returns_true_before_midnight_utc(tmp_path: Path) -> None:
+    """
+    D6d: is_limit_wait() must return 0 (still waiting) when LIMIT_WAIT_STATE_FILE
+    contains a midnight-UTC target epoch that has not yet passed.
+
+    Failure mode: if this returns 1, the RED handler proceeds to restart during
+    the quota window — causing the same crash-loop the fix was designed to prevent.
+    """
+    limit_state_file = tmp_path / "health-limit-wait-state"
+
+    # Write a state file with a target epoch 2 hours from now
+    now = int(time.time())
+    future_midnight = now + 7200  # 2 hours ahead
+    limit_state_file.write_text(f"{now} 7200 {future_midnight} midnight-utc\n")
+
+    fragment = _is_limit_wait_script(limit_state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 0, (
+        "is_limit_wait() returned 1 (not waiting) when the target midnight-UTC "
+        "epoch is still 2 hours in the future. Restarts should be suppressed "
+        "until the quota window expires.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_is_limit_wait_returns_false_when_no_state_file(tmp_path: Path) -> None:
+    """
+    D6e: is_limit_wait() must return 1 (not waiting) when LIMIT_WAIT_STATE_FILE
+    does not exist.
+
+    Failure mode: if this returns 0, all RED events are permanently suppressed
+    even without a prior quota detection.
+    """
+    limit_state_file = tmp_path / "health-limit-wait-state"  # not created
+
+    fragment = _is_limit_wait_script(limit_state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "is_limit_wait() returned 0 (waiting) when LIMIT_WAIT_STATE_FILE does "
+        "not exist. Without a state file, no quota event was recorded and "
+        "restarts must not be suppressed.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_is_limit_wait_returns_false_and_cleans_up_after_midnight_utc(
+    tmp_path: Path,
+) -> None:
+    """
+    D6f: is_limit_wait() must return 1 (no longer waiting) and remove the state
+    file when the stored target epoch has already passed.
+
+    Failure mode: if this returns 0 after midnight UTC, the quota guard never
+    expires and restarts are suppressed permanently — the system stays down even
+    after the quota resets.
+    """
+    limit_state_file = tmp_path / "health-limit-wait-state"
+
+    # Write a state file with a target epoch in the past (quota reset already happened)
+    past_midnight = int(time.time()) - 3600  # 1 hour ago
+    recorded_at = past_midnight - 43200  # recorded 12 hours before that
+    limit_state_file.write_text(f"{recorded_at} 43200 {past_midnight} midnight-utc\n")
+
+    fragment = _is_limit_wait_script(limit_state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "is_limit_wait() returned 0 (still waiting) after midnight UTC has passed. "
+        "The quota should have reset and normal restart logic should resume.\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert not limit_state_file.exists(), (
+        "is_limit_wait() did not remove the stale LIMIT_WAIT_STATE_FILE after "
+        "midnight UTC passed. The stale file may suppress future restart attempts.\n"
+        f"stderr: {result.stderr!r}"
+    )


### PR DESCRIPTION
## What this is

PR #724 (commit d44d7ee) shipped `check_usage_limit()` and `is_limit_wait()` in `health-check-v3.sh` to prevent crash-looping during quota exhaustion. The fix itself was correct and is live on main. This PR adds the missing test coverage for those two functions.

## Gap being closed

The quota path had zero test coverage. A future change to `check_usage_limit()` or `is_limit_wait()` — even a typo — would ship silently. These tests give the same regression protection the compaction and WFM-freshness paths already have.

## What the tests verify (D6a–D6f)

Six smoke tests using the same bash-fragment extraction technique already established in this file:

- **D6a** — `check_usage_limit()` returns 0 and writes `LIMIT_WAIT_STATE_FILE` when session log is fresh and contains a quota phrase
- **D6b** — returns 1 (no false positive) when session log does not exist
- **D6c** — returns 1 when session log exists but is older than the 10-minute recency guard (quota phrase from a prior session must not suppress current crash restarts)
- **D6d** — `is_limit_wait()` returns 0 (still waiting) when state file present and target epoch is in the future
- **D6e** — returns 1 when state file does not exist
- **D6f** — returns 1 and removes the stale state file when midnight UTC has already passed (quota reset path)

## Functional approach

Tests extract functions from the live script using `_extract_function()` and stub all external dependencies (Telegram, dedup dir, log file) — pure, isolated, no network calls. The constants `LIMIT_LOG_RECENCY_SECONDS = 600` mirror the script's recency guard directly so tests are self-documenting against the spec.

## Tests run

- [x] `uv run pytest tests/smoke/test_health_check.py -v` — 16 passed, 0 failed (6 new + 10 existing)

## Manual test

N/A — this change is entirely internal test coverage; no systemd, cron, external services, or runtime state is touched.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, pure test-only change
- [x] User-visible outcome verified — N/A, no user-visible behavior changed
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: not applicable