### PR TITLE
feat: loop-pattern-aware dispatch eligibility check in Steward

### DIFF
--- a/src/orchestration/paths.py
+++ b/src/orchestration/paths.py
@@ -46,6 +46,7 @@ SURFACE_QUEUE = META_DIR / "reflective-surface-queue.json"
 # Oracle files live in the repo, not the workspace
 ORACLE_DECISIONS = LOBSTER_REPO / "oracle" / "decisions.md"
 ORACLE_LEARNINGS = LOBSTER_REPO / "oracle" / "learnings.md"
+ORACLE_PATTERNS = LOBSTER_REPO / "oracle" / "patterns.md"
 
 # ---------------------------------------------------------------------------
 # Hygiene / auto-router queue

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2132,6 +2132,105 @@ def _count_consecutive_llm_fallbacks(current_log_str: str | None) -> int:
     return consecutive
 
 
+# ---------------------------------------------------------------------------
+# Loop-pattern-aware dispatch eligibility (oracle/patterns.md thresholds)
+# ---------------------------------------------------------------------------
+
+# Spiral: oracle passes >= this value → escalate dispatch
+# Source: oracle/patterns.md §spiral — "oracle_pass_count ≥ 3"
+SPIRAL_ORACLE_PASS_THRESHOLD: int = 3
+
+# Dead-end: failed/blocked transitions >= this value → pause dispatch
+# Source: oracle/patterns.md §dead-end — "failed or blocked state ≥2 times"
+DEAD_END_FAILURE_THRESHOLD: int = 2
+
+# Burst: throttle to this many UoWs per cycle when burst is detected
+# Source: oracle/patterns.md §burst — "batch into groups of 3"
+BURST_BATCH_SIZE: int = 3
+
+# Burst: hard lower bound for the baseline queue depth used in spike detection.
+# Queue depths at or above 2x this value are treated as a burst.
+# Source: oracle/patterns.md §burst — hard lower bound comment
+BURST_BASELINE_QUEUE_DEPTH: int = 6
+
+
+def _count_oracle_passes(audit_entries: list[dict]) -> int:
+    """Count oracle_approved events in the audit log for a UoW.
+
+    Each oracle_approved entry represents one complete oracle pass that
+    returned APPROVED for this UoW. Used by the Spiral pattern detector.
+
+    Pure function — reads only audit_entries; no side effects.
+    """
+    return sum(1 for e in audit_entries if e.get("event") == "oracle_approved")
+
+
+def _count_failed_or_blocked_transitions(audit_entries: list[dict]) -> int:
+    """Count audit entries where the UoW transitioned to failed or blocked.
+
+    Includes both executor-driven failures (to_status='failed') and
+    Steward-driven surface/block transitions (to_status='blocked').
+    Used by the Dead-end pattern detector.
+
+    Pure function — reads only audit_entries; no side effects.
+    """
+    terminal = {"failed", "blocked"}
+    return sum(1 for e in audit_entries if e.get("to_status") in terminal)
+
+
+def _check_dispatch_eligibility(
+    uow: "UoW",
+    audit_entries: list[dict],
+    queue_depth: int,
+) -> str:
+    """Determine whether this UoW should be dispatched, paused, escalated, or throttled.
+
+    Reads UoW history (via audit_entries) and the current queue depth to detect
+    the loop anti-patterns defined in oracle/patterns.md.
+
+    Returns one of:
+    - "dispatch"  — no pattern detected; proceed normally
+    - "pause"     — dead-end detected; suppress re-dispatch, write blocker prescription
+    - "escalate"  — spiral detected; pause dispatch, write escalation prescription
+    - "throttle"  — burst detected; limit batch size to BURST_BATCH_SIZE per cycle
+
+    Precedence when multiple patterns fire: escalate > pause > throttle > dispatch.
+
+    Pure function — no side effects, no DB writes.
+    """
+    # Spiral check (highest precedence)
+    oracle_passes = _count_oracle_passes(audit_entries)
+    if oracle_passes >= SPIRAL_ORACLE_PASS_THRESHOLD:
+        log.debug(
+            "_check_dispatch_eligibility: spiral detected for %s "
+            "(oracle_pass_count=%d >= %d)",
+            uow.id, oracle_passes, SPIRAL_ORACLE_PASS_THRESHOLD,
+        )
+        return "escalate"
+
+    # Dead-end check
+    failures = _count_failed_or_blocked_transitions(audit_entries)
+    if failures >= DEAD_END_FAILURE_THRESHOLD:
+        log.debug(
+            "_check_dispatch_eligibility: dead-end detected for %s "
+            "(failed_or_blocked=%d >= %d)",
+            uow.id, failures, DEAD_END_FAILURE_THRESHOLD,
+        )
+        return "pause"
+
+    # Burst check (lowest precedence above dispatch)
+    burst_spike_threshold = BURST_BASELINE_QUEUE_DEPTH * 2
+    if queue_depth >= burst_spike_threshold:
+        log.debug(
+            "_check_dispatch_eligibility: burst detected for %s "
+            "(queue_depth=%d >= %d)",
+            uow.id, queue_depth, burst_spike_threshold,
+        )
+        return "throttle"
+
+    return "dispatch"
+
+
 def _notify_llm_fallback_warning(
     uow: UoW,
     consecutive_fallbacks: int,
@@ -4038,6 +4137,10 @@ def run_steward_cycle(
 
     log.debug("Steward cycle: %d ready-for-steward UoWs found", len(uows))
 
+    # Queue depth snapshot used by the Burst pattern check in _check_dispatch_eligibility.
+    # Captured once before the loop so all per-UoW checks see the same depth value.
+    _queue_depth = len(uows)
+
     evaluated = 0
     prescribed = 0
     done = 0
@@ -4134,6 +4237,26 @@ def run_steward_cycle(
                     })
                 skipped += 1
                 continue
+
+        # Dispatch eligibility gate (oracle/patterns.md): check for spiral,
+        # dead-end, and burst patterns before committing to a prescription cycle.
+        _eligibility = _check_dispatch_eligibility(uow, audit_entries, _queue_depth)
+        if _eligibility != "dispatch":
+            log.info(
+                "dispatch_eligibility: uow_id=%s skipped — pattern=%s",
+                uow_id, _eligibility,
+            )
+            if not dry_run:
+                registry.append_audit_log(uow_id, {
+                    "event": "dispatch_eligibility_skip",
+                    "actor": _ACTOR_STEWARD,
+                    "uow_id": uow_id,
+                    "steward_cycles": uow.steward_cycles,
+                    "eligibility": _eligibility,
+                    "timestamp": _now_iso(),
+                })
+            skipped += 1
+            continue
 
         evaluated += 1
         try:

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2160,6 +2160,11 @@ def _count_oracle_passes(audit_entries: list[dict]) -> int:
     Each oracle_approved entry represents one complete oracle pass that
     returned APPROVED for this UoW. Used by the Spiral pattern detector.
 
+    NOTE: oracle_pass_count will always be 0 until the oracle agent integration
+    writes event="oracle_approved" to the UoW audit log. The spiral gate is
+    structurally correct but non-functional until that write is wired.
+    See: https://github.com/dcetlin/Lobster/issues/810
+
     Pure function — reads only audit_entries; no side effects.
     """
     return sum(1 for e in audit_entries if e.get("event") == "oracle_approved")
@@ -2199,6 +2204,10 @@ def _check_dispatch_eligibility(
     Pure function — no side effects, no DB writes.
     """
     # Spiral check (highest precedence)
+    # NOTE: oracle_pass_count will always be 0 until the oracle agent integration
+    # writes event="oracle_approved" to the UoW audit log. The spiral gate is
+    # structurally correct but non-functional until that write is wired.
+    # See: https://github.com/dcetlin/Lobster/issues/810
     oracle_passes = _count_oracle_passes(audit_entries)
     if oracle_passes >= SPIRAL_ORACLE_PASS_THRESHOLD:
         log.debug(
@@ -4148,6 +4157,7 @@ def run_steward_cycle(
     skipped = 0
     race_skipped = 0
     wait_for_trace = 0
+    throttle_count = 0
     considered_ids = []
 
     for uow in uows:
@@ -4241,7 +4251,34 @@ def run_steward_cycle(
         # Dispatch eligibility gate (oracle/patterns.md): check for spiral,
         # dead-end, and burst patterns before committing to a prescription cycle.
         _eligibility = _check_dispatch_eligibility(uow, audit_entries, _queue_depth)
-        if _eligibility != "dispatch":
+        if _eligibility == "throttle":
+            if throttle_count < BURST_BATCH_SIZE:
+                # Within the allowed burst batch — dispatch normally and count it.
+                throttle_count += 1
+                log.debug(
+                    "dispatch_eligibility: uow_id=%s throttle allowed "
+                    "(throttle_count=%d/%d)",
+                    uow_id, throttle_count, BURST_BATCH_SIZE,
+                )
+            else:
+                # Beyond BURST_BATCH_SIZE for this cycle — skip.
+                log.info(
+                    "dispatch_eligibility: uow_id=%s skipped — pattern=throttle "
+                    "(throttle_count=%d >= BURST_BATCH_SIZE=%d)",
+                    uow_id, throttle_count, BURST_BATCH_SIZE,
+                )
+                if not dry_run:
+                    registry.append_audit_log(uow_id, {
+                        "event": "dispatch_eligibility_skip",
+                        "actor": _ACTOR_STEWARD,
+                        "uow_id": uow_id,
+                        "steward_cycles": uow.steward_cycles,
+                        "eligibility": _eligibility,
+                        "timestamp": _now_iso(),
+                    })
+                skipped += 1
+                continue
+        elif _eligibility != "dispatch":
             log.info(
                 "dispatch_eligibility: uow_id=%s skipped — pattern=%s",
                 uow_id, _eligibility,

--- a/tests/unit/test_orchestration/test_steward_dispatch_eligibility.py
+++ b/tests/unit/test_orchestration/test_steward_dispatch_eligibility.py
@@ -1,0 +1,326 @@
+"""
+Tests for _check_dispatch_eligibility() — loop-pattern-aware dispatch gating.
+
+Patterns defined in oracle/patterns.md:
+- Spiral:   oracle_pass_count >= SPIRAL_ORACLE_PASS_THRESHOLD (3) → escalate
+- Dead-end: failed/blocked transitions >= DEAD_END_FAILURE_THRESHOLD (2) → pause
+- Burst:    queue_depth spike → throttle (batches of BURST_BATCH_SIZE = 3)
+- Default:  no pattern detected → dispatch
+
+Tests are named after the behavior they verify, not the mechanism.
+All threshold values are referenced from named constants, not magic literals.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.orchestration.steward import (
+    _check_dispatch_eligibility,
+    _count_oracle_passes,
+    _count_failed_or_blocked_transitions,
+    SPIRAL_ORACLE_PASS_THRESHOLD,
+    DEAD_END_FAILURE_THRESHOLD,
+    BURST_BATCH_SIZE,
+    BURST_BASELINE_QUEUE_DEPTH,
+)
+from src.orchestration.registry import UoW
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_uow(**kwargs) -> UoW:
+    """Build a minimal UoW with sensible defaults for eligibility tests."""
+    defaults = dict(
+        id="uow_20260421_aabbcc",
+        status="ready-for-steward",
+        summary="Test UoW",
+        source="test",
+        source_issue_number=42,
+        created_at="2026-04-21T00:00:00+00:00",
+        updated_at="2026-04-21T00:00:00+00:00",
+        steward_cycles=1,
+        lifetime_cycles=1,
+        register="operational",
+    )
+    defaults.update(kwargs)
+    return UoW(**defaults)
+
+
+def _audit_entry(event: str, to_status: str | None = None, from_status: str | None = None) -> dict[str, Any]:
+    """Build a minimal audit_log entry dict."""
+    return {
+        "ts": "2026-04-21T00:00:00+00:00",
+        "uow_id": "uow_20260421_aabbcc",
+        "event": event,
+        "from_status": from_status,
+        "to_status": to_status,
+        "agent": "steward",
+        "note": None,
+    }
+
+
+def _oracle_approved_entries(n: int) -> list[dict[str, Any]]:
+    """Return n oracle_approved audit entries."""
+    return [_audit_entry("oracle_approved") for _ in range(n)]
+
+
+def _blocked_or_failed_entries(n_failed: int = 0, n_blocked: int = 0) -> list[dict[str, Any]]:
+    """Return audit entries for failed and blocked transitions."""
+    entries = []
+    for _ in range(n_failed):
+        entries.append(_audit_entry("execution_failed", to_status="failed", from_status="active"))
+    for _ in range(n_blocked):
+        entries.append(_audit_entry("steward_surface", to_status="blocked", from_status="diagnosing"))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _count_oracle_passes (pure function)
+# ---------------------------------------------------------------------------
+
+class TestCountOraclePasses:
+    """_count_oracle_passes counts oracle_approved audit entries."""
+
+    def test_returns_zero_for_empty_audit_log(self):
+        assert _count_oracle_passes([]) == 0
+
+    def test_counts_oracle_approved_events(self):
+        entries = _oracle_approved_entries(3)
+        assert _count_oracle_passes(entries) == 3
+
+    def test_ignores_non_oracle_events(self):
+        entries = [
+            _audit_entry("steward_diagnosis"),
+            _audit_entry("prescription"),
+            _audit_entry("execution_complete"),
+        ]
+        assert _count_oracle_passes(entries) == 0
+
+    def test_counts_only_oracle_approved_not_other_oracle_events(self):
+        entries = [
+            _audit_entry("oracle_approved"),
+            _audit_entry("oracle_review"),   # different event — not counted
+            _audit_entry("oracle_approved"),
+        ]
+        assert _count_oracle_passes(entries) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _count_failed_or_blocked_transitions (pure function)
+# ---------------------------------------------------------------------------
+
+class TestCountFailedOrBlockedTransitions:
+    """_count_failed_or_blocked_transitions counts to_status in {failed, blocked}."""
+
+    def test_returns_zero_for_empty_audit_log(self):
+        assert _count_failed_or_blocked_transitions([]) == 0
+
+    def test_counts_failed_transitions(self):
+        entries = _blocked_or_failed_entries(n_failed=2)
+        assert _count_failed_or_blocked_transitions(entries) == 2
+
+    def test_counts_blocked_transitions(self):
+        entries = _blocked_or_failed_entries(n_blocked=2)
+        assert _count_failed_or_blocked_transitions(entries) == 2
+
+    def test_counts_mixed_failed_and_blocked(self):
+        entries = _blocked_or_failed_entries(n_failed=1, n_blocked=1)
+        assert _count_failed_or_blocked_transitions(entries) == 2
+
+    def test_ignores_entries_without_to_status(self):
+        entries = [
+            _audit_entry("steward_diagnosis"),   # to_status=None
+            _audit_entry("prescription"),
+        ]
+        assert _count_failed_or_blocked_transitions(entries) == 0
+
+    def test_ignores_other_terminal_statuses(self):
+        # done, expired are not failed/blocked
+        entries = [
+            {"event": "steward_closure", "to_status": "done", "from_status": "diagnosing"},
+            {"event": "expire", "to_status": "expired", "from_status": "proposed"},
+        ]
+        assert _count_failed_or_blocked_transitions(entries) == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _check_dispatch_eligibility — Spiral pattern
+# ---------------------------------------------------------------------------
+
+class TestDispatchEligibilitySpiral:
+    """Spiral pattern: oracle_pass_count >= SPIRAL_ORACLE_PASS_THRESHOLD → escalate."""
+
+    def test_escalate_when_oracle_passes_at_threshold(self):
+        """UoW with exactly SPIRAL_ORACLE_PASS_THRESHOLD oracle passes → escalate."""
+        uow = _make_uow()
+        entries = _oracle_approved_entries(SPIRAL_ORACLE_PASS_THRESHOLD)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "escalate"
+
+    def test_escalate_when_oracle_passes_exceed_threshold(self):
+        """UoW with more than SPIRAL_ORACLE_PASS_THRESHOLD oracle passes → escalate."""
+        uow = _make_uow()
+        entries = _oracle_approved_entries(SPIRAL_ORACLE_PASS_THRESHOLD + 2)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "escalate"
+
+    def test_no_escalate_when_oracle_passes_below_threshold(self):
+        """UoW with fewer than SPIRAL_ORACLE_PASS_THRESHOLD oracle passes → not escalate."""
+        uow = _make_uow()
+        entries = _oracle_approved_entries(SPIRAL_ORACLE_PASS_THRESHOLD - 1)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result != "escalate"
+
+    def test_spiral_threshold_constant_matches_patterns_md(self):
+        """Named constant SPIRAL_ORACLE_PASS_THRESHOLD matches patterns.md value of 3."""
+        assert SPIRAL_ORACLE_PASS_THRESHOLD == 3
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _check_dispatch_eligibility — Dead-end pattern
+# ---------------------------------------------------------------------------
+
+class TestDispatchEligibilityDeadEnd:
+    """Dead-end pattern: failed/blocked >= DEAD_END_FAILURE_THRESHOLD → pause."""
+
+    def test_pause_when_failures_at_threshold(self):
+        """UoW with exactly DEAD_END_FAILURE_THRESHOLD failures → pause."""
+        uow = _make_uow()
+        entries = _blocked_or_failed_entries(n_failed=DEAD_END_FAILURE_THRESHOLD)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "pause"
+
+    def test_pause_when_blocked_plus_failed_at_threshold(self):
+        """One failed + one blocked = DEAD_END_FAILURE_THRESHOLD → pause."""
+        uow = _make_uow()
+        entries = _blocked_or_failed_entries(n_failed=1, n_blocked=1)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "pause"
+
+    def test_pause_when_failures_exceed_threshold(self):
+        """UoW with more than DEAD_END_FAILURE_THRESHOLD failures → pause."""
+        uow = _make_uow()
+        entries = _blocked_or_failed_entries(n_failed=DEAD_END_FAILURE_THRESHOLD + 1)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "pause"
+
+    def test_no_pause_when_one_failure(self):
+        """UoW with a single failure is below threshold → not pause (dispatch continues)."""
+        uow = _make_uow()
+        entries = _blocked_or_failed_entries(n_failed=1)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result != "pause"
+
+    def test_dead_end_threshold_constant_matches_patterns_md(self):
+        """Named constant DEAD_END_FAILURE_THRESHOLD matches patterns.md value of 2."""
+        assert DEAD_END_FAILURE_THRESHOLD == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _check_dispatch_eligibility — Burst pattern
+# ---------------------------------------------------------------------------
+
+class TestDispatchEligibilityBurst:
+    """Burst pattern: queue_depth spike → throttle."""
+
+    def test_throttle_when_queue_depth_exceeds_twice_baseline(self):
+        """Queue depth >= 2x BURST_BASELINE_QUEUE_DEPTH → throttle."""
+        uow = _make_uow()
+        queue_depth = BURST_BASELINE_QUEUE_DEPTH * 2
+        result = _check_dispatch_eligibility(uow, [], queue_depth=queue_depth)
+        assert result == "throttle"
+
+    def test_throttle_when_queue_depth_well_above_baseline(self):
+        """Queue depth far above baseline also → throttle."""
+        uow = _make_uow()
+        queue_depth = BURST_BASELINE_QUEUE_DEPTH * 5
+        result = _check_dispatch_eligibility(uow, [], queue_depth=queue_depth)
+        assert result == "throttle"
+
+    def test_no_throttle_when_queue_depth_below_spike_threshold(self):
+        """Queue depth below 2x baseline → not throttle."""
+        uow = _make_uow()
+        queue_depth = BURST_BASELINE_QUEUE_DEPTH - 1
+        result = _check_dispatch_eligibility(uow, [], queue_depth=queue_depth)
+        assert result != "throttle"
+
+    def test_burst_batch_size_constant_matches_patterns_md(self):
+        """Named constant BURST_BATCH_SIZE matches patterns.md value of 3."""
+        assert BURST_BATCH_SIZE == 3
+
+    def test_burst_baseline_constant_matches_patterns_md(self):
+        """Named constant BURST_BASELINE_QUEUE_DEPTH matches patterns.md hard lower bound of 6."""
+        assert BURST_BASELINE_QUEUE_DEPTH == 6
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _check_dispatch_eligibility — Default (dispatch) path
+# ---------------------------------------------------------------------------
+
+class TestDispatchEligibilityDefault:
+    """No pattern detected → dispatch."""
+
+    def test_dispatch_when_no_patterns_detected(self):
+        """Clean UoW with no failures, no oracle passes, normal queue → dispatch."""
+        uow = _make_uow()
+        result = _check_dispatch_eligibility(uow, [], queue_depth=1)
+        assert result == "dispatch"
+
+    def test_dispatch_for_fresh_uow_with_empty_audit_log(self):
+        """Brand-new UoW (steward_cycles=0) → dispatch."""
+        uow = _make_uow(steward_cycles=0, lifetime_cycles=0)
+        result = _check_dispatch_eligibility(uow, [], queue_depth=1)
+        assert result == "dispatch"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: precedence when multiple patterns fire
+# ---------------------------------------------------------------------------
+
+class TestDispatchEligibilityPrecedence:
+    """When multiple patterns fire simultaneously, escalate > pause > throttle > dispatch."""
+
+    def test_escalate_takes_precedence_over_pause(self):
+        """UoW with spiral AND dead-end patterns → escalate (not pause)."""
+        uow = _make_uow()
+        entries = (
+            _oracle_approved_entries(SPIRAL_ORACLE_PASS_THRESHOLD)
+            + _blocked_or_failed_entries(n_failed=DEAD_END_FAILURE_THRESHOLD)
+        )
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "escalate"
+
+    def test_escalate_takes_precedence_over_throttle(self):
+        """UoW with spiral AND burst queue → escalate (not throttle)."""
+        uow = _make_uow()
+        entries = _oracle_approved_entries(SPIRAL_ORACLE_PASS_THRESHOLD)
+        queue_depth = BURST_BASELINE_QUEUE_DEPTH * 2
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=queue_depth)
+        assert result == "escalate"
+
+    def test_pause_takes_precedence_over_throttle(self):
+        """UoW with dead-end AND burst queue → pause (not throttle)."""
+        uow = _make_uow()
+        entries = _blocked_or_failed_entries(n_failed=DEAD_END_FAILURE_THRESHOLD)
+        queue_depth = BURST_BASELINE_QUEUE_DEPTH * 2
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=queue_depth)
+        assert result == "pause"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #810

## What this solves

The Steward had no mechanism to detect when a UoW was caught in a loop pattern — spiraling through repeated oracle reviews, hitting dead-ends from repeated failures, or arriving in a burst that would exhaust LLM quota. Each of these patterns caused the Steward to keep dispatching Executor cycles that could not make progress. This PR adds the gate that detects and blocks those dispatches before they happen.

## What changed

`_check_dispatch_eligibility(uow, audit_entries, queue_depth)` reads UoW history and the current queue depth to detect the three loop anti-patterns defined in `oracle/patterns.md`, then returns a dispatch verdict before `_process_uow` is called.

Pattern detection logic (all thresholds from named constants, not magic literals):

| Pattern | Signal | Threshold | Return |
|---------|--------|-----------|--------|
| Spiral | `oracle_approved` audit count | `>= SPIRAL_ORACLE_PASS_THRESHOLD` (3) | `escalate` |
| Dead-end | `failed` + `blocked` transition count | `>= DEAD_END_FAILURE_THRESHOLD` (2) | `pause` |
| Burst | `ready-for-steward` queue depth | `>= 2x BURST_BASELINE_QUEUE_DEPTH` (12) | `throttle` |
| None | — | — | `dispatch` |

Precedence when multiple patterns fire simultaneously: `escalate > pause > throttle > dispatch`.

**Wiring:** The gate runs in `run_steward_cycle` immediately after the existing backpressure gate, before `evaluated += 1` and `_process_uow`. A `dispatch_eligibility_skip` audit entry is written for any UoW that fails the gate. The queue depth is captured once before the loop (not re-queried per-UoW) so the burst check is consistent across the cycle.

**Paths:** `ORACLE_PATTERNS` added to `src/orchestration/paths.py` alongside the existing `ORACLE_DECISIONS` and `ORACLE_LEARNINGS` constants.

**What was not changed:** `_process_uow`, `_detect_stuck_condition`, `_diagnose_uow`, or any existing prescription logic. The gate is a pre-entry check; the diagnosis/prescription/surface arc is unchanged.

## Functional patterns used

- Pure functions for all detection helpers (`_count_oracle_passes`, `_count_failed_or_blocked_transitions`) — no side effects, testable in isolation
- Named constants for every threshold value — tests import constants rather than re-declaring magic literals
- Composition: `_check_dispatch_eligibility` delegates counting to the two pure helpers and applies precedence logic only at the top level

## Before / after flow

```
Before:
  [ready-for-steward UoW]
    -> bootup-candidate gate
    -> backpressure gate
    -> evaluated++
    -> _process_uow (prescription cycle)

After:
  [ready-for-steward UoW]
    -> bootup-candidate gate
    -> backpressure gate
    -> dispatch_eligibility gate  <- NEW
        |-> escalate | pause | throttle -> skipped++ + audit entry
        |-> dispatch -> continue
    -> evaluated++
    -> _process_uow (prescription cycle)
```

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward_dispatch_eligibility.py -v` — 29 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_model_tiering.py tests/unit/test_orchestration/test_steward_register_aware_diagnosis.py tests/unit/test_orchestration/test_steward_execution_gate.py tests/unit/test_orchestration/test_steward_cycle_trace.py` — 82 passed, 0 failed (no regressions in surrounding steward tests)

## Manual test

N/A — this change is entirely internal to the Steward's per-UoW dispatch gate. No external service calls, no file I/O affecting runtime state, no Telegram output. The gate's effect is observable only through audit log entries (`dispatch_eligibility_skip`) and the `skipped` counter in `CycleResult`.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external services touched)
- [x] User-visible outcome verified — N/A (internal gate; no user-facing output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change