### PR TITLE
oracle: wire OODA constraint-3 Encoded Orientation check into Stage 2

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -74,6 +74,8 @@ Read the implementation (diff, code, output). Evaluate:
 - What patterns does this introduce that will propagate?
 - What does this make easier for future work? What does it make harder?
 
+**Encoded Orientation (OODA constraint-3):** Does this PR constitute an Encoded Orientation decision — i.e., does it encode a new behavioral orientation into persistent system artifacts (agent definitions, bootup files, gate tables, vision.yaml, CLAUDE.md)? If yes, verify: (a) a prior logged decision exists in `oracle/decisions.md` or equivalent, and (b) the change has a traceable anchor in `vision.yaml` (an `inviolable_constraints`, `operating_principles`, or `active_project` field that directly motivates the change). If either is absent, flag as NEEDS_CHANGES with rationale explaining which anchor is missing. If this PR is purely mechanical (bug fix, typo, refactor with no behavioral intent change, or infrastructure wiring with no new orientation encoded), this check passes automatically — state why it is mechanical.
+
 ---
 
 ## Output


### PR DESCRIPTION
## Summary

`vision.yaml` defines `inviolable_constraints[constraint-3]` (Encoded Orientation), which requires that any decision encoding a new behavioral orientation into persistent system artifacts must have a prior logged decision and a traceable vision.yaml anchor. Until this PR, no agent definition enforced this constraint — it was structurally orphaned.

This PR adds an explicit named check to the oracle's Stage 2 review criteria. The oracle is the correct enforcement point because it gates every PR before merge.

## What changed

A single named check — **Encoded Orientation (OODA constraint-3)** — was added to the Stage 2 section of `.claude/agents/lobster-oracle.md`. It requires the oracle to:

1. Determine whether the PR constitutes an Encoded Orientation decision (encodes new behavioral orientation into agent definitions, bootup files, gate tables, vision.yaml, or CLAUDE.md).
2. If yes: verify (a) a prior logged decision exists in `oracle/decisions.md` or equivalent, and (b) the change has a traceable anchor in `vision.yaml` (`inviolable_constraints`, `operating_principles`, or `active_project`).
3. If either anchor is absent: flag NEEDS_CHANGES with specific rationale.
4. If the PR is purely mechanical (bug fix, typo, refactor, infrastructure wiring with no behavioral intent change): the check passes automatically — oracle states why it is mechanical.

The check is inserted as a bold named paragraph within Stage 2, matching the voice and format of the existing section.

## What was not changed

- No new agents, no new workflow steps, no redesign of the oracle flow.
- `sys.dispatcher.bootup.md` was evaluated for a natural home for a discoverability reference — no natural section exists there for constraint references, so that step was skipped per the prescription.
- CLAUDE.md's Tier-1 Gate Register was not modified — constraint enforcement belongs in the oracle agent definition, not the dispatcher gate table.

## Functional patterns

Pure behavioral instruction layer edit — no code. The change is declarative: it names a check, specifies what to verify, gives the failure condition, and gives the pass condition for mechanical PRs to prevent false positives.

## Tests run

- [x] Read the edited section of `lobster-oracle.md` — Encoded Orientation check present at line 77, names constraint-3, specifies both required anchors (decisions.md + vision.yaml), gives explicit pass condition for mechanical PRs.
- [x] Verified against `vision.yaml` constraint-3 verbatim — the check accurately reflects the constraint's full requirement (prior logged decision + traceable vision.yaml anchor).
- [ ] No automated tests applicable — behavioral instruction layer edit only.

## Manual test

N/A — this change is entirely internal to the oracle agent definition. No external service calls, no file I/O affecting runtime state, no systemd/cron involvement.

## Definition of Done

- [x] Unit tests pass with proper mocking — N/A (no code)
- [x] Integration/manual test — N/A (behavioral instruction edit)
- [x] User-visible outcome: oracle will now flag Encoded Orientation PRs that lack a prior decision or vision.yaml anchor — verifiable on the next oracle run against an orientation-encoding PR
- [x] Side-effect audit: no floods, no writes, no unintended volume — edit is read-only at runtime
- [x] External service calls: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)