### PR TITLE
refactor: consolidate write_inbox_message() into shared utility (closes #781)

### DIFF
--- a/scheduled-tasks/auto-router.py
+++ b/scheduled-tasks/auto-router.py
@@ -37,6 +37,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from src.orchestration.paths import SURFACE_QUEUE  # noqa: E402
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir, write_inbox_message  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -327,51 +328,6 @@ def apply_routing(
     return [update(i) for i in items]
 
 
-# ---------------------------------------------------------------------------
-# Inbox / task-output I/O helpers
-# ---------------------------------------------------------------------------
-
-def _inbox_dir() -> Path:
-    """Return the inbox directory path, creating it if needed."""
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    inbox = Path(messages_base) / "inbox"
-    inbox.mkdir(parents=True, exist_ok=True)
-    return inbox
-
-
-def _task_outputs_dir() -> Path:
-    """Return the task-outputs directory path, creating it if needed."""
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    task_outputs = Path(messages_base) / "task-outputs"
-    task_outputs.mkdir(parents=True, exist_ok=True)
-    return task_outputs
-
-
-def write_inbox_message(chat_id: int, text: str, timestamp: str) -> str:
-    """
-    Write a single subagent_result message to the inbox using atomic tmp-then-replace.
-    Returns the message ID. Side effects isolated here.
-    """
-    inbox = _inbox_dir()
-    msg_id = f"auto_router_{uuid.uuid4().hex}"
-    msg = {
-        "id": msg_id,
-        "type": "subagent_result",
-        "task_id": msg_id,
-        "chat_id": chat_id,
-        "source": os.environ.get("LOBSTER_DEFAULT_SOURCE", "telegram"),
-        "text": text,
-        "status": "success",
-        "sent_reply_to_user": False,
-        "timestamp": timestamp,
-    }
-    out_path = inbox / f"{msg_id}.json"
-    tmp_path = Path(str(out_path) + ".tmp")
-    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp_path.replace(out_path)
-    return msg_id
-
-
 def write_task_output(output: str, status: str, timestamp: str) -> None:
     """Write a task output record to the task-outputs directory."""
     task_outputs = _task_outputs_dir()
@@ -444,7 +400,7 @@ def run() -> int:
             msg_text = format_design_surface_message(item)
             design_count += 1
 
-        write_inbox_message(ADMIN_CHAT_ID, msg_text, timestamp_iso)
+        write_inbox_message("auto-router", ADMIN_CHAT_ID, msg_text, timestamp_iso)
 
     # Update queue
     updated_items = apply_routing(items, routed_pairs, timestamp_iso)

--- a/scheduled-tasks/daily-metrics.py
+++ b/scheduled-tasks/daily-metrics.py
@@ -27,6 +27,16 @@ import uuid
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir, write_inbox_message  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Pure data helpers
@@ -352,40 +362,6 @@ def format_report(
 JOB_NAME = "daily-metrics"
 
 
-def _inbox_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    inbox = Path(messages_base) / "inbox"
-    inbox.mkdir(parents=True, exist_ok=True)
-    return inbox
-
-
-def _task_outputs_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    task_outputs = Path(messages_base) / "task-outputs"
-    task_outputs.mkdir(parents=True, exist_ok=True)
-    return task_outputs
-
-
-def write_inbox_message(chat_id: int, text: str, timestamp: str) -> None:
-    inbox = _inbox_dir()
-    msg_id = f"{JOB_NAME}_{uuid.uuid4().hex}"
-    msg = {
-        "id": msg_id,
-        "type": "subagent_result",
-        "task_id": msg_id,
-        "chat_id": chat_id,
-        "source": "telegram",
-        "text": text,
-        "status": "success",
-        "sent_reply_to_user": False,
-        "timestamp": timestamp,
-    }
-    out_path = inbox / f"{msg_id}.json"
-    tmp_path = Path(str(out_path) + ".tmp")
-    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp_path.replace(out_path)
-
-
 def write_task_output_record(output: str, status: str, timestamp: str) -> None:
     task_outputs = _task_outputs_dir()
     date_prefix = timestamp[:19].replace(":", "").replace("-", "").replace("T", "-")
@@ -409,7 +385,7 @@ def deliver(summary: str, date: str) -> None:
     """
     chat_id = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    write_inbox_message(chat_id, summary, timestamp)
+    write_inbox_message(JOB_NAME, chat_id, summary, timestamp)
     write_task_output_record(f"Daily metrics for {date} delivered to Telegram.", "success", timestamp)
 
 

--- a/scheduled-tasks/pattern-candidate-sweep.py
+++ b/scheduled-tasks/pattern-candidate-sweep.py
@@ -34,6 +34,16 @@ from collections import Counter
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir, write_inbox_message  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Stop words — common English terms that carry no semantic signal
@@ -284,40 +294,6 @@ def write_artifact(sweeps_dir: Path, path: Path, content: str) -> None:
 JOB_NAME = "pattern-candidate-sweep"
 
 
-def _inbox_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    inbox = Path(messages_base) / "inbox"
-    inbox.mkdir(parents=True, exist_ok=True)
-    return inbox
-
-
-def _task_outputs_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    task_outputs = Path(messages_base) / "task-outputs"
-    task_outputs.mkdir(parents=True, exist_ok=True)
-    return task_outputs
-
-
-def write_inbox_message(chat_id: int, text: str, timestamp: str) -> None:
-    inbox = _inbox_dir()
-    msg_id = f"{JOB_NAME}_{uuid.uuid4().hex}"
-    msg = {
-        "id": msg_id,
-        "type": "subagent_result",
-        "task_id": msg_id,
-        "chat_id": chat_id,
-        "source": "telegram",
-        "text": text,
-        "status": "success",
-        "sent_reply_to_user": False,
-        "timestamp": timestamp,
-    }
-    out_path = inbox / f"{msg_id}.json"
-    tmp_path = Path(str(out_path) + ".tmp")
-    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp_path.replace(out_path)
-
-
 def write_task_output_record(output: str, status: str, timestamp: str) -> None:
     task_outputs = _task_outputs_dir()
     date_prefix = timestamp[:19].replace(":", "").replace("-", "").replace("T", "-")
@@ -337,7 +313,7 @@ def write_task_output_record(output: str, status: str, timestamp: str) -> None:
 def deliver_and_log(summary: str, artifact_path_str: str) -> None:
     chat_id = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    write_inbox_message(chat_id, summary, timestamp)
+    write_inbox_message(JOB_NAME, chat_id, summary, timestamp)
     write_task_output_record(
         f"Sweep complete. Artifact: {artifact_path_str}. Summary sent to Telegram.",
         "success",

--- a/scheduled-tasks/proposals-digest.py
+++ b/scheduled-tasks/proposals-digest.py
@@ -25,6 +25,16 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir, write_inbox_message  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -198,45 +208,6 @@ def format_task_summary(delivered: int, remaining: int) -> str:
 # Inbox / task-output I/O helpers
 # ---------------------------------------------------------------------------
 
-def _inbox_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    inbox = Path(messages_base) / "inbox"
-    inbox.mkdir(parents=True, exist_ok=True)
-    return inbox
-
-
-def _task_outputs_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    task_outputs = Path(messages_base) / "task-outputs"
-    task_outputs.mkdir(parents=True, exist_ok=True)
-    return task_outputs
-
-
-def write_inbox_message(chat_id: int, text: str, ts: str) -> None:
-    """
-    Write a subagent_result message to the Lobster inbox.
-    The dispatcher picks it up and routes it via send_reply.
-    All I/O is isolated to this function.
-    """
-    inbox = _inbox_dir()
-    msg_id = f"proposals_digest_{uuid.uuid4().hex}"
-    msg = {
-        "id": msg_id,
-        "type": "subagent_result",
-        "task_id": msg_id,
-        "chat_id": chat_id,
-        "source": "telegram",
-        "text": text,
-        "status": "success",
-        "sent_reply_to_user": False,
-        "timestamp": ts,
-    }
-    out_path = inbox / f"{msg_id}.json"
-    tmp_path = Path(str(out_path) + ".tmp")
-    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp_path.replace(out_path)
-
-
 def write_task_output(output: str, status: str, ts: str) -> None:
     task_outputs = _task_outputs_dir()
     date_prefix = ts[:19].replace(":", "").replace("-", "").replace("T", "-")
@@ -306,7 +277,7 @@ def run() -> int:
     ]
 
     for msg_text in messages:
-        write_inbox_message(chat_id, msg_text, ts)
+        write_inbox_message(JOB_NAME, chat_id, msg_text, ts)
 
     # Mark delivered entries in the file
     updated_content = mark_all_delivered(content, to_deliver, date_today)

--- a/scheduled-tasks/surface-queue-delivery.py
+++ b/scheduled-tasks/surface-queue-delivery.py
@@ -35,6 +35,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from src.orchestration.paths import SURFACE_QUEUE  # noqa: E402
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir, write_inbox_message  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -301,47 +302,6 @@ def format_summary(delivered_count: int, archived_count: int, remaining_count: i
 # Inbox / task-output I/O helpers
 # ---------------------------------------------------------------------------
 
-def _inbox_dir() -> Path:
-    """Return the inbox directory path, creating it if needed."""
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    inbox = Path(messages_base) / "inbox"
-    inbox.mkdir(parents=True, exist_ok=True)
-    return inbox
-
-
-def _task_outputs_dir() -> Path:
-    """Return the task-outputs directory path, creating it if needed."""
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    task_outputs = Path(messages_base) / "task-outputs"
-    task_outputs.mkdir(parents=True, exist_ok=True)
-    return task_outputs
-
-
-def write_inbox_message(chat_id: int, text: str, timestamp: str) -> None:
-    """
-    Write a single subagent_result message to the inbox.
-    The dispatcher picks it up and routes it via send_reply.
-    Pure side-effect boundary: all I/O is isolated here.
-    """
-    inbox = _inbox_dir()
-    msg_id = f"surface_queue_delivery_{uuid.uuid4().hex}"
-    msg = {
-        "id": msg_id,
-        "type": "subagent_result",
-        "task_id": msg_id,
-        "chat_id": chat_id,
-        "source": "telegram",
-        "text": text,
-        "status": "success",
-        "sent_reply_to_user": False,
-        "timestamp": timestamp,
-    }
-    out_path = inbox / f"{msg_id}.json"
-    tmp_path = Path(str(out_path) + ".tmp")
-    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp_path.replace(out_path)
-
-
 def write_task_output(output: str, status: str, timestamp: str) -> None:
     """
     Write a task output record directly to the task-outputs directory.
@@ -374,7 +334,7 @@ def deliver(digest_text: str, job_summary: str) -> None:
     """
     chat_id = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    write_inbox_message(chat_id, digest_text, timestamp)
+    write_inbox_message("surface-queue-delivery", chat_id, digest_text, timestamp)
     write_task_output(job_summary, "success", timestamp)
 
 

--- a/scheduled-tasks/weekly-epistemic-retro.py
+++ b/scheduled-tasks/weekly-epistemic-retro.py
@@ -27,6 +27,16 @@ import uuid
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir, write_inbox_message  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Pure data helpers
@@ -287,40 +297,6 @@ def write_artifact(retros_dir: Path, path: Path, content: str) -> None:
 JOB_NAME = "weekly-epistemic-retro"
 
 
-def _inbox_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    inbox = Path(messages_base) / "inbox"
-    inbox.mkdir(parents=True, exist_ok=True)
-    return inbox
-
-
-def _task_outputs_dir() -> Path:
-    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
-    task_outputs = Path(messages_base) / "task-outputs"
-    task_outputs.mkdir(parents=True, exist_ok=True)
-    return task_outputs
-
-
-def write_inbox_message(chat_id: int, text: str, timestamp: str) -> None:
-    inbox = _inbox_dir()
-    msg_id = f"{JOB_NAME}_{uuid.uuid4().hex}"
-    msg = {
-        "id": msg_id,
-        "type": "subagent_result",
-        "task_id": msg_id,
-        "chat_id": chat_id,
-        "source": "telegram",
-        "text": text,
-        "status": "success",
-        "sent_reply_to_user": False,
-        "timestamp": timestamp,
-    }
-    out_path = inbox / f"{msg_id}.json"
-    tmp_path = Path(str(out_path) + ".tmp")
-    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp_path.replace(out_path)
-
-
 def write_task_output_record(output: str, status: str, timestamp: str) -> None:
     task_outputs = _task_outputs_dir()
     date_prefix = timestamp[:19].replace(":", "").replace("-", "").replace("T", "-")
@@ -344,7 +320,7 @@ def deliver_and_log(summary: str, artifact_path_str: str) -> None:
     """
     chat_id = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    write_inbox_message(chat_id, summary, timestamp)
+    write_inbox_message(JOB_NAME, chat_id, summary, timestamp)
     write_task_output_record(
         f"Retro completed. Artifact written to {artifact_path_str}. Summary delivered to Telegram.",
         "success",

--- a/src/utils/inbox_write.py
+++ b/src/utils/inbox_write.py
@@ -1,0 +1,91 @@
+"""
+Shared inbox I/O helpers for Lobster scheduled-task scripts.
+
+Consolidates the copy-pasted write_inbox_message() / _inbox_dir() pattern
+that previously appeared in six separate scripts (issue #781).
+
+Public API
+----------
+write_inbox_message(job_name, chat_id, text, timestamp) -> str
+    Write a subagent_result JSON to ~/messages/inbox/ using atomic
+    tmp-then-rename.  Returns the message ID so callers can log it.
+
+_inbox_dir() -> Path
+_task_outputs_dir() -> Path
+    Directory helpers; exposed for scripts that need the raw path (e.g. to
+    construct task-output filenames with a consistent date prefix).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+
+
+def _inbox_dir() -> Path:
+    """Return the inbox directory path, creating it if needed."""
+    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
+    inbox = Path(messages_base) / "inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+    return inbox
+
+
+def _task_outputs_dir() -> Path:
+    """Return the task-outputs directory path, creating it if needed."""
+    messages_base = os.environ.get("LOBSTER_MESSAGES", str(Path.home() / "messages"))
+    task_outputs = Path(messages_base) / "task-outputs"
+    task_outputs.mkdir(parents=True, exist_ok=True)
+    return task_outputs
+
+
+def write_inbox_message(
+    job_name: str,
+    chat_id: int,
+    text: str,
+    timestamp: str,
+) -> str:
+    """
+    Write a single subagent_result message to the Lobster inbox.
+
+    Uses atomic tmp-then-rename so the dispatcher never reads a partial file.
+    The dispatcher picks up the file and routes it via send_reply.
+
+    Parameters
+    ----------
+    job_name:
+        Short identifier for the calling job (e.g. ``"daily-metrics"``).
+        Used as the prefix of the generated message ID so log entries are
+        traceable back to their origin.
+    chat_id:
+        Telegram chat ID to deliver the message to.
+    text:
+        Human-readable message body.
+    timestamp:
+        ISO-8601 timestamp string (e.g. ``datetime.now(timezone.utc).isoformat()``).
+
+    Returns
+    -------
+    str
+        The generated message ID (``"<job_name>_<uuid-hex>"``).
+    """
+    inbox = _inbox_dir()
+    msg_id = f"{job_name}_{uuid.uuid4().hex}"
+    source = os.environ.get("LOBSTER_DEFAULT_SOURCE", "telegram")
+    msg = {
+        "id": msg_id,
+        "type": "subagent_result",
+        "task_id": msg_id,
+        "chat_id": chat_id,
+        "source": source,
+        "text": text,
+        "status": "success",
+        "sent_reply_to_user": False,
+        "timestamp": timestamp,
+    }
+    out_path = inbox / f"{msg_id}.json"
+    tmp_path = Path(str(out_path) + ".tmp")
+    tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp_path.replace(out_path)
+    return msg_id

--- a/tests/unit/test_inbox_write.py
+++ b/tests/unit/test_inbox_write.py
@@ -1,0 +1,127 @@
+"""
+Tests for src/utils/inbox_write.py
+
+Verifies the behavior of the consolidated write_inbox_message() function
+that replaces the copy-pasted implementations across 6 scheduled-task scripts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir, write_inbox_message
+
+
+# ---------------------------------------------------------------------------
+# _inbox_dir / _task_outputs_dir
+# ---------------------------------------------------------------------------
+
+class TestDirectoryHelpers:
+    def test_inbox_dir_uses_lobster_messages_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        result = _inbox_dir()
+        assert result == tmp_path / "inbox"
+        assert result.is_dir()
+
+    def test_task_outputs_dir_uses_lobster_messages_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        result = _task_outputs_dir()
+        assert result == tmp_path / "task-outputs"
+        assert result.is_dir()
+
+    def test_inbox_dir_falls_back_to_home_messages(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("LOBSTER_MESSAGES", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = _inbox_dir()
+        assert result == tmp_path / "messages" / "inbox"
+
+    def test_directories_are_created_if_absent(self, tmp_path, monkeypatch):
+        messages_root = tmp_path / "new_messages_dir"
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(messages_root))
+        assert not messages_root.exists()
+        _inbox_dir()
+        assert (messages_root / "inbox").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# write_inbox_message — schema correctness
+# ---------------------------------------------------------------------------
+
+class TestWriteInboxMessageSchema:
+    def test_writes_valid_json_with_correct_fields(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_DEFAULT_SOURCE", "telegram")
+        msg_id = write_inbox_message(
+            job_name="test-job",
+            chat_id=12345,
+            text="hello world",
+            timestamp="2026-04-20T01:00:00+00:00",
+        )
+        inbox = tmp_path / "inbox"
+        written = list(inbox.glob("*.json"))
+        assert len(written) == 1
+        payload = json.loads(written[0].read_text())
+        assert payload["type"] == "subagent_result"
+        assert payload["chat_id"] == 12345
+        assert payload["text"] == "hello world"
+        assert payload["status"] == "success"
+        assert payload["sent_reply_to_user"] is False
+        assert payload["timestamp"] == "2026-04-20T01:00:00+00:00"
+        assert payload["id"] == msg_id
+        assert payload["task_id"] == msg_id
+
+    def test_msg_id_prefixed_with_job_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        msg_id = write_inbox_message("daily-metrics", 1, "text", "2026-04-20T00:00:00Z")
+        assert msg_id.startswith("daily-metrics_")
+
+    def test_returns_msg_id_string(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        result = write_inbox_message("weekly-epistemic-retro", 99, "x", "2026-04-20T00:00:00Z")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_each_call_generates_unique_msg_id(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        id1 = write_inbox_message("job", 1, "a", "2026-04-20T00:00:00Z")
+        id2 = write_inbox_message("job", 1, "b", "2026-04-20T00:00:00Z")
+        assert id1 != id2
+
+    def test_source_uses_lobster_default_source_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_DEFAULT_SOURCE", "slack")
+        write_inbox_message("job", 1, "msg", "2026-04-20T00:00:00Z")
+        inbox = tmp_path / "inbox"
+        payload = json.loads(next(inbox.glob("*.json")).read_text())
+        assert payload["source"] == "slack"
+
+    def test_source_defaults_to_telegram_when_env_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        monkeypatch.delenv("LOBSTER_DEFAULT_SOURCE", raising=False)
+        write_inbox_message("job", 1, "msg", "2026-04-20T00:00:00Z")
+        inbox = tmp_path / "inbox"
+        payload = json.loads(next(inbox.glob("*.json")).read_text())
+        assert payload["source"] == "telegram"
+
+
+# ---------------------------------------------------------------------------
+# write_inbox_message — atomic write (no .tmp files left behind)
+# ---------------------------------------------------------------------------
+
+class TestAtomicWrite:
+    def test_no_tmp_file_left_after_write(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        write_inbox_message("job", 1, "text", "2026-04-20T00:00:00Z")
+        inbox = tmp_path / "inbox"
+        tmp_files = list(inbox.glob("*.tmp"))
+        assert tmp_files == [], f"leftover .tmp files: {tmp_files}"
+
+    def test_output_file_named_after_msg_id(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        msg_id = write_inbox_message("surface-queue-delivery", 2, "t", "2026-04-20T00:00:00Z")
+        inbox = tmp_path / "inbox"
+        assert (inbox / f"{msg_id}.json").exists()


### PR DESCRIPTION
## Problem

Any schema change to the inbox message format — adding a required field, renaming a key, changing the `sent_reply_to_user` default — required identical edits in six separate files. One would inevitably be missed, creating a silent inconsistency in the inbox record from whichever job ran first after the partial update.

## What changed

A canonical `write_inbox_message(job_name, chat_id, text, timestamp) -> str` now lives in `src/utils/inbox_write.py`. The six scripts (`auto-router.py`, `daily-metrics.py`, `pattern-candidate-sweep.py`, `proposals-digest.py`, `surface-queue-delivery.py`, `weekly-epistemic-retro.py`) import from it and remove their local copies.

Two smaller decisions made during consolidation:

- **Return type standardized to `str` (msg_id)** — `auto-router.py` already returned the msg_id; the other five returned `None`. All six now return `str`. Callers that previously ignored the return value continue to work.
- **Source field uses `LOBSTER_DEFAULT_SOURCE` env var** — `auto-router.py` did this correctly; the other five hardcoded `"telegram"`. The canonical implementation matches `auto-router.py`'s behavior.

No behavioral changes beyond the source field fix. The atomic tmp-then-rename write pattern and schema fields are identical to the existing implementations.

Scripts that did not have path setup (`daily-metrics.py`, `pattern-candidate-sweep.py`, `proposals-digest.py`, `weekly-epistemic-retro.py`) received the standard `_REPO_ROOT` sys.path block that `auto-router.py` and `surface-queue-delivery.py` already used.

## Functional patterns

- `write_inbox_message()` is a pure function with a single side-effect boundary: one atomic filesystem write at the end. No shared state, no mutation of inputs.
- `_inbox_dir()` and `_task_outputs_dir()` remain re-exported from the shared module so that each script's `write_task_output` function (which is still local, and was not in scope for this issue) continues to call them without modification.

## Out of scope

`write_task_output` / `write_task_output_record` functions in each script were not touched — they are structurally similar but have per-script filename conventions (e.g., `{date_prefix}-auto-router.json`) that would require a different consolidation approach. That's a follow-on.

`executor.py`, `registry.py`, and WOS orchestration files were not modified.

## Tests run

- [x] `uv run pytest tests/unit/test_inbox_write.py -v` — 12 passed, 0 failed
- [x] `uv run pytest tests/unit/test_surface_queue_delivery.py -v` — 20 passed, 0 failed (regression check on most affected script)
- [x] `uv run pytest tests/unit/ -x -q` — 483 passed, 1 pre-existing failure (`test_dispatch_job_sh.py::TestRunJobShDisabledFlag::test_disabled_job_writes_no_inbox_message` — confirmed failing on `main` before this branch)

## Manual test

N/A — this change is entirely internal filesystem refactoring. No external service calls, no systemd units, no schema changes. The write path is exercised by the unit tests using `LOBSTER_MESSAGES` env override and `tmp_path` fixtures.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — not applicable (pure refactor, no external services)
- [x] User-visible outcome verified — not applicable (no user-visible behavior changed)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none introduced