### PR TITLE
feat: route cron jobs through dispatcher Agent mechanism (Phase 2+3)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -848,6 +848,56 @@ Implementation: `route_wos_message` is the single entry point. The handler is `h
 
 ---
 
+### scheduled_job_trigger (`type: "scheduled_job_trigger"`)
+
+Written by `scheduled-tasks/post-job-trigger.sh` when a cron entry fires. Each trigger identifies a job by name; the dispatcher reads the corresponding task file and spawns a subagent.
+
+```
+1. mark_processing(message_id)
+
+2. job_name = msg["job_name"]
+   chat_id  = msg.get("chat_id", 0)
+
+3. task_file = f"~/lobster-workspace/scheduled-jobs/tasks/{job_name}.md"
+   If the task file does not exist:
+       send_reply(chat_id, f"Scheduled job '{job_name}' has no task file — skipping.")
+       mark_processed(message_id)
+       continue
+
+4. task_content = <contents of task file>
+   epoch        = int(time.time())
+   prompt = (
+       f"---\n"
+       f"task_id: job-{job_name}-{epoch}\n"
+       f"chat_id: {chat_id}\n"
+       f"source: scheduled_job\n"
+       f"---\n\n"
+       + task_content
+   )
+   Task(
+       prompt=prompt,
+       subagent_type="lobster-generalist",
+       run_in_background=True,
+   )
+
+5. mark_processed(message_id)
+```
+
+Rules: do NOT await the subagent result inline. The subagent calls `send_reply` + `write_result` on its own. If `chat_id` is 0 (system-sourced trigger), do not call `send_reply` for errors — log silently.
+
+---
+
+### wfm_watchdog (`type: "wfm_watchdog"`)
+
+Injected by `scripts/wfm-watchdog.sh` when `wait_for_messages` appears to have been frozen for >35 minutes. This synthetic message unblocks WFM so the dispatcher can resume.
+
+1. mark_processed(message_id)  <- no action needed, just clear it
+2. Call wait_for_messages() again immediately
+
+Rules: never `send_reply`. Do not log or relay. The watchdog already sent a Telegram alert. This message exists only to unblock WFM -- treat as a no-op and resume the loop.
+
+---
+
 ## Message Source Handling
 
 Always pass the correct `source` parameter to `send_reply` — Telegram and Slack messages may arrive interleaved.

--- a/scheduled-tasks/deprecated/sync-crontab.sh
+++ b/scheduled-tasks/deprecated/sync-crontab.sh
@@ -17,7 +17,7 @@ set -e
 WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 REPO_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 JOBS_FILE="$WORKSPACE/scheduled-jobs/jobs.json"
-RUNNER="$REPO_DIR/scheduled-tasks/dispatch-job.sh"
+RUNNER="$REPO_DIR/scheduled-tasks/post-job-trigger.sh"
 CRONTAB_FILE="/var/spool/cron/crontabs/$(whoami)"
 
 # Check if cron is available at all

--- a/scheduled-tasks/post-job-trigger.sh
+++ b/scheduled-tasks/post-job-trigger.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Lobster Cron-to-Dispatcher Trigger
+#
+# Writes a scheduled_job_trigger inbox message so the dispatcher spawns a
+# subagent for the job. Does NOT invoke Claude directly.
+#
+# Usage: post-job-trigger.sh <job-name>
+#
+# This replaces run-job.sh as the cron entry point.  The dispatcher reads the
+# trigger message and spawns a lobster-generalist subagent with the task file
+# content prepended by YAML frontmatter.  See the scheduled_job_trigger handler
+# in .claude/sys.dispatcher.bootup.md for the full dispatcher-side protocol.
+
+set -e
+
+JOB_NAME="$1"
+
+if [ -z "$JOB_NAME" ]; then
+    echo "Usage: $0 <job-name>"
+    exit 1
+fi
+
+# Load env files so tokens and config (including LOBSTER_ADMIN_CHAT_ID) are
+# available when running from cron.  Mirror the approach used in dispatch-job.sh.
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+JOBS_FILE="${SCHEDULED_JOBS_FILE:-$WORKSPACE/scheduled-jobs/jobs.json}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+INBOX_DIR="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
+TIMESTAMP=$(date -Iseconds)
+
+# Ensure directories exist
+mkdir -p "$LOG_DIR" "$INBOX_DIR"
+
+LOG_FILE="$LOG_DIR/${JOB_NAME}.log"
+
+# --- Check enabled flag in jobs.json ---
+if [ -f "$JOBS_FILE" ]; then
+    if command -v jq &>/dev/null; then
+        ENABLED=$(jq -r --arg name "$JOB_NAME" '.jobs[$name].enabled // true' "$JOBS_FILE" 2>/dev/null || echo "true")
+    else
+        ENABLED=$(uv run - "$JOBS_FILE" "$JOB_NAME" << 'PYEOF'
+import json, sys
+jobs_file = sys.argv[1]
+job_name  = sys.argv[2]
+try:
+    with open(jobs_file) as f:
+        data = json.load(f)
+    job = data.get('jobs', {}).get(job_name, {})
+    print(str(job.get('enabled', True)).lower())
+except Exception:
+    print('true')
+PYEOF
+        2>/dev/null)
+    fi
+    if [ "$ENABLED" = "false" ]; then
+        # Job disabled — exit silently (no log noise)
+        exit 0
+    fi
+fi
+
+# --- Write scheduled_job_trigger to inbox ---
+EPOCH=$(date +%s)
+FILENAME="scheduled_job_${JOB_NAME}_${EPOCH}.json"
+
+CHAT_ID="${LOBSTER_ADMIN_CHAT_ID:-0}"
+
+uv run - \
+    "${INBOX_DIR}/${FILENAME}" \
+    "${JOB_NAME}" \
+    "${TIMESTAMP}" \
+    "${CHAT_ID}" \
+    << 'PYEOF'
+import json, os, sys
+
+out_path  = sys.argv[1]
+job_name  = sys.argv[2]
+timestamp = sys.argv[3]
+chat_id   = sys.argv[4]
+
+msg = {
+    "type": "scheduled_job_trigger",
+    "job_name": job_name,
+    "timestamp": timestamp,
+    "chat_id": chat_id,
+    "source": "cron",
+}
+
+tmp_path = out_path + ".tmp"
+with open(tmp_path, "w") as f:
+    json.dump(msg, f, ensure_ascii=False, indent=2)
+    f.flush()
+
+os.replace(tmp_path, out_path)
+print(f"trigger written: {out_path}")
+PYEOF
+
+echo "[$TIMESTAMP] trigger written" >> "$LOG_FILE" 2>&1 || true

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4394,6 +4394,36 @@ PYEOF
         warn "jobs.json not found — skipping Migration 122f (council-note-check registration)"
     fi
 
+    # Migration 123: Rewrite crontab entries to use post-job-trigger.sh
+    # Cron jobs that previously called dispatch-job.sh now call post-job-trigger.sh,
+    # which writes a scheduled_job_trigger inbox message (vs scheduled_reminder).
+    # The dispatcher handles both types, so existing jobs continue to work during
+    # the transition. run-job.sh entries (older installs) are also caught.
+    if crontab -l 2>/dev/null | grep -qE '(run-job|dispatch-job)\.sh.*# LOBSTER-SCHEDULED'; then
+        log_step "123" "Rewriting crontab entries: run-job.sh / dispatch-job.sh → post-job-trigger.sh"
+        crontab -l 2>/dev/null | sed 's|run-job\.sh|post-job-trigger.sh|g; s|dispatch-job\.sh|post-job-trigger.sh|g' | crontab -
+        log_ok "Crontab entries updated"
+        migrated=$((migrated + 1))
+    else
+        substep "Migration 123: no run-job.sh / dispatch-job.sh LOBSTER-SCHEDULED crontab entries — skipping"
+    fi
+
+    # Migration 124: [PHASE 3 — apply only after 7 clean days] Remove block-claude-p hook
+    #
+    # PHASE 3 NOTE: This step is a stub. Run manually after post-job-trigger.sh
+    # has been in production for ≥7 days with zero new entries in
+    # ~/lobster-workspace/logs/claude-p-blocks.jsonl.
+    # Uncomment and run when ready:
+    #
+    # log_step "124" "Phase 3: removing block-claude-p hook from settings.json"
+    # SETTINGS=~/.claude/settings.json
+    # if [ -f "$SETTINGS" ]; then
+    #   TMP_SETTINGS=$(mktemp)
+    #   jq 'del(.hooks[] | select(. | tostring | contains("block-claude-p")))' \
+    #       "$SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$SETTINGS"
+    #   log_ok "block-claude-p hook removed from settings.json"
+    # fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

**Before:** Cron jobs either called `claude -p` directly (run-job.sh, older installs) or wrote `scheduled_reminder` inbox messages (dispatch-job.sh). The `claude -p` path bypasses structured subagent dispatch, consuming tokens unpredictably and dropping the dispatcher's MCP stdio connection (incident 2026-03-25).

**After:** A new `post-job-trigger.sh` cron entry point writes `scheduled_job_trigger` inbox messages. The dispatcher reads the corresponding task file and spawns a `lobster-generalist` subagent via the Agent tool — no `claude -p` involved.

### Before flow
```
cron → run-job.sh → claude -p <task content>
          ↑ spawns a new Claude process inline, bypasses write_result
```

### After flow
```
cron → post-job-trigger.sh → ~/messages/inbox/scheduled_job_<name>_<epoch>.json
                                        ↓
                              dispatcher (wait_for_messages)
                                        ↓
                              reads task file → spawns Agent(lobster-generalist)
                                        ↓
                              subagent: send_reply + write_result
```

## Changes

- **`scheduled-tasks/post-job-trigger.sh`** — new cron entry point; checks `jobs.json` enabled flag, writes `scheduled_job_trigger` JSON to inbox, logs one line to `scheduled-jobs/logs/<job-name>.log`
- **`.claude/sys.dispatcher.bootup.md`** — documents the `scheduled_job_trigger` handler: extract `job_name`/`chat_id`, read task file, spawn Agent, mark_processed
- **`scheduled-tasks/deprecated/sync-crontab.sh`** — updated `RUNNER` from `dispatch-job.sh` to `post-job-trigger.sh` (dispatch-job.sh remains on disk for compatibility)
- **`scripts/upgrade.sh`** — Migration 83: rewrites existing `run-job.sh`/`dispatch-job.sh` LOBSTER-SCHEDULED crontab entries to use `post-job-trigger.sh`; Migration 84: Phase 3 cleanup stub (block-claude-p hook removal, commented out — apply after 7 clean days)

## Acceptance criteria

- [ ] `scheduled-tasks/post-job-trigger.sh` exists and is executable
- [ ] Script checks `jobs.json` enabled flag and exits 0 silently when disabled
- [ ] Script writes valid `scheduled_job_trigger` JSON to `~/messages/inbox/`
- [ ] `sync-crontab.sh` (deprecated) references `post-job-trigger.sh` as RUNNER
- [ ] Dispatcher bootup doc has `scheduled_job_trigger` handler instructions
- [ ] `upgrade.sh` Migration 83 rewrites crontab entries
- [ ] `upgrade.sh` Migration 84 (Phase 3 block-claude-p hook removal) is present but commented out

## Phase 3 prep

Migration 84 in `upgrade.sh` stubs the removal of the `block-claude-p` PreToolUse hook. It is entirely commented out. Apply manually after `post-job-trigger.sh` has been in production for ≥7 days with zero new entries in `~/lobster-workspace/logs/claude-p-blocks.jsonl`.

## References

Closes part of #882. Phase 1 (`block-claude-p` hook, warn mode) was addressed in #889.