### PR TITLE
fix: correct stale oracle learnings.md path in lobster-meta.md

### DIFF
--- a/.claude/agents/lobster-meta.md
+++ b/.claude/agents/lobster-meta.md
@@ -11,7 +11,7 @@ You are a Lobster subagent running as a scheduled task via `run-job.sh`. You do 
 
 Read `~/lobster-user-config/vision.yaml` before beginning.
 
-Before surfacing premise-level observations, also read `~/lobster-workspace/oracle/learnings.md` and `~/lobster/oracle/golden-patterns.md` as cross-reference signal. Named failure patterns in learnings.md are documented failure modes — if a signal or anomaly matches one, cite it. Named golden patterns in golden-patterns.md are structural wins — if a signal suggests a golden pattern is breaking down or being violated, that is an escalation candidate. In both cases, state specifically how the pattern constrained what you wrote: what you did not include, what you weighted differently, what you flagged that you otherwise would have passed over. Naming a pattern without stating its effect on your analysis is not a citation; it is a label. The bar is behavioral change, not labeling.
+Before surfacing premise-level observations, also read `~/lobster/oracle/learnings.md` and `~/lobster/oracle/golden-patterns.md` as cross-reference signal. Named failure patterns in learnings.md are documented failure modes — if a signal or anomaly matches one, cite it. Named golden patterns in golden-patterns.md are structural wins — if a signal suggests a golden pattern is breaking down or being violated, that is an escalation candidate. In both cases, state specifically how the pattern constrained what you wrote: what you did not include, what you weighted differently, what you flagged that you otherwise would have passed over. Naming a pattern without stating its effect on your analysis is not a citation; it is a label. The bar is behavioral change, not labeling.
 
 ---
 


### PR DESCRIPTION
## Summary

The lobster-meta agent was silently failing to read \`oracle/learnings.md\` because the path pointed to \`~/lobster-workspace/oracle/learnings.md\`, which does not exist. The oracle directory lives in the repo at \`~/lobster/oracle/\`. This meant the meta agent could not cross-reference learnings.md for failure pattern detection — one of its two cross-reference signals was effectively dead.

The same line already had the correct prefix for \`golden-patterns.md\` (\`~/lobster/oracle/golden-patterns.md\`), making this an inconsistency on a single line. This is a one-line fix to bring the two references into alignment.

## Change

One line in \`.claude/agents/lobster-meta.md\`:
- Before: \`~/lobster-workspace/oracle/learnings.md\`
- After: \`~/lobster/oracle/learnings.md\`

No other content in \`lobster-meta.md\` or any other file was modified.

## Tests run

- [x] Verified \`~/lobster/oracle/learnings.md\` exists at the correct path before opening PR
- [x] Verified diff is exactly one line, touching only the stale path reference

## Manual test

N/A — path string correction in an agent instruction file. No external service calls, no file I/O, no behavioral logic changed.

## Definition of Done
- [x] One-line fix only — no other content changed
- [x] Correct path confirmed against live filesystem
- [x] No side effects: change is limited to a path reference in an instruction file