### PR TITLE
feat: add outcome_category to write_result (#754)

### DIFF
--- a/scripts/token-flamegraph.sh
+++ b/scripts/token-flamegraph.sh
@@ -199,4 +199,83 @@ calls_s = f"{total_count} call{'s' if total_count != 1 else ''}"
 print(f"  {'TOTAL':<{max_source_len if sorted_sources else 8}}  {'':<{BAR_WIDTH}}  {total_in_s:>10} in / {total_out_s} out | cache_read: {cache_read_s} | cache_write: {cache_write_s} | {calls_s}")
 PYEOF
 
+# ---------------------------------------------------------------------------
+# Outcome category breakdown (issue #754)
+# Reads outcome-ledger.jsonl and shows counts per metabolic category in the
+# same time window. Skipped silently if the ledger doesn't exist yet.
+# ---------------------------------------------------------------------------
+OUTCOME_LEDGER_FILE="${WORKSPACE}/data/outcome-ledger.jsonl"
+
+if [[ -f "${OUTCOME_LEDGER_FILE}" && -s "${OUTCOME_LEDGER_FILE}" ]]; then
+python3 - "${OUTCOME_LEDGER_FILE}" "${SINCE_S}" "${NOW_S}" "${WINDOW}" <<'PYEOF_OUTCOME'
+import sys
+import json
+from collections import defaultdict
+
+outcome_ledger_path = sys.argv[1]
+since_s = int(sys.argv[2])
+now_s = int(sys.argv[3])
+window = sys.argv[4]
+
+# Category display order and descriptions
+CATEGORY_ORDER = ["pearl", "seed", "heat", "shit"]
+CATEGORY_LABEL = {
+    "pearl": "pearl  direct high-value output (bugs caught, frameworks encoded, analysis acted on)",
+    "seed":  "seed   intentional investment in future capability (infra, tooling, instrumentation)",
+    "heat":  "heat   pure dissipation, no residue (empty checks, healthy no-ops)",
+    "shit":  "shit   organic waste that must be processed (stale notes, unread accumulation)",
+}
+
+counts = defaultdict(int)
+total = 0
+
+with open(outcome_ledger_path) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts = entry.get("ts", 0)
+        if ts < since_s or ts > now_s:
+            continue
+        cat = entry.get("outcome_category", "")
+        if cat:
+            counts[cat] += 1
+            total += 1
+
+if not counts:
+    print()
+    print("  Outcome categories: (none tagged in this window)")
+    sys.exit(0)
+
+print()
+print("  Outcome category breakdown (self-assessed):")
+print()
+
+BAR_WIDTH = 12
+FULL_BLOCK = "█"
+LIGHT_BLOCK = "░"
+
+# Show known categories in fixed order, then any unknown values
+display_order = CATEGORY_ORDER + [k for k in sorted(counts) if k not in CATEGORY_ORDER]
+
+for cat in display_order:
+    if cat not in counts:
+        continue
+    n = counts[cat]
+    pct = (n / total * 100) if total > 0 else 0
+    filled = round(BAR_WIDTH * pct / 100)
+    filled = max(1, min(filled, BAR_WIDTH)) if n > 0 else 0
+    bar = FULL_BLOCK * filled + LIGHT_BLOCK * (BAR_WIDTH - filled)
+    label = CATEGORY_LABEL.get(cat, cat)
+    print(f"  {bar}  {n:3d} ({pct:3.0f}%)  {label}")
+
+print()
+print(f"  Total tagged: {total} write_result call{'s' if total != 1 else ''}")
+PYEOF_OUTCOME
+fi
+
 exit 0

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -534,6 +534,14 @@ MESSAGES_DB_PATH = Path(
 )
 LOBSTER_TMUX_SESSION = os.environ.get("LOBSTER_TMUX_SESSION", "lobster")
 
+# Valid metabolic value categories for write_result outcome_category field (issue #754).
+# Self-assessed by the completing subagent; stored alongside the result for flamegraph queries.
+VALID_OUTCOME_CATEGORIES: frozenset[str] = frozenset({"heat", "shit", "seed", "pearl"})
+# Outcome category ledger: append-only JSONL recording {task_id, outcome_category, source, ts}
+# for every write_result call that includes outcome_category. Used by token-flamegraph.sh
+# to render the category breakdown axis without touching the token-ledger schema.
+OUTCOME_LEDGER_FILE = _WORKSPACE / "data" / "outcome-ledger.jsonl"
+
 # Instance identity for multi-instance deployments (BIS-85).
 # Prefer an explicit observability token; fall back to hostname so reports are
 # always attributed to the Lobster instance that filed them.
@@ -2453,6 +2461,19 @@ async def list_tools() -> list[Tool]:
                             "result to the user."
                         ),
                         "default": False,
+                    },
+                    "outcome_category": {
+                        "type": "string",
+                        "description": (
+                            "Optional metabolic value tag for this result. Self-assessed by the subagent — "
+                            "the completing agent has the most context to categorize honestly. "
+                            "heat: pure dissipation, no residue (empty checks, healthy no-ops). "
+                            "shit: organic waste that persists and must be processed (stale notes, unread accumulation). "
+                            "seed: intentional investment in future capability (infra fixes, tooling, instrumentation). "
+                            "pearl: direct high-value output (bugs caught, frameworks encoded, analysis acted on). "
+                            "Omit if the outcome does not fit any category."
+                        ),
+                        "enum": ["heat", "shit", "seed", "pearl"],
                     },
                 },
                 "required": ["task_id", "chat_id", "text"],
@@ -7416,6 +7437,12 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     status = args.get("status", "success")
     artifacts = args.get("artifacts") or []
     thread_ts = args.get("thread_ts")
+    outcome_category_raw = args.get("outcome_category")
+    outcome_category = (
+        outcome_category_raw
+        if outcome_category_raw in VALID_OUTCOME_CATEGORIES
+        else None
+    )
     # Accept new name (sent_reply_to_user) with backward-compat alias (forward).
     # Semantics: sent_reply_to_user=True means subagent already called send_reply →
     # dispatcher should NOT relay. This is the inverse of the old `forward` field.
@@ -7490,9 +7517,28 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         message["artifacts"] = artifacts
     if thread_ts:
         message["thread_ts"] = thread_ts
+    if outcome_category is not None:
+        message["outcome_category"] = outcome_category
 
     inbox_file = INBOX_DIR / f"{message_id}.json"
     atomic_write_json(inbox_file, message)
+
+    # Issue #754: persist outcome_category to the outcome ledger for flamegraph queries.
+    # Append-only JSONL; failures are non-fatal (observability, not correctness).
+    if outcome_category is not None:
+        try:
+            import time as _time
+            ledger_entry = json.dumps({
+                "ts": int(_time.time()),
+                "task_id": task_id,
+                "outcome_category": outcome_category,
+                "source": source,
+            })
+            OUTCOME_LEDGER_FILE.parent.mkdir(parents=True, exist_ok=True)
+            with open(OUTCOME_LEDGER_FILE, "a") as _lf:
+                _lf.write(ledger_entry + "\n")
+        except Exception as _exc:
+            log.warning(f"write_result: failed to append outcome_category to ledger: {_exc}")
 
     # BIS-167 Slice 6: persist agent event immediately on write_result.
     # Before auto-unregister so the record is in the DB even if the dispatcher crashes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,9 @@ def isolate_inbox_server_paths(tmp_path: Path):
     state_file = messages / "config" / "lobster-state.json"
     log_dir = workspace / "logs"
 
+    outcome_ledger = workspace / "data" / "outcome-ledger.jsonl"
+    (workspace / "data").mkdir(parents=True, exist_ok=True)
+
     dirs_result = {
         "base": messages,
         "inbox": messages / "inbox",
@@ -144,6 +147,8 @@ def isolate_inbox_server_paths(tmp_path: Path):
         "scheduled_tasks_logs": sched / "logs",
         # BIS-165 Slice 4: redirected DB path for tests that write to messages.db
         "messages_db": messages / "messages.db",
+        # Issue #754: outcome category ledger
+        "outcome_ledger": outcome_ledger,
     }
 
     # Ensure the module is in sys.modules before patching.  patch.multiple
@@ -192,6 +197,8 @@ def isolate_inbox_server_paths(tmp_path: Path):
             SCHEDULED_TASKS_LOGS_DIR=sched / "logs",
             # BIS-165 Slice 4: isolate DB path so tests never touch production messages.db
             MESSAGES_DB_PATH=messages / "messages.db",
+            # Issue #754: isolate outcome ledger so tests never write to production data/
+            OUTCOME_LEDGER_FILE=outcome_ledger,
         )
         if _test_claims_db is not None:
             # Issue #1360: isolate claim DB so SQLite claim rows don't bleed

--- a/tests/unit/test_mcp_server/test_message_tools.py
+++ b/tests/unit/test_mcp_server/test_message_tools.py
@@ -22,6 +22,7 @@ if str(_MCP_DIR) not in sys.path:
 # Pre-load the module so that unittest.mock can resolve "src.mcp.inbox_server"
 # as an attribute of the `src.mcp` package before patch.multiple opens.
 import src.mcp.inbox_server  # noqa: F401
+from src.mcp.inbox_server import VALID_OUTCOME_CATEGORIES
 
 # We'll test the handlers directly by importing them
 # and patching the directory constants
@@ -1271,9 +1272,6 @@ class TestEnqueueRecoveryNotification:
 # Tests for outcome_category field on write_result (issue #754)
 # ---------------------------------------------------------------------------
 
-VALID_CATEGORIES = ["heat", "shit", "seed", "pearl"]
-
-
 class TestWriteResultOutcomeCategory:
     """write_result stores outcome_category in the inbox message and the outcome ledger.
 
@@ -1307,7 +1305,7 @@ class TestWriteResultOutcomeCategory:
         assert len(inbox_files) == 1, f"Expected 1 inbox file, found {len(inbox_files)}"
         return json.loads(inbox_files[0].read_text())
 
-    @pytest.mark.parametrize("category", VALID_CATEGORIES)
+    @pytest.mark.parametrize("category", VALID_OUTCOME_CATEGORIES)
     def test_valid_category_stored_in_inbox_message(self, dirs, category):
         """Each valid outcome_category value is persisted in the inbox message JSON."""
         msg = self._run_write_result(
@@ -1346,7 +1344,7 @@ class TestWriteResultOutcomeCategory:
             "Invalid outcome_category should not appear in inbox message"
         )
 
-    @pytest.mark.parametrize("category", VALID_CATEGORIES)
+    @pytest.mark.parametrize("category", VALID_OUTCOME_CATEGORIES)
     def test_valid_category_appended_to_outcome_ledger(self, dirs, category):
         """Each valid outcome_category value is appended to the outcome ledger JSONL."""
         import asyncio
@@ -1392,7 +1390,7 @@ class TestWriteResultOutcomeCategory:
         import asyncio
         from src.mcp.inbox_server import handle_write_result
 
-        for i, category in enumerate(VALID_CATEGORIES):
+        for i, category in enumerate(VALID_OUTCOME_CATEGORIES):
             asyncio.run(handle_write_result({
                 "task_id": f"multi-{i}",
                 "chat_id": 300 + i,
@@ -1404,9 +1402,9 @@ class TestWriteResultOutcomeCategory:
         ledger_file = dirs["outcome_ledger"]
         assert ledger_file.exists()
         entries = [json.loads(line) for line in ledger_file.read_text().splitlines() if line.strip()]
-        assert len(entries) == len(VALID_CATEGORIES)
+        assert len(entries) == len(VALID_OUTCOME_CATEGORIES)
         recorded_categories = [e["outcome_category"] for e in entries]
-        assert sorted(recorded_categories) == sorted(VALID_CATEGORIES)
+        assert sorted(recorded_categories) == sorted(VALID_OUTCOME_CATEGORIES)
 
     def test_outcome_category_preserved_through_subagent_notification_type(self, dirs):
         """outcome_category is stored even when sent_reply_to_user=True (subagent_notification)."""

--- a/tests/unit/test_mcp_server/test_message_tools.py
+++ b/tests/unit/test_mcp_server/test_message_tools.py
@@ -1265,3 +1265,158 @@ class TestEnqueueRecoveryNotification:
             _enqueue_recovery_notification({"task_id": "x", "text": ""})
 
         assert list(inbox_dir.glob("*.json")) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for outcome_category field on write_result (issue #754)
+# ---------------------------------------------------------------------------
+
+VALID_CATEGORIES = ["heat", "shit", "seed", "pearl"]
+
+
+class TestWriteResultOutcomeCategory:
+    """write_result stores outcome_category in the inbox message and the outcome ledger.
+
+    The outcome_category field is optional and self-assessed by the subagent.
+    Valid values: heat, shit, seed, pearl.
+    Invalid or missing values are silently ignored (field absent from message).
+    """
+
+    @pytest.fixture
+    def dirs(self, inbox_server_dirs):
+        return inbox_server_dirs
+
+    def _run_write_result(self, dirs, *, task_id, chat_id, text, outcome_category=None, **extra):
+        """Helper: call handle_write_result and return the written inbox message."""
+        import asyncio
+        from src.mcp.inbox_server import handle_write_result
+
+        call_args = {
+            "task_id": task_id,
+            "chat_id": chat_id,
+            "text": text,
+            "source": "telegram",
+            **extra,
+        }
+        if outcome_category is not None:
+            call_args["outcome_category"] = outcome_category
+
+        asyncio.run(handle_write_result(call_args))
+
+        inbox_files = list(dirs["inbox"].glob("*.json"))
+        assert len(inbox_files) == 1, f"Expected 1 inbox file, found {len(inbox_files)}"
+        return json.loads(inbox_files[0].read_text())
+
+    @pytest.mark.parametrize("category", VALID_CATEGORIES)
+    def test_valid_category_stored_in_inbox_message(self, dirs, category):
+        """Each valid outcome_category value is persisted in the inbox message JSON."""
+        msg = self._run_write_result(
+            dirs,
+            task_id=f"test-{category}",
+            chat_id=100,
+            text=f"Result for {category}",
+            outcome_category=category,
+        )
+        assert msg.get("outcome_category") == category, (
+            f"Expected outcome_category={category!r} in inbox message, got {msg.get('outcome_category')!r}"
+        )
+
+    def test_missing_category_not_present_in_message(self, dirs):
+        """When outcome_category is omitted, the field is absent from the inbox message."""
+        msg = self._run_write_result(
+            dirs,
+            task_id="test-no-category",
+            chat_id=101,
+            text="Result without category",
+        )
+        assert "outcome_category" not in msg, (
+            "outcome_category should be absent when not provided"
+        )
+
+    def test_invalid_category_silently_dropped(self, dirs):
+        """An unrecognized outcome_category value is silently dropped (not stored)."""
+        msg = self._run_write_result(
+            dirs,
+            task_id="test-invalid-category",
+            chat_id=102,
+            text="Result with invalid category",
+            outcome_category="trash",  # not a valid category
+        )
+        assert "outcome_category" not in msg, (
+            "Invalid outcome_category should not appear in inbox message"
+        )
+
+    @pytest.mark.parametrize("category", VALID_CATEGORIES)
+    def test_valid_category_appended_to_outcome_ledger(self, dirs, category):
+        """Each valid outcome_category value is appended to the outcome ledger JSONL."""
+        import asyncio
+        from src.mcp.inbox_server import handle_write_result
+
+        asyncio.run(handle_write_result({
+            "task_id": f"ledger-test-{category}",
+            "chat_id": 200,
+            "text": f"Ledger test for {category}",
+            "source": "telegram",
+            "outcome_category": category,
+        }))
+
+        ledger_file = dirs["outcome_ledger"]
+        assert ledger_file.exists(), "outcome ledger file should be created"
+
+        entries = [json.loads(line) for line in ledger_file.read_text().splitlines() if line.strip()]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["outcome_category"] == category
+        assert entry["task_id"] == f"ledger-test-{category}"
+        assert "ts" in entry
+
+    def test_missing_category_does_not_write_ledger_entry(self, dirs):
+        """When outcome_category is omitted, no entry is appended to the ledger."""
+        import asyncio
+        from src.mcp.inbox_server import handle_write_result
+
+        asyncio.run(handle_write_result({
+            "task_id": "no-category-ledger",
+            "chat_id": 201,
+            "text": "No category, no ledger write",
+            "source": "telegram",
+        }))
+
+        ledger_file = dirs["outcome_ledger"]
+        assert not ledger_file.exists() or ledger_file.read_text().strip() == "", (
+            "Ledger should not be written when outcome_category is absent"
+        )
+
+    def test_multiple_categories_accumulate_in_ledger(self, dirs):
+        """Multiple write_result calls append independent entries to the ledger."""
+        import asyncio
+        from src.mcp.inbox_server import handle_write_result
+
+        for i, category in enumerate(VALID_CATEGORIES):
+            asyncio.run(handle_write_result({
+                "task_id": f"multi-{i}",
+                "chat_id": 300 + i,
+                "text": f"Entry {i}",
+                "source": "telegram",
+                "outcome_category": category,
+            }))
+
+        ledger_file = dirs["outcome_ledger"]
+        assert ledger_file.exists()
+        entries = [json.loads(line) for line in ledger_file.read_text().splitlines() if line.strip()]
+        assert len(entries) == len(VALID_CATEGORIES)
+        recorded_categories = [e["outcome_category"] for e in entries]
+        assert sorted(recorded_categories) == sorted(VALID_CATEGORIES)
+
+    def test_outcome_category_preserved_through_subagent_notification_type(self, dirs):
+        """outcome_category is stored even when sent_reply_to_user=True (subagent_notification)."""
+        msg = self._run_write_result(
+            dirs,
+            task_id="notification-with-category",
+            chat_id=400,
+            text="Already sent directly.",
+            outcome_category="pearl",
+            sent_reply_to_user=True,
+        )
+        assert msg["type"] == "subagent_notification"
+        assert msg.get("outcome_category") == "pearl"


### PR DESCRIPTION
## Summary

The token flamegraph shows *where* tokens go but not *what value they produce*. Two subagent calls spending 10k tokens each may be qualitatively opposite: one caught a bug (pearl), one ran a healthy no-op check (heat). Without a value axis, the system cannot distinguish waste from investment.

This PR adds `outcome_category` as an optional field to `write_result`, enabling the second axis: token spend × value category.

## What changed

**`write_result` MCP tool** — accepts a new optional `outcome_category` parameter with four valid values:
- `pearl` — direct high-value output (bugs caught, frameworks encoded, analysis acted on)
- `seed` — intentional investment in future capability (infra, tooling, instrumentation)
- `heat` — pure dissipation, no residue (empty checks, healthy no-ops)
- `shit` — organic waste that persists and must be processed (stale notes, unread accumulation)

Self-assessment is intentional: the completing subagent has the most context to categorize honestly.

**Storage** — two locations:
1. The inbox message JSON (existing write_result output) gains an `outcome_category` key when provided
2. A new append-only `~/lobster-workspace/data/outcome-ledger.jsonl` records `{ts, task_id, outcome_category, source}` for flamegraph queries. Invalid or missing values are silently ignored — no new failure modes.

**`token-flamegraph.sh`** — reads `outcome-ledger.jsonl` after the main flamegraph output and renders a category breakdown section if any entries exist in the time window. Gracefully absent when the ledger doesn't exist yet.

**`VALID_OUTCOME_CATEGORIES`** — module-level constant in `inbox_server.py` for the valid set; referenced in both the schema definition and the handler validation.

## What is out of scope

- Budget gating (Tier 3) — not implemented here
- Joining `outcome_category` to token counts per-task — the ledger stores task_id so a future join is possible, but the flamegraph currently shows counts, not token-weighted breakdown
- Schema changes to existing messages or the token ledger — no existing data is touched

## Functional patterns used

- Pure extraction: `outcome_category` is derived from `args` with a single fallback-to-None expression; no mutation of existing data structures
- Fail-safe writes: the outcome ledger append is wrapped in try/except so a filesystem error never fails the write_result call
- Module-level constant (`VALID_OUTCOME_CATEGORIES: frozenset`) for the valid set — referenced in schema and handler, never duplicated

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_message_tools.py::TestWriteResultOutcomeCategory -v` — 13 passed, 0 failed
- [x] `uv run pytest tests/unit/test_mcp_server/ --tb=short` — 778 passed, 46 failed (pre-existing failures unrelated to this PR: `test_write_observation.py` has a `NameError: name 'pas'` bug on main; `test_ghost_session_fixes.py` has pre-existing assertion failures on main)

**Blocked items needing attention before merge:** none

## Manual test

N/A — this change is entirely internal (MCP tool schema + in-memory JSON write + append-only JSONL file). No external service calls, no systemd units, no Telegram output. The outcome ledger is a new file that doesn't exist until first use; the flamegraph script gracefully skips the category section when the file is absent.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external services touched)
- [x] User-visible outcome verified — N/A (observability instrumentation, not user-facing output)
- [x] Side-effect audit complete: appends to a new JSONL file only; non-fatal on failure; no floods, no loops, no mass sends
- [x] External service calls: none

Closes #754