### PR TITLE
fix: replace hardcoded UTC-4 with ZoneInfo in usage-retro.py

### DIFF
--- a/scripts/usage-retro.py
+++ b/scripts/usage-retro.py
@@ -20,9 +20,10 @@ import json
 import os
 import argparse
 from collections import defaultdict
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
-ET = timezone(timedelta(hours=-4))
+ET = ZoneInfo("America/New_York")
 WORKSPACE = os.environ.get("LOBSTER_WORKSPACE", os.path.expanduser("~/lobster-workspace"))
 LEDGER_PATH = os.path.join(WORKSPACE, "data", "token-ledger.jsonl")
 


### PR DESCRIPTION
\`usage-retro.py\` had \`ET = timezone(timedelta(hours=-4))\`, which hardcodes EDT (UTC-4) year-round. From November through mid-March, New York is on EST (UTC-5), so all timestamps displayed by this script would be off by one hour during winter months.

This PR fixes that by using \`ZoneInfo("America/New_York")\` from the standard library (Python 3.9+), which automatically applies the correct offset for the date being displayed.

## What changed

- \`from zoneinfo import ZoneInfo\` added
- \`ET = timezone(timedelta(hours=-4))\` replaced with \`ET = ZoneInfo("America/New_York")\`
- \`timezone\` removed from the \`datetime\` import (no longer used)
- \`timedelta\` is retained — it is still used in \`load_records()\` for the \`--days\` cutoff calculation

All existing usages of \`ET\` pass it as \`tz=ET\` to \`datetime.fromtimestamp()\` and \`datetime.now()\`, which is the correct API for ZoneInfo objects. No other changes.

Closes #757

## Tests run
- [x] \`uv run scripts/usage-retro.py --help\` — runs cleanly, no import errors
- [ ] Live ledger run against production data — skipped: no ledger file in this environment; the change is a timezone definition swap with no logic change

## Manual test
N/A — this change is entirely internal to the timezone definition. No external service calls, no file I/O changes, no user-visible output format changes (the timestamp format string is unchanged; only the offset applied will now be correct in winter).

## Definition of Done
- [x] Fix is correct: ZoneInfo is stdlib in Python 3.9+, used correctly with \`tz=\` parameter
- [x] No behavior change during EDT (summer) — \`America/New_York\` resolves to UTC-4 from mid-March through early November, identical to the previous hardcoded value
- [x] Correct behavior added during EST (winter) — UTC-5 applied automatically Nov–Mar
- [x] \`timezone\` import cleaned up (was only used for the ET definition)