### PR TITLE
fix: pass CLAUDE_CODE_OAUTH_TOKEN env to claude -p in executor subprocess dispatch

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -65,6 +65,7 @@ from orchestration.error_capture import (
     classify_error,
     has_repeated_error,
 )
+from orchestration.steward import _build_claude_env
 
 
 # ---------------------------------------------------------------------------
@@ -933,13 +934,16 @@ def _dispatch_via_claude_p(instructions: str, uow_id: str) -> str:
         "--max-turns", "40",
     ]
 
-    # Use error capture to detect and log subprocess failures with context
+    # Use error capture to detect and log subprocess failures with context.
+    # Pass an explicit env so CLAUDE_CODE_OAUTH_TOKEN is present even when
+    # this function is called from a cron job that strips the parent env.
     proc, error = run_subprocess_with_error_capture(
         component="executor",
         uow_id=uow_id,
         command=command,
         timeout_seconds=_get_claude_p_timeout(),
         check=True,  # Log errors at ERROR level for fatal issues
+        env=_build_claude_env(),
     )
 
     # If error occurred, classify and decide whether to raise
@@ -1064,12 +1068,15 @@ def _dispatch_via_stub(register_name: str, instructions: str, uow_id: str) -> st
         "--max-turns", "40",
     ]
 
+    # Pass an explicit env so CLAUDE_CODE_OAUTH_TOKEN is present even when
+    # called from a cron job that strips the parent environment.
     proc, error = run_subprocess_with_error_capture(
         component="executor",
         uow_id=uow_id,
         command=command,
         timeout_seconds=_get_claude_p_timeout(),
         check=True,
+        env=_build_claude_env(),
     )
 
     if error:

--- a/tests/unit/test_orchestration/test_executor_subprocess.py
+++ b/tests/unit/test_orchestration/test_executor_subprocess.py
@@ -33,6 +33,8 @@ from orchestration.executor import (
     ExecutorOutcome,
     _result_json_path,
     _noop_dispatcher,
+    _dispatch_via_claude_p,
+    _dispatch_via_stub,
 )
 
 
@@ -349,3 +351,92 @@ class TestHappyPath:
         output_ref = _get_output_ref(db_path, uow_id)
         data = _read_result_json(output_ref)
         assert data.get("executor_id") == "task-xyz-run-id"
+
+
+# ---------------------------------------------------------------------------
+# Auth token passthrough — CLAUDE_CODE_OAUTH_TOKEN must reach the subprocess
+# ---------------------------------------------------------------------------
+
+class TestAuthTokenPassthrough:
+    """
+    _dispatch_via_claude_p and _dispatch_via_stub must pass CLAUDE_CODE_OAUTH_TOKEN
+    to run_subprocess_with_error_capture via the env= kwarg.
+
+    Cron strips the inherited environment, so without explicit env injection the
+    subprocess never receives the OAuth token and fails authentication. The fix
+    calls _build_claude_env() — which reads the token from the process environment
+    or falls back to ~/.claude/.credentials.json — and passes the result as env=.
+
+    These tests patch run_subprocess_with_error_capture inside the executor module
+    and capture the env kwarg to confirm the token is present.
+    """
+
+    def test_dispatch_via_claude_p_passes_oauth_token_in_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_dispatch_via_claude_p passes CLAUDE_CODE_OAUTH_TOKEN to the subprocess env."""
+        import orchestration.executor as executor_mod
+
+        captured_envs: list[dict] = []
+
+        def mock_run_capture(*args, **kwargs):
+            captured_envs.append(kwargs.get("env") or {})
+            proc = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            return proc, None
+
+        monkeypatch.setattr(executor_mod, "run_subprocess_with_error_capture", mock_run_capture)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test-token-executor")
+
+        _dispatch_via_claude_p("do the thing", "uow-test-auth-001")
+
+        assert len(captured_envs) == 1, "Expected exactly one subprocess call"
+        assert captured_envs[0].get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-test-token-executor"
+
+    def test_dispatch_via_stub_passes_oauth_token_in_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_dispatch_via_stub passes CLAUDE_CODE_OAUTH_TOKEN to the subprocess env."""
+        import orchestration.executor as executor_mod
+
+        captured_envs: list[dict] = []
+
+        def mock_run_capture(*args, **kwargs):
+            captured_envs.append(kwargs.get("env") or {})
+            proc = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            return proc, None
+
+        monkeypatch.setattr(executor_mod, "run_subprocess_with_error_capture", mock_run_capture)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test-token-stub")
+
+        _dispatch_via_stub("frontier-writer", "do the thing", "uow-test-auth-002")
+
+        assert len(captured_envs) == 1, "Expected exactly one subprocess call"
+        assert captured_envs[0].get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-test-token-stub"
+
+    def test_dispatch_via_claude_p_falls_back_to_credentials_json(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When CLAUDE_CODE_OAUTH_TOKEN is absent from env, _build_claude_env reads it from credentials.json."""
+        import orchestration.executor as executor_mod
+        import orchestration.steward as steward_mod
+
+        captured_envs: list[dict] = []
+
+        def mock_run_capture(*args, **kwargs):
+            captured_envs.append(kwargs.get("env") or {})
+            proc = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            return proc, None
+
+        # Write a credentials.json in a temp dir and point _CREDENTIALS_PATH at it
+        creds_file = tmp_path / ".credentials.json"
+        creds_file.write_text(
+            '{"claudeAiOauth": {"accessToken": "sk-ant-oat01-from-credentials-json"}}'
+        )
+        monkeypatch.setattr(steward_mod, "_CREDENTIALS_PATH", creds_file)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(executor_mod, "run_subprocess_with_error_capture", mock_run_capture)
+
+        _dispatch_via_claude_p("do the thing", "uow-test-auth-003")
+
+        assert len(captured_envs) == 1
+        assert captured_envs[0].get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-from-credentials-json"


### PR DESCRIPTION
## Problem

Every WOS UoW dispatched via the legacy `claude -p` subprocess path (`_dispatch_via_claude_p` and `_dispatch_via_stub`) fails authentication when invoked from cron. Cron runs with a stripped environment — `CLAUDE_CODE_OAUTH_TOKEN` is never inherited, so the subprocess cannot authenticate and exits non-zero immediately.

## What changed

`_dispatch_via_claude_p` and `_dispatch_via_stub` in `src/orchestration/executor.py` now call `_build_claude_env()` (imported from `steward.py`) and pass the result as `env=` to `run_subprocess_with_error_capture`.

`_build_claude_env` already existed and handled this exact scenario: it checks `os.environ` first (fast path for interactive sessions), and falls back to reading `accessToken` from `~/.claude/.credentials.json` (the path that matters for cron). `run_subprocess_with_error_capture` already accepted an `env=` parameter — it was simply never passed from these two call sites.

The change is two call sites, one new import.

## Functional patterns

Pure function composition: `_build_claude_env()` is a pure function (reads env + file, returns a dict copy) called inline at the subprocess boundary. No shared mutable state introduced.

## What is out of scope

- The primary `_dispatch_via_inbox` path is not touched — it writes a message to the inbox and returns immediately without spawning a subprocess, so it is not affected by the cron env-stripping problem.
- `steward.py`'s `_llm_prescribe` already called `_build_claude_env` correctly and is unchanged.
- The pre-existing `TestOptimisticLock` failures in `tests/unit/test_executor.py` are not introduced by this PR — they fail identically on `main` (confirmed by running against the unmodified branch).

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_executor_subprocess.py -v` — 16 passed, 0 failed (includes 3 new `TestAuthTokenPassthrough` tests)
- [x] `uv run pytest tests/unit/test_orchestration/test_executor_subprocess.py tests/unit/test_orchestration/test_executor_register_routing.py tests/unit/test_executor.py -q` — 87 passed, 3 pre-existing `TestOptimisticLock` failures (confirmed identical on `main`)

## Manual test

N/A — this change is entirely internal to the subprocess env construction. The fix affects a code path that is only exercised when the legacy `claude -p` subprocess dispatcher is active (non-default in production; the primary path is `_dispatch_via_inbox`). No external service calls, no file I/O beyond what `_build_claude_env` already does, no Telegram output.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (internal env dict construction, no external boundary)
- [x] User-visible outcome — N/A (infrastructure fix, no user-facing output)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume — change only affects which env dict is passed to an existing subprocess call
- [x] External service calls: mocked in tests