### PR TITLE
fix: WOS small issues — UoWStatus enum, classifier wiring, upgrade.sh syntax

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1576,6 +1576,9 @@ EOF
                 }]
             }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
             substep "Registered on-fresh-start SessionStart hook in settings.json"
+            migrated=$((migrated + 1))
+        fi
+    fi
 
     # Migration 37: Create proprioceptive memory directory.
     # Stores concrete semantic mirroring instances (alignment/misalignment moments)

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 import sqlite3
 import uuid
 from collections.abc import Callable
@@ -23,6 +24,8 @@ from datetime import datetime, timezone, timedelta
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Protocol
+
+log = logging.getLogger("registry")
 
 
 # ---------------------------------------------------------------------------
@@ -57,10 +60,14 @@ class UoWStatus(StrEnum):
     DONE = "done"
     FAILED = "failed"
     EXPIRED = "expired"
+    # CANCELLED: terminal status used when a UoW is explicitly cancelled.
+    # Treated as terminal (allows re-proposal). Previously a legacy DB-only value
+    # not covered by the enum — UoWStatus('cancelled') raised ValueError.
+    CANCELLED = "cancelled"
 
     def is_terminal(self) -> bool:
-        """True for statuses that allow re-proposal (done, failed, expired)."""
-        return self in {UoWStatus.DONE, UoWStatus.FAILED, UoWStatus.EXPIRED}
+        """True for statuses that allow re-proposal (done, failed, expired, cancelled)."""
+        return self in {UoWStatus.DONE, UoWStatus.FAILED, UoWStatus.EXPIRED, UoWStatus.CANCELLED}
 
     def is_in_flight(self) -> bool:
         """True for statuses that block re-proposal (active, executing, pending, ready-for-steward, ready-for-executor, diagnosing)."""
@@ -466,8 +473,8 @@ class Registry:
             conn.execute("BEGIN IMMEDIATE")
 
             # Cross-sweep-date pre-check: any non-terminal record for this issue?
-            # 'cancelled' is a legacy status (not in UoWStatus enum) treated as terminal
-            # so that re-proposal is allowed after a cancellation.
+            # 'cancelled' is a terminal status (UoWStatus.CANCELLED) that allows
+            # re-proposal after a cancellation.
             existing = conn.execute(
                 """
                 SELECT id, status FROM uow_registry
@@ -522,6 +529,24 @@ class Registry:
             # Use source_ref from IssueSnapshot if provided; fall back for backwards compatibility.
             source = source_ref if source_ref else f"github:issue/{issue_number}"
 
+            # Classify posture and route_reason via routing_classifier.
+            # Runs the first-match-wins rules from classifier.yaml against the
+            # prescription metadata available at germination time (type, and any
+            # other fields callers choose to provide in the future).
+            # Falls back to solo/classifier-unavailable if the YAML is absent.
+            try:
+                from orchestration.routing_classifier import classify_posture
+                classifier_result = classify_posture({"type": uow_type})
+                germination_posture = classifier_result.posture
+                germination_route_reason = classifier_result.route_reason
+            except Exception as _classifier_exc:
+                log.warning(
+                    "routing_classifier failed for UoW (issue #%s) — using legacy defaults: %s",
+                    issue_number, _classifier_exc,
+                )
+                germination_posture = "solo"
+                germination_route_reason = _LEGACY_ROUTE_REASON
+
             # Audit entry is written BEFORE the INSERT (Principle 1: audit first).
             # If the INSERT fails, both roll back together.
             self._write_audit(conn, uow_id=uow_id, event="created", to_status="proposed")
@@ -536,7 +561,7 @@ class Registry:
                     status, posture, created_at, updated_at, summary,
                     success_criteria, route_reason, route_evidence, trigger,
                     issue_url, register, uow_mode, source_ref
-                ) VALUES (?, ?, ?, ?, ?, 'proposed', 'solo', ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, 'proposed', ?, ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?, ?, ?, ?)
                 """,
                 (
                     uow_id,
@@ -544,11 +569,12 @@ class Registry:
                     source,
                     issue_number,
                     sweep_date,
+                    germination_posture,
                     now,
                     now,
                     title,
                     success_criteria,
-                    _LEGACY_ROUTE_REASON,
+                    germination_route_reason,
                     resolved_issue_url,
                     register,
                     register,  # uow_mode mirrors register at germination time

--- a/src/orchestration/routing_classifier.py
+++ b/src/orchestration/routing_classifier.py
@@ -1,0 +1,193 @@
+"""
+routing_classifier.py — WOS routing classifier for UoW posture assignment.
+
+Loads classifier.yaml from ~/lobster-user-config/orchestration/classifier.yaml
+and applies first-match-wins rules to prescription metadata to determine posture
+and route_reason for a UoW at germination time.
+
+Rules structure (classifier.yaml):
+  rules:
+    - name: <str>
+      priority: <int>          # higher = evaluated first
+      conditions: []           # AND-joined; empty = catch-all
+        - field: <str>         # field in the prescription metadata dict
+          op: eq | gt | lt | contains
+          value: <scalar>
+      posture: <str>           # solo | sequential | review-loop | fan-out
+      route_reason_template: <str>
+
+Usage:
+    from orchestration.routing_classifier import classify_posture, ClassifierResult
+
+    result = classify_posture({"type": "seed", "risk": "high", "files_touched": 3})
+    # result.posture == "sequential"
+    # result.route_reason == "Rule 'design-first' matched: type=seed"
+
+The classifier is loaded from disk once per process call (no caching — the file
+is small and reads are cheap; avoids stale-cache bugs in long-running processes).
+Falls back to solo posture with FALLBACK_ROUTE_REASON when the YAML is absent or
+malformed — germination must never fail due to classifier unavailability.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("routing_classifier")
+
+# Default classifier YAML path — overridable via env var for tests.
+_DEFAULT_CLASSIFIER_PATH = Path(
+    os.environ.get(
+        "WOS_CLASSIFIER_YAML",
+        Path.home() / "lobster-user-config" / "orchestration" / "classifier.yaml",
+    )
+)
+
+# Written to route_reason when the classifier file is absent or cannot be parsed.
+FALLBACK_ROUTE_REASON = "classifier-unavailable: defaulting to solo"
+
+# Written to route_reason when no rule matches (should not happen if YAML has a catch-all).
+NO_MATCH_ROUTE_REASON = "classifier: no rule matched — defaulting to solo"
+
+# Default posture when classifier is unavailable or no rule matches.
+FALLBACK_POSTURE = "solo"
+
+
+@dataclass(frozen=True)
+class ClassifierResult:
+    """Result of running the routing classifier against prescription metadata."""
+    posture: str
+    route_reason: str
+    rule_name: str | None = None
+
+
+def _load_classifier_yaml(path: Path) -> list[dict] | None:
+    """
+    Load and return sorted classifier rules from the YAML file.
+
+    Returns None when the file is absent or cannot be parsed — callers fall
+    back to FALLBACK_POSTURE without raising.
+
+    Rules are sorted by priority descending (highest priority evaluated first).
+    """
+    if not path.exists():
+        log.debug("Classifier YAML not found at %s — using fallback posture", path)
+        return None
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        log.warning(
+            "PyYAML not available — cannot load classifier.yaml. "
+            "Install pyyaml to enable posture classification."
+        )
+        return None
+    try:
+        with path.open() as f:
+            data = yaml.safe_load(f)
+        rules = data.get("rules", [])
+        return sorted(rules, key=lambda r: r.get("priority", 0), reverse=True)
+    except Exception as exc:
+        log.warning("Failed to parse classifier YAML at %s — %s", path, exc)
+        return None
+
+
+def _evaluate_condition(condition: dict, metadata: dict[str, Any]) -> bool:
+    """
+    Evaluate a single condition against prescription metadata.
+
+    Supported operators: eq, gt, lt, contains.
+    Missing fields are treated as falsy — the condition fails safely.
+    """
+    field = condition.get("field", "")
+    op = condition.get("op", "eq")
+    expected = condition.get("value")
+    actual = metadata.get(field)
+
+    if actual is None:
+        return False
+
+    match op:
+        case "eq":
+            return str(actual) == str(expected)
+        case "gt":
+            try:
+                return float(actual) > float(expected)
+            except (TypeError, ValueError):
+                return False
+        case "lt":
+            try:
+                return float(actual) < float(expected)
+            except (TypeError, ValueError):
+                return False
+        case "contains":
+            return str(expected) in str(actual)
+        case _:
+            log.warning("Unknown classifier condition operator %r — treating as False", op)
+            return False
+
+
+def _rule_matches(rule: dict, metadata: dict[str, Any]) -> bool:
+    """
+    Return True if all conditions in the rule match the metadata (AND-joined).
+
+    An empty conditions list is a catch-all — always matches.
+    """
+    conditions = rule.get("conditions", [])
+    return all(_evaluate_condition(c, metadata) for c in conditions)
+
+
+def classify_posture(
+    metadata: dict[str, Any],
+    classifier_path: Path | None = None,
+) -> ClassifierResult:
+    """
+    Run first-match-wins classifier rules against prescription metadata.
+
+    Args:
+        metadata: Dict of prescription fields. Recognized keys per classifier.yaml:
+            - type: "seed" | "executable" (UoW type from germination)
+            - risk: "high" | "medium" | "low" (optional, from prescription)
+            - files_touched: int (optional, from prescription)
+        classifier_path: Override path to classifier.yaml. Defaults to
+            ~/lobster-user-config/orchestration/classifier.yaml.
+            Overridable via WOS_CLASSIFIER_YAML env var.
+
+    Returns:
+        ClassifierResult with posture and route_reason. Never raises — falls
+        back to solo on any error so germination is never blocked.
+    """
+    path = classifier_path or _DEFAULT_CLASSIFIER_PATH
+    rules = _load_classifier_yaml(path)
+
+    if rules is None:
+        return ClassifierResult(
+            posture=FALLBACK_POSTURE,
+            route_reason=FALLBACK_ROUTE_REASON,
+            rule_name=None,
+        )
+
+    for rule in rules:
+        if _rule_matches(rule, metadata):
+            posture = rule.get("posture", FALLBACK_POSTURE)
+            route_reason = rule.get("route_reason_template", f"Rule {rule.get('name')!r} matched")
+            rule_name = rule.get("name")
+            log.debug(
+                "Classifier matched rule %r — posture=%s, route_reason=%r",
+                rule_name, posture, route_reason,
+            )
+            return ClassifierResult(
+                posture=posture,
+                route_reason=route_reason,
+                rule_name=rule_name,
+            )
+
+    log.warning("Classifier: no rule matched for metadata %r — defaulting to solo", metadata)
+    return ClassifierResult(
+        posture=FALLBACK_POSTURE,
+        route_reason=NO_MATCH_ROUTE_REASON,
+        rule_name=None,
+    )

--- a/src/orchestration/routing_classifier.py
+++ b/src/orchestration/routing_classifier.py
@@ -39,13 +39,18 @@ from typing import Any
 
 log = logging.getLogger("routing_classifier")
 
-# Default classifier YAML path — overridable via env var for tests.
-_DEFAULT_CLASSIFIER_PATH = Path(
-    os.environ.get(
-        "WOS_CLASSIFIER_YAML",
-        Path.home() / "lobster-user-config" / "orchestration" / "classifier.yaml",
-    )
+# Default classifier YAML path fallback — used when WOS_CLASSIFIER_YAML is not set.
+# NOT read at import time; _default_classifier_path() is called lazily at classify_posture
+# call time so that monkeypatch.setenv("WOS_CLASSIFIER_YAML", ...) takes effect in tests.
+_CLASSIFIER_YAML_DEFAULT_FALLBACK = (
+    Path.home() / "lobster-user-config" / "orchestration" / "classifier.yaml"
 )
+
+
+def _default_classifier_path() -> Path:
+    """Return the default classifier path, reading WOS_CLASSIFIER_YAML at call time."""
+    env_val = os.environ.get("WOS_CLASSIFIER_YAML")
+    return Path(env_val) if env_val else _CLASSIFIER_YAML_DEFAULT_FALLBACK
 
 # Written to route_reason when the classifier file is absent or cannot be parsed.
 FALLBACK_ROUTE_REASON = "classifier-unavailable: defaulting to solo"
@@ -160,7 +165,7 @@ def classify_posture(
         ClassifierResult with posture and route_reason. Never raises — falls
         back to solo on any error so germination is never blocked.
     """
-    path = classifier_path or _DEFAULT_CLASSIFIER_PATH
+    path = classifier_path if classifier_path is not None else _default_classifier_path()
     rules = _load_classifier_yaml(path)
 
     if rules is None:

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -24,9 +24,21 @@ import json
 import sqlite3
 import subprocess
 import sys
+import textwrap
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 import pytest
+
+# Minimal classifier YAML used in tests that need deterministic route_reason output.
+# Contains only a catch-all rule so any metadata produces "classifier-test: catch-all matched".
+_TEST_CLASSIFIER_YAML = textwrap.dedent("""\
+    rules:
+      - name: test-catch-all
+        priority: 0
+        conditions: []
+        posture: solo
+        route_reason_template: "classifier-test: catch-all matched"
+""")
 
 # Path to the registry module under src/orchestration/
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
@@ -95,8 +107,16 @@ class TestSchemaInit:
 # ---------------------------------------------------------------------------
 
 class TestUpsert:
-    def test_insert_new_proposed_record(self, registry, db_path):
+    def test_insert_new_proposed_record(self, registry, db_path, tmp_path, monkeypatch):
         from src.orchestration.registry import UpsertInserted
+        # Point WOS_CLASSIFIER_YAML at a known test fixture so the classifier fires
+        # with deterministic output. This distinguishes correct wiring (catch-all rule
+        # produces "classifier-test: catch-all matched") from silent fallback
+        # ("classifier-unavailable: defaulting to solo").
+        classifier_yaml = tmp_path / "test_classifier.yaml"
+        classifier_yaml.write_text(_TEST_CLASSIFIER_YAML)
+        monkeypatch.setenv("WOS_CLASSIFIER_YAML", str(classifier_yaml))
+
         today = datetime.now(timezone.utc).date().isoformat()
         result = registry.upsert(issue_number=1, title="First issue", sweep_date=today, success_criteria="Test completion.")
         assert isinstance(result, UpsertInserted)
@@ -108,14 +128,11 @@ class TestUpsert:
         assert row["status"] == "proposed"
         assert row["source_issue_number"] == 1
         assert row["posture"] == "solo"
-        # route_reason is now set by the routing classifier at germination time.
-        # The exact value depends on whether classifier.yaml is available:
-        # - With YAML: "Rule 'default' (catch-all) matched" (catch-all rule)
-        # - Without YAML: "classifier-unavailable: defaulting to solo"
-        # In both cases, the legacy "phase1-default: no classifier" value must NOT appear.
-        assert row["route_reason"] is not None
-        assert row["route_reason"] != "phase1-default: no classifier", (
-            "Legacy route_reason still written — classifier not wired in correctly"
+        # The classifier must fire and use the catch-all rule from the test fixture.
+        # "classifier-unavailable: defaulting to solo" would indicate the env var
+        # override did not reach classify_posture — i.e., the classifier is not wired.
+        assert row["route_reason"] == "classifier-test: catch-all matched", (
+            f"Expected classifier to fire with test fixture, got: {row['route_reason']!r}"
         )
         conn.close()
 

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -108,7 +108,15 @@ class TestUpsert:
         assert row["status"] == "proposed"
         assert row["source_issue_number"] == 1
         assert row["posture"] == "solo"
-        assert row["route_reason"] == "phase1-default: no classifier"
+        # route_reason is now set by the routing classifier at germination time.
+        # The exact value depends on whether classifier.yaml is available:
+        # - With YAML: "Rule 'default' (catch-all) matched" (catch-all rule)
+        # - Without YAML: "classifier-unavailable: defaulting to solo"
+        # In both cases, the legacy "phase1-default: no classifier" value must NOT appear.
+        assert row["route_reason"] is not None
+        assert row["route_reason"] != "phase1-default: no classifier", (
+            "Legacy route_reason still written — classifier not wired in correctly"
+        )
         conn.close()
 
     def test_upsert_stores_success_criteria(self, registry, db_path):

--- a/tests/unit/test_orchestration/test_routing_classifier.py
+++ b/tests/unit/test_orchestration/test_routing_classifier.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for routing_classifier.py — WOS posture assignment via first-match-wins rules.
+
+Tests verify behavior, not implementation detail:
+- type=seed maps to sequential posture (design-first rule)
+- risk=high maps to review-loop posture (high-risk-review rule)
+- files_touched>5 AND type=executable maps to fan-out posture
+- catch-all maps to solo posture
+- Missing YAML falls back gracefully (never raises)
+- Malformed YAML falls back gracefully
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_classifier_yaml(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content))
+
+
+CANONICAL_CLASSIFIER_YAML = """\
+    # WOS Routing Classifier — first-match-wins
+    rules:
+      - name: design-first
+        priority: 10
+        conditions:
+          - field: type
+            op: eq
+            value: seed
+        posture: sequential
+        route_reason_template: "Rule 'design-first' matched: type=seed"
+
+      - name: high-risk-review
+        priority: 9
+        conditions:
+          - field: risk
+            op: eq
+            value: high
+        posture: review-loop
+        route_reason_template: "Rule 'high-risk-review' matched: risk=high"
+
+      - name: parallelizable-multifile
+        priority: 8
+        conditions:
+          - field: files_touched
+            op: gt
+            value: 5
+          - field: type
+            op: eq
+            value: executable
+        posture: fan-out
+        route_reason_template: "Rule 'parallelizable-multifile' matched: files_touched>5 AND type=executable"
+
+      - name: default
+        priority: 0
+        conditions: []
+        posture: solo
+        route_reason_template: "Rule 'default' (catch-all) matched"
+"""
+
+
+@pytest.fixture
+def classifier_yaml_path(tmp_path: Path) -> Path:
+    yaml_path = tmp_path / "classifier.yaml"
+    _write_classifier_yaml(yaml_path, CANONICAL_CLASSIFIER_YAML)
+    return yaml_path
+
+
+# ---------------------------------------------------------------------------
+# Posture assignment tests — behavior named after the spec requirement
+# ---------------------------------------------------------------------------
+
+class TestPostureAssignment:
+    def test_seed_type_assigns_sequential_posture(self, classifier_yaml_path):
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture({"type": "seed"}, classifier_path=classifier_yaml_path)
+        assert result.posture == "sequential"
+        assert result.rule_name == "design-first"
+
+    def test_high_risk_assigns_review_loop_posture(self, classifier_yaml_path):
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture({"risk": "high"}, classifier_path=classifier_yaml_path)
+        assert result.posture == "review-loop"
+        assert result.rule_name == "high-risk-review"
+
+    def test_multifile_executable_assigns_fan_out_posture(self, classifier_yaml_path):
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture(
+            {"files_touched": 10, "type": "executable"},
+            classifier_path=classifier_yaml_path,
+        )
+        assert result.posture == "fan-out"
+        assert result.rule_name == "parallelizable-multifile"
+
+    def test_default_catch_all_assigns_solo_posture(self, classifier_yaml_path):
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture({"type": "executable"}, classifier_path=classifier_yaml_path)
+        assert result.posture == "solo"
+        assert result.rule_name == "default"
+
+    def test_first_match_wins_seed_takes_priority_over_high_risk(self, classifier_yaml_path):
+        """When type=seed AND risk=high, design-first (priority 10) fires before high-risk-review (priority 9)."""
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture(
+            {"type": "seed", "risk": "high"},
+            classifier_path=classifier_yaml_path,
+        )
+        assert result.posture == "sequential"
+        assert result.rule_name == "design-first"
+
+    def test_multifile_condition_requires_both_fields(self, classifier_yaml_path):
+        """files_touched>5 alone (without type=executable) should not trigger fan-out."""
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture(
+            {"files_touched": 10},  # type not set
+            classifier_path=classifier_yaml_path,
+        )
+        # Should fall through to catch-all
+        assert result.posture == "solo"
+
+    def test_route_reason_reflects_matched_rule(self, classifier_yaml_path):
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture({"type": "seed"}, classifier_path=classifier_yaml_path)
+        assert "design-first" in result.route_reason
+
+    def test_files_touched_boundary_exactly_5_does_not_trigger_fan_out(self, classifier_yaml_path):
+        """files_touched must be strictly greater than 5 (op: gt)."""
+        from src.orchestration.routing_classifier import classify_posture
+        result = classify_posture(
+            {"files_touched": 5, "type": "executable"},
+            classifier_path=classifier_yaml_path,
+        )
+        assert result.posture == "solo"
+
+
+# ---------------------------------------------------------------------------
+# Fallback behavior tests — classifier must never block germination
+# ---------------------------------------------------------------------------
+
+class TestFallbackBehavior:
+    def test_missing_yaml_returns_solo_posture(self, tmp_path):
+        from src.orchestration.routing_classifier import classify_posture, FALLBACK_POSTURE
+        absent_path = tmp_path / "nonexistent.yaml"
+        result = classify_posture({"type": "seed"}, classifier_path=absent_path)
+        assert result.posture == FALLBACK_POSTURE
+
+    def test_missing_yaml_does_not_raise(self, tmp_path):
+        from src.orchestration.routing_classifier import classify_posture
+        absent_path = tmp_path / "nonexistent.yaml"
+        # Must not raise — germination must never fail due to classifier absence
+        result = classify_posture({}, classifier_path=absent_path)
+        assert result is not None
+
+    def test_malformed_yaml_returns_fallback(self, tmp_path):
+        from src.orchestration.routing_classifier import classify_posture, FALLBACK_POSTURE
+        bad_yaml = tmp_path / "bad.yaml"
+        bad_yaml.write_text(": this is: not: valid yaml: [[[")
+        result = classify_posture({"type": "seed"}, classifier_path=bad_yaml)
+        assert result.posture == FALLBACK_POSTURE
+
+    def test_missing_field_in_metadata_fails_condition_safely(self, classifier_yaml_path):
+        """A condition referencing a field not in the metadata dict should fail gracefully."""
+        from src.orchestration.routing_classifier import classify_posture
+        # risk field absent — high-risk-review rule should not match
+        result = classify_posture({"type": "executable"}, classifier_path=classifier_yaml_path)
+        assert result.posture == "solo"  # falls through to catch-all
+
+    def test_env_var_overrides_default_classifier_path(self, tmp_path, monkeypatch):
+        """WOS_CLASSIFIER_YAML env var should redirect classifier loading."""
+        from src.orchestration.routing_classifier import classify_posture
+        override_yaml = tmp_path / "custom_classifier.yaml"
+        _write_classifier_yaml(override_yaml, CANONICAL_CLASSIFIER_YAML)
+        monkeypatch.setenv("WOS_CLASSIFIER_YAML", str(override_yaml))
+        # Re-import to pick up env var; pass classifier_path=None to use env default
+        result = classify_posture({"type": "seed"})
+        assert result.posture == "sequential"


### PR DESCRIPTION
## What problem does this solve?

Three independent WOS defects that were surfaced during a status check:

1. **`UoWStatus('cancelled')` raised ValueError** — the value existed in the DB and was referenced in SQL queries as a terminal status, but was not a member of the `UoWStatus` enum. Any code path that deserialized a cancelled UoW from the DB would crash.

2. **classifier.yaml was never called at germination** — the routing classifier (`~/lobster-user-config/orchestration/classifier.yaml`) had 4 first-match-wins rules for posture assignment, but germination hardcoded `posture='solo'` and wrote the legacy placeholder `"phase1-default: no classifier"` to every UoW. The classifier existed but had no effect.

3. **`upgrade.sh` failed to parse** — Migration 35 opened two nested `if` blocks that were never closed with `fi` before Migration 37 began. `bash -n upgrade.sh` exited non-zero, meaning the upgrade script could not be sourced at all.

## What this changes

**Fix 1 — UoWStatus.CANCELLED:** Added `CANCELLED = "cancelled"` to the enum and updated `is_terminal()` to include it. Updated the stale comment in `_upsert_typed` that called it a "legacy status not in the enum." No behavior change for non-cancelled UoWs.

**Fix 2 — Classifier wiring:** Created `src/orchestration/routing_classifier.py` — a pure function module that loads classifier.yaml and runs first-match-wins rules against prescription metadata. Wired into `Registry._upsert_typed` so posture and route_reason are classifier-derived at germination. Falls back to `solo` / `"classifier-unavailable: defaulting to solo"` when the YAML is absent or unreadable — germination never fails due to classifier unavailability. Currently only `type` is passed from germination metadata (the other classifier fields — `risk`, `files_touched` — are not yet available at germination time, so the `design-first` rule for `type=seed` is the only non-default rule that can fire today).

**Fix 3 — upgrade.sh syntax:** Added `migrated=$((migrated + 1))`, `fi`, and `fi` to close Migration 35's two open `if` blocks before Migration 37 begins. `bash -n scripts/upgrade.sh` now exits 0.

## What is NOT changed

- Executor dispatch path is unchanged — posture classification happens at germination, not dispatch.
- Existing UoWs in the DB are unaffected (no migration to backfill `route_reason`).
- The classifier.yaml file itself is unchanged (it lives in `lobster-user-config`, not this repo).
- No CI configuration or test infrastructure was modified.

## Functional patterns

Pure function composition: `routing_classifier.py` is a pure module — `classify_posture(metadata, path)` takes data in, returns a typed result, no side effects. The fallback chain (`_load_classifier_yaml` → `_rule_matches` → `classify_posture`) composes small functions without mutation.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_routing_classifier.py -v` — 13 passed, 0 failed (new tests for classifier behavior)
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py -q` — 71 passed, 0 failed
- [x] `bash -n scripts/upgrade.sh` — exit 0 (syntax check for Fix 3)
- [x] `uv run pytest tests/unit/ -q --ignore=tests/unit/test_attunement.py --ignore=tests/unit/test_dispatch_job_sh.py -k "registry or executor or wos or uow or classifier or routing"` — pre-existing failures in `test_executor.py::TestOptimisticLock` (3 tests) and `test_registry_cli.py::TestApproveCommand::test_approve_idempotent_on_pending` confirmed pre-existing on `main` before this branch.

## Manual test

N/A — no changes to systemd, cron, external services, file I/O, or DB schema. The classifier wiring affects in-process germination only; new UoWs created after this merges will have classifier-derived posture.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external service calls)
- [x] User-visible outcome: not applicable — internal WOS plumbing only
- [x] Side-effect audit complete: classifier runs at germination (pure function, no I/O beyond YAML read); upgrade.sh fix is additive only
- [x] External service calls: none