### PR TITLE
hygiene: update dispatch-job.sh tombstone with Phase 2 tracking issue and eligibility date

### DIFF
--- a/scheduled-tasks/dispatch-job.sh
+++ b/scheduled-tasks/dispatch-job.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # Lobster Scheduled Job Dispatcher
 #
-# DEPRECATED (issue #1083 — Phase 1 tombstone)
+# DEPRECATED (issue #1083 — Phase 1 tombstone, merged 2026-04-12)
 # New jobs should be managed by systemd timers via the MCP create_scheduled_job tool.
 # This script remains on disk for compatibility with jobs that have not yet been
 # migrated. It will be archived to scheduled-tasks/deprecated/ in Phase 2 (after
-# 2 weeks of stable systemd-timer operation).
+# 2 weeks of stable systemd-timer operation — eligible after 2026-04-26).
+#
+# Phase 2 tracking: dcetlin/Lobster#785
+# Before archiving, bot-talk-check-dispatch.sh must be updated to replace the
+# 6 exec calls that delegate to this script.
 #
 # Writes a scheduled_reminder message into the Lobster inbox so the dispatcher
 # spawns a subagent for the job. Does NOT invoke Claude directly.


### PR DESCRIPTION
## Why this exists

The Phase 1 tombstone for `dispatch-job.sh` (merged 2026-04-12, commit `792fe608`) referenced issue #1083, which is now closed. The tombstone comment gave no concrete date for when Phase 2 archival would be eligible and no open issue to track it. A future engineer running this hygiene check had no actionable pointer.

This PR gives the tombstone two things it was missing: the exact eligibility date (2026-04-26, 2 weeks after Phase 1) and a live tracking issue number (dcetlin/Lobster#785) with the prerequisite checklist for Phase 2.

## What changed

`scheduled-tasks/dispatch-job.sh` tombstone comment updated to add:
- The Phase 1 merge date (`2026-04-12`) so the 2-week clock is unambiguous
- The Phase 2 eligibility date (`2026-04-26`)
- A reference to dcetlin/Lobster#785, which contains the prerequisite checklist (systemd timers stable, no alerts during stabilization window, `bot-talk-check-dispatch.sh` replacement logic tested before archival)
- A note that `bot-talk-check-dispatch.sh` has 6 `exec` calls that must be replaced before `dispatch-job.sh` is archived — so the Phase 2 engineer doesn't discover that dependency mid-archival

## What is out of scope

- No archival is performed here — Phase 2 conditions (2-week stabilization) are not yet met as of 2026-04-19
- `bot-talk-check-dispatch.sh` is not modified — it still works correctly
- No functional code changes

## Functional patterns

Pure comment-only change; no logic affected.

## Tests run

- [x] `bash -n scheduled-tasks/dispatch-job.sh` — syntax check passes
- [x] `bash -n scheduled-tasks/bot-talk-check-dispatch.sh` — syntax check passes, no functional change

## Manual test

N/A — comment-only change, no runtime behavior affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (comment-only change)
- [x] User-visible outcome — N/A (no runtime behavior)
- [x] Side-effect audit — no floods, no writes, no unintended volume
- [x] External service calls — none

Relates to dcetlin/Lobster#785