### PR TITLE
Remove duplicated _default_db_path() from three heartbeat scripts

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -53,6 +53,8 @@ _SRC_ROOT = _REPO_ROOT / "src"
 if str(_SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(_SRC_ROOT))
 
+from src.orchestration.paths import REGISTRY_DB
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -117,20 +119,6 @@ def _warn_if_legacy_registry_exists() -> None:
 # ---------------------------------------------------------------------------
 
 RECOVERY_STALE_MINUTES: int = 5
-
-
-# ---------------------------------------------------------------------------
-# DB path helper — mirrors steward-heartbeat.py
-# ---------------------------------------------------------------------------
-
-def _default_db_path() -> Path:
-    workspace = Path(os.environ.get(
-        "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
-    ))
-    env_override = os.environ.get("REGISTRY_DB_PATH")
-    if env_override:
-        return Path(env_override)
-    return workspace / "orchestration" / "registry.db"
 
 
 # ---------------------------------------------------------------------------
@@ -451,7 +439,7 @@ def main() -> int:
 
     from src.orchestration.registry import Registry
 
-    db_path = _default_db_path()
+    db_path = REGISTRY_DB
     if not db_path.exists():
         log.error("Registry DB not found at %s — run install/migrate first", db_path)
         return 1

--- a/scheduled-tasks/garden-caretaker.py
+++ b/scheduled-tasks/garden-caretaker.py
@@ -43,6 +43,8 @@ _SRC_ROOT = _REPO_ROOT / "src"
 if str(_SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(_SRC_ROOT))
 
+from src.orchestration.paths import REGISTRY_DB
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -60,18 +62,6 @@ log = logging.getLogger("garden-caretaker")
 
 _REPO = "dcetlin/Lobster"
 _JOB_NAME = "garden-caretaker"
-
-
-# ---------------------------------------------------------------------------
-# Path helpers — mirrors executor-heartbeat.py convention
-# ---------------------------------------------------------------------------
-
-def _default_db_path() -> Path:
-    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
-    env_override = os.environ.get("REGISTRY_DB_PATH")
-    if env_override:
-        return Path(env_override)
-    return workspace / "orchestration" / "registry.db"
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +120,7 @@ def main() -> int:
         return 0
 
     # Resolve DB path and verify it exists
-    db_path = _default_db_path()
+    db_path = REGISTRY_DB
     if not db_path.exists():
         log.error("Registry DB not found at %s — run install/migrate first", db_path)
         return 1

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -55,6 +55,7 @@ _REPO_ROOT = Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from src.orchestration.paths import REGISTRY_DB
 from src.orchestration.steward import is_bootup_candidate_gate_active, run_steward_cycle
 from src.orchestration.github_sync import run_post_completion_sync
 
@@ -204,18 +205,6 @@ class _Clock(Protocol):
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def _default_db_path() -> Path:
-    workspace = Path(os.environ.get(
-        "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
-    ))
-    # Primary: orchestration/registry.db (used by registry_cli.py and the Executor)
-    # Fallback: REGISTRY_DB_PATH env override (used in tests and alternate installs)
-    env_override = os.environ.get("REGISTRY_DB_PATH")
-    if env_override:
-        return Path(env_override)
-    return workspace / "orchestration" / "registry.db"
 
 
 def _warn_if_legacy_registry_exists() -> None:
@@ -541,7 +530,7 @@ def main() -> int:
 
     from src.orchestration.registry import Registry
 
-    db_path = _default_db_path()
+    db_path = REGISTRY_DB
     if not db_path.exists():
         log.error("Registry DB not found at %s — run install/migrate first", db_path)
         return 1

--- a/src/orchestration/paths.py
+++ b/src/orchestration/paths.py
@@ -12,6 +12,7 @@ Usage:
 Environment variables honored:
     LOBSTER_WORKSPACE  — workspace root (default: ~/lobster-workspace)
     LOBSTER_REPO       — repo root (default: ~/lobster)
+    REGISTRY_DB_PATH   — override path for registry.db (default: <workspace>/orchestration/registry.db)
 """
 
 import os
@@ -33,7 +34,7 @@ LOBSTER_REPO = Path(
 # WOS / orchestration
 # ---------------------------------------------------------------------------
 
-REGISTRY_DB = LOBSTER_WORKSPACE / "orchestration" / "registry.db"
+REGISTRY_DB = Path(os.environ["REGISTRY_DB_PATH"]) if os.environ.get("REGISTRY_DB_PATH") else LOBSTER_WORKSPACE / "orchestration" / "registry.db"
 WOS_CONFIG = LOBSTER_WORKSPACE / "data" / "wos-config.json"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three heartbeat scripts (`executor-heartbeat.py`, `steward-heartbeat.py`, `garden-caretaker.py`) each contained an identical `_default_db_path()` function that re-implemented path logic already centralized in `src/orchestration/paths.py`. This PR consolidates them to use the canonical `REGISTRY_DB` constant.

One gap existed before this change: `paths.py` exported `REGISTRY_DB` as a plain path derived only from `LOBSTER_WORKSPACE`, without honoring the `REGISTRY_DB_PATH` env override that all three inline functions supported. This PR fixes `paths.py` to check `REGISTRY_DB_PATH` first, so the consolidation is behavior-preserving.

## What changed

- `src/orchestration/paths.py`: `REGISTRY_DB` now checks `REGISTRY_DB_PATH` env var before falling back to `<workspace>/orchestration/registry.db`. Also adds `REGISTRY_DB_PATH` to the module-level docstring of honored env vars.
- `scheduled-tasks/executor-heartbeat.py`: removed `_default_db_path()` (lines 126-133), added `from src.orchestration.paths import REGISTRY_DB` import, replaced `db_path = _default_db_path()` with `db_path = REGISTRY_DB`.
- `scheduled-tasks/steward-heartbeat.py`: same three changes applied.
- `scheduled-tasks/garden-caretaker.py`: same three changes applied. Also removed the now-empty `# Path helpers` section header.

No other logic was changed in any of these files.

## Functional pattern

Pure constant — `REGISTRY_DB` is now a module-level value computed once at import time, derived from env vars (read-only inputs). All call sites consume it as an immutable value. No side effects at call site.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_executor_heartbeat.py` — 22 passed
- [x] `uv run pytest tests/unit/test_orchestration/test_garden_caretaker.py tests/unit/test_orchestration/test_registry.py` — 122 passed
- [x] `grep -n "_default_db_path" ...` on all three files — zero matches (verified)
- [x] `grep -n "REGISTRY_DB" ...` on all three files — exactly one import + one usage per file (verified)
- [ ] Full `uv run pytest tests/unit/` suite — not completed in this session due to test runner hanging on slow tests; the 483-pass / 1-fail baseline was confirmed on main (pre-existing failure: `test_dispatch_job_sh::test_disabled_job_writes_no_inbox_message`)

**Blocked items needing attention before merge:** None. The pre-existing test failure is unrelated to this change.

## Manual test

N/A — this change is purely internal refactoring. No external services, no file I/O changes, no cron or systemd changes. The heartbeat scripts continue to resolve to the same DB path at runtime.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, internal refactor only
- [x] User-visible outcome verified — N/A, no user-visible behavior changed
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change