### PR TITLE
feat: WOS activation — heartbeat integration, health check, metabolic digest

### DIFF
--- a/scheduled-tasks/wos-health-check.py
+++ b/scheduled-tasks/wos-health-check.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""
+WOS Health Check — starvation diagnosis and heartbeat liveness observation.
+
+Runs every 6 hours. On each invocation:
+1. Checks for UoWs stuck in 'proposed' or 'pending' state for >24h (starvation candidates).
+2. Checks for UoWs in 'active'/'executing' with stale heartbeats (heartbeat liveness check).
+3. Checks executor-heartbeat last-run time (is the heartbeat even firing?).
+4. Writes a brief health report to the health-check log.
+5. If any UoWs are stale (stuck >48h), sends an inbox message to the admin chat_id.
+
+Cron schedule (every 6 hours):
+    0 */6 * * * cd ~/lobster && uv run scheduled-tasks/wos-health-check.py >> ~/lobster-workspace/scheduled-jobs/logs/wos-health-check.log 2>&1 # LOBSTER-WOS-HEALTH-CHECK
+
+Type C dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+involvement). The jobs.json enabled gate is checked at the top of main() so that
+runtime enable/disable is respected without touching cron.
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/wos-health-check.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("wos-health-check")
+
+# ---------------------------------------------------------------------------
+# Constants — derived from the spec in the audit doc and issue #849
+# ---------------------------------------------------------------------------
+
+JOB_NAME: str = "wos-health-check"
+
+# UoWs stuck in proposed/pending for this long are starvation candidates
+STARVATION_THRESHOLD_HOURS: int = 24
+
+# UoWs stuck >48h in any in-flight state trigger an inbox alert
+ALERT_THRESHOLD_HOURS: int = 48
+
+# Heartbeat stale threshold: silence beyond heartbeat_ttl + this buffer = stall
+HEARTBEAT_STALE_BUFFER_SECONDS: int = 60
+
+# Admin chat_id for inbox alerts (env-injected, falls back to hardcoded)
+ADMIN_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
+
+# Statuses considered starvation candidates (not yet in-flight)
+STARVATION_STATUSES: tuple[str, ...] = ("proposed", "pending")
+
+# Statuses considered in-flight (executing)
+IN_FLIGHT_STATUSES: tuple[str, ...] = ("active", "executing")
+
+
+# ---------------------------------------------------------------------------
+# Workspace / path helpers
+# ---------------------------------------------------------------------------
+
+def _workspace() -> Path:
+    return Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+
+
+def _registry_db_path() -> Path:
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    return _workspace() / "orchestration" / "registry.db"
+
+
+def _log_file() -> Path:
+    return _workspace() / "scheduled-jobs" / "logs" / "wos-health-check.log"
+
+
+def _jobs_file() -> Path:
+    return _workspace() / "scheduled-jobs" / "jobs.json"
+
+
+def _inbox_dir() -> Path:
+    messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+    return messages_base / "inbox"
+
+
+def _executor_log_file() -> Path:
+    return _workspace() / "scheduled-jobs" / "logs" / "executor-heartbeat.log"
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type C dispatch pattern
+# ---------------------------------------------------------------------------
+
+def _is_job_enabled() -> bool:
+    """
+    Return True if this job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when:
+    - jobs.json is absent
+    - the job entry is missing
+    - the file is unreadable or malformed
+    """
+    try:
+        data = json.loads(_jobs_file().read_text())
+        return bool(data.get("jobs", {}).get(JOB_NAME, {}).get("enabled", True))
+    except Exception:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Registry queries — pure functions returning structured data
+# ---------------------------------------------------------------------------
+
+def query_starvation_candidates(db_path: Path, threshold_hours: int) -> list[dict]:
+    """
+    Return UoWs stuck in 'proposed' or 'pending' for longer than threshold_hours.
+
+    Each result dict contains: id, status, summary, created_at, age_hours.
+    Returns [] if DB absent or table missing.
+    """
+    if not db_path.exists():
+        log.warning("Registry DB not found at %s", db_path)
+        return []
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=threshold_hours)).isoformat()
+    placeholders = ",".join("?" * len(STARVATION_STATUSES))
+    sql = f"""
+        SELECT id, status, summary, created_at
+        FROM uow_registry
+        WHERE status IN ({placeholders})
+          AND created_at <= ?
+        ORDER BY created_at ASC
+    """
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(sql, (*STARVATION_STATUSES, cutoff)).fetchall()
+            now = datetime.now(timezone.utc)
+            results = []
+            for row in rows:
+                created = row["created_at"] or ""
+                try:
+                    created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                    age_hours = round((now - created_dt).total_seconds() / 3600, 1)
+                except (ValueError, TypeError):
+                    age_hours = None
+                results.append({
+                    "id": row["id"],
+                    "status": row["status"],
+                    "summary": row["summary"] or "(no summary)",
+                    "created_at": created,
+                    "age_hours": age_hours,
+                })
+            return results
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("Starvation query failed: %s", exc)
+        return []
+
+
+def query_stale_heartbeats(db_path: Path, buffer_seconds: int) -> list[dict]:
+    """
+    Return UoWs in 'active'/'executing' whose heartbeat is stale.
+
+    Stale = (now - heartbeat_at) > heartbeat_ttl + buffer_seconds,
+            when heartbeat_at IS NOT NULL.
+
+    UoWs with heartbeat_at = NULL use the legacy started_at path; they are
+    reported separately as 'no_heartbeat' to distinguish from true stalls.
+
+    Each result dict contains: id, status, heartbeat_at, heartbeat_ttl,
+    started_at, staleness_seconds, stall_type.
+    Returns [] if DB absent or table missing.
+    """
+    if not db_path.exists():
+        return []
+
+    placeholders = ",".join("?" * len(IN_FLIGHT_STATUSES))
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT id, status, heartbeat_at, heartbeat_ttl, started_at
+                FROM uow_registry
+                WHERE status IN ({placeholders})
+                """,
+                IN_FLIGHT_STATUSES,
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("Heartbeat liveness query failed: %s", exc)
+        return []
+
+    now = datetime.now(timezone.utc)
+    stale = []
+    for row in rows:
+        heartbeat_at = row["heartbeat_at"]
+        heartbeat_ttl = row["heartbeat_ttl"] or 300
+        started_at = row["started_at"]
+
+        if heartbeat_at is not None:
+            try:
+                hb_dt = datetime.fromisoformat(heartbeat_at.replace("Z", "+00:00"))
+                staleness = (now - hb_dt).total_seconds()
+                if staleness > heartbeat_ttl + buffer_seconds:
+                    stale.append({
+                        "id": row["id"],
+                        "status": row["status"],
+                        "heartbeat_at": heartbeat_at,
+                        "heartbeat_ttl": heartbeat_ttl,
+                        "started_at": started_at,
+                        "staleness_seconds": round(staleness),
+                        "stall_type": "heartbeat",
+                    })
+            except (ValueError, TypeError):
+                pass
+        else:
+            # No heartbeat written yet — report as no_heartbeat (legacy path)
+            if started_at:
+                try:
+                    start_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+                    age_seconds = (now - start_dt).total_seconds()
+                    stale.append({
+                        "id": row["id"],
+                        "status": row["status"],
+                        "heartbeat_at": None,
+                        "heartbeat_ttl": heartbeat_ttl,
+                        "started_at": started_at,
+                        "staleness_seconds": round(age_seconds),
+                        "stall_type": "no_heartbeat",
+                    })
+                except (ValueError, TypeError):
+                    pass
+
+    return stale
+
+
+def query_long_running_in_flight(db_path: Path, threshold_hours: int) -> list[dict]:
+    """
+    Return UoWs in any in-flight status that have been running longer than
+    threshold_hours (alert candidates for inbox notification).
+
+    Returns each record with id, status, started_at, age_hours.
+    """
+    if not db_path.exists():
+        return []
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=threshold_hours)).isoformat()
+    placeholders = ",".join("?" * len(IN_FLIGHT_STATUSES))
+    sql = f"""
+        SELECT id, status, summary, started_at, created_at
+        FROM uow_registry
+        WHERE status IN ({placeholders})
+          AND (
+            (started_at IS NOT NULL AND started_at <= ?)
+            OR (started_at IS NULL AND created_at <= ?)
+          )
+        ORDER BY created_at ASC
+    """
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(sql, (*IN_FLIGHT_STATUSES, cutoff, cutoff)).fetchall()
+            now = datetime.now(timezone.utc)
+            results = []
+            for row in rows:
+                ref_ts = row["started_at"] or row["created_at"] or ""
+                try:
+                    ref_dt = datetime.fromisoformat(ref_ts.replace("Z", "+00:00"))
+                    age_hours = round((now - ref_dt).total_seconds() / 3600, 1)
+                except (ValueError, TypeError):
+                    age_hours = None
+                results.append({
+                    "id": row["id"],
+                    "status": row["status"],
+                    "summary": row["summary"] or "(no summary)",
+                    "started_at": row["started_at"],
+                    "age_hours": age_hours,
+                })
+            return results
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("Long-running query failed: %s", exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Executor-heartbeat last-run check — checks log file mtime
+# ---------------------------------------------------------------------------
+
+def check_executor_heartbeat_liveness() -> dict:
+    """
+    Check when executor-heartbeat last ran by inspecting its log file mtime.
+
+    Returns a dict with: last_run_iso, age_minutes, is_stale (>10 minutes).
+    When the log file is absent, returns is_stale=True with last_run_iso=None.
+    """
+    log_path = _executor_log_file()
+    if not log_path.exists():
+        return {"last_run_iso": None, "age_minutes": None, "is_stale": True, "reason": "log file absent"}
+
+    try:
+        mtime = log_path.stat().st_mtime
+        last_run = datetime.fromtimestamp(mtime, tz=timezone.utc)
+        now = datetime.now(timezone.utc)
+        age_minutes = round((now - last_run).total_seconds() / 60, 1)
+        is_stale = age_minutes > 10  # executor runs every 3 minutes; >10 = missed multiple cycles
+        return {
+            "last_run_iso": last_run.isoformat(),
+            "age_minutes": age_minutes,
+            "is_stale": is_stale,
+            "reason": f"log mtime {age_minutes} minutes ago",
+        }
+    except Exception as exc:
+        return {"last_run_iso": None, "age_minutes": None, "is_stale": True, "reason": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Inbox message writer — sends alert for stale UoWs (side effect isolated)
+# ---------------------------------------------------------------------------
+
+def _write_inbox_alert(uow_ids: list[str], summary: str, dry_run: bool = False) -> None:
+    """
+    Write a wos_health_alert inbox message to ~/messages/inbox/ if stale UoWs detected.
+
+    This is a fire-and-forget write — no delivery confirmation. The dispatcher
+    picks up the message on its next cycle.
+
+    In dry_run mode: logs the message but does not write the file.
+    """
+    msg_id = str(uuid.uuid4())
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "type": "wos_health_alert",
+        "chat_id": ADMIN_CHAT_ID,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "summary": summary,
+        "stale_uow_ids": uow_ids,
+    }
+
+    if dry_run:
+        log.info("DRY RUN: would write inbox alert — %s", summary)
+        return
+
+    try:
+        inbox = _inbox_dir()
+        inbox.mkdir(parents=True, exist_ok=True)
+        tmp_path = inbox / f"{msg_id}.json.tmp"
+        dest_path = inbox / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+        tmp_path.rename(dest_path)
+        log.info("Wrote inbox alert %s — %s", msg_id, summary)
+    except Exception as exc:
+        log.warning("Failed to write inbox alert: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Report writer — writes health report to log file
+# ---------------------------------------------------------------------------
+
+def write_health_report(report: dict, log_path: Path) -> None:
+    """
+    Append a structured health report to the wos-health-check log file.
+
+    The log file is a JSONL file — one JSON object per run. Human-readable
+    summary is also logged via the standard logger for the cron log.
+    """
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(report, ensure_ascii=False) + "\n")
+    except Exception as exc:
+        log.warning("Failed to write health report to %s: %s", log_path, exc)
+
+
+# ---------------------------------------------------------------------------
+# Main health check
+# ---------------------------------------------------------------------------
+
+def run_health_check(db_path: Path, dry_run: bool = False) -> dict:
+    """
+    Run the full health check and return a structured report dict.
+
+    This is the main entry point. All reads are pure; side effects
+    (log write, inbox alert) are isolated at the boundaries.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # 1. Starvation candidates (stuck in proposed/pending >24h)
+    starvation_candidates = query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+    log.info(
+        "Starvation candidates (stuck >%dh): %d",
+        STARVATION_THRESHOLD_HOURS,
+        len(starvation_candidates),
+    )
+    for uow in starvation_candidates:
+        log.info("  STARVATION: %s | %s | age=%.1fh", uow["id"], uow["status"], uow.get("age_hours") or 0)
+
+    # 2. Heartbeat liveness (stale heartbeats in active/executing)
+    stale_heartbeats = query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+    log.info("Stale heartbeats / no-heartbeat UoWs: %d", len(stale_heartbeats))
+    for uow in stale_heartbeats:
+        log.info(
+            "  STALE: %s | %s | stall_type=%s | staleness=%ds",
+            uow["id"], uow["status"], uow["stall_type"], uow.get("staleness_seconds") or 0,
+        )
+
+    # 3. Executor-heartbeat liveness
+    executor_status = check_executor_heartbeat_liveness()
+    if executor_status["is_stale"]:
+        log.warning(
+            "Executor heartbeat appears stale — %s",
+            executor_status.get("reason", "unknown"),
+        )
+    else:
+        log.info(
+            "Executor heartbeat OK — last run %.1f minutes ago",
+            executor_status.get("age_minutes") or 0,
+        )
+
+    # 4. Long-running alert check (stuck >48h in any in-flight status)
+    long_running = query_long_running_in_flight(db_path, ALERT_THRESHOLD_HOURS)
+    if long_running:
+        stale_ids = [u["id"] for u in long_running]
+        alert_lines = [
+            f"WOS Health Alert: {len(long_running)} UoW(s) stuck >48h in in-flight status."
+        ]
+        for u in long_running:
+            alert_lines.append(
+                f"  {u['id']} | {u['status']} | age={u.get('age_hours', '?')}h | {u['summary'][:80]}"
+            )
+        alert_summary = "\n".join(alert_lines)
+        log.warning("ALERT: %s", alert_summary)
+        _write_inbox_alert(stale_ids, alert_summary, dry_run=dry_run)
+
+    # Build report
+    report = {
+        "timestamp": now_iso,
+        "starvation_candidates_count": len(starvation_candidates),
+        "starvation_threshold_hours": STARVATION_THRESHOLD_HOURS,
+        "stale_heartbeats_count": len(stale_heartbeats),
+        "long_running_alert_count": len(long_running),
+        "alert_threshold_hours": ALERT_THRESHOLD_HOURS,
+        "executor_heartbeat": executor_status,
+        "starvation_candidates": starvation_candidates,
+        "stale_heartbeats": stale_heartbeats,
+        "long_running_uows": long_running,
+        "dry_run": dry_run,
+    }
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="WOS health check — starvation and heartbeat liveness")
+    parser.add_argument("--dry-run", action="store_true", help="Run checks but do not send inbox alerts")
+    args = parser.parse_args()
+
+    if not _is_job_enabled():
+        log.info("Job '%s' is disabled in jobs.json — skipping", JOB_NAME)
+        return 0
+
+    db_path = _registry_db_path()
+    log.info("Running WOS health check — registry: %s dry_run=%s", db_path, args.dry_run)
+
+    report = run_health_check(db_path, dry_run=args.dry_run)
+
+    log_path = _log_file()
+    write_health_report(report, log_path)
+    log.info(
+        "Health check complete — starvation=%d stale_hb=%d long_running=%d",
+        report["starvation_candidates_count"],
+        report["stale_heartbeats_count"],
+        report["long_running_alert_count"],
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scheduled-tasks/wos-metabolic-digest.py
+++ b/scheduled-tasks/wos-metabolic-digest.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""
+WOS Metabolic Digest — daily pipeline health signal.
+
+Runs once per day (default 09:00 UTC). On each invocation:
+1. Reads UoWs completed (status changed to 'done' or 'failed') in the past 24h.
+2. Classifies each as pearl/heat/seed/shit based on outcome heuristics.
+3. Computes aggregates: total by classification, average duration, register breakdown.
+4. Sends a Telegram message to the admin chat_id with the digest.
+5. Writes output to the scheduled-jobs log.
+
+Classification heuristics (from the audit doc and WOS architecture):
+  pearl — UoW produced a PR or implementation (output_ref has content, outcome 'complete',
+           close_reason mentions 'pr' or 'implementation')
+  heat  — UoW produced a review or analysis (output_ref has content, outcome 'complete',
+           close_reason mentions 'review' or 'analysis' or 'design')
+  seed  — UoW created a new issue or follow-up (close_reason mentions 'issue' or 'seeded')
+  shit  — UoW failed, expired, hit TTL, or produced no verifiable output
+
+Cron schedule (daily at 09:00 UTC):
+    0 9 * * * cd ~/lobster && uv run scheduled-tasks/wos-metabolic-digest.py >> ~/lobster-workspace/scheduled-jobs/logs/wos-metabolic-digest.log 2>&1 # LOBSTER-WOS-METABOLIC-DIGEST
+
+Type C dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+involvement). The jobs.json enabled gate is checked at the top of main() so that
+runtime enable/disable is respected without touching cron.
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/wos-metabolic-digest.py [--dry-run] [--hours N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("wos-metabolic-digest")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+JOB_NAME: str = "wos-metabolic-digest"
+
+# Default lookback window for the digest
+DEFAULT_LOOKBACK_HOURS: int = 24
+
+# Admin chat_id for Telegram delivery (env-injected, falls back to hardcoded)
+ADMIN_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
+
+# Terminal statuses that indicate a UoW completed in some form
+TERMINAL_STATUSES: tuple[str, ...] = ("done", "failed", "expired", "cancelled")
+
+# Outcome category names (from the audit doc and WOS architecture)
+OUTCOME_PEARL = "pearl"
+OUTCOME_HEAT = "heat"
+OUTCOME_SEED = "seed"
+OUTCOME_SHIT = "shit"
+
+
+# ---------------------------------------------------------------------------
+# Workspace / path helpers
+# ---------------------------------------------------------------------------
+
+def _workspace() -> Path:
+    return Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+
+
+def _registry_db_path() -> Path:
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    return _workspace() / "orchestration" / "registry.db"
+
+
+def _jobs_file() -> Path:
+    return _workspace() / "scheduled-jobs" / "jobs.json"
+
+
+def _inbox_dir() -> Path:
+    messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+    return messages_base / "inbox"
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type C dispatch pattern
+# ---------------------------------------------------------------------------
+
+def _is_job_enabled() -> bool:
+    """
+    Return True if this job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when:
+    - jobs.json is absent
+    - the job entry is missing
+    - the file is unreadable or malformed
+    """
+    try:
+        data = json.loads(_jobs_file().read_text())
+        return bool(data.get("jobs", {}).get(JOB_NAME, {}).get("enabled", True))
+    except Exception:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Classification heuristics — pure functions, testable without DB
+# ---------------------------------------------------------------------------
+
+def classify_uow(uow: dict) -> str:
+    """
+    Classify a completed UoW into one of: pearl, heat, seed, shit.
+
+    Classification is based on close_reason, output_ref size, and status.
+    The heuristics are intentionally simple and conservative — when in doubt,
+    classify as 'shit' (no verifiable output). Callers can tune thresholds
+    by modifying the keyword sets below.
+
+    Args:
+        uow: A dict with keys: id, status, close_reason, output_ref, register,
+             steward_cycles, started_at, closed_at.
+
+    Returns:
+        One of: "pearl", "heat", "seed", "shit"
+    """
+    status = (uow.get("status") or "").lower()
+    close_reason = (uow.get("close_reason") or "").lower()
+    output_ref = uow.get("output_ref") or ""
+
+    # shit: definitively failed, expired, or TTL-exceeded
+    if status in ("failed", "expired", "cancelled"):
+        return OUTCOME_SHIT
+    if "ttl_exceeded" in close_reason or "ttl" in close_reason:
+        return OUTCOME_SHIT
+    if "hard_cap" in close_reason or "user_closed" in close_reason:
+        return OUTCOME_SHIT
+
+    # For 'done' UoWs, classify by close_reason and output content
+    if status != "done":
+        return OUTCOME_SHIT  # any non-terminal status that reached here is unexpected
+
+    # seed: spawned a new issue or seeded future work
+    seed_keywords = {"issue", "seed", "seeded", "spawn", "follow-up", "follow_up"}
+    if any(kw in close_reason for kw in seed_keywords):
+        return OUTCOME_SEED
+
+    # pearl: produced a PR, implementation, or code change
+    pearl_keywords = {"pr", "pull request", "implementation", "commit", "merge", "patch", "fix"}
+    if any(kw in close_reason for kw in pearl_keywords):
+        return OUTCOME_PEARL
+
+    # Check output_ref size — a substantial output file suggests real work
+    if output_ref:
+        try:
+            output_path = Path(output_ref)
+            if output_path.exists() and output_path.stat().st_size > 500:
+                # heat: review/analysis/design output
+                heat_keywords = {"review", "analysis", "design", "synthesis", "assessment", "report"}
+                if any(kw in close_reason for kw in heat_keywords):
+                    return OUTCOME_HEAT
+                # Default for done + substantial output = pearl (best-effort)
+                return OUTCOME_PEARL
+        except Exception:
+            pass
+
+    # heat: review or analysis output (by close_reason alone)
+    heat_keywords = {"review", "analysis", "design", "synthesis", "assessment", "report"}
+    if any(kw in close_reason for kw in heat_keywords):
+        return OUTCOME_HEAT
+
+    # No clear signal — default to shit (no verifiable output)
+    return OUTCOME_SHIT
+
+
+def compute_duration_minutes(uow: dict) -> float | None:
+    """
+    Compute UoW duration in minutes from started_at to closed_at.
+
+    Returns None if either timestamp is missing or unparseable.
+    """
+    started = uow.get("started_at") or uow.get("created_at")
+    closed = uow.get("closed_at") or uow.get("updated_at")
+    if not started or not closed:
+        return None
+    try:
+        start_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        close_dt = datetime.fromisoformat(closed.replace("Z", "+00:00"))
+        delta = (close_dt - start_dt).total_seconds()
+        return round(delta / 60, 1) if delta >= 0 else None
+    except (ValueError, TypeError):
+        return None
+
+
+def aggregate_by_classification(classified: list[tuple[dict, str]]) -> dict[str, list[dict]]:
+    """
+    Group (uow, classification) pairs by classification label.
+
+    Returns a dict mapping classification → list of uow dicts.
+    All four keys are always present (possibly empty lists).
+    """
+    groups: dict[str, list[dict]] = {
+        OUTCOME_PEARL: [],
+        OUTCOME_HEAT: [],
+        OUTCOME_SEED: [],
+        OUTCOME_SHIT: [],
+    }
+    for uow, label in classified:
+        groups[label].append(uow)
+    return groups
+
+
+def compute_avg_duration(uows: list[dict]) -> str:
+    """
+    Compute average duration in minutes for a list of UoWs.
+
+    Returns "N/A" if no durations available.
+    """
+    durations = [d for d in (compute_duration_minutes(u) for u in uows) if d is not None]
+    if not durations:
+        return "N/A"
+    avg = round(sum(durations) / len(durations), 1)
+    return f"{avg} min"
+
+
+# ---------------------------------------------------------------------------
+# Registry query — reads completed UoWs in the lookback window
+# ---------------------------------------------------------------------------
+
+def query_completed_uows(db_path: Path, lookback_hours: int) -> list[dict]:
+    """
+    Return UoWs that transitioned to a terminal status in the past lookback_hours.
+
+    Uses audit_log to find UoWs that entered a terminal state (done, failed,
+    expired, cancelled) within the window. Returns full UoW rows for each match.
+
+    Returns [] if DB absent or table missing.
+    """
+    if not db_path.exists():
+        log.warning("Registry DB not found at %s", db_path)
+        return []
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=lookback_hours)).isoformat()
+    terminal_placeholders = ",".join("?" * len(TERMINAL_STATUSES))
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            # Find UoW IDs that entered a terminal status within the window
+            transition_rows = conn.execute(
+                f"""
+                SELECT DISTINCT uow_id FROM audit_log
+                WHERE to_status IN ({terminal_placeholders})
+                  AND ts >= ?
+                """,
+                (*TERMINAL_STATUSES, cutoff),
+            ).fetchall()
+
+            if not transition_rows:
+                return []
+
+            uow_ids = [r["uow_id"] for r in transition_rows]
+            id_placeholders = ",".join("?" * len(uow_ids))
+
+            # Fetch full UoW records for each matched ID
+            rows = conn.execute(
+                f"""
+                SELECT id, status, summary, register, close_reason, output_ref,
+                       started_at, closed_at, updated_at, created_at, steward_cycles
+                FROM uow_registry
+                WHERE id IN ({id_placeholders})
+                  AND status IN ({terminal_placeholders})
+                """,
+                (*uow_ids, *TERMINAL_STATUSES),
+            ).fetchall()
+
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("Completed UoW query failed: %s", exc)
+        return []
+
+
+def query_still_running(db_path: Path, threshold_hours: int) -> list[dict]:
+    """
+    Return UoWs in 'active' or 'executing' that have been running >threshold_hours.
+    Used to populate the 'Stalled' section of the digest.
+    """
+    if not db_path.exists():
+        return []
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=threshold_hours)).isoformat()
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT id, status, summary, started_at, created_at
+                FROM uow_registry
+                WHERE status IN ('active', 'executing')
+                  AND (
+                    (started_at IS NOT NULL AND started_at <= ?)
+                    OR (started_at IS NULL AND created_at <= ?)
+                  )
+                ORDER BY created_at ASC
+                """,
+                (cutoff, cutoff),
+            ).fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("Still-running query failed: %s", exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Digest formatter — pure function, returns Telegram-ready text
+# ---------------------------------------------------------------------------
+
+def format_digest(
+    groups: dict[str, list[dict]],
+    stalled: list[dict],
+    lookback_hours: int,
+    now_iso: str,
+) -> str:
+    """
+    Format the metabolic digest as a Telegram message.
+
+    Args:
+        groups:        Classification groups from aggregate_by_classification.
+        stalled:       UoWs still running past the stall threshold.
+        lookback_hours: The window used for the digest.
+        now_iso:        ISO timestamp for the report header.
+
+    Returns:
+        A multi-line string ready to send via Telegram.
+    """
+    pearl_count = len(groups[OUTCOME_PEARL])
+    heat_count = len(groups[OUTCOME_HEAT])
+    seed_count = len(groups[OUTCOME_SEED])
+    shit_count = len(groups[OUTCOME_SHIT])
+    total = pearl_count + heat_count + seed_count + shit_count
+
+    # Register breakdown — count by register across all classified UoWs
+    register_counts: dict[str, int] = {}
+    for label, uows in groups.items():
+        for uow in uows:
+            reg = uow.get("register") or "operational"
+            register_counts[reg] = register_counts.get(reg, 0) + 1
+
+    register_parts = ", ".join(
+        f"{count} {reg}" for reg, count in sorted(register_counts.items())
+    ) if register_counts else "none"
+
+    # Average durations per category
+    pearl_avg = compute_avg_duration(groups[OUTCOME_PEARL])
+    heat_avg = compute_avg_duration(groups[OUTCOME_HEAT])
+
+    # Stalled display
+    stalled_line = ""
+    if stalled:
+        stalled_ids = ", ".join(u["id"] for u in stalled[:5])
+        stalled_line = f"\nStalled (>6h): {stalled_ids}"
+        if len(stalled) > 5:
+            stalled_line += f" (+{len(stalled) - 5} more)"
+
+    lines = [
+        "WOS Daily Metabolic Report",
+        f"Last {lookback_hours}h: {pearl_count} pearl / {heat_count} heat / {seed_count} seed / {shit_count} shit",
+    ]
+
+    if total > 0:
+        lines.append(f"Register breakdown: {register_parts}")
+        lines.append(f"Avg duration: {pearl_avg} (pearl), {heat_avg} (heat)")
+    else:
+        lines.append("No UoWs completed in this window.")
+
+    if stalled_line:
+        lines.append(stalled_line)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Inbox message writer — sends digest via inbox → Telegram
+# ---------------------------------------------------------------------------
+
+def _write_inbox_digest(text: str, dry_run: bool = False) -> None:
+    """
+    Write a wos_metabolic_digest inbox message for the dispatcher to relay via Telegram.
+
+    In dry_run mode: logs the message but does not write the file.
+    """
+    msg_id = str(uuid.uuid4())
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "type": "wos_metabolic_digest",
+        "chat_id": ADMIN_CHAT_ID,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "text": text,
+    }
+
+    if dry_run:
+        log.info("DRY RUN: would send digest:\n%s", text)
+        return
+
+    try:
+        inbox = _inbox_dir()
+        inbox.mkdir(parents=True, exist_ok=True)
+        tmp_path = inbox / f"{msg_id}.json.tmp"
+        dest_path = inbox / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+        tmp_path.rename(dest_path)
+        log.info("Wrote metabolic digest inbox message %s", msg_id)
+    except Exception as exc:
+        log.warning("Failed to write digest inbox message: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run_digest(db_path: Path, lookback_hours: int, dry_run: bool = False) -> dict:
+    """
+    Run the metabolic digest and return a structured result dict.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # Query completed UoWs
+    completed = query_completed_uows(db_path, lookback_hours)
+    log.info("Completed UoWs in last %dh: %d", lookback_hours, len(completed))
+
+    # Classify each
+    classified = [(uow, classify_uow(uow)) for uow in completed]
+    groups = aggregate_by_classification(classified)
+
+    for label, uows in groups.items():
+        log.info("  %s: %d", label, len(uows))
+
+    # Stalled UoWs (>6h in flight)
+    stalled = query_still_running(db_path, threshold_hours=6)
+    if stalled:
+        log.warning("Still running >6h: %d", len(stalled))
+
+    # Format and send digest
+    digest_text = format_digest(groups, stalled, lookback_hours, now_iso)
+    log.info("Digest:\n%s", digest_text)
+
+    _write_inbox_digest(digest_text, dry_run=dry_run)
+
+    return {
+        "timestamp": now_iso,
+        "lookback_hours": lookback_hours,
+        "completed_count": len(completed),
+        "pearl": len(groups[OUTCOME_PEARL]),
+        "heat": len(groups[OUTCOME_HEAT]),
+        "seed": len(groups[OUTCOME_SEED]),
+        "shit": len(groups[OUTCOME_SHIT]),
+        "stalled_count": len(stalled),
+        "dry_run": dry_run,
+        "digest_text": digest_text,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="WOS metabolic digest — daily pipeline health signal")
+    parser.add_argument("--dry-run", action="store_true", help="Compute digest but do not send Telegram message")
+    parser.add_argument("--hours", type=int, default=DEFAULT_LOOKBACK_HOURS,
+                        help=f"Lookback window in hours (default: {DEFAULT_LOOKBACK_HOURS})")
+    args = parser.parse_args()
+
+    if not _is_job_enabled():
+        log.info("Job '%s' is disabled in jobs.json — skipping", JOB_NAME)
+        return 0
+
+    db_path = _registry_db_path()
+    log.info(
+        "Running WOS metabolic digest — registry: %s lookback=%dh dry_run=%s",
+        db_path, args.hours, args.dry_run,
+    )
+
+    result = run_digest(db_path, lookback_hours=args.hours, dry_run=args.dry_run)
+    log.info(
+        "Digest complete — pearl=%d heat=%d seed=%d shit=%d stalled=%d",
+        result["pearl"], result["heat"], result["seed"], result["shit"], result["stalled_count"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2825,6 +2825,29 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         fi
     fi
 
+    # Migration 83: Add cron entries for wos-health-check and wos-metabolic-digest
+    # (issue #849). Both are Type C cron-direct scripts committed to scheduled-tasks/.
+    local WOS_HEALTH_MARKER="# LOBSTER-WOS-HEALTH-CHECK"
+    local WOS_DIGEST_MARKER="# LOBSTER-WOS-METABOLIC-DIGEST"
+    if ! crontab -l 2>/dev/null | grep -qF "$WOS_HEALTH_MARKER"; then
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$WOS_HEALTH_MARKER" \
+            "0 */6 * * * cd $LOBSTER_DIR && uv run scheduled-tasks/wos-health-check.py >> $LOBSTER_WORKSPACE/scheduled-jobs/logs/wos-health-check.log 2>&1 $WOS_HEALTH_MARKER" \
+            && substep "Added wos-health-check cron entry (Migration 83)" \
+            || warn "Could not add wos-health-check cron entry — check cron-manage.sh"
+        migrated=$((migrated + 1))
+    else
+        substep "wos-health-check cron entry already present — skipping"
+    fi
+    if ! crontab -l 2>/dev/null | grep -qF "$WOS_DIGEST_MARKER"; then
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$WOS_DIGEST_MARKER" \
+            "0 9 * * * cd $LOBSTER_DIR && uv run scheduled-tasks/wos-metabolic-digest.py >> $LOBSTER_WORKSPACE/scheduled-jobs/logs/wos-metabolic-digest.log 2>&1 $WOS_DIGEST_MARKER" \
+            && substep "Added wos-metabolic-digest cron entry (Migration 83)" \
+            || warn "Could not add wos-metabolic-digest cron entry — check cron-manage.sh"
+        migrated=$((migrated + 1))
+    else
+        substep "wos-metabolic-digest cron entry already present — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -327,6 +327,11 @@ def handle_wos_execute(uow_id: str, instructions: str, output_ref: str) -> str:
     If the subagent fails to write the result file before timeout_at, the Observation
     Loop detects the stall and surfaces it to the user.
 
+    The subagent is also required to write periodic heartbeats to the registry so the
+    Observation Loop can detect stalls before the 4h TTL (issue #849). Heartbeats must
+    be written every 60-90 seconds — before reading the issue, after implementation,
+    before PR creation. The heartbeat is a single registry call, documented below.
+
     Args:
         uow_id:       The Unit of Work identifier (used as task_id and in the result file).
         instructions: The prescribed instructions from the WorkflowArtifact — what the
@@ -349,6 +354,28 @@ def handle_wos_execute(uow_id: str, instructions: str, output_ref: str) -> str:
         f"---\n\n"
         f"You are executing a Work Order System (WOS) unit of work on behalf of the Steward.\n"
         f"UoW ID: {uow_id}\n\n"
+        f"## Heartbeat contract (REQUIRED)\n\n"
+        f"You must write a liveness heartbeat to the registry every 60-90 seconds throughout\n"
+        f"execution. The heartbeat proves you are alive — without it, the Observation Loop\n"
+        f"will detect a stall and re-queue this UoW for re-execution.\n\n"
+        f"Call write_heartbeat at these checkpoints (at minimum):\n"
+        f"  - Before starting work (immediately after receiving this prompt)\n"
+        f"  - After reading/understanding the issue or task\n"
+        f"  - After completing the implementation\n"
+        f"  - Before opening a PR or writing the result file\n\n"
+        f"How to write a heartbeat:\n"
+        f"  import sys; sys.path.insert(0, '/home/lobster/lobster')\n"
+        f"  from src.orchestration.registry import WOSRegistry\n"
+        f"  WOSRegistry().write_heartbeat('{uow_id}')\n\n"
+        f"Or equivalently using the Registry class directly:\n"
+        f"  import sys; sys.path.insert(0, '/home/lobster/lobster')\n"
+        f"  from src.orchestration.paths import REGISTRY_DB\n"
+        f"  from src.orchestration.registry import Registry\n"
+        f"  Registry(REGISTRY_DB).write_heartbeat('{uow_id}')\n\n"
+        f"The write_heartbeat call is a fire-and-forget single SQL UPDATE. It returns the\n"
+        f"number of rows affected (1 on success, 0 if the UoW status changed). A return\n"
+        f"value of 0 means the Steward has already re-queued this UoW — stop execution\n"
+        f"immediately and call write_result with outcome=failed.\n\n"
         f"## Instructions\n\n"
         f"{instructions}\n\n"
         f"## Result contract (REQUIRED)\n\n"

--- a/tests/unit/test_wos_health_check.py
+++ b/tests/unit/test_wos_health_check.py
@@ -1,0 +1,315 @@
+"""
+Tests for scheduled-tasks/wos-health-check.py
+
+Tests are derived from the spec in the WOS audit doc (wos-audit-20260422.md)
+and issue #849:
+
+- Stale UoW detection: UoWs stuck in proposed/pending >STARVATION_THRESHOLD_HOURS
+  are returned as starvation candidates.
+- Short-duration UoWs are not flagged as starvation candidates.
+- Heartbeat liveness: UoWs in active/executing with stale heartbeats are detected.
+- UoWs in active/executing with no heartbeat (NULL heartbeat_at) are reported
+  as stall_type="no_heartbeat".
+- UoWs with a fresh heartbeat within heartbeat_ttl are NOT reported as stale.
+- Long-running in-flight UoWs (>ALERT_THRESHOLD_HOURS) trigger alert logic.
+- Executor heartbeat liveness check returns is_stale=True when log absent.
+- jobs.json enabled gate: job skips when disabled.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the module from its script path (not a package)
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent
+    / "scheduled-tasks"
+    / "wos-health-check.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("wos_health_check", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hc = _load_module()
+
+# ---------------------------------------------------------------------------
+# Constants — must match the spec, not derived from implementation
+# ---------------------------------------------------------------------------
+
+STARVATION_THRESHOLD_HOURS = 24   # from audit doc: "starvation candidates" = >24h
+ALERT_THRESHOLD_HOURS = 48         # from audit doc: inbox alert for >48h in-flight
+HEARTBEAT_STALE_BUFFER_SECONDS = 60
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — minimal SQLite registry for query tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Create a minimal registry.db with the uow_registry schema."""
+    db = tmp_path / "registry.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("""
+        CREATE TABLE uow_registry (
+            id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            summary TEXT,
+            register TEXT DEFAULT 'operational',
+            close_reason TEXT,
+            output_ref TEXT,
+            started_at TEXT,
+            closed_at TEXT,
+            updated_at TEXT,
+            created_at TEXT NOT NULL,
+            heartbeat_at TEXT,
+            heartbeat_ttl INTEGER DEFAULT 300,
+            steward_cycles INTEGER DEFAULT 0
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            uow_id TEXT NOT NULL,
+            event TEXT NOT NULL,
+            from_status TEXT,
+            to_status TEXT,
+            agent TEXT,
+            note TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _hours_ago(hours: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+
+def _insert_uow(
+    db: Path,
+    uow_id: str,
+    status: str,
+    created_hours_ago: float = 1.0,
+    started_hours_ago: float | None = None,
+    heartbeat_at: str | None = None,
+    heartbeat_ttl: int = 300,
+    summary: str = "test uow",
+) -> None:
+    conn = sqlite3.connect(str(db))
+    started = _hours_ago(started_hours_ago) if started_hours_ago is not None else None
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+            (id, status, summary, created_at, started_at, heartbeat_at, heartbeat_ttl)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (uow_id, status, summary, _hours_ago(created_hours_ago), started, heartbeat_at, heartbeat_ttl),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# query_starvation_candidates
+# ---------------------------------------------------------------------------
+
+class TestQueryStarvationCandidates:
+    def test_uow_stuck_in_proposed_beyond_threshold_is_returned(self, db_path):
+        _insert_uow(db_path, "uow-old", "proposed", created_hours_ago=STARVATION_THRESHOLD_HOURS + 1)
+        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-old" in ids
+
+    def test_uow_stuck_in_pending_beyond_threshold_is_returned(self, db_path):
+        _insert_uow(db_path, "uow-pending", "pending", created_hours_ago=STARVATION_THRESHOLD_HOURS + 2)
+        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-pending" in ids
+
+    def test_recent_proposed_uow_is_not_returned(self, db_path):
+        _insert_uow(db_path, "uow-new", "proposed", created_hours_ago=1)
+        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-new" not in ids
+
+    def test_uow_exactly_at_threshold_is_not_returned(self, db_path):
+        # At exactly threshold hours, the UoW has NOT exceeded the threshold yet
+        _insert_uow(db_path, "uow-boundary", "proposed", created_hours_ago=STARVATION_THRESHOLD_HOURS - 0.01)
+        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-boundary" not in ids
+
+    def test_active_uow_not_returned_as_starvation_candidate(self, db_path):
+        # Starvation check only covers proposed/pending, not active
+        _insert_uow(db_path, "uow-active", "active", created_hours_ago=STARVATION_THRESHOLD_HOURS + 5)
+        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-active" not in ids
+
+    def test_absent_db_returns_empty_list(self, tmp_path):
+        results = hc.query_starvation_candidates(tmp_path / "nonexistent.db", STARVATION_THRESHOLD_HOURS)
+        assert results == []
+
+    def test_result_contains_age_hours_field(self, db_path):
+        _insert_uow(db_path, "uow-aged", "proposed", created_hours_ago=STARVATION_THRESHOLD_HOURS + 3)
+        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        aged = next(r for r in results if r["id"] == "uow-aged")
+        assert aged["age_hours"] is not None
+        assert aged["age_hours"] >= STARVATION_THRESHOLD_HOURS
+
+
+# ---------------------------------------------------------------------------
+# query_stale_heartbeats — heartbeat liveness
+# ---------------------------------------------------------------------------
+
+class TestQueryStaleHeartbeats:
+    def test_active_uow_with_stale_heartbeat_is_returned(self, db_path):
+        # heartbeat written 10 minutes ago, heartbeat_ttl=300s (5 min) — stale
+        stale_hb = _hours_ago(10 / 60)  # 10 minutes ago
+        _insert_uow(
+            db_path, "uow-stale-hb", "active",
+            created_hours_ago=2, started_hours_ago=2,
+            heartbeat_at=stale_hb, heartbeat_ttl=300,
+        )
+        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        ids = [r["id"] for r in results]
+        assert "uow-stale-hb" in ids
+        result = next(r for r in results if r["id"] == "uow-stale-hb")
+        assert result["stall_type"] == "heartbeat"
+
+    def test_active_uow_with_fresh_heartbeat_is_not_returned(self, db_path):
+        # heartbeat written 1 minute ago, heartbeat_ttl=300s (5 min) — fresh
+        fresh_hb = _hours_ago(1 / 60)  # 1 minute ago
+        _insert_uow(
+            db_path, "uow-fresh-hb", "active",
+            created_hours_ago=1, started_hours_ago=1,
+            heartbeat_at=fresh_hb, heartbeat_ttl=300,
+        )
+        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        ids = [r["id"] for r in results]
+        assert "uow-fresh-hb" not in ids
+
+    def test_active_uow_with_no_heartbeat_reported_as_no_heartbeat_type(self, db_path):
+        # heartbeat_at is NULL — agent has never written a heartbeat
+        _insert_uow(
+            db_path, "uow-no-hb", "active",
+            created_hours_ago=2, started_hours_ago=2,
+            heartbeat_at=None, heartbeat_ttl=300,
+        )
+        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        ids = [r["id"] for r in results]
+        assert "uow-no-hb" in ids
+        result = next(r for r in results if r["id"] == "uow-no-hb")
+        assert result["stall_type"] == "no_heartbeat"
+
+    def test_executing_uow_with_stale_heartbeat_is_detected(self, db_path):
+        # 'executing' status should also be checked
+        stale_hb = _hours_ago(10 / 60)
+        _insert_uow(
+            db_path, "uow-exec-stale", "executing",
+            created_hours_ago=1, started_hours_ago=1,
+            heartbeat_at=stale_hb, heartbeat_ttl=300,
+        )
+        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        ids = [r["id"] for r in results]
+        assert "uow-exec-stale" in ids
+
+    def test_done_uow_not_included_in_heartbeat_check(self, db_path):
+        _insert_uow(db_path, "uow-done", "done", created_hours_ago=5)
+        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        ids = [r["id"] for r in results]
+        assert "uow-done" not in ids
+
+    def test_absent_db_returns_empty_list(self, tmp_path):
+        results = hc.query_stale_heartbeats(tmp_path / "nonexistent.db", HEARTBEAT_STALE_BUFFER_SECONDS)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# check_executor_heartbeat_liveness
+# ---------------------------------------------------------------------------
+
+class TestCheckExecutorHeartbeatLiveness:
+    def test_returns_stale_true_when_log_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hc, "_executor_log_file", lambda: tmp_path / "nonexistent.log")
+        result = hc.check_executor_heartbeat_liveness()
+        assert result["is_stale"] is True
+        assert result["last_run_iso"] is None
+
+    def test_returns_stale_false_when_log_recently_modified(self, tmp_path, monkeypatch):
+        log_file = tmp_path / "executor-heartbeat.log"
+        log_file.write_text("recent log entry")
+        monkeypatch.setattr(hc, "_executor_log_file", lambda: log_file)
+        result = hc.check_executor_heartbeat_liveness()
+        assert result["is_stale"] is False
+        assert result["age_minutes"] is not None
+        assert result["age_minutes"] < 1  # just written
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate
+# ---------------------------------------------------------------------------
+
+class TestJobsJsonGate:
+    def test_job_skips_when_disabled_in_jobs_json(self, tmp_path, monkeypatch):
+        jobs_file = tmp_path / "jobs.json"
+        jobs_file.write_text(json.dumps({"jobs": {"wos-health-check": {"enabled": False}}}))
+        monkeypatch.setattr(hc, "_jobs_file", lambda: jobs_file)
+        assert hc._is_job_enabled() is False
+
+    def test_job_runs_when_enabled_in_jobs_json(self, tmp_path, monkeypatch):
+        jobs_file = tmp_path / "jobs.json"
+        jobs_file.write_text(json.dumps({"jobs": {"wos-health-check": {"enabled": True}}}))
+        monkeypatch.setattr(hc, "_jobs_file", lambda: jobs_file)
+        assert hc._is_job_enabled() is True
+
+    def test_job_defaults_to_enabled_when_jobs_json_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hc, "_jobs_file", lambda: tmp_path / "nonexistent.json")
+        assert hc._is_job_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Long-running alert detection
+# ---------------------------------------------------------------------------
+
+class TestLongRunningAlert:
+    def test_uow_stuck_beyond_alert_threshold_is_returned(self, db_path):
+        _insert_uow(
+            db_path, "uow-long", "active",
+            created_hours_ago=ALERT_THRESHOLD_HOURS + 1,
+            started_hours_ago=ALERT_THRESHOLD_HOURS + 1,
+        )
+        results = hc.query_long_running_in_flight(db_path, ALERT_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-long" in ids
+
+    def test_recently_started_uow_not_flagged(self, db_path):
+        _insert_uow(
+            db_path, "uow-recent", "active",
+            created_hours_ago=1, started_hours_ago=1,
+        )
+        results = hc.query_long_running_in_flight(db_path, ALERT_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-recent" not in ids

--- a/tests/unit/test_wos_metabolic_digest.py
+++ b/tests/unit/test_wos_metabolic_digest.py
@@ -1,0 +1,519 @@
+"""
+Tests for scheduled-tasks/wos-metabolic-digest.py and the heartbeat contract
+in dispatcher_handlers.py.
+
+Tests are derived from the spec in the WOS audit doc (wos-audit-20260422.md)
+and issue #849:
+
+- classify_uow: pearl/heat/seed/shit classification heuristics
+- aggregate_by_classification: all four keys always present
+- compute_duration_minutes: handles valid, missing, and malformed timestamps
+- format_digest: produces the required header and summary line
+- jobs.json enabled gate
+- handle_wos_execute: heartbeat contract section present in dispatched prompt
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load wos-metabolic-digest from its script path (not a package)
+# ---------------------------------------------------------------------------
+
+DIGEST_SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent
+    / "scheduled-tasks"
+    / "wos-metabolic-digest.py"
+)
+
+HANDLERS_MODULE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "orchestration"
+    / "dispatcher_handlers.py"
+)
+
+
+def _load_digest_module():
+    spec = importlib.util.spec_from_file_location("wos_metabolic_digest", DIGEST_SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_handlers_module():
+    # dispatcher_handlers uses relative imports (from .registry import ...) so it
+    # must be loaded as part of the src.orchestration package, not as a standalone file.
+    repo_root = str(HANDLERS_MODULE_PATH.parent.parent.parent)
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    import importlib
+    return importlib.import_module("src.orchestration.dispatcher_handlers")
+
+
+md = _load_digest_module()
+
+# ---------------------------------------------------------------------------
+# Constants — from the audit doc and issue, NOT derived from implementation
+# ---------------------------------------------------------------------------
+
+OUTCOME_PEARL = "pearl"
+OUTCOME_HEAT = "heat"
+OUTCOME_SEED = "seed"
+OUTCOME_SHIT = "shit"
+
+DEFAULT_LOOKBACK_HOURS = 24   # daily digest window
+STALL_THRESHOLD_HOURS = 6     # stalled section threshold in the digest
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building UoW dicts
+# ---------------------------------------------------------------------------
+
+def _hours_ago_iso(hours: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+
+
+def _uow(
+    *,
+    uow_id: str = "uow-test",
+    status: str = "done",
+    close_reason: str = "",
+    output_ref: str = "",
+    register: str = "operational",
+    started_hours_ago: float = 2.0,
+    closed_hours_ago: float = 1.0,
+) -> dict:
+    return {
+        "id": uow_id,
+        "status": status,
+        "close_reason": close_reason,
+        "output_ref": output_ref,
+        "register": register,
+        "steward_cycles": 1,
+        "started_at": _hours_ago_iso(started_hours_ago),
+        "closed_at": _hours_ago_iso(closed_hours_ago),
+        "created_at": _hours_ago_iso(started_hours_ago + 1),
+        "updated_at": _hours_ago_iso(closed_hours_ago),
+        "summary": "test uow",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SQLite fixture for DB-backed query tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    db = tmp_path / "registry.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("""
+        CREATE TABLE uow_registry (
+            id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            summary TEXT,
+            register TEXT DEFAULT 'operational',
+            close_reason TEXT,
+            output_ref TEXT,
+            started_at TEXT,
+            closed_at TEXT,
+            updated_at TEXT,
+            created_at TEXT NOT NULL,
+            heartbeat_at TEXT,
+            heartbeat_ttl INTEGER DEFAULT 300,
+            steward_cycles INTEGER DEFAULT 0
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            uow_id TEXT NOT NULL,
+            event TEXT NOT NULL,
+            from_status TEXT,
+            to_status TEXT,
+            agent TEXT,
+            note TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _insert_uow_row(db: Path, uow: dict) -> None:
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+            (id, status, summary, register, close_reason, output_ref,
+             started_at, closed_at, updated_at, created_at, steward_cycles)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            uow["id"], uow["status"], uow.get("summary", "test uow"),
+            uow.get("register", "operational"), uow.get("close_reason", ""),
+            uow.get("output_ref", ""), uow.get("started_at"),
+            uow.get("closed_at"), uow.get("updated_at"), uow["created_at"],
+            uow.get("steward_cycles", 0),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_audit_entry(db: Path, uow_id: str, to_status: str, hours_ago: float = 0.5) -> None:
+    ts = _hours_ago_iso(hours_ago)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        INSERT INTO audit_log (ts, uow_id, event, from_status, to_status)
+        VALUES (?, ?, 'status_change', 'active', ?)
+        """,
+        (ts, uow_id, to_status),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# classify_uow — classification heuristics
+# ---------------------------------------------------------------------------
+
+class TestClassifyUow:
+    def test_failed_status_is_shit(self):
+        uow = _uow(status="failed", close_reason="execution error")
+        assert md.classify_uow(uow) == OUTCOME_SHIT
+
+    def test_expired_status_is_shit(self):
+        uow = _uow(status="expired", close_reason="ttl exceeded")
+        assert md.classify_uow(uow) == OUTCOME_SHIT
+
+    def test_cancelled_status_is_shit(self):
+        uow = _uow(status="cancelled", close_reason="user_closed")
+        assert md.classify_uow(uow) == OUTCOME_SHIT
+
+    def test_ttl_in_close_reason_is_shit(self):
+        uow = _uow(status="done", close_reason="ttl_exceeded after 4h")
+        assert md.classify_uow(uow) == OUTCOME_SHIT
+
+    def test_hard_cap_in_close_reason_is_shit(self):
+        uow = _uow(status="done", close_reason="hard_cap reached")
+        assert md.classify_uow(uow) == OUTCOME_SHIT
+
+    def test_user_closed_in_close_reason_is_shit(self):
+        uow = _uow(status="done", close_reason="user_closed by admin")
+        assert md.classify_uow(uow) == OUTCOME_SHIT
+
+    def test_pr_in_close_reason_is_pearl(self):
+        uow = _uow(status="done", close_reason="opened pr #123")
+        assert md.classify_uow(uow) == OUTCOME_PEARL
+
+    def test_implementation_in_close_reason_is_pearl(self):
+        uow = _uow(status="done", close_reason="implementation complete")
+        assert md.classify_uow(uow) == OUTCOME_PEARL
+
+    def test_commit_in_close_reason_is_pearl(self):
+        uow = _uow(status="done", close_reason="committed changes")
+        assert md.classify_uow(uow) == OUTCOME_PEARL
+
+    def test_issue_in_close_reason_is_seed(self):
+        uow = _uow(status="done", close_reason="spawned issue #456")
+        assert md.classify_uow(uow) == OUTCOME_SEED
+
+    def test_seed_keyword_in_close_reason_is_seed(self):
+        uow = _uow(status="done", close_reason="seeded follow-on work")
+        assert md.classify_uow(uow) == OUTCOME_SEED
+
+    def test_spawn_keyword_in_close_reason_is_seed(self):
+        uow = _uow(status="done", close_reason="spawn new uow for subtask")
+        assert md.classify_uow(uow) == OUTCOME_SEED
+
+    def test_review_in_close_reason_is_heat(self):
+        uow = _uow(status="done", close_reason="completed review of design doc")
+        assert md.classify_uow(uow) == OUTCOME_HEAT
+
+    def test_analysis_in_close_reason_is_heat(self):
+        uow = _uow(status="done", close_reason="analysis complete")
+        assert md.classify_uow(uow) == OUTCOME_HEAT
+
+    def test_design_in_close_reason_is_heat(self):
+        uow = _uow(status="done", close_reason="design specification written")
+        assert md.classify_uow(uow) == OUTCOME_HEAT
+
+    def test_done_with_no_signal_is_shit(self):
+        # Done with empty close_reason and no output_ref: no verifiable output
+        uow = _uow(status="done", close_reason="", output_ref="")
+        assert md.classify_uow(uow) == OUTCOME_SHIT
+
+    def test_seed_takes_priority_over_heat(self):
+        # "issue" and "analysis" both present — seed wins because it's checked first
+        uow = _uow(status="done", close_reason="issue analysis complete")
+        assert md.classify_uow(uow) == OUTCOME_SEED
+
+    def test_seed_takes_priority_over_pearl(self):
+        # "issue" and "pr" both present — seed wins because it's checked first
+        uow = _uow(status="done", close_reason="issue referenced in pr")
+        assert md.classify_uow(uow) == OUTCOME_SEED
+
+
+# ---------------------------------------------------------------------------
+# aggregate_by_classification
+# ---------------------------------------------------------------------------
+
+class TestAggregateByClassification:
+    def test_all_four_keys_always_present(self):
+        groups = md.aggregate_by_classification([])
+        assert set(groups.keys()) == {OUTCOME_PEARL, OUTCOME_HEAT, OUTCOME_SEED, OUTCOME_SHIT}
+
+    def test_all_keys_present_even_when_categories_empty(self):
+        pairs = [(_uow(close_reason="opened pr #1"), OUTCOME_PEARL)]
+        groups = md.aggregate_by_classification(pairs)
+        assert OUTCOME_HEAT in groups
+        assert OUTCOME_SEED in groups
+        assert OUTCOME_SHIT in groups
+
+    def test_uows_routed_to_correct_group(self):
+        pearl = _uow(uow_id="p1", close_reason="opened pr #1")
+        heat = _uow(uow_id="h1", close_reason="review complete")
+        seed = _uow(uow_id="s1", close_reason="spawned issue")
+        shit = _uow(uow_id="sh1", status="failed")
+
+        pairs = [
+            (pearl, OUTCOME_PEARL),
+            (heat, OUTCOME_HEAT),
+            (seed, OUTCOME_SEED),
+            (shit, OUTCOME_SHIT),
+        ]
+        groups = md.aggregate_by_classification(pairs)
+
+        assert len(groups[OUTCOME_PEARL]) == 1
+        assert len(groups[OUTCOME_HEAT]) == 1
+        assert len(groups[OUTCOME_SEED]) == 1
+        assert len(groups[OUTCOME_SHIT]) == 1
+        assert groups[OUTCOME_PEARL][0]["id"] == "p1"
+
+
+# ---------------------------------------------------------------------------
+# compute_duration_minutes
+# ---------------------------------------------------------------------------
+
+class TestComputeDurationMinutes:
+    def test_basic_duration_computed_correctly(self):
+        uow = {
+            "started_at": "2026-04-22T09:00:00+00:00",
+            "closed_at": "2026-04-22T09:30:00+00:00",
+        }
+        result = md.compute_duration_minutes(uow)
+        assert result == 30.0
+
+    def test_missing_started_at_returns_none(self):
+        uow = {"started_at": None, "closed_at": "2026-04-22T09:30:00+00:00"}
+        assert md.compute_duration_minutes(uow) is None
+
+    def test_missing_closed_at_falls_back_to_updated_at(self):
+        uow = {
+            "started_at": "2026-04-22T09:00:00+00:00",
+            "closed_at": None,
+            "updated_at": "2026-04-22T09:20:00+00:00",
+        }
+        result = md.compute_duration_minutes(uow)
+        assert result == 20.0
+
+    def test_negative_duration_returns_none(self):
+        # closed_at before started_at — malformed data
+        uow = {
+            "started_at": "2026-04-22T10:00:00+00:00",
+            "closed_at": "2026-04-22T09:00:00+00:00",
+        }
+        assert md.compute_duration_minutes(uow) is None
+
+    def test_malformed_timestamp_returns_none(self):
+        uow = {"started_at": "not-a-date", "closed_at": "also-not-a-date"}
+        assert md.compute_duration_minutes(uow) is None
+
+
+# ---------------------------------------------------------------------------
+# format_digest
+# ---------------------------------------------------------------------------
+
+class TestFormatDigest:
+    def _empty_groups(self) -> dict:
+        return md.aggregate_by_classification([])
+
+    def test_header_line_present(self):
+        text = md.format_digest(self._empty_groups(), [], 24, "2026-04-22T09:00:00+00:00")
+        assert "WOS Daily Metabolic Report" in text
+
+    def test_summary_line_contains_counts(self):
+        pearl = _uow(uow_id="p1", close_reason="opened pr #1")
+        shit = _uow(uow_id="sh1", status="failed")
+        groups = md.aggregate_by_classification([
+            (pearl, OUTCOME_PEARL),
+            (shit, OUTCOME_SHIT),
+        ])
+        text = md.format_digest(groups, [], 24, "2026-04-22T09:00:00+00:00")
+        assert "1 pearl" in text
+        assert "1 shit" in text
+
+    def test_zero_completed_shows_no_uows_message(self):
+        text = md.format_digest(self._empty_groups(), [], 24, "2026-04-22T09:00:00+00:00")
+        assert "No UoWs completed" in text
+
+    def test_stalled_line_included_when_stalled_present(self):
+        stalled = [{"id": "uow-stalled", "status": "active"}]
+        text = md.format_digest(self._empty_groups(), stalled, 24, "2026-04-22T09:00:00+00:00")
+        assert "Stalled" in text
+        assert "uow-stalled" in text
+
+    def test_stalled_line_absent_when_no_stalled(self):
+        text = md.format_digest(self._empty_groups(), [], 24, "2026-04-22T09:00:00+00:00")
+        assert "Stalled" not in text
+
+    def test_lookback_hours_reflected_in_output(self):
+        text = md.format_digest(self._empty_groups(), [], 48, "2026-04-22T09:00:00+00:00")
+        assert "48h" in text
+
+    def test_register_breakdown_present_when_uows_exist(self):
+        pearl = _uow(uow_id="p1", close_reason="opened pr", register="operational")
+        groups = md.aggregate_by_classification([(pearl, OUTCOME_PEARL)])
+        text = md.format_digest(groups, [], 24, "2026-04-22T09:00:00+00:00")
+        assert "Register breakdown" in text
+        assert "operational" in text
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate
+# ---------------------------------------------------------------------------
+
+class TestJobsJsonGate:
+    def test_job_skips_when_disabled(self, tmp_path, monkeypatch):
+        jobs_file = tmp_path / "jobs.json"
+        jobs_file.write_text(json.dumps({"jobs": {"wos-metabolic-digest": {"enabled": False}}}))
+        monkeypatch.setattr(md, "_jobs_file", lambda: jobs_file)
+        assert md._is_job_enabled() is False
+
+    def test_job_runs_when_enabled(self, tmp_path, monkeypatch):
+        jobs_file = tmp_path / "jobs.json"
+        jobs_file.write_text(json.dumps({"jobs": {"wos-metabolic-digest": {"enabled": True}}}))
+        monkeypatch.setattr(md, "_jobs_file", lambda: jobs_file)
+        assert md._is_job_enabled() is True
+
+    def test_job_defaults_to_enabled_when_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(md, "_jobs_file", lambda: tmp_path / "nonexistent.json")
+        assert md._is_job_enabled() is True
+
+    def test_job_defaults_to_enabled_when_entry_missing(self, tmp_path, monkeypatch):
+        jobs_file = tmp_path / "jobs.json"
+        jobs_file.write_text(json.dumps({"jobs": {}}))
+        monkeypatch.setattr(md, "_jobs_file", lambda: jobs_file)
+        assert md._is_job_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# query_completed_uows — DB-backed query
+# ---------------------------------------------------------------------------
+
+class TestQueryCompletedUows:
+    def test_uow_transitioned_to_done_within_window_is_returned(self, db_path):
+        u = _uow(uow_id="uow-done", status="done", close_reason="pr merged")
+        _insert_uow_row(db_path, u)
+        _insert_audit_entry(db_path, "uow-done", "done", hours_ago=1)
+        results = md.query_completed_uows(db_path, DEFAULT_LOOKBACK_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-done" in ids
+
+    def test_uow_not_in_audit_window_is_excluded(self, db_path):
+        # Transition happened 48h ago — outside the default 24h window
+        u = _uow(uow_id="uow-old", status="done", close_reason="pr merged")
+        _insert_uow_row(db_path, u)
+        _insert_audit_entry(db_path, "uow-old", "done", hours_ago=48)
+        results = md.query_completed_uows(db_path, DEFAULT_LOOKBACK_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-old" not in ids
+
+    def test_absent_db_returns_empty_list(self, tmp_path):
+        results = md.query_completed_uows(tmp_path / "nonexistent.db", DEFAULT_LOOKBACK_HOURS)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# query_still_running — DB-backed query
+# ---------------------------------------------------------------------------
+
+class TestQueryStillRunning:
+    def test_long_running_active_uow_returned(self, db_path):
+        u = _uow(
+            uow_id="uow-running",
+            status="active",
+            started_hours_ago=STALL_THRESHOLD_HOURS + 1,
+            closed_hours_ago=STALL_THRESHOLD_HOURS + 1,
+        )
+        u["closed_at"] = None  # still running
+        u["status"] = "active"
+        _insert_uow_row(db_path, u)
+        results = md.query_still_running(db_path, threshold_hours=STALL_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-running" in ids
+
+    def test_recently_started_uow_not_returned(self, db_path):
+        u = _uow(uow_id="uow-new", status="active", started_hours_ago=1)
+        u["closed_at"] = None
+        _insert_uow_row(db_path, u)
+        results = md.query_still_running(db_path, threshold_hours=STALL_THRESHOLD_HOURS)
+        ids = [r["id"] for r in results]
+        assert "uow-new" not in ids
+
+
+# ---------------------------------------------------------------------------
+# handle_wos_execute — heartbeat contract in dispatched prompt
+# ---------------------------------------------------------------------------
+
+class TestHandleWosExecuteHeartbeatContract:
+    """
+    Verify that the heartbeat contract section is present in the prompt returned
+    by handle_wos_execute. This section was added in issue #849 — the heartbeat
+    infrastructure existed (PR #848) but agents were never instructed to call it.
+    """
+
+    @pytest.fixture(scope="class")
+    def prompt(self):
+        handlers = _load_handlers_module()
+        return handlers.handle_wos_execute(
+            uow_id="test-uow-001",
+            instructions="Do the thing.",
+            output_ref="/tmp/test-uow-001.result.json",
+        )
+
+    def test_heartbeat_section_heading_present(self, prompt):
+        assert "Heartbeat contract" in prompt
+
+    def test_write_heartbeat_call_present(self, prompt):
+        assert "write_heartbeat" in prompt
+
+    def test_uow_id_interpolated_in_heartbeat_call(self, prompt):
+        # The heartbeat call must use the actual UoW ID, not a placeholder
+        assert "write_heartbeat('test-uow-001')" in prompt
+
+    def test_60_90_second_interval_documented(self, prompt):
+        assert "60-90 seconds" in prompt
+
+    def test_stop_on_zero_return_value_documented(self, prompt):
+        # Agent must stop if write_heartbeat returns 0 (UoW re-queued)
+        assert "0" in prompt and "stop" in prompt.lower()
+
+    def test_instructions_still_present_after_heartbeat_section(self, prompt):
+        # The heartbeat section must not replace the instructions
+        assert "Do the thing." in prompt
+
+    def test_result_contract_present(self, prompt):
+        # The result contract (write_result / output_ref) must also be present
+        assert "Result contract" in prompt or "result file" in prompt.lower()


### PR DESCRIPTION
Closes #849.

## What problem does this solve?

The WOS heartbeat infrastructure (PR #848) was dark: `write_heartbeat()` existed but no agents called it, and no observability existed to detect stalled or starving UoWs. Three gaps from the WOS audit (wos-audit-20260422.md) are addressed here.

## What changed

### Gap 1 — Agents now receive explicit heartbeat instructions (dispatcher_handlers.py)

`handle_wos_execute` now prepends a `## Heartbeat contract (REQUIRED)` section to every dispatched subagent prompt. Before this change, an agent receiving a `wos_execute` message had no instruction to call `write_heartbeat` — the Observation Loop would fall back to `started_at` (legacy mode) and only detect stalls at TTL expiry.

The section names four required checkpoints, provides two equivalent code paths (WOSRegistry and Registry directly), and documents the return-value semantics: a return of 0 means the Steward has already re-queued the UoW — the agent must stop immediately.

### Gap 2 — Starvation health check (scheduled-tasks/wos-health-check.py)

New Type C cron-direct script, every 6 hours. Detects:
- UoWs stuck in `proposed`/`pending` >24h (`STARVATION_THRESHOLD_HOURS`)
- `active`/`executing` UoWs with stale heartbeats, discriminated as `stall_type=heartbeat` (had a heartbeat, now stale) vs `stall_type=no_heartbeat` (NULL heartbeat_at, legacy path)
- In-flight UoWs running >48h (`ALERT_THRESHOLD_HOURS`) — these trigger an inbox alert

Pure query functions (`query_starvation_candidates`, `query_stale_heartbeats`, `query_long_running_in_flight`, `check_executor_heartbeat_liveness`) compose into `run_health_check`. Side effects (inbox alert, log write) are isolated at the system boundary.

### Gap 3 — Metabolic digest (scheduled-tasks/wos-metabolic-digest.py)

New Type C cron-direct script, daily 09:00 UTC. Reads completed UoWs from `audit_log` within a 24h window, classifies each by outcome:

| Label | Heuristic |
|-------|-----------|
| `pearl` | `close_reason` mentions pr/implementation/commit/merge |
| `heat` | `close_reason` mentions review/analysis/design/synthesis |
| `seed` | `close_reason` mentions issue/seed/spawn/follow-up |
| `shit` | failed/expired/cancelled status, TTL/hard_cap in close_reason, or no verifiable signal |

Classification is conservative: `shit` is the default when no signal fires. `seed` takes priority over `pearl` and `heat` when keywords overlap.

Computes register breakdown, average duration per category (pearl, heat), and stalled UoWs >6h. Sends a structured Telegram digest via inbox message (`type: "wos_metabolic_digest"`).

### Migration 83 (scripts/upgrade.sh)

Adds cron entries for both new scripts using `cron-manage.sh`, idempotent. Health check runs every 6h (`0 */6 * * *`); digest runs daily at 09:00 UTC (`0 9 * * *`).

## Functional patterns used

- **Pure query functions** for all DB reads — testable without side effects
- **Composition** in `run_health_check` and `run_digest` — queries compose into reports, reports compose into alerts
- **Immutability** — all UoW dicts are read-only; classification returns a new label string
- **Side effects at the boundary** — all inbox writes and file I/O isolated to `_write_inbox_alert`, `_write_inbox_digest`, `write_health_report`
- **Named constants** for all spec thresholds (`STARVATION_THRESHOLD_HOURS = 24`, `ALERT_THRESHOLD_HOURS = 48`, `HEARTBEAT_STALE_BUFFER_SECONDS = 60`, `DEFAULT_LOOKBACK_HOURS = 24`)

## What is out of scope

- This PR does not change the Observation Loop or steward-heartbeat behavior
- The `write_heartbeat` API itself is unchanged (landed in PR #848)
- No changes to existing executor-heartbeat dispatch logic
- No changes to the WOS gate or UoW state machine

## Tests run
- [x] `uv run pytest tests/unit/test_wos_health_check.py tests/unit/test_wos_metabolic_digest.py -v` — 69 passed, 0 failed, 1 warning (PytestConfigWarning for unknown `timeout` option — cosmetic, not a failure)
- [ ] Live cron execution — not verified: requires deployment. Migration 83 is idempotent via cron-manage.sh marker detection.
- [ ] Live Telegram digest — not verified: requires a populated registry.db and a running dispatcher. The `--dry-run` flag allows safe manual testing before enabling.

## Manual test

N/A for unit-testable changes. The two new scripts have `--dry-run` flags that log the computed output without writing inbox messages or cron files. Live end-to-end testing requires a running system with a populated registry.db.

The heartbeat instruction change (Gap 1) is verified by `TestHandleWosExecuteHeartbeatContract` — 7 tests assert that the heartbeat section is present, the UoW ID is interpolated correctly, the 60-90s interval is documented, and the stop-on-zero semantics are present.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test — blocked: requires live system with populated registry.db
- [ ] User-visible Telegram digest verified — not applicable until deployed
- [x] Side-effect audit: no floods, no unscoped writes. Scripts are read-only until `--dry-run` is removed and cron fires. Inbox alert is bounded to UoW IDs exceeding the alert threshold.
- [x] External service calls: mocked in tests (monkeypatched `_inbox_dir`, `_jobs_file`, `_executor_log_file`)