### PR TITLE
feat(wos): add /decide defer — acknowledge blocked UoWs without forcing retry or close

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -182,31 +182,65 @@ def handle_decide_close(uow_id: str, *, registry: "Registry") -> str:
     )
 
 
-_VALID_DECIDE_ACTIONS = frozenset({"proceed", "abandon", "retry"})
+_VALID_DECIDE_ACTIONS = frozenset({"proceed", "abandon", "retry", "defer"})
+
+
+def handle_decide_defer(uow_id: str, note: str = "", *, registry: "Registry") -> str:
+    """
+    Handle a decide_defer action for a UoW.
+
+    Called when Dan sends `/decide <uow-id> defer [note]` to explicitly
+    acknowledge a blocked UoW without yet choosing to retry or close it.
+    The UoW remains in `blocked` status; a dated audit entry records the
+    deferral decision and any operator note for future context.
+
+    No status transition occurs — the UoW stays blocked until a subsequent
+    decide-proceed, decide-retry, or decide-close.
+    """
+    rows = registry.decide_defer(uow_id, note=note)
+    if rows == 1:
+        note_suffix = f"\nNote recorded: {note}" if note else ""
+        return (
+            f"UoW `{uow_id}` deferred.\n"
+            f"Status: `blocked` (unchanged) \u2014 audit entry written."
+            + note_suffix
+        )
+    return (
+        f"UoW `{uow_id}` could not be deferred \u2014 it is not currently in `blocked` status.\n"
+        f"Run `/wos status blocked` to see blocked UoWs."
+    )
 
 
 def handle_decide(uow_id: str, action: str, *, registry: "Registry") -> str:
     """
-    Handle /decide <uow-id> <proceed|abandon|retry[force]>.
+    Handle /decide <uow-id> <proceed|abandon|retry[force]|defer[note]>.
 
     Provides a single unified command for resolving blocked UoWs from Telegram.
     Action semantics:
-      proceed     — unblock and re-queue to ready-for-steward (preserves steward_cycles)
-      retry       — reset steward_cycles to 0 and re-queue to ready-for-steward (full retry)
-      retry force — override the hard-cap commitment gate (explicit operator intent required)
-      abandon     — close the UoW as user-requested failure (blocked → failed)
+      proceed          — unblock and re-queue to ready-for-steward (preserves steward_cycles)
+      retry            — reset steward_cycles to 0 and re-queue to ready-for-steward (full retry)
+      retry force      — override the hard-cap commitment gate (explicit operator intent required)
+      abandon          — close the UoW as user-requested failure (blocked → failed)
+      defer [note]     — leave in blocked, write a dated audit entry with optional note
 
-    All three actions operate only on UoWs in `blocked` status — optimistic lock
+    All actions operate only on UoWs in `blocked` status — optimistic lock
     prevents accidental double-writes if the UoW has already been advanced.
 
     Returns a human-readable Telegram message describing the outcome.
     """
-    # Support "retry force" as a two-word action token
+    # Support "retry force" as a two-word action token.
+    # Support "defer <note>" where any trailing text after "defer" is the note.
     action_normalized = action.lower().strip()
     force_retry = False
+    defer_note = ""
+
     if action_normalized in ("retry force", "force retry"):
         action_normalized = "retry"
         force_retry = True
+    elif action_normalized.startswith("defer "):
+        # "defer waiting on external review" → action=defer, note="waiting on external review"
+        defer_note = action.strip()[len("defer "):].strip()
+        action_normalized = "defer"
 
     if action_normalized not in _VALID_DECIDE_ACTIONS:
         valid = ", ".join(sorted(_VALID_DECIDE_ACTIONS))
@@ -232,6 +266,8 @@ def handle_decide(uow_id: str, action: str, *, registry: "Registry") -> str:
             return handle_decide_retry(uow_id, registry=registry, force=force_retry)
         case "abandon":
             return handle_decide_close(uow_id, registry=registry)
+        case "defer":
+            return handle_decide_defer(uow_id, defer_note, registry=registry)
         case _:
             # Unreachable — guarded by frozenset check above — but satisfies mypy exhaustiveness
             return f"Unhandled action `{action}`."

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1584,6 +1584,67 @@ class Registry:
         finally:
             conn.close()
 
+    def decide_defer(self, uow_id: str, *, note: str = "") -> int:
+        """
+        Defer a blocked UoW — leave it in `blocked` status with an audit note.
+
+        Intended for use when Dan sends `/decide <uow-id> defer [note]` to
+        explicitly acknowledge a blocked UoW without yet choosing to retry or close
+        it. The UoW remains in `blocked` status; the audit entry records the deferral
+        decision and any operator note for future context.
+
+        No status transition occurs — this is a record-only operation. The UoW will
+        remain blocked until a subsequent decide-retry, decide-proceed, or decide-close.
+
+        Returns rows_affected (1 on success, 0 if UoW is not in blocked status).
+        Writes audit entry atomically in the same transaction as the SELECT-guard.
+        """
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+
+            # Optimistic lock: only write the audit entry if the UoW is still blocked.
+            row = conn.execute(
+                "SELECT id FROM uow_registry WHERE id = ? AND status = 'blocked'",
+                (uow_id,),
+            ).fetchone()
+
+            if row is None:
+                conn.rollback()
+                return 0
+
+            note_json = json.dumps({
+                "event": "decide_defer",
+                "actor": "user",
+                "uow_id": uow_id,
+                "timestamp": now,
+                "note": note or "user deferred — UoW remains blocked pending future decision",
+            })
+
+            conn.execute(
+                """
+                INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+                VALUES (?, ?, 'decide_defer', 'blocked', 'blocked', 'user', ?)
+                """,
+                (now, uow_id, note_json),
+            )
+
+            # Touch updated_at so callers can detect a recent decision was recorded.
+            conn.execute(
+                "UPDATE uow_registry SET updated_at = ? WHERE id = ? AND status = 'blocked'",
+                (now, uow_id),
+            )
+
+            conn.commit()
+            return 1
+
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
     def registry_health(self) -> GateStatus:
         """
         Report registry health / autonomy gate status.

--- a/tests/unit/test_orchestration/test_dispatcher_integration.py
+++ b/tests/unit/test_orchestration/test_dispatcher_integration.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 import pytest
 
-from src.orchestration.dispatcher_handlers import handle_approve, handle_confirm, handle_decide, handle_wos_execute, handle_wos_status, handle_wos_unblock
+from src.orchestration.dispatcher_handlers import handle_approve, handle_confirm, handle_decide, handle_decide_defer, handle_wos_execute, handle_wos_status, handle_wos_unblock
 
 
 @pytest.fixture
@@ -318,3 +318,120 @@ class TestHandleDecide:
         handle_decide(result.id, "retry", registry=registry)
         uow = registry.get(result.id)
         assert uow.steward_cycles == 0  # reset
+
+
+# ---------------------------------------------------------------------------
+# /decide defer tests — issue #343
+# ---------------------------------------------------------------------------
+
+# Named constant: the expected event name written to audit_log on defer.
+DECIDE_DEFER_AUDIT_EVENT = "decide_defer"
+
+
+class TestHandleDecideDefer:
+    """Tests for /decide <uow-id> defer — leave blocked, write audit entry."""
+
+    def test_defer_leaves_uow_in_blocked_status(self, registry, blocked_uow_id):
+        """defer does not transition the UoW — it stays in blocked status."""
+        response = handle_decide(blocked_uow_id, "defer", registry=registry)
+        assert "deferred" in response.lower()
+        uow = registry.get(blocked_uow_id)
+        assert uow.status.value == "blocked"
+
+    def test_defer_writes_audit_entry(self, registry, blocked_uow_id):
+        """defer writes a decide_defer audit log entry — the deferral is auditable."""
+        import sqlite3
+        handle_decide(blocked_uow_id, "defer", registry=registry)
+        conn = sqlite3.connect(str(registry.db_path))
+        row = conn.execute(
+            "SELECT event, from_status, to_status, agent FROM audit_log WHERE uow_id=? AND event=?",
+            (blocked_uow_id, DECIDE_DEFER_AUDIT_EVENT),
+        ).fetchone()
+        conn.close()
+        assert row is not None, "audit log must contain a decide_defer entry"
+        assert row[1] == "blocked"   # from_status
+        assert row[2] == "blocked"   # to_status (no transition)
+        assert row[3] == "user"      # actor
+
+    def test_defer_with_note_includes_note_in_response(self, registry, blocked_uow_id):
+        """defer <note> includes the operator note in the response."""
+        note = "waiting on external security review"
+        response = handle_decide(blocked_uow_id, f"defer {note}", registry=registry)
+        assert note in response
+
+    def test_defer_with_note_records_note_in_audit_log(self, registry, blocked_uow_id):
+        """defer <note> persists the note text in the audit_log entry."""
+        import sqlite3
+        import json
+        note = "blocked by upstream API outage"
+        handle_decide(blocked_uow_id, f"defer {note}", registry=registry)
+        conn = sqlite3.connect(str(registry.db_path))
+        row = conn.execute(
+            "SELECT note FROM audit_log WHERE uow_id=? AND event=?",
+            (blocked_uow_id, DECIDE_DEFER_AUDIT_EVENT),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        note_payload = json.loads(row[0])
+        assert note in note_payload["note"]
+
+    def test_defer_without_note_uses_default_message(self, registry, blocked_uow_id):
+        """defer with no note writes a default audit message — not an empty string."""
+        import sqlite3
+        import json
+        handle_decide(blocked_uow_id, "defer", registry=registry)
+        conn = sqlite3.connect(str(registry.db_path))
+        row = conn.execute(
+            "SELECT note FROM audit_log WHERE uow_id=? AND event=?",
+            (blocked_uow_id, DECIDE_DEFER_AUDIT_EVENT),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        note_payload = json.loads(row[0])
+        assert note_payload["note"], "default note must be a non-empty string"
+
+    def test_defer_on_non_blocked_uow_returns_error(self, registry):
+        """defer on a non-blocked UoW returns an informative error, not a crash."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        result = registry.upsert(issue_number=310, title="Active defer test", sweep_date=today, success_criteria="Test done.")
+        registry.set_status_direct(result.id, "active")
+        response = handle_decide(result.id, "defer", registry=registry)
+        assert "not currently in" in response.lower() or "could not be" in response.lower()
+
+    def test_defer_does_not_reset_steward_cycles(self, registry):
+        """defer leaves steward_cycles unchanged — it is a record-only operation."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        result = registry.upsert(issue_number=311, title="Cycles defer test", sweep_date=today, success_criteria="Test done.")
+        import sqlite3
+        conn = sqlite3.connect(str(registry.db_path))
+        conn.execute("UPDATE uow_registry SET status='blocked', steward_cycles=4 WHERE id=?", (result.id,))
+        conn.commit()
+        conn.close()
+        handle_decide(result.id, "defer", registry=registry)
+        uow = registry.get(result.id)
+        assert uow.steward_cycles == 4  # unchanged
+
+    def test_defer_is_listed_in_unknown_action_error(self, registry, blocked_uow_id):
+        """The error message for unknown actions lists defer among valid options."""
+        response = handle_decide(blocked_uow_id, "frobnicate", registry=registry)
+        assert "defer" in response.lower()
+
+    def test_handle_decide_defer_standalone_function(self, registry, blocked_uow_id):
+        """handle_decide_defer is callable directly — same semantics as via handle_decide."""
+        response = handle_decide_defer(blocked_uow_id, "direct call test", registry=registry)
+        assert "deferred" in response.lower()
+        uow = registry.get(blocked_uow_id)
+        assert uow.status.value == "blocked"
+
+    def test_defer_idempotent_multiple_calls_each_write_audit_entry(self, registry, blocked_uow_id):
+        """Multiple defer calls each write a separate audit entry — deferral is a log, not a state."""
+        import sqlite3
+        handle_decide(blocked_uow_id, "defer first", registry=registry)
+        handle_decide(blocked_uow_id, "defer second", registry=registry)
+        conn = sqlite3.connect(str(registry.db_path))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM audit_log WHERE uow_id=? AND event=?",
+            (blocked_uow_id, DECIDE_DEFER_AUDIT_EVENT),
+        ).fetchone()[0]
+        conn.close()
+        assert count == 2, "each defer call must produce a distinct audit entry"


### PR DESCRIPTION
## Problem

Blocked UoWs had two and only two exit paths: retry (re-queue) or close (fail). When a UoW blocks because of an external dependency — an upstream API outage, a review waiting for another party — neither choice was right. Retrying wastes a steward cycle against a condition that hasn't changed. Closing loses work that should resume. The queue rotted with no auditable acknowledgment that Dan had seen the blocked item.

Issue #343 called this out as a Phase 2 gap.

## What this changes

Adds a `defer` action to `/decide`:

```
/decide <uow-id> defer [optional note]
```

The UoW stays in `blocked` status. A `decide_defer` audit entry is written with the operator note (and a default message if none is given). No status transition occurs. Subsequent retry/proceed/close calls still work — defer is not a terminal state.

The action also accepts inline notes: `/decide abc-123 defer waiting on legal sign-off` records the note text verbatim in the audit payload.

## Before / after

```
Before:
  blocked UoW → (retry  → ready-for-steward, cycles reset)
                (proceed → ready-for-steward, cycles preserved)
                (abandon → failed)
  No "I've seen this, come back later" path. Queue rots silently.

After:
  blocked UoW → (proceed → ready-for-steward, cycles preserved)
                (retry   → ready-for-steward, cycles reset)
                (abandon → failed)
                (defer   → blocked, audit entry written)  ← new
```

## Implementation

- `Registry.decide_defer(uow_id, note)`: optimistic lock on `blocked`, writes `decide_defer` audit entry (from=blocked, to=blocked, actor=user), touches `updated_at`. Pure SQL, no status column written.
- `handle_decide_defer()` in `dispatcher_handlers.py`: standalone pure function, same pattern as `handle_decide_retry` / `handle_decide_close`.
- `handle_decide()` extended: `defer` added to `_VALID_DECIDE_ACTIONS` frozenset; `"defer <note>"` prefix parsed before the frozenset guard; `match/case` exhaustiveness maintained.

Functional patterns used: pure functions (all handlers are side-effect-free at I/O boundaries), immutability (no in-place mutation of registry rows beyond `updated_at`), pattern matching (`match/case` in `handle_decide`), optimistic locking as the concurrency primitive.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_dispatcher_integration.py -q` — 46 passed (includes 10 new defer tests)
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_dispatcher_integration.py -q` — 116 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/ -q` — 929 passed, 1 pre-existing failure (`test_approve_idempotent_on_pending` in `test_registry_cli.py`, present on `main` before this PR)

Pre-existing failure: `test_approve_idempotent_on_pending` fails on `main` (verified) due to an auto-advance behavior change unrelated to this PR. Not introduced here.

## Manual test

N/A — this change is entirely internal registry + handler logic. No external services, no Telegram output, no file I/O, no systemd. The user-visible outcome (Telegram response text) is covered by the unit test assertions on return values of `handle_decide_defer`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, no external dependencies
- [x] User-visible outcome verified — handler return values asserted in unit tests
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #343