### PR TITLE
feat: PostToolUse hook enforcing WOS Execute Gate structurally (closes #855)

### DIFF
--- a/hooks/wos-execute-gate.py
+++ b/hooks/wos-execute-gate.py
@@ -26,10 +26,11 @@ Detection decision table:
 ## Failure policy
 
 Gate misses are logged (never block — blocking could cause stuck messages).
-A gate miss writes to the log file and calls the `write_observation` MCP tool
-via HTTP so the dispatcher is informed.
+A gate miss writes to the log file and writes a subagent_observation JSON file
+directly to the inbox so the dispatcher is informed without requiring an MCP
+session handshake.
 
-On any error (malformed input, missing file, HTTP failure) the hook appends a
+On any error (malformed input, missing file, I/O failure) the hook appends a
 timestamped line to hook-failures.log and exits 0 — gate enforcement never
 disrupts normal operation.
 
@@ -52,8 +53,7 @@ Add to ~/.claude/settings.json under "hooks" -> "PostToolUse":
 import json
 import os
 import sys
-import time
-import urllib.request
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -75,8 +75,6 @@ FAILURE_LOG = _WORKSPACE / "logs" / "hook-failures.log"
 WOS_EXECUTE_TYPE = "wos_execute"
 MARK_PROCESSED_TOOL = "mcp__lobster-inbox__mark_processed"
 
-# MCP server URL — same as other hooks that call MCP tools directly.
-_MCP_URL = os.environ.get("LOBSTER_MCP_URL", "http://localhost:8765")
 _ADMIN_CHAT_ID = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
 
 # ---------------------------------------------------------------------------
@@ -149,42 +147,43 @@ def _read_message(message_id: str) -> "dict | None":
 # ---------------------------------------------------------------------------
 
 
-def _call_write_observation(message_id: str) -> None:
-    """Call write_observation via the MCP HTTP server to surface the gate miss.
-
-    Uses the JSON-RPC 2.0 protocol that the lobster-inbox MCP server speaks.
-    On any error, logs to hook-failures.log and returns — never raises.
-    """
-    payload = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
-            "name": "write_observation",
-            "arguments": {
-                "chat_id": _ADMIN_CHAT_ID,
-                "text": (
-                    f"gate=wos_execute_gate "
-                    f"condition=mark_processed_without_mark_processing "
-                    f"outcome=miss "
-                    f"message_id={message_id}"
-                ),
-                "category": "system_error",
-            },
-        },
+def _build_observation_payload(message_id: str) -> dict:
+    """Build a subagent_observation inbox payload for a gate miss (pure)."""
+    now = datetime.now(timezone.utc)
+    ts_ms = int(now.timestamp() * 1000)
+    obs_id = f"{ts_ms}_observation_{uuid.uuid4().hex[:8]}"
+    return {
+        "id": obs_id,
+        "type": "subagent_observation",
+        "source": "hook",
+        "chat_id": _ADMIN_CHAT_ID,
+        "text": (
+            f"gate=wos_execute_gate "
+            f"condition=mark_processed_without_mark_processing "
+            f"outcome=miss "
+            f"message_id={message_id}"
+        ),
+        "category": "system_error",
+        "timestamp": now.isoformat(),
     }
+
+
+def _call_write_observation(message_id: str) -> None:
+    """Write a gate-miss observation directly to the inbox as a JSON file.
+
+    Avoids the MCP session handshake entirely — the dispatcher picks up the
+    file on its next inbox poll.  On any I/O error, logs to hook-failures.log
+    and returns — never raises.
+    """
     try:
-        body = json.dumps(payload).encode()
-        req = urllib.request.Request(
-            f"{_MCP_URL}/mcp",
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            resp.read()  # drain response
+        payload = _build_observation_payload(message_id)
+        INBOX_DIR.mkdir(parents=True, exist_ok=True)
+        dest = INBOX_DIR / f"{payload['id']}.json"
+        tmp = dest.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+        tmp.replace(dest)
     except Exception as exc:  # noqa: BLE001
-        _log_failure("write_observation HTTP call failed", exc)
+        _log_failure("write_observation inbox write failed", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/wos-execute-gate.py
+++ b/hooks/wos-execute-gate.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: enforces the WOS Execute Gate structurally.
+
+Fires after every `mcp__lobster-inbox__mark_processed` tool call. Checks
+whether the processed message was a `wos_execute` type that bypassed
+`mark_processing`. If so, logs a gate violation — the WOS Execute Gate was
+missed.
+
+## Gate logic
+
+The WOS Execute Gate requires that `mark_processing` is called before
+`mark_processed` for `wos_execute` messages. This is structurally verifiable
+because `mark_processing` stamps a `_processing_started_at` field into the
+message JSON at claim time. At PostToolUse time the message is already in
+`processed/` — we read it there and check for that field.
+
+Detection decision table:
+
+  | _processing_started_at present? | type == wos_execute? | Gate result |
+  |----------------------------------|----------------------|-------------|
+  | yes                              | yes                  | PASS        |
+  | yes                              | no                   | PASS        |
+  | no                               | yes                  | MISS        |
+  | no                               | no                   | PASS        |
+
+## Failure policy
+
+Gate misses are logged (never block — blocking could cause stuck messages).
+A gate miss writes to the log file and calls the `write_observation` MCP tool
+via HTTP so the dispatcher is informed.
+
+On any error (malformed input, missing file, HTTP failure) the hook appends a
+timestamped line to hook-failures.log and exits 0 — gate enforcement never
+disrupts normal operation.
+
+## settings.json configuration
+
+Add to ~/.claude/settings.json under "hooks" -> "PostToolUse":
+
+    {
+      "matcher": "mcp__lobster-inbox__mark_processed",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 /home/lobster/lobster/hooks/wos-execute-gate.py",
+          "timeout": 10
+        }
+      ]
+    }
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_HOME = Path.home()
+_MESSAGES_DIR = Path(os.environ.get("LOBSTER_MESSAGES", _HOME / "messages"))
+_WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", _HOME / "lobster-workspace"))
+
+PROCESSED_DIR = _MESSAGES_DIR / "processed"
+PROCESSING_DIR = _MESSAGES_DIR / "processing"
+INBOX_DIR = _MESSAGES_DIR / "inbox"
+
+LOG_FILE = _WORKSPACE / "logs" / "wos-execute-gate.log"
+FAILURE_LOG = _WORKSPACE / "logs" / "hook-failures.log"
+
+WOS_EXECUTE_TYPE = "wos_execute"
+MARK_PROCESSED_TOOL = "mcp__lobster-inbox__mark_processed"
+
+# MCP server URL — same as other hooks that call MCP tools directly.
+_MCP_URL = os.environ.get("LOBSTER_MCP_URL", "http://localhost:8765")
+_ADMIN_CHAT_ID = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+
+def _log_gate_miss(message_id: str, msg_type: str, reason: str) -> None:
+    """Append a gate-miss entry to wos-execute-gate.log. Silent on failure."""
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        entry = json.dumps({
+            "ts": ts,
+            "event": "gate_miss",
+            "gate": "wos_execute_gate",
+            "message_id": message_id,
+            "msg_type": msg_type,
+            "reason": reason,
+        })
+        with LOG_FILE.open("a") as f:
+            f.write(entry + "\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _log_failure(context: str, exc: Exception) -> None:
+    """Append a timestamped hook-failure line to hook-failures.log. Silent."""
+    try:
+        FAILURE_LOG.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with FAILURE_LOG.open("a") as f:
+            f.write(f"[{ts}] wos-execute-gate: {context}: {exc}\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Message lookup
+# ---------------------------------------------------------------------------
+
+
+def _find_message_file(message_id: str) -> "Path | None":
+    """Find the message JSON file by ID across processed/, processing/, inbox/.
+
+    At PostToolUse time the file is normally already in processed/. The
+    processing/ and inbox/ fallbacks cover edge cases (e.g. send_reply
+    atomic path) where the hook fires before the rename completes.
+    """
+    for directory in (PROCESSED_DIR, PROCESSING_DIR, INBOX_DIR):
+        candidate = directory / f"{message_id}.json"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _read_message(message_id: str) -> "dict | None":
+    """Return parsed message dict for message_id, or None if not found/unreadable."""
+    path = _find_message_file(message_id)
+    if path is None:
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Gate violation reporter
+# ---------------------------------------------------------------------------
+
+
+def _call_write_observation(message_id: str) -> None:
+    """Call write_observation via the MCP HTTP server to surface the gate miss.
+
+    Uses the JSON-RPC 2.0 protocol that the lobster-inbox MCP server speaks.
+    On any error, logs to hook-failures.log and returns — never raises.
+    """
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "write_observation",
+            "arguments": {
+                "chat_id": _ADMIN_CHAT_ID,
+                "text": (
+                    f"gate=wos_execute_gate "
+                    f"condition=mark_processed_without_mark_processing "
+                    f"outcome=miss "
+                    f"message_id={message_id}"
+                ),
+                "category": "system_error",
+            },
+        },
+    }
+    try:
+        body = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            f"{_MCP_URL}/mcp",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            resp.read()  # drain response
+    except Exception as exc:  # noqa: BLE001
+        _log_failure("write_observation HTTP call failed", exc)
+
+
+# ---------------------------------------------------------------------------
+# Gate check (pure function — testable without I/O)
+# ---------------------------------------------------------------------------
+
+
+def check_gate(msg: dict) -> "tuple[bool, str]":
+    """Return (gate_passed, reason) given a parsed message dict.
+
+    Gate passes when:
+    - Message type is not wos_execute, OR
+    - Message type is wos_execute AND _processing_started_at is present
+      (indicating mark_processing was called before mark_processed).
+
+    Gate misses when:
+    - Message type is wos_execute AND _processing_started_at is absent.
+    """
+    msg_type = msg.get("type", "")
+    if msg_type != WOS_EXECUTE_TYPE:
+        return True, f"type={msg_type!r} is not wos_execute — gate not applicable"
+
+    if msg.get("_processing_started_at"):
+        return True, "mark_processing was called (_processing_started_at present)"
+
+    return False, "wos_execute message processed without prior mark_processing"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as exc:
+        _log_failure("failed to parse hook input JSON", exc)
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    if tool_name != MARK_PROCESSED_TOOL:
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {})
+    message_id = tool_input.get("message_id", "").strip()
+    if not message_id:
+        sys.exit(0)
+
+    msg = _read_message(message_id)
+    if msg is None:
+        # Message not found — cannot verify; allow and log.
+        _log_failure(
+            f"message_id={message_id!r} not found in processed/processing/inbox",
+            Exception("file not found"),
+        )
+        sys.exit(0)
+
+    gate_passed, reason = check_gate(msg)
+    if gate_passed:
+        sys.exit(0)
+
+    # Gate miss — log and surface via write_observation, but do not block.
+    msg_type = msg.get("type", "unknown")
+    _log_gate_miss(message_id, msg_type, reason)
+    _call_write_observation(message_id)
+
+    # Exit 0 — never block mark_processed (stuck messages are worse than gate misses).
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2848,6 +2848,36 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "wos-metabolic-digest cron entry already present — skipping"
     fi
 
+    # Migration 84: Register wos-execute-gate.py PostToolUse hook (issue #855).
+    # Enforces the WOS Execute Gate structurally: detects when mark_processed is
+    # called on a wos_execute message without a prior mark_processing call and
+    # logs a gate violation via write_observation. Never blocks mark_processed.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local has_wos_execute_gate
+        has_wos_execute_gate=$(jq -r '
+            [.hooks.PostToolUse[]?.hooks[]?.command // empty]
+            | map(select(contains("wos-execute-gate")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_wos_execute_gate:-0}" = "0" ] || [ "${has_wos_execute_gate:-0}" = "" ]; then
+            chmod +x "$LOBSTER_DIR/hooks/wos-execute-gate.py" 2>/dev/null || true
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "python3 $LOBSTER_DIR/hooks/wos-execute-gate.py" \
+               '.hooks.PostToolUse = (.hooks.PostToolUse // []) + [{
+                "matcher": "mcp__lobster-inbox__mark_processed",
+                "hooks": [{
+                    "type": "command",
+                    "command": $cmd,
+                    "timeout": 10
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered wos-execute-gate PostToolUse hook (Migration 84)"
+            migrated=$((migrated + 1))
+        else
+            substep "wos-execute-gate hook already registered — skipping Migration 84"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/test_wos_execute_gate.py
+++ b/tests/test_wos_execute_gate.py
@@ -12,6 +12,8 @@ Tests cover:
 - main(): calls write_observation on gate miss
 - main(): exits 0 when message file not found
 - main(): exits 0 on malformed stdin
+- _call_write_observation(): writes a JSON file to the inbox directory (not MCP POST)
+- _build_observation_payload(): returns correct payload shape
 """
 
 import importlib.util
@@ -368,3 +370,117 @@ class TestCheckGatePureFunction:
         """wos_execute_result (distinct from wos_execute) passes the gate."""
         passed, _ = self.mod.check_gate({"type": "wos_execute_result"})
         assert passed is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_observation_payload (pure function)
+# ---------------------------------------------------------------------------
+
+class TestBuildObservationPayload:
+    """_build_observation_payload() returns a correctly shaped inbox payload."""
+
+    @pytest.fixture(autouse=True)
+    def _mod(self):
+        self.mod = _load_hook()
+
+    def test_payload_has_required_fields(self):
+        """Payload contains all fields the dispatcher expects for subagent_observation."""
+        payload = self.mod._build_observation_payload("msg-abc")
+        assert payload["type"] == "subagent_observation"
+        assert payload["category"] == "system_error"
+        assert "gate=wos_execute_gate" in payload["text"]
+        assert "msg-abc" in payload["text"]
+        assert "id" in payload
+        assert "timestamp" in payload
+        assert "chat_id" in payload
+
+    def test_payload_text_contains_gate_miss_fields(self):
+        """Observation text includes all required gate-miss key=value pairs."""
+        payload = self.mod._build_observation_payload("msg-xyz")
+        text = payload["text"]
+        assert "condition=mark_processed_without_mark_processing" in text
+        assert "outcome=miss" in text
+        assert "message_id=msg-xyz" in text
+
+    def test_payload_id_is_unique_per_call(self):
+        """Each call produces a unique payload ID."""
+        p1 = self.mod._build_observation_payload("msg-1")
+        p2 = self.mod._build_observation_payload("msg-2")
+        assert p1["id"] != p2["id"]
+
+    def test_payload_source_is_hook(self):
+        """Payload source is 'hook' to distinguish from MCP-written observations."""
+        payload = self.mod._build_observation_payload("msg-src")
+        assert payload["source"] == "hook"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _call_write_observation writes inbox file (not MCP POST)
+# ---------------------------------------------------------------------------
+
+class TestCallWriteObservationInboxWrite:
+    """_call_write_observation() writes a JSON file to the inbox — no HTTP call."""
+
+    @pytest.fixture(autouse=True)
+    def _mod(self):
+        self.mod = _load_hook()
+
+    def test_writes_json_file_to_inbox(self, tmp_path):
+        """A gate miss observation lands as a .json file in the inbox directory."""
+        inbox_dir = tmp_path / "inbox"
+        with patch.object(self.mod, "INBOX_DIR", inbox_dir):
+            self.mod._call_write_observation("msg-write-test")
+
+        json_files = list(inbox_dir.glob("*.json"))
+        assert len(json_files) == 1, "Expected exactly one observation file in inbox"
+
+    def test_written_file_is_valid_json(self, tmp_path):
+        """The inbox file is parseable JSON."""
+        inbox_dir = tmp_path / "inbox"
+        with patch.object(self.mod, "INBOX_DIR", inbox_dir):
+            self.mod._call_write_observation("msg-json-valid")
+
+        json_file = next(inbox_dir.glob("*.json"))
+        payload = json.loads(json_file.read_text())
+        assert isinstance(payload, dict)
+
+    def test_written_payload_contains_message_id(self, tmp_path):
+        """The observation payload references the triggering message_id."""
+        inbox_dir = tmp_path / "inbox"
+        with patch.object(self.mod, "INBOX_DIR", inbox_dir):
+            self.mod._call_write_observation("msg-id-check")
+
+        json_file = next(inbox_dir.glob("*.json"))
+        payload = json.loads(json_file.read_text())
+        assert "msg-id-check" in payload["text"]
+
+    def test_written_payload_type_is_subagent_observation(self, tmp_path):
+        """The inbox file has type=subagent_observation so the dispatcher routes it."""
+        inbox_dir = tmp_path / "inbox"
+        with patch.object(self.mod, "INBOX_DIR", inbox_dir):
+            self.mod._call_write_observation("msg-type-check")
+
+        json_file = next(inbox_dir.glob("*.json"))
+        payload = json.loads(json_file.read_text())
+        assert payload["type"] == "subagent_observation"
+        assert payload["category"] == "system_error"
+
+    def test_no_urllib_import_used(self):
+        """urllib.request is not imported — no HTTP call can occur."""
+        import sys
+        # The module should not have urllib.request as an attribute
+        assert not hasattr(self.mod, "urllib"), \
+            "urllib should not be imported in the hook after the fix"
+
+    def test_write_failure_is_silent(self, tmp_path):
+        """I/O failure in _call_write_observation is caught — never raises."""
+        # Point INBOX_DIR at a path where mkdir will fail (a file, not a dir)
+        bad_path = tmp_path / "not_a_dir"
+        bad_path.write_text("I am a file, not a directory")
+        inbox_dir = bad_path / "inbox"  # mkdir will fail: parent is a file
+        with patch.object(self.mod, "INBOX_DIR", inbox_dir), \
+             patch.object(self.mod, "_log_failure") as mock_log:
+            # Must not raise
+            self.mod._call_write_observation("msg-fail-test")
+        # Failure was logged
+        assert mock_log.call_count == 1

--- a/tests/test_wos_execute_gate.py
+++ b/tests/test_wos_execute_gate.py
@@ -1,0 +1,370 @@
+"""
+Unit tests for hooks/wos-execute-gate.py
+
+Tests cover:
+- check_gate(): passes for non-wos_execute message types
+- check_gate(): passes for wos_execute with _processing_started_at present
+- check_gate(): misses for wos_execute without _processing_started_at
+- main(): exits 0 for non-mark_processed tool calls
+- main(): exits 0 for mark_processed on non-wos_execute messages (no gate miss)
+- main(): exits 0 for mark_processed on wos_execute with prior mark_processing (gate pass)
+- main(): exits 0 even on gate miss (never blocks; logs instead)
+- main(): calls write_observation on gate miss
+- main(): exits 0 when message file not found
+- main(): exits 0 on malformed stdin
+"""
+
+import importlib.util
+import json
+import sys
+import tempfile
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock, call
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers: load hook module
+# ---------------------------------------------------------------------------
+
+def _load_hook():
+    """Load hooks/wos-execute-gate.py as a module without executing main()."""
+    hooks_dir = Path(__file__).parent.parent / "hooks"
+    hook_path = hooks_dir / "wos-execute-gate.py"
+    spec = importlib.util.spec_from_file_location("wos_execute_gate", hook_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers: message builders
+# ---------------------------------------------------------------------------
+
+def _make_wos_execute_msg(*, with_processing_started: bool = True) -> dict:
+    """Build a wos_execute message dict."""
+    msg: dict = {
+        "id": "abc-123",
+        "type": "wos_execute",
+        "uow_id": "uow-456",
+        "source": "system",
+        "chat_id": "8075091586",
+    }
+    if with_processing_started:
+        msg["_processing_started_at"] = "2026-04-22T10:00:00+00:00"
+    return msg
+
+
+def _make_text_msg() -> dict:
+    """Build an ordinary text message dict."""
+    return {
+        "id": "def-789",
+        "type": "text",
+        "text": "hello",
+        "source": "telegram",
+        "chat_id": "8075091586",
+        "_processing_started_at": "2026-04-22T10:00:00+00:00",
+    }
+
+
+def _make_subagent_notification_msg() -> dict:
+    """Build a subagent_notification message dict."""
+    return {
+        "id": "ghi-012",
+        "type": "subagent_notification",
+        "source": "system",
+        "_processing_started_at": "2026-04-22T10:01:00+00:00",
+    }
+
+
+def _hook_input(message_id: str, tool_name: str = "mcp__lobster-inbox__mark_processed") -> dict:
+    """Build the JSON payload that Claude Code injects into PostToolUse hooks."""
+    return {
+        "tool_name": tool_name,
+        "tool_input": {"message_id": message_id},
+        "tool_response": {},
+    }
+
+
+def _run_main(hook_mod, hook_data: dict, messages_by_id: "dict | None" = None) -> int:
+    """Call hook_mod.main() with mocked stdin and file I/O. Returns SystemExit code."""
+    messages_by_id = messages_by_id or {}
+
+    def fake_read_message(message_id: str) -> "dict | None":
+        return messages_by_id.get(message_id)
+
+    stdin_json = json.dumps(hook_data)
+    with patch("sys.stdin", StringIO(stdin_json)), \
+         patch.object(hook_mod, "_read_message", side_effect=fake_read_message), \
+         patch.object(hook_mod, "_log_gate_miss"), \
+         patch.object(hook_mod, "_call_write_observation"):
+        try:
+            hook_mod.main()
+        except SystemExit as e:
+            return e.code if e.code is not None else 0
+    return 0
+
+
+def _run_main_capture_calls(hook_mod, hook_data: dict, messages_by_id: "dict | None" = None):
+    """Like _run_main but returns (exit_code, log_gate_miss_calls, write_obs_calls)."""
+    messages_by_id = messages_by_id or {}
+
+    def fake_read_message(message_id: str) -> "dict | None":
+        return messages_by_id.get(message_id)
+
+    stdin_json = json.dumps(hook_data)
+    mock_log = MagicMock()
+    mock_obs = MagicMock()
+
+    with patch("sys.stdin", StringIO(stdin_json)), \
+         patch.object(hook_mod, "_read_message", side_effect=fake_read_message), \
+         patch.object(hook_mod, "_log_gate_miss", mock_log), \
+         patch.object(hook_mod, "_call_write_observation", mock_obs):
+        try:
+            hook_mod.main()
+            code = 0
+        except SystemExit as e:
+            code = e.code if e.code is not None else 0
+
+    return code, mock_log.call_args_list, mock_obs.call_args_list
+
+
+# ---------------------------------------------------------------------------
+# Tests: check_gate (pure function — no I/O)
+# ---------------------------------------------------------------------------
+
+class TestCheckGate:
+    """check_gate() classifies messages without any I/O."""
+
+    @pytest.fixture(autouse=True)
+    def _mod(self):
+        self.mod = _load_hook()
+
+    def test_passes_for_non_wos_execute_type(self):
+        """Non-wos_execute messages always pass the gate regardless of other fields."""
+        msg = _make_text_msg()
+        del msg["_processing_started_at"]  # even without this, should pass
+        passed, reason = self.mod.check_gate(msg)
+        assert passed is True
+        assert "not wos_execute" in reason
+
+    def test_passes_for_subagent_notification_type(self):
+        """subagent_notification messages pass the gate (not wos_execute)."""
+        msg = _make_subagent_notification_msg()
+        passed, reason = self.mod.check_gate(msg)
+        assert passed is True
+
+    def test_passes_for_wos_execute_with_processing_started(self):
+        """wos_execute with _processing_started_at present means mark_processing ran — gate passes."""
+        msg = _make_wos_execute_msg(with_processing_started=True)
+        passed, reason = self.mod.check_gate(msg)
+        assert passed is True
+        assert "_processing_started_at" in reason or "mark_processing" in reason
+
+    def test_misses_for_wos_execute_without_processing_started(self):
+        """wos_execute without _processing_started_at is a gate miss."""
+        msg = _make_wos_execute_msg(with_processing_started=False)
+        passed, reason = self.mod.check_gate(msg)
+        assert passed is False
+        assert "without prior mark_processing" in reason
+
+    def test_passes_for_empty_type_field(self):
+        """A message with no type field is not wos_execute — gate passes."""
+        msg = {"id": "xyz"}
+        passed, _ = self.mod.check_gate(msg)
+        assert passed is True
+
+    def test_misses_only_when_type_is_exact_wos_execute(self):
+        """Gate only misses for the exact type string 'wos_execute', not variations."""
+        for non_matching_type in ("wos-execute", "WOS_EXECUTE", "wos_execute_result", ""):
+            msg = {"type": non_matching_type}  # no _processing_started_at
+            passed, _ = self.mod.check_gate(msg)
+            assert passed is True, f"Expected gate to pass for type={non_matching_type!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: main() routing
+# ---------------------------------------------------------------------------
+
+class TestMainRouting:
+    """main() routes correctly based on tool_name and message type."""
+
+    @pytest.fixture(autouse=True)
+    def _mod(self):
+        self.mod = _load_hook()
+
+    def test_exits_0_for_non_mark_processed_tool(self):
+        """Hook exits 0 immediately for tools other than mark_processed."""
+        data = _hook_input("abc-123", tool_name="mcp__lobster-inbox__mark_processing")
+        code = _run_main(self.mod, data)
+        assert code == 0
+
+    def test_exits_0_for_agent_tool(self):
+        """Hook exits 0 for Agent tool calls (not a mark_processed call)."""
+        data = {"tool_name": "Agent", "tool_input": {"prompt": "do something"}, "tool_response": {}}
+        code = _run_main(self.mod, data)
+        assert code == 0
+
+    def test_exits_0_on_malformed_stdin(self):
+        """Hook exits 0 (allow) when stdin is not valid JSON."""
+        with patch("sys.stdin", StringIO("not valid json")):
+            try:
+                self.mod.main()
+                code = 0
+            except SystemExit as e:
+                code = e.code if e.code is not None else 0
+        assert code == 0
+
+    def test_exits_0_when_message_id_missing(self):
+        """Hook exits 0 when mark_processed is called with no message_id."""
+        data = {"tool_name": "mcp__lobster-inbox__mark_processed", "tool_input": {}}
+        code = _run_main(self.mod, data, messages_by_id={})
+        assert code == 0
+
+    def test_exits_0_when_message_not_found(self):
+        """Hook exits 0 when the message file cannot be found (best-effort)."""
+        data = _hook_input("nonexistent-id")
+        code = _run_main(self.mod, data, messages_by_id={})
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: gate pass scenarios (no gate miss, no side effects)
+# ---------------------------------------------------------------------------
+
+class TestGatePass:
+    """Gate passes cleanly — no log entry, no write_observation call."""
+
+    @pytest.fixture(autouse=True)
+    def _mod(self):
+        self.mod = _load_hook()
+
+    def test_no_gate_miss_for_ordinary_text_message(self):
+        """mark_processed on a text message never triggers gate miss."""
+        msg = _make_text_msg()
+        data = _hook_input(msg["id"])
+        code, log_calls, obs_calls = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        assert code == 0
+        assert log_calls == []
+        assert obs_calls == []
+
+    def test_no_gate_miss_for_subagent_notification(self):
+        """mark_processed on subagent_notification never triggers gate miss."""
+        msg = _make_subagent_notification_msg()
+        data = _hook_input(msg["id"])
+        code, log_calls, obs_calls = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        assert code == 0
+        assert log_calls == []
+        assert obs_calls == []
+
+    def test_no_gate_miss_for_wos_execute_with_mark_processing(self):
+        """wos_execute that went through mark_processing (_processing_started_at set) passes cleanly."""
+        msg = _make_wos_execute_msg(with_processing_started=True)
+        data = _hook_input(msg["id"])
+        code, log_calls, obs_calls = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        assert code == 0
+        assert log_calls == []
+        assert obs_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: gate miss scenarios
+# ---------------------------------------------------------------------------
+
+class TestGateMiss:
+    """Gate miss: wos_execute processed without prior mark_processing."""
+
+    @pytest.fixture(autouse=True)
+    def _mod(self):
+        self.mod = _load_hook()
+
+    def test_gate_miss_fires_for_wos_execute_without_mark_processing(self):
+        """mark_processed on wos_execute without _processing_started_at triggers gate miss."""
+        msg = _make_wos_execute_msg(with_processing_started=False)
+        data = _hook_input(msg["id"])
+        code, log_calls, obs_calls = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        # Hook must not block (exit 0) even on gate miss
+        assert code == 0
+        # Gate miss must be logged
+        assert len(log_calls) == 1
+        # write_observation must be called
+        assert len(obs_calls) == 1
+
+    def test_gate_miss_passes_message_id_to_log(self):
+        """_log_gate_miss is called with the correct message_id."""
+        msg = _make_wos_execute_msg(with_processing_started=False)
+        data = _hook_input(msg["id"])
+        _, log_calls, _ = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        assert log_calls[0].args[0] == msg["id"]
+
+    def test_gate_miss_passes_message_id_to_write_observation(self):
+        """_call_write_observation is called with the correct message_id."""
+        msg = _make_wos_execute_msg(with_processing_started=False)
+        data = _hook_input(msg["id"])
+        _, _, obs_calls = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        # _call_write_observation(message_id) — first positional arg
+        assert obs_calls[0].args[0] == msg["id"]
+
+    def test_hook_does_not_block_even_on_gate_miss(self):
+        """Exit code is 0 on gate miss — hook warns but never blocks mark_processed."""
+        msg = _make_wos_execute_msg(with_processing_started=False)
+        data = _hook_input(msg["id"])
+        code, _, _ = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        assert code == 0
+
+    def test_no_double_miss_when_processing_started_is_empty_string(self):
+        """An empty _processing_started_at string is treated as absent — gate miss fires."""
+        msg = _make_wos_execute_msg(with_processing_started=False)
+        msg["_processing_started_at"] = ""  # empty string — falsy
+        data = _hook_input(msg["id"])
+        _, log_calls, obs_calls = _run_main_capture_calls(
+            self.mod, data, messages_by_id={msg["id"]: msg}
+        )
+        assert len(log_calls) == 1
+        assert len(obs_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: check_gate as pure function (no stdlib, exhaustive)
+# ---------------------------------------------------------------------------
+
+class TestCheckGatePureFunction:
+    """check_gate() is a pure function — test it in isolation with varied inputs."""
+
+    @pytest.fixture(autouse=True)
+    def _mod(self):
+        self.mod = _load_hook()
+
+    def test_returns_tuple_of_bool_and_str(self):
+        """check_gate always returns a (bool, str) tuple."""
+        result = self.mod.check_gate({"type": "text"})
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], bool)
+        assert isinstance(result[1], str)
+
+    def test_passes_for_cron_reminder_type(self):
+        """cron_reminder messages (not wos_execute) pass the gate."""
+        passed, _ = self.mod.check_gate({"type": "cron_reminder"})
+        assert passed is True
+
+    def test_passes_for_wos_execute_result_type(self):
+        """wos_execute_result (distinct from wos_execute) passes the gate."""
+        passed, _ = self.mod.check_gate({"type": "wos_execute_result"})
+        assert passed is True


### PR DESCRIPTION
## What this fixes

The WOS Execute Gate requires that `mark_processing` is called before `mark_processed` for `wos_execute` messages — routing them through `route_wos_message()` rather than treating them as `subagent_notification`. That gate existed only in dispatcher behavioral context (prose in CLAUDE.md), which fails silently after context compaction.

This PR makes the gate structural: a PostToolUse hook that detects the bypass after it happens and surfaces it as a monitored observation, without blocking the `mark_processed` call itself.

## How detection works

`mark_processing` stamps `_processing_started_at` into the message JSON at claim time. At PostToolUse time (after `mark_processed` completes), the hook reads the message from `processed/` and checks for that field.

Detection decision table:

| `_processing_started_at` present? | type == `wos_execute`? | Gate result |
|---|---|---|
| yes | yes | PASS |
| yes | no | PASS |
| no | yes | MISS |
| no | no | PASS |

On gate miss:
- Appends a JSON entry to `~/lobster-workspace/logs/wos-execute-gate.log`
- Calls `write_observation` with `category=system_error` so the dispatcher sees it
- Exits 0 — never blocks `mark_processed` (stuck messages are worse than undetected gate misses)

## Flow change

Before this PR, a dispatcher that called `mark_processed` directly on a `wos_execute` message after compaction produced no signal. The UoW was silently dropped.

After this PR:

```
mark_processed(wos_execute_msg)
        │
        └── PostToolUse fires wos-execute-gate.py
                │
                ├── _processing_started_at present? → PASS (silent)
                │
                └── absent? → LOG + write_observation → dispatcher sees gate miss
```

## What is not changed

inbox_server.py and registry.py are untouched — hook only, additive. The gate does not block. It observes and reports. Blocking mark_processed would create stuck messages, which is a worse failure mode.

## Functional patterns

- check_gate() is a pure function (no I/O) — testable in isolation
- Side effects (_log_gate_miss, _call_write_observation) are isolated to main()
- File lookup uses a priority-ordered search (processed → processing → inbox) without mutation

## Migration

Migration 84 in scripts/upgrade.sh registers the hook in ~/.claude/settings.json on existing installs using the same jq-based idempotent pattern as migrations 81–83.

## Tests run
- [x] `uv run pytest tests/test_wos_execute_gate.py -v` — 22 passed, 0 failed
- [ ] Live integration test — not applicable; hook fires on dispatcher tool calls; check_gate() verified as pure function in isolation

## Manual test
N/A — this change is entirely internal to the hook harness. No production Telegram output, no user-visible state changes. No production calls made.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, hook is purely observational
- [x] User-visible outcome — N/A, monitoring hook only
- [x] Side-effect audit: hook always exits 0; no floods, no blocking, log writes only
- [x] External service calls: write_observation mocked in all tests; in production calls localhost:8765 only

Closes #855