### PR TITLE
docs: clarify seed→pearl transition rule in system-metabolism.md

### DIFF
--- a/philosophy/frontier/system-metabolism.md
+++ b/philosophy/frontier/system-metabolism.md
@@ -46,6 +46,16 @@ Direct high-value output. The artifact deserves to exist and is immediately usef
 
 Examples: philosophy sessions that encode a new framework, bugs caught before production, analysis that feeds a decision, a diagnosis that changes behavior. Pearls are what the system is for.
 
+### Category Transitions
+
+Categories are not permanent. An artifact's classification reflects its current role, not its origin.
+
+**Seed → Pearl**: occurs when the artifact is actively embedded in the runtime decision path — included in bootup context, cited in a running agent's working context, or actively driving dispatcher behavior. The trigger is *operational reference*, not mere existence. A frontier doc that sits in the filesystem is a seed; the same doc injected into bootup is a pearl.
+
+**Pearl → Shit**: occurs when the pearl is superseded and no longer the active source of truth — a doc replaced by a newer version, a decision overridden, a canonical entry that has gone stale. Superseded pearls that are not eviscerated become clutter.
+
+**Seed → Shit (rot)**: occurs when a seed has not been germinated in 60-90 days and is no longer viable. See also: Open Questions below, where this threshold is discussed. Hygiene sweeps should flag old seeds for human review.
+
 ---
 
 ## Grounding Table
@@ -57,7 +67,7 @@ Examples: philosophy sessions that encode a new framework, bugs caught before pr
 | Compost path | Nightly consolidation job (extracts from session notes → canonical memory), philosophy harvest job |
 | Evisceration path | Hygiene sweep (issues opened but never resolved), manual evisceration on stale frontier docs |
 | Seeds | Infra PRs, new MCP tools, flamegraph Tier 2/3 work, this document |
-| Pearls | philosophy/frontier/ docs actively referenced in bootup, bugs caught by oracle, canonical memory entries the dispatcher reads |
+| Pearls | philosophy/frontier/ docs actively referenced in bootup *(seed until bootup-embedded; see Category Transitions)*, bugs caught by oracle, canonical memory entries the dispatcher reads |
 | Accumulation threshold | Shit backlog growing faster than composting throughput → escalate |
 
 ---


### PR DESCRIPTION
## Summary

The oracle review of PR #755 flagged an internal inconsistency in `system-metabolism.md`: the taxonomy section classifies frontier docs as **seeds**, while the grounding table's pearl row lists frontier docs actively referenced in bootup as **pearls**. These are compatible, but the transition logic was missing — an agent applying the taxonomy algorithmically had no rule to resolve the conflict.

This PR makes the transition logic explicit.

## What changed

Added a **Category Transitions** subsection at the end of the Metabolic Taxonomy section, immediately before the Grounding Table. It states:

- **Seed → Pearl**: triggered by *operational reference* — inclusion in bootup context, citation in a running agent's working context, or active use in dispatcher behavior. Existence alone does not trigger the transition.
- **Pearl → Shit**: triggered by supersession — a newer version replaces the doc, a decision is overridden, or a canonical entry goes stale.
- **Seed → Shit (rot)**: triggered by 60-90 days without germination. This threshold was already stated in Open Questions; the new subsection consolidates the reference rather than duplicating it.

Also annotated the grounding table's pearl row: `philosophy/frontier/ docs actively referenced in bootup *(seed until bootup-embedded; see Category Transitions)*`. This makes the lifecycle visible at the point where a reader encounters the pearl classification, without removing or restructuring the existing row.

## What was not changed

Document structure, section order, and voice are unchanged. The Open Questions section's discussion of the 60-90 day rot threshold is left in place (the transition section cross-references it rather than replacing it). No other files were modified.

## Tests run

- [x] Manual diff review — 11 insertions, 1 deletion, no structural changes
- [ ] Automated tests — N/A (documentation only)

## Manual test

N/A — documentation change, no runtime behavior affected.

## Definition of Done

- [x] No external services involved
- [x] No user-visible runtime output
- [x] Side-effect audit: none — doc-only change

Closes #758