### PR TITLE
fix(bootup): align spawned-agent signal with user.base.bootup.md

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -218,7 +218,7 @@ Your reply text here.
 **When you have NO side effects:** write nothing — omit the footer completely. Do NOT write `side-effects: none`.
 
 Signal legend (10-signal set):
-- `🤖` spawned — subagent or background task launched
+- `🚀 spawned  <task-name>` — agent or background task launched (include the task slug; list each on its own line)
 - `✅` done — task completed
 - `🐙` PR — pull request opened or updated
 - `🔀` merged — PR or branch merged


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

`sys.subagent.bootup.md` declared `🤖` as the spawned-agent signal in its 10-signal legend, while `user.base.bootup.md` (lines 190 and 201) declares `🚀 spawned  <task-name>`. A subagent reading the system bootup file would emit `🤖` and omit the task slug — the wrong emoji and missing information — while the user file tells the dispatcher to expect `🚀 spawned  <task-name>`.

The contradiction means any subagent following sys.subagent.bootup.md produces footers that don't match the dispatcher's expected format.

## Change

Single-line fix in the signal legend:

```
- `🤖` spawned — subagent or background task launched
+ `🚀 spawned  <task-name>` — agent or background task launched (include the task slug; list each on its own line)
```

The replacement wording matches `user.base.bootup.md` line 190 exactly, including the two-space separator and the task-slug instruction.

The `🤖🦞 Lobster` GitHub attribution lines (lines 416-419) are unchanged — those are a different use of `🤖` and are not spawned-agent signals.

## Out of scope

- `user.base.bootup.md` — not touched
- All other signal definitions (`🔴`, `🟡`, `✅`, `🦞`, etc.) — unchanged
- No surrounding prose rewritten beyond the one affected bullet

## Tests run
- [x] `grep -n "🤖" .claude/sys.subagent.bootup.md` — confirmed only GitHub attribution lines remain; spawned-signal line is gone
- [x] Cross-checked line 221 of modified file against `user.base.bootup.md` lines 190 and 201 — exact match on emoji, spacing, and description text
- [ ] Automated test suite — N/A: documentation/config file with no executable tests

## Manual test
N/A — this change is entirely internal to a bootup context file. No runtime behavior, no external service call, no file I/O beyond the config file itself. Correctness verified by grep and cross-file comparison.

## Definition of Done
- [x] Unit tests pass with proper mocking — N/A (doc-only change)
- [x] Integration/manual test run — N/A
- [x] User-visible outcome verified — N/A (internal signal legend, no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none