### PR TITLE
docs: correct model tier table in sys.subagent.bootup.md

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -360,10 +360,9 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 
 **Agent model assignments:**
 
-- **Opus**: `functional-engineer`, `gsd-debugger` -- tasks requiring deep reasoning
-- **Sonnet**: `gsd-executor`, `gsd-planner`, `gsd-phase-researcher`, `gsd-codebase-mapper`, `gsd-research-synthesizer`, `gsd-roadmapper`, `gsd-project-researcher` -- structured work
-- **Haiku**: `gsd-verifier`, `gsd-plan-checker`, `gsd-integration-checker` -- pass/fail evaluation
-- **Inherit (Sonnet)**: `lobster-generalist` -- inherits from `CLAUDE_CODE_SUBAGENT_MODEL` env var
+- **Opus**: `functional-engineer`, `lobster-oracle`, `review` -- tasks requiring deep adversarial reasoning or thorough code review
+- **Sonnet**: `brain-dumps`, `compact-catchup`, `lobster-auditor`, `lobster-generalist`, `lobster-hygiene`, `lobster-meta`, `nightly-consolidation`, `session-note-polish` -- structured work, synthesis, planning
+- **Haiku**: `lobster-ops`, `session-note-appender` -- lightweight ops and incremental logging
 
 **When to override:** If a task normally handled by a Sonnet agent requires unusually deep reasoning (e.g., a complex multi-system execution plan), consider using `functional-engineer` (Opus) instead.
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The model tier table in `.claude/sys.subagent.bootup.md` listed agents from a prior architecture (all the `gsd-*` family) that no longer exist, while omitting the 11 agents that are actually defined and in use. Any subagent reading this table to understand dispatch conventions would get a completely wrong picture of what agents are available.

## What changed

**Removed (11 ghost agents — no definition files exist):**
`gsd-debugger`, `gsd-executor`, `gsd-planner`, `gsd-phase-researcher`, `gsd-codebase-mapper`, `gsd-research-synthesizer`, `gsd-roadmapper`, `gsd-project-researcher`, `gsd-verifier`, `gsd-plan-checker`, `gsd-integration-checker`

**Added (11 real agents — assignments derived from `model:` frontmatter field):**
- Opus: `lobster-oracle`, `review`
- Sonnet: `brain-dumps`, `compact-catchup`, `lobster-auditor`, `lobster-hygiene`, `lobster-meta`, `nightly-consolidation`, `session-note-polish`
- Haiku: `lobster-ops`, `session-note-appender`

`functional-engineer` (Opus) and `lobster-generalist` (Sonnet) were already correct and are retained. The "Inherit (Sonnet)" label on `lobster-generalist` was removed — its frontmatter explicitly sets `model: claude-sonnet-4-6`, it does not inherit.

No behavior changed. This is a documentation correction only — the agent dispatch mechanism reads frontmatter directly, not this table.

## Tests run
- [x] Verified each added agent's model tier against its `.md` frontmatter `model:` field
- [x] Verified all removed agents have no `.md` file in `.claude/agents/`
- [ ] Automated test suite — N/A: documentation-only change, no code paths affected

## Manual test
N/A — purely internal documentation. No external services, no file I/O affecting runtime state, no scheduled jobs.

## Definition of Done
- [x] Unit tests pass with proper mocking — N/A (doc change)
- [x] Integration/manual test — N/A
- [x] User-visible outcome — N/A (subagent bootup doc, not user-facing)
- [x] Side-effect audit: no floods, no shared state writes, no production data affected
- [x] External service calls: none