### PR TITLE
fix: warn when Claude API token near expiry in _build_claude_env

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -166,6 +166,48 @@ _LLM_FALLBACK_WARNING_THRESHOLD = 3
 # Path to Claude Code credentials (OAuth tokens).
 _CREDENTIALS_PATH = Path(os.path.expanduser("~/.claude/.credentials.json"))
 
+# Warn when the token expires within this many seconds (2 hours).
+_TOKEN_EXPIRY_WARN_SECONDS = 2 * 3600
+
+
+def _check_token_expiry(expires_at: object) -> None:
+    """Log a warning or error if the OAuth token is near expiry or already expired.
+
+    Handles both ISO 8601 strings and Unix timestamps (int/float).  If the
+    value is absent, None, or unparseable the function logs at DEBUG level and
+    returns — this is not treated as an error.
+    """
+    if expires_at is None:
+        log.debug("_build_claude_env: expiresAt not present in credentials.json — skipping expiry check")
+        return
+
+    now = datetime.now(timezone.utc)
+
+    try:
+        if isinstance(expires_at, (int, float)):
+            expiry = datetime.fromtimestamp(expires_at, tz=timezone.utc)
+        else:
+            expiry = datetime.fromisoformat(str(expires_at))
+            # Attach UTC if the parsed datetime is naive.
+            if expiry.tzinfo is None:
+                expiry = expiry.replace(tzinfo=timezone.utc)
+    except (ValueError, OSError, OverflowError) as exc:
+        log.debug("_build_claude_env: could not parse expiresAt %r: %s — skipping expiry check", expires_at, exc)
+        return
+
+    hours_remaining = (expiry - now).total_seconds() / 3600
+
+    if hours_remaining < 0:
+        log.error(
+            "Claude API token expired %.1f hours ago — prescription will fail with 401",
+            abs(hours_remaining),
+        )
+    elif hours_remaining * 3600 < _TOKEN_EXPIRY_WARN_SECONDS:
+        log.warning(
+            "Claude API token expires in %.1f hours — refresh credentials before next cycle",
+            hours_remaining,
+        )
+
 
 def _build_claude_env() -> dict[str, str]:
     """Build an environment dict suitable for spawning a `claude -p` subprocess.
@@ -202,6 +244,7 @@ def _build_claude_env() -> dict[str, str]:
         if token:
             env["CLAUDE_CODE_OAUTH_TOKEN"] = token
             log.debug("_build_claude_env: injected CLAUDE_CODE_OAUTH_TOKEN from credentials.json")
+        _check_token_expiry(oauth.get("expiresAt"))
     except (OSError, json.JSONDecodeError, KeyError) as exc:
         log.warning("_build_claude_env: could not read credentials.json: %s", exc)
 

--- a/tests/unit/test_orchestration/test_build_claude_env_expiry.py
+++ b/tests/unit/test_orchestration/test_build_claude_env_expiry.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for _build_claude_env() expiry awareness.
+
+Covers:
+- test_build_claude_env_warns_near_expiry: token expiring in 1 hour → WARNING logged
+- test_build_claude_env_errors_on_expired: token expired 1 hour ago → ERROR logged
+- test_build_claude_env_no_expiry_field: credentials without expiresAt → no warning/error
+- test_build_claude_env_unix_timestamp_near_expiry: expiresAt as Unix int → WARNING logged
+- test_build_claude_env_malformed_expiry: unparseable expiresAt → only DEBUG, no warning/error
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.orchestration.steward import (
+    _TOKEN_EXPIRY_WARN_SECONDS,
+    _build_claude_env,
+    _check_token_expiry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_credentials(expires_at=None, access_token="tok-abc") -> str:
+    """Build a minimal credentials.json payload."""
+    oauth: dict = {"accessToken": access_token}
+    if expires_at is not None:
+        oauth["expiresAt"] = expires_at
+    return json.dumps({"claudeAiOauth": oauth})
+
+
+# ---------------------------------------------------------------------------
+# Tests for _check_token_expiry (pure unit — no filesystem)
+# ---------------------------------------------------------------------------
+
+class TestCheckTokenExpiry:
+    def test_warns_near_expiry_iso_string(self, caplog):
+        """Token expiring in 1 hour (well within 2-hour threshold) → WARNING."""
+        soon = datetime.now(timezone.utc) + timedelta(hours=1)
+        with caplog.at_level("WARNING", logger="src.orchestration.steward"):
+            _check_token_expiry(soon.isoformat())
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "Expected a WARNING log for near-expiry token"
+        assert "expires in" in warnings[0].message
+
+    def test_errors_on_expired_iso_string(self, caplog):
+        """Token expired 1 hour ago → ERROR."""
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        with caplog.at_level("ERROR", logger="src.orchestration.steward"):
+            _check_token_expiry(past.isoformat())
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert errors, "Expected an ERROR log for expired token"
+        assert "expired" in errors[0].message
+
+    def test_no_warning_for_fresh_token(self, caplog):
+        """Token expiring in 10 hours (beyond 2-hour threshold) → no warning/error."""
+        future = datetime.now(timezone.utc) + timedelta(hours=10)
+        with caplog.at_level("DEBUG", logger="src.orchestration.steward"):
+            _check_token_expiry(future.isoformat())
+        bad = [r for r in caplog.records if r.levelname in ("WARNING", "ERROR")]
+        assert not bad, f"Unexpected warning/error for fresh token: {bad}"
+
+    def test_warns_near_expiry_unix_timestamp(self, caplog):
+        """expiresAt as a Unix integer (1 hour from now) → WARNING."""
+        soon = datetime.now(timezone.utc) + timedelta(hours=1)
+        unix_ts = soon.timestamp()
+        with caplog.at_level("WARNING", logger="src.orchestration.steward"):
+            _check_token_expiry(unix_ts)
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "Expected a WARNING log for near-expiry Unix timestamp"
+
+    def test_no_log_for_none(self, caplog):
+        """None expiresAt → only DEBUG, no warning/error."""
+        with caplog.at_level("DEBUG", logger="src.orchestration.steward"):
+            _check_token_expiry(None)
+        bad = [r for r in caplog.records if r.levelname in ("WARNING", "ERROR")]
+        assert not bad, f"Unexpected warning/error for None expiresAt: {bad}"
+
+    def test_debug_for_malformed_expiry(self, caplog):
+        """Unparseable expiresAt → only DEBUG, no warning/error."""
+        with caplog.at_level("DEBUG", logger="src.orchestration.steward"):
+            _check_token_expiry("not-a-date")
+        bad = [r for r in caplog.records if r.levelname in ("WARNING", "ERROR")]
+        assert not bad, f"Unexpected warning/error for malformed expiresAt: {bad}"
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_claude_env() (filesystem-level — mock credentials.json)
+# ---------------------------------------------------------------------------
+
+class TestBuildClaudeEnv:
+    def test_build_claude_env_warns_near_expiry(self, caplog, tmp_path, monkeypatch):
+        """Mock credentials with expiresAt 1 hour from now → WARNING logged."""
+        soon = datetime.now(timezone.utc) + timedelta(hours=1)
+        creds_file = tmp_path / ".credentials.json"
+        creds_file.write_text(_make_credentials(expires_at=soon.isoformat()))
+
+        import src.orchestration.steward as steward_mod
+        monkeypatch.setattr(steward_mod, "_CREDENTIALS_PATH", creds_file)
+        # Ensure CLAUDE_CODE_OAUTH_TOKEN is not in env so we hit the slow path.
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        with caplog.at_level("WARNING", logger="src.orchestration.steward"):
+            _build_claude_env()
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "Expected WARNING for near-expiry token in _build_claude_env"
+        assert "expires in" in warnings[0].message
+
+    def test_build_claude_env_errors_on_expired(self, caplog, tmp_path, monkeypatch):
+        """Mock credentials with expiresAt 1 hour ago → ERROR logged."""
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        creds_file = tmp_path / ".credentials.json"
+        creds_file.write_text(_make_credentials(expires_at=past.isoformat()))
+
+        import src.orchestration.steward as steward_mod
+        monkeypatch.setattr(steward_mod, "_CREDENTIALS_PATH", creds_file)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        with caplog.at_level("ERROR", logger="src.orchestration.steward"):
+            _build_claude_env()
+
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert errors, "Expected ERROR for expired token in _build_claude_env"
+        assert "expired" in errors[0].message
+
+    def test_build_claude_env_no_expiry_field(self, caplog, tmp_path, monkeypatch):
+        """credentials.json without expiresAt → no warning or error logged."""
+        creds_file = tmp_path / ".credentials.json"
+        creds_file.write_text(_make_credentials())  # no expires_at
+
+        import src.orchestration.steward as steward_mod
+        monkeypatch.setattr(steward_mod, "_CREDENTIALS_PATH", creds_file)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        with caplog.at_level("DEBUG", logger="src.orchestration.steward"):
+            _build_claude_env()
+
+        bad = [r for r in caplog.records if r.levelname in ("WARNING", "ERROR")]
+        assert not bad, f"Unexpected warning/error when expiresAt absent: {bad}"
+
+    def test_build_claude_env_fast_path_skips_expiry_check(self, caplog, monkeypatch):
+        """When CLAUDE_CODE_OAUTH_TOKEN already set in env, credentials.json is not read."""
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "already-set")
+
+        with caplog.at_level("DEBUG", logger="src.orchestration.steward"):
+            env = _build_claude_env()
+
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "already-set"
+        # No expiry-related log should appear since we never read credentials.json.
+        bad = [r for r in caplog.records if "expir" in r.message.lower() and r.levelname in ("WARNING", "ERROR")]
+        assert not bad, f"Unexpected expiry log on fast path: {bad}"


### PR DESCRIPTION
## Problem

When a Claude OAuth token expires, `_build_claude_env()` silently returns a stale token and the prescription subprocess fails with a 401. There is no advance warning — the failure is indistinguishable from any other subprocess error until logs are dug through after the fact.

## What this changes

Adds a `_check_token_expiry()` helper (pure function, no side effects beyond logging) called from the slow path in `_build_claude_env()` after credentials are loaded:

- Token expires **within 2 hours** (`_TOKEN_EXPIRY_WARN_SECONDS = 7200`): logs `WARNING` with hours remaining.
- Token **already expired**: logs `ERROR` with how long ago it expired.
- `expiresAt` **absent or None**: logs `DEBUG` only — credentials without an expiry field are not treated as a problem.
- `expiresAt` **unparseable**: logs `DEBUG` only — graceful degradation, no exception raised.

Handles both ISO 8601 strings and Unix timestamps (int/float). The function signature and return value of `_build_claude_env()` are unchanged. No refresh logic is implemented.

The fast path (token already in environment) is unaffected — credentials.json is never read and no expiry check is performed.

## Functional patterns

Pure helper function (`_check_token_expiry`) with explicit input/output contract isolated from I/O. Side effects (logging) are contained in this helper and do not propagate to `_build_claude_env()`'s return value.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_build_claude_env_expiry.py -v` — 10 passed, 0 failed
  - `test_warns_near_expiry_iso_string` — WARNING logged for token 1 hour away (ISO string)
  - `test_errors_on_expired_iso_string` — ERROR logged for token 1 hour past expiry
  - `test_no_warning_for_fresh_token` — no warning for token 10 hours away
  - `test_warns_near_expiry_unix_timestamp` — WARNING logged for Unix int timestamp
  - `test_no_log_for_none` — no warning/error when expiresAt is None
  - `test_debug_for_malformed_expiry` — no warning/error for unparseable value
  - `test_build_claude_env_warns_near_expiry` — integration path: monkeypatched credentials file, WARNING surfaced
  - `test_build_claude_env_errors_on_expired` — integration path: ERROR surfaced
  - `test_build_claude_env_no_expiry_field` — integration path: no warning when field absent
  - `test_build_claude_env_fast_path_skips_expiry_check` — fast path does not trigger any expiry log

## Manual test

N/A — this change is entirely internal (logging only). No external services, no file I/O on runtime state, no systemd or cron changes.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (logging only, no external calls)
- [x] User-visible outcome verified — N/A (log output only, not user-facing)
- [x] Side-effect audit complete: no floods, no unscoped writes — function only appends to log
- [x] External service calls — none

Closes #775