### PR TITLE
refactor(wos): simplify inline callers now that Registry has a canonical default

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -4169,12 +4169,7 @@ def run_steward_cycle(
     from src.orchestration.registry import Registry
 
     if registry is None:
-        if db_path is None:
-            workspace = Path(os.environ.get(
-                "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
-            ))
-            db_path = workspace / "orchestration" / "registry.db"
-        registry = Registry(db_path)
+        registry = Registry(db_path)  # db_path=None → Registry resolves canonical path
 
     _github_client = github_client or _default_github_client
     _gate = bootup_candidate_gate if bootup_candidate_gate is not None else BOOTUP_CANDIDATE_GATE

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -308,11 +308,12 @@ def maybe_complete_wos_uow(
     uow_id = task_id[len(WOS_TASK_ID_PREFIX):]
     try:
         from orchestration.registry import Registry, UoWStatus
+        from orchestration.paths import REGISTRY_DB
 
-        workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
-        env_override = os.environ.get("REGISTRY_DB_PATH")
-        db_path = Path(env_override) if env_override else workspace / "orchestration" / "registry.db"
-
+        # Use canonical REGISTRY_DB path (honours REGISTRY_DB_PATH env override).
+        # Existence check before Registry() so we skip gracefully in test envs
+        # that have no WOS install.
+        db_path = REGISTRY_DB
         if not db_path.exists():
             log.debug(
                 "maybe_complete_wos_uow: registry DB not found at %s — "
@@ -321,7 +322,7 @@ def maybe_complete_wos_uow(
             )
             return
 
-        registry = Registry(db_path)
+        registry = Registry()
         uow = registry.get(uow_id)
         if uow is None:
             log.debug(


### PR DESCRIPTION
## Summary

PR #859 gave `Registry.__init__` a canonical default (`db_path: Path | None = None`) that resolves the path via `REGISTRY_DB_PATH` env var or `paths.REGISTRY_DB`. Two callers still contain inline path-derivation logic that duplicates what `paths.py` already centralises — this PR removes that duplication.

**Problem being solved:** `steward.run_steward_cycle` and `wos_completion.maybe_complete_wos_uow` each re-derived the registry DB path by reading `LOBSTER_WORKSPACE` and `REGISTRY_DB_PATH` env vars inline. This is the exact drift pattern that paths.py was created to prevent (issue notes on #4, #5, #6). Now that `Registry()` handles this resolution internally, the inline derivations are dead weight.

**Changes:**

- `src/orchestration/steward.py`: Removed the 4-line inline path block inside the `if registry is None:` guard. Now passes `db_path` directly (which may be `None`) to `Registry(db_path)` — `Registry.__init__` handles `None` correctly.
- `src/orchestration/wos_completion.py`: Replaced the inline `workspace` + `env_override` derivation with `from orchestration.paths import REGISTRY_DB`. The existence guard is preserved (so the function still skips gracefully in test envs with no WOS install) and `Registry()` is called with no args.
- `scheduled-tasks/executor-heartbeat.py`: Already imports `REGISTRY_DB` from `paths.py` and passes it explicitly — unchanged per task spec.

**Functional patterns used:** Pure computation for path resolution (moved to `Registry.__init__`); dependency injection preserved via the `registry` parameter; existence guard retained as the explicit skip condition before construction.

## Tests run
- [x] `uv run python -c "from src.orchestration.registry import Registry; r = Registry(); print('default path OK:', r.db_path)"` — passed, printed canonical workspace path
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_registry_cli.py tests/integration/test_wos_registry_bugs.py -q` — 97 passed, 5 pre-existing failures (confirmed identical before and after our changes via `git stash` comparison). The 5 failures are `TestRepoFromIssueUrl` (function does not exist in current codebase) and `test_approve_idempotent_on_pending` (test expectation predates the pending-is-not-a-resting-state change).
- [ ] Steward integration tests — blocked: `src.ooda` module not present in this environment (`ModuleNotFoundError: No module named 'src.ooda'`). Pre-existing gap, not caused by this change.

## Manual test
N/A — this change is purely internal path cleanup. No external services, no file I/O beyond what the smoke test above exercised, no user-visible output.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, change is internal refactor
- [x] User-visible outcome verified — N/A, no user-visible behavior changes
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none introduced