### PR TITLE
feat(hooks): promote Dispatch template and PR Merge gates to hook enforcement

### DIFF
--- a/hooks/dispatch-template-check.py
+++ b/hooks/dispatch-template-check.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: blocks Agent calls from the dispatcher where the prompt lacks
+dispatch template fields.
+
+Every subagent spawned by the dispatcher must include both:
+  - 'Minimum viable output: <deliverable>'
+  - 'Boundary: do not <X>'
+
+These fields enforce the Dispatch template gate from the Tier-1 Gate Register in
+CLAUDE.md, ensuring the dispatcher always scopes its subagents explicitly. This
+survives context compaction because the enforcement is mechanical, not advisory.
+
+Only fires for Agent tool calls from the dispatcher. Subagents are exempt.
+
+Exit codes:
+  0 — tool is not Agent, session is a subagent, or both template fields are present
+  2 — hard block: dispatcher called Agent without required dispatch template fields
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from session_role import is_dispatcher_session
+
+REQUIRED_FIELDS = [
+    "Minimum viable output:",
+    "Boundary:",
+]
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+tool_name = data.get("tool_name", "")
+tool_input = data.get("tool_input", {})
+
+if tool_name != "Agent":
+    sys.exit(0)
+
+if not is_dispatcher_session(data):
+    sys.exit(0)
+
+prompt = tool_input.get("prompt", "")
+
+missing = [field for field in REQUIRED_FIELDS if field not in prompt]
+
+if not missing:
+    sys.exit(0)
+
+missing_list = ", ".join(f"'{f}'" for f in missing)
+print(
+    f"BLOCKED: Agent prompt missing dispatch template field(s): {missing_list}.\n"
+    "Every subagent call must include 'Minimum viable output: <deliverable>' and\n"
+    "'Boundary: do not <X>' in the prompt body.\n"
+    "See Tier-1 Gate Register in CLAUDE.md (Dispatch template gate).",
+    file=sys.stderr,
+)
+sys.exit(2)

--- a/hooks/pr-merge-gate.py
+++ b/hooks/pr-merge-gate.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: blocks 'gh pr merge' commands where the oracle has not approved
+the PR.
+
+The PR Merge Gate in CLAUDE.md requires that every code PR pass oracle review before
+merge. This hook enforces that requirement mechanically: any 'gh pr merge <N>' command
+is blocked unless oracle/decisions.md contains a 'VERDICT: APPROVED' entry for PR #N
+as its most recent verdict.
+
+If no oracle entry exists for the PR, a warning is printed but the merge is not
+blocked — the PR may be infrastructure-level or pre-oracle.
+
+Exit codes:
+  0 — not a merge command, no PR number found, oracle APPROVED, or no oracle entry
+  2 — hard block: oracle verdict is not APPROVED
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+
+DECISIONS_FILE = Path(__file__).parent.parent / "oracle" / "decisions.md"
+
+
+def extract_pr_number(command: str) -> "int | None":
+    """Extract the PR number from a gh pr merge command.
+
+    Handles forms like:
+      gh pr merge 123
+      gh pr merge --squash 123
+      gh pr merge 123 --squash
+      gh pr merge https://github.com/owner/repo/pull/123
+    """
+    # Find the start of 'gh pr merge' in the command
+    merge_match = re.search(r'gh\s+pr\s+merge\b', command)
+    if not merge_match:
+        return None
+
+    # Work on the substring after 'gh pr merge'
+    rest = command[merge_match.end():]
+
+    # Try the specific regex from the spec first
+    spec_match = re.search(r'\b(\d+)\b', rest)
+    if spec_match:
+        return int(spec_match.group(1))
+
+    return None
+
+
+def find_oracle_verdict(pr_number: int) -> "str | None":
+    """Find the most recent oracle verdict for a PR number.
+
+    Returns 'APPROVED', 'NEEDS_CHANGES', or None if no entry exists.
+    The most recent entry is the topmost section in the file.
+    """
+    if not DECISIONS_FILE.exists():
+        return None
+
+    content = DECISIONS_FILE.read_text()
+
+    # Split into sections by ### [
+    sections = re.split(r'(?=### \[)', content)
+
+    pr_token = f"PR #{pr_number}"
+    pr_boundary_re = re.compile(rf'PR #{re.escape(str(pr_number))}(?!\d)')
+
+    for section in sections:
+        if not section.strip():
+            continue
+        # Check if the header line contains PR #<number> as a whole token
+        header_line = section.split('\n', 1)[0]
+        if not pr_boundary_re.search(header_line):
+            continue
+        # Found the most recent entry for this PR number
+        if '**VERDICT: APPROVED**' in section:
+            return 'APPROVED'
+        if '**VERDICT: NEEDS_CHANGES**' in section:
+            return 'NEEDS_CHANGES'
+        # Some other verdict
+        verdict_match = re.search(r'\*\*VERDICT:\s*([^*]+)\*\*', section)
+        if verdict_match:
+            return verdict_match.group(1).strip()
+        return 'UNKNOWN'
+
+    return None
+
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+tool_name = data.get("tool_name", "")
+tool_input = data.get("tool_input", {})
+
+if tool_name != "Bash":
+    sys.exit(0)
+
+command = tool_input.get("command", "")
+
+if "gh pr merge" not in command:
+    sys.exit(0)
+
+pr_number = extract_pr_number(command)
+if pr_number is None:
+    # Cannot determine PR number — do not block
+    sys.exit(0)
+
+verdict = find_oracle_verdict(pr_number)
+
+if verdict is None:
+    # No oracle entry — warn but do not block (may be pre-oracle or infrastructure)
+    print(
+        f"WARNING: gh pr merge attempted for PR #{pr_number} but no oracle entry found in "
+        f"oracle/decisions.md. Allowing merge — add an oracle review if this is a code PR.",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+if verdict == 'APPROVED':
+    sys.exit(0)
+
+print(
+    f"BLOCKED: gh pr merge attempted for PR #{pr_number} but oracle verdict is {verdict} (not APPROVED).\n"
+    "Run the oracle agent first and confirm APPROVED appears in oracle/decisions.md before merging.\n"
+    "PR Merge Gate — see Tier-1 Gate Register in CLAUDE.md.",
+    file=sys.stderr,
+)
+sys.exit(2)

--- a/oracle/learnings.md
+++ b/oracle/learnings.md
@@ -925,3 +925,11 @@ When an oracle agent's instruction file specifies path A for output and the code
 **Learning: Assertion fixes at the correct line without docstring corrections leave the gate contract undocumented**
 When `approve()` was updated to advance `proposed → pending → ready-for-steward` atomically, the integration test assertion was updated to expect `ready-for-steward`. But the `TestBootupCandidateGate` class docstring still reads "stays in 'pending' until the gate is cleared" and `_seed_uow`'s docstring still reads "approve-to-pending steps." Both are now wrong. The PR #607 learning (comment/code mismatch at state-machine transitions causes silent state divergence) applies at the docstring level as well as the code level. A test assertion that is correct but whose surrounding docstring is wrong gives the next reader an incorrect mental model of the gate contract. Detection: when a PR updates a status assertion from state A to state B, also scan the class docstring and any helper function docstrings that describe the state being tested.
 
+
+---
+
+### [2026-04-22] Relay filter gate is not hook-enforceable
+
+The Relay filter gate ("key signal in paragraph 1 of send_reply") cannot be promoted to a PreToolUse/PostToolUse hook. The rule requires semantic judgment — "key signal" is not a string pattern but a rhetorical concept (what matters most to the reader in context). Attempting mechanical enforcement via paragraph-split position would generate false positives for any multi-paragraph reply where the first paragraph is legitimately framing. The gate remains advisory.
+
+Design gates and Bias to Action are similarly not hook-enforceable for the same reason (mode classification requires understanding intent, not matching text patterns).

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2766,6 +2766,62 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         fi
     fi
 
+    # Migration 81: Register dispatch-template-check.py PreToolUse hook (uow_20260421_715745).
+    # Enforces Dispatch template gate: every Agent call from the dispatcher must include
+    # 'Minimum viable output:' and 'Boundary:' in the prompt, surviving context compaction.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local has_dispatch_template_check
+        has_dispatch_template_check=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+            | map(select(contains("dispatch-template-check")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_dispatch_template_check:-0}" = "0" ] || [ "${has_dispatch_template_check:-0}" = "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "python3 $LOBSTER_DIR/hooks/dispatch-template-check.py" \
+               '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                "matcher": "Agent",
+                "hooks": [{
+                    "type": "command",
+                    "command": $cmd,
+                    "timeout": 5
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered dispatch-template-check PreToolUse hook (Migration 81)"
+            migrated=$((migrated + 1))
+        else
+            substep "dispatch-template-check hook already registered — skipping Migration 81"
+        fi
+    fi
+
+    # Migration 82: Register pr-merge-gate.py PreToolUse hook (uow_20260421_715745).
+    # Enforces PR Merge Gate: 'gh pr merge' commands require a VERDICT: APPROVED entry in
+    # oracle/decisions.md for that PR number, surviving context compaction.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local has_pr_merge_gate
+        has_pr_merge_gate=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+            | map(select(contains("pr-merge-gate")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_pr_merge_gate:-0}" = "0" ] || [ "${has_pr_merge_gate:-0}" = "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "python3 $LOBSTER_DIR/hooks/pr-merge-gate.py" \
+               '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": $cmd,
+                    "timeout": 5
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered pr-merge-gate PreToolUse hook (Migration 82)"
+            migrated=$((migrated + 1))
+        else
+            substep "pr-merge-gate hook already registered — skipping Migration 82"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## What this solves

Two advisory gates in the Tier-1 Gate Register were survivable only as long as context persisted — after compaction, the dispatcher could forget to include dispatch template fields in Agent prompts or attempt to merge a PR without oracle approval. This PR makes both gates mechanical (PreToolUse hooks) so they enforce regardless of context state.

## Changes

**hooks/dispatch-template-check.py** — PreToolUse on Agent. Blocks any dispatcher Agent call that lacks `Minimum viable output:` or `Boundary:` in the prompt body. Subagents are exempt (checked via `is_dispatcher_session()`). Error message names the missing fields and cites CLAUDE.md.

**hooks/pr-merge-gate.py** — PreToolUse on Bash. Scans for `gh pr merge <N>` and looks up `oracle/decisions.md` for the most recent verdict on PR #N. APPROVED → allow. NEEDS_CHANGES or other → block. No oracle entry → warn but allow (pre-oracle and infrastructure PRs are not blocked). PR number is extracted from any position in the merge command (before or after flags, URL form).

**scripts/upgrade.sh** — Migrations 80 and 81 register both hooks as PreToolUse entries in `~/.claude/settings.json`. Each migration includes an idempotency guard (jq check for the hook command string before appending).

**oracle/learnings.md** — Documents why Relay filter, Design Gate, and Bias to Action cannot be promoted to hooks: all three require semantic judgment about message intent or rhetorical priority that no string pattern captures reliably. The gates remain advisory.

## Functional patterns used

Pure functions for verdict extraction and PR number parsing — both are stateless transformations with explicit return types (`str | None`, `int | None`). Side effects (file reads, stderr writes, process exit) are isolated to the `main` flow at the module boundary.

## What is not changed

- CLAUDE.md advisory gate text is unchanged.
- No bootup files modified.
- Hooks are registered only via `upgrade.sh` migration — `~/.claude/settings.json` is not directly edited by this PR.
- Migrations 78 and 79 (already present in main) are untouched.

## Tests run

- [x] `dispatch-template-check.py`: verified exit 0 when both fields present, exit 0 for non-Agent tools, exit 0 for subagent sessions (no `session_id` match)
- [x] `pr-merge-gate.py`: verified exit 0 for non-merge Bash commands, exit 0 with warning for unknown PR number, exit 0 for PR #753 (APPROVED in real decisions.md), exit 2 blocked for NEEDS_CHANGES (unit-tested verdict logic inline)
- [x] Oracle verdict extraction: boundary test confirms PR #99 does not match PR #999 entries
- [x] PR number extraction: tested `gh pr merge 123`, `gh pr merge --squash 123`, `gh pr merge 123 --squash`, URL form, no-number form

## Manual test

N/A — hooks are PreToolUse Python scripts with no external service calls, file I/O beyond reading decisions.md, or systemd/cron involvement. The registration path (upgrade.sh) modifies settings.json via jq, which is unit-testable but not run here (requires a live settings.json with the full hook schema).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A for these hooks
- [x] User-visible outcome: not applicable (internal enforcement hooks, no user-facing output)
- [x] Side-effect audit complete: hooks exit 0/2 only, no writes to shared state
- [x] External service calls: none