### PR TITLE
feat: ScalingGovernor — cap UoW dispatch when Attunement evidence is absent

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -292,6 +292,11 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
             ineligible_count, RECOVERY_STALE_MINUTES,
         )
 
+    # Scaling governor — cap dispatch when no Attunement evidence at this scale.
+    from src.orchestration.scaling_governor import ScalingGovernor
+    governor = ScalingGovernor(registry.db_path)
+    decision = governor.check(proposed_n=eligible_count)
+
     dispatched = 0
     skipped = 0
     errors = 0
@@ -302,6 +307,11 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
             "%d eligible — skipping all (dry-run mode)",
             ready_count, eligible_count,
         )
+        if decision.capped:
+            log.info(
+                "ScalingGovernor (DRY RUN): would cap from %d to %d (reason: %s)",
+                decision.proposed_n, decision.allowed_n, decision.cap_reason,
+            )
         return {
             "evaluated": ready_count,
             "ready": ready_count,
@@ -309,7 +319,17 @@ def run_executor_cycle(registry, dry_run: bool = False) -> dict:
             "dispatched": 0,
             "skipped": ready_count,
             "errors": 0,
+            "governor_cap": decision.allowed_n if decision.capped else None,
+            "attunement_scale": decision.attunement_scale,
         }
+
+    if decision.capped:
+        eligible_uows = eligible_uows[:decision.allowed_n]
+        eligible_count = decision.allowed_n
+        log.info(
+            "ScalingGovernor: cap applied — %d eligible, dispatching %d (reason: %s)",
+            decision.proposed_n, decision.allowed_n, decision.cap_reason,
+        )
 
     if eligible_count == 0:
         log.debug("Executor cycle: no eligible UoWs to dispatch")

--- a/src/orchestration/scaling_governor.py
+++ b/src/orchestration/scaling_governor.py
@@ -1,0 +1,250 @@
+"""
+Scaling Governor — progressive dispatch gate for WOS executor cycles.
+
+Prevents catastrophic failure modes by capping UoW injection when Attunement
+evidence at the requested scale is absent. This is a developmental mechanism:
+the goal is to make failure developmental (specific, traceable, small) rather
+than catastrophic (uniform, scale-filling).
+
+Design reference: WOS UoW uow_20260423_c87689.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config path (overridable for tests)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_WOS_CONFIG_PATH: Optional[Path] = None  # Resolved lazily if None
+
+
+def _get_wos_config_path() -> Path:
+    """Return the wos-config.json path, using paths.py default if not overridden."""
+    if _DEFAULT_WOS_CONFIG_PATH is not None:
+        return _DEFAULT_WOS_CONFIG_PATH
+    try:
+        from src.orchestration.paths import WOS_CONFIG
+        return WOS_CONFIG
+    except ImportError:
+        import os
+        workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+        return workspace / "data" / "wos-config.json"
+
+
+# ---------------------------------------------------------------------------
+# GovernorDecision dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class GovernorDecision:
+    proposed_n: int           # how many UoWs were eligible
+    allowed_n: int            # how many are permitted this cycle
+    capped: bool              # True when allowed_n < proposed_n
+    cap_reason: Optional[str] # human-readable, None when not capped
+    attunement_scale: int     # largest N with >= 80% success evidence (0 if none)
+
+
+# ---------------------------------------------------------------------------
+# Pure computation function (testable without a live DB)
+# ---------------------------------------------------------------------------
+
+def _compute_decision(proposed_n: int, attunement_scale: int) -> GovernorDecision:
+    """
+    Compute the GovernorDecision from proposed_n and attunement_scale.
+
+    This is a pure function — no I/O, no DB access. ScalingGovernor.check()
+    calls this after querying the DB and checking the override flag.
+
+    Cap logic:
+    - If attunement_scale >= proposed_n: no cap.
+    - If attunement_scale < proposed_n: cap at max(1, proposed_n // 5).
+    """
+    if attunement_scale >= proposed_n:
+        return GovernorDecision(
+            proposed_n=proposed_n,
+            allowed_n=proposed_n,
+            capped=False,
+            cap_reason=None,
+            attunement_scale=attunement_scale,
+        )
+
+    allowed_n = max(1, proposed_n // 5)
+    cap_reason = (
+        f"no Attunement evidence at scale {proposed_n} "
+        f"(largest clean window: {attunement_scale}); "
+        f"capping at {allowed_n} (N/5)"
+    )
+    return GovernorDecision(
+        proposed_n=proposed_n,
+        allowed_n=allowed_n,
+        capped=True,
+        cap_reason=cap_reason,
+        attunement_scale=attunement_scale,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ScalingGovernor class
+# ---------------------------------------------------------------------------
+
+class ScalingGovernor:
+    """
+    Progressive dispatch gate that caps UoW injection when Attunement evidence
+    at the requested scale is absent.
+
+    Usage:
+        governor = ScalingGovernor(registry.db_path)
+        decision = governor.check(proposed_n=eligible_count)
+        if decision.capped:
+            eligible_uows = eligible_uows[:decision.allowed_n]
+    """
+
+    def __init__(
+        self,
+        registry_db_path,
+        wos_config_path: Optional[Path] = None,
+    ) -> None:
+        try:
+            self._db_path = Path(registry_db_path)
+        except (TypeError, ValueError) as exc:
+            log.warning(
+                "ScalingGovernor: invalid registry_db_path %r — %s; DB queries will fail safely",
+                registry_db_path,
+                exc,
+            )
+            self._db_path = None  # type: ignore[assignment]
+        self._wos_config_path = wos_config_path  # None = use default
+
+    def _resolve_config_path(self) -> Path:
+        if self._wos_config_path is not None:
+            return self._wos_config_path
+        return _get_wos_config_path()
+
+    def _read_override_flag(self) -> bool:
+        """Return True if scaling_governor_override is set in wos-config.json."""
+        try:
+            config_path = self._resolve_config_path()
+            with config_path.open() as fh:
+                config = json.load(fh)
+            return bool(config.get("scaling_governor_override", False))
+        except Exception:
+            return False
+
+    def _query_attunement_scale(self, proposed_n: int) -> int:
+        """
+        Query the registry DB for the most recent 500 terminal UoWs and compute
+        attunement_scale: the largest power-of-2 window size w where the most
+        recent w UoWs have success rate >= 80%.
+
+        Returns 0 if the DB is unavailable or has no terminal UoWs.
+        """
+        if self._db_path is None:
+            log.warning("ScalingGovernor: db_path unavailable — treating attunement_scale=0")
+            return 0
+
+        try:
+            conn = sqlite3.connect(str(self._db_path), timeout=5.0)
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT status FROM uow_registry
+                    WHERE status IN ('done', 'failed')
+                    ORDER BY updated_at DESC
+                    LIMIT 500
+                    """,
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception as exc:
+            log.warning("ScalingGovernor: DB query failed — %s; treating attunement_scale=0", exc)
+            return 0
+
+        if not rows:
+            return 0
+
+        statuses = [r[0] for r in rows]
+        n_rows = len(statuses)
+
+        # Check windows of size w (powers of 2) up to proposed_n.
+        # Find the largest w <= proposed_n where the most recent w UoWs
+        # have success rate >= 80%.
+        best_w = 0
+        w = 1
+        while w <= proposed_n:
+            if w <= n_rows:
+                window = statuses[:w]
+                success_count = sum(1 for s in window if s == "done")
+                rate = success_count / w
+                if rate >= 0.80:
+                    best_w = w
+            w *= 2
+
+        return best_w
+
+    def check(self, proposed_n: int) -> GovernorDecision:
+        """
+        Check whether the proposed dispatch count should be capped.
+
+        Never raises — all exceptions are caught and result in a safe cap.
+        """
+        try:
+            # Compute attunement_scale first (needed for override reporting too).
+            attunement_scale = self._query_attunement_scale(proposed_n)
+
+            # Check override flag.
+            if self._read_override_flag():
+                log.warning(
+                    "ScalingGovernor: scaling_governor_override=true — bypassing cap "
+                    "(attunement_scale=%d, proposed_n=%d)",
+                    attunement_scale,
+                    proposed_n,
+                )
+                decision = GovernorDecision(
+                    proposed_n=proposed_n,
+                    allowed_n=proposed_n,
+                    capped=False,
+                    cap_reason=None,
+                    attunement_scale=attunement_scale,
+                )
+            else:
+                decision = _compute_decision(proposed_n, attunement_scale)
+
+            log.info(
+                "ScalingGovernor: proposed=%d allowed=%d capped=%s "
+                "attunement_scale=%d cap_reason=%s",
+                decision.proposed_n,
+                decision.allowed_n,
+                decision.capped,
+                decision.attunement_scale,
+                decision.cap_reason,
+            )
+            return decision
+
+        except Exception as exc:
+            log.error(
+                "ScalingGovernor: unexpected error — %s; applying safe cap (proposed_n=%d)",
+                exc,
+                proposed_n,
+                exc_info=True,
+            )
+            # Safe fallback: apply cap with attunement_scale=0.
+            fallback = _compute_decision(proposed_n, 0)
+            log.info(
+                "ScalingGovernor: proposed=%d allowed=%d capped=%s "
+                "attunement_scale=%d cap_reason=%s",
+                fallback.proposed_n,
+                fallback.allowed_n,
+                fallback.capped,
+                fallback.attunement_scale,
+                fallback.cap_reason,
+            )
+            return fallback

--- a/tests/unit/test_orchestration/test_executor_heartbeat.py
+++ b/tests/unit/test_orchestration/test_executor_heartbeat.py
@@ -318,6 +318,9 @@ class TestRunExecutorCycleDispatchEligibility:
 
         The heartbeat imports from src.orchestration.executor (not
         orchestration.executor), so the patch must target that module object.
+
+        Also patches ScalingGovernor to return a no-cap decision so tests
+        verify dispatch eligibility logic without governor interference.
         """
         import importlib
         # Ensure src.orchestration.executor is loaded so we can patch it
@@ -328,6 +331,24 @@ class TestRunExecutorCycleDispatchEligibility:
             src_executor_mod, "_dispatch_via_inbox",
             lambda i, u, **kw: inbox_called.append(u) or "msg-id",
         )
+
+        # Patch ScalingGovernor so it does not cap in dispatch-eligibility tests.
+        # These tests verify staleness-gate logic; governor logic is tested separately.
+        import src.orchestration.scaling_governor as _sg_mod
+        from src.orchestration.scaling_governor import GovernorDecision
+
+        class _NoCapGovernor:
+            def __init__(self, *a, **kw): pass
+            def check(self, proposed_n: int) -> GovernorDecision:
+                return GovernorDecision(
+                    proposed_n=proposed_n,
+                    allowed_n=proposed_n,
+                    capped=False,
+                    cap_reason=None,
+                    attunement_scale=proposed_n,
+                )
+
+        monkeypatch.setattr(_sg_mod, "ScalingGovernor", _NoCapGovernor)
 
     def test_fresh_uow_dispatched_immediately(
         self, registry, db_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_orchestration/test_scaling_governor.py
+++ b/tests/unit/test_orchestration/test_scaling_governor.py
@@ -1,0 +1,275 @@
+"""
+Tests for src/orchestration/scaling_governor.py.
+
+Coverage:
+1. No terminal UoWs → attunement_scale=0, cap fires, allowed_n = proposed_n // 5.
+2. 8 terminal UoWs, 7 done (87.5% success) → attunement_scale=8, no cap when proposed_n <= 8.
+3. 8 clean UoWs but proposed_n=50 → cap fires, allowed_n=10.
+4. Override flag (scaling_governor_override: true) → capped=False even with 0 Attunement.
+5. DB read failure → cap fires safely (no exception propagated).
+6. proposed_n=1 → allowed_n=1 (minimum 1 enforced, never 0).
+7. _compute_decision is importable and testable without a live DB.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.orchestration.scaling_governor import (
+    GovernorDecision,
+    ScalingGovernor,
+    _compute_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — create a minimal registry DB with terminal UoW rows
+# ---------------------------------------------------------------------------
+
+_REGISTRY_SCHEMA = """
+CREATE TABLE IF NOT EXISTS uow_registry (
+    id          TEXT    PRIMARY KEY,
+    status      TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+"""
+
+
+def _make_db(tmp_path: Path, rows: list[tuple[str, str]]) -> Path:
+    """
+    Create a minimal registry DB at tmp_path/registry.db with the given rows.
+
+    rows: list of (id, status) tuples — updated_at is set to a fixed timestamp.
+    """
+    db_path = tmp_path / "registry.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(_REGISTRY_SCHEMA)
+    for i, (row_id, status) in enumerate(rows):
+        conn.execute(
+            "INSERT INTO uow_registry (id, status, updated_at) VALUES (?, ?, ?)",
+            (row_id, status, f"2026-04-23T10:{i:02d}:00Z"),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _make_wos_config(tmp_path: Path, override: bool) -> Path:
+    """Write a wos-config.json with scaling_governor_override set."""
+    cfg_path = tmp_path / "wos-config.json"
+    cfg_path.write_text(json.dumps({"scaling_governor_override": override}))
+    return cfg_path
+
+
+# ---------------------------------------------------------------------------
+# _compute_decision — pure function tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+class TestComputeDecision:
+    def test_no_cap_when_attunement_meets_proposed(self) -> None:
+        d = _compute_decision(proposed_n=8, attunement_scale=8)
+        assert d.capped is False
+        assert d.allowed_n == 8
+        assert d.cap_reason is None
+
+    def test_no_cap_when_attunement_exceeds_proposed(self) -> None:
+        d = _compute_decision(proposed_n=4, attunement_scale=8)
+        assert d.capped is False
+        assert d.allowed_n == 4
+
+    def test_cap_fires_when_attunement_below_proposed(self) -> None:
+        d = _compute_decision(proposed_n=50, attunement_scale=8)
+        assert d.capped is True
+        assert d.allowed_n == 10  # 50 // 5
+
+    def test_cap_reason_is_human_readable(self) -> None:
+        d = _compute_decision(proposed_n=50, attunement_scale=8)
+        assert "50" in d.cap_reason
+        assert "8" in d.cap_reason
+        assert "10" in d.cap_reason
+
+    def test_minimum_allowed_n_is_1(self) -> None:
+        d = _compute_decision(proposed_n=1, attunement_scale=0)
+        assert d.allowed_n == 1
+
+    def test_proposed_n_4_attunement_0_cap_fires(self) -> None:
+        d = _compute_decision(proposed_n=4, attunement_scale=0)
+        assert d.capped is True
+        assert d.allowed_n == 1  # 4 // 5 = 0, floored to 1
+
+    def test_fields_are_frozen(self) -> None:
+        d = _compute_decision(proposed_n=8, attunement_scale=8)
+        with pytest.raises(Exception):
+            d.capped = True  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — No terminal UoWs: attunement_scale=0, cap fires
+# ---------------------------------------------------------------------------
+
+class TestNoTerminalUoWs:
+    def test_cap_fires_with_empty_db(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, [])
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=10)
+        assert decision.attunement_scale == 0
+        assert decision.capped is True
+        assert decision.allowed_n == 2  # 10 // 5
+
+    def test_allowed_n_minimum_1_with_proposed_1(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, [])
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=1)
+        assert decision.allowed_n == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — 8 terminal UoWs, 7 done (87.5%): attunement_scale=8, no cap <= 8
+# ---------------------------------------------------------------------------
+
+class TestEightUoWsSevenDone:
+    def _make_rows(self) -> list[tuple[str, str]]:
+        """7 done + 1 failed = 8 rows, 87.5% success rate."""
+        rows = [(f"uow-{i:03d}", "done") for i in range(7)]
+        rows.append(("uow-007", "failed"))
+        return rows
+
+    def test_attunement_scale_is_8(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, self._make_rows())
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=8)
+        assert decision.attunement_scale == 8
+
+    def test_no_cap_when_proposed_le_8(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, self._make_rows())
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=8)
+        assert decision.capped is False
+        assert decision.allowed_n == 8
+
+    def test_cap_fires_when_proposed_is_4(self, tmp_path: Path) -> None:
+        # With proposed_n=4, only windows w=1,2,4 are checked (powers of 2 up to 4).
+        # Most recent rows (DESC): failed, done, done, done, done, done, done, done.
+        # w=1: 0/1=0% fails. w=2: 1/2=50% fails. w=4: 3/4=75% fails.
+        # → attunement_scale=0 for proposed_n=4, cap fires.
+        db_path = _make_db(tmp_path, self._make_rows())
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=4)
+        # The governor only checks windows up to proposed_n, and windows <= 4 fail.
+        assert decision.capped is True
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — 8 clean UoWs, proposed_n=50: cap fires, allowed_n=10
+# ---------------------------------------------------------------------------
+
+class TestEightCleanUoWsWithLargeProposed:
+    def _make_rows(self) -> list[tuple[str, str]]:
+        return [(f"uow-{i:03d}", "done") for i in range(8)]
+
+    def test_cap_fires_for_proposed_50(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, self._make_rows())
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=50)
+        assert decision.capped is True
+        assert decision.allowed_n == 10
+
+    def test_attunement_scale_is_8(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, self._make_rows())
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=50)
+        assert decision.attunement_scale == 8
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Override flag: capped=False even with 0 Attunement evidence
+# ---------------------------------------------------------------------------
+
+class TestOverrideFlag:
+    def test_override_bypasses_cap(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, [])  # empty DB → attunement=0 normally
+        cfg_path = _make_wos_config(tmp_path, override=True)
+        governor = ScalingGovernor(db_path, wos_config_path=cfg_path)
+        decision = governor.check(proposed_n=100)
+        assert decision.capped is False
+        assert decision.allowed_n == 100
+
+    def test_override_still_reports_attunement_scale(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, [])
+        cfg_path = _make_wos_config(tmp_path, override=True)
+        governor = ScalingGovernor(db_path, wos_config_path=cfg_path)
+        decision = governor.check(proposed_n=10)
+        assert decision.attunement_scale == 0
+
+    def test_no_override_applies_cap(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, [])
+        cfg_path = _make_wos_config(tmp_path, override=False)
+        governor = ScalingGovernor(db_path, wos_config_path=cfg_path)
+        decision = governor.check(proposed_n=10)
+        assert decision.capped is True
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — DB read failure: cap fires safely, no exception propagated
+# ---------------------------------------------------------------------------
+
+class TestDbReadFailure:
+    def test_nonexistent_db_does_not_raise(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "nonexistent.db"
+        cfg_path = _make_wos_config(tmp_path, override=False)
+        governor = ScalingGovernor(db_path, wos_config_path=cfg_path)
+        decision = governor.check(proposed_n=10)
+        # Should not raise; should return a safe capped decision.
+        assert isinstance(decision, GovernorDecision)
+        assert decision.capped is True
+
+    def test_corrupt_db_does_not_raise(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "corrupt.db"
+        db_path.write_bytes(b"not a sqlite database")
+        cfg_path = _make_wos_config(tmp_path, override=False)
+        governor = ScalingGovernor(db_path, wos_config_path=cfg_path)
+        decision = governor.check(proposed_n=10)
+        assert isinstance(decision, GovernorDecision)
+        # attunement_scale=0 when DB fails
+        assert decision.attunement_scale == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — proposed_n=1: allowed_n=1, never 0
+# ---------------------------------------------------------------------------
+
+class TestProposedNOfOne:
+    def test_allowed_n_is_1_with_no_history(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path, [])
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=1)
+        assert decision.allowed_n == 1
+
+    def test_allowed_n_is_1_even_when_cap_applies(self, tmp_path: Path) -> None:
+        # Cap: 1 // 5 = 0, floored to 1.
+        db_path = _make_db(tmp_path, [])
+        governor = ScalingGovernor(db_path)
+        decision = governor.check(proposed_n=1)
+        assert decision.allowed_n >= 1
+
+
+# ---------------------------------------------------------------------------
+# GovernorDecision is a frozen dataclass importable without a live DB
+# ---------------------------------------------------------------------------
+
+class TestGovernorDecisionImportable:
+    def test_can_construct_without_db(self) -> None:
+        d = GovernorDecision(
+            proposed_n=10,
+            allowed_n=2,
+            capped=True,
+            cap_reason="test",
+            attunement_scale=0,
+        )
+        assert d.proposed_n == 10
+        assert d.allowed_n == 2
+        assert d.capped is True


### PR DESCRIPTION
## Summary

- Adds `src/orchestration/scaling_governor.py` with `ScalingGovernor` class and `GovernorDecision` frozen dataclass
- Integrates governor gate into `run_executor_cycle()` in `executor-heartbeat.py` between eligible UoW filtering and dispatch loop
- Dry-run branch now includes `governor_cap` and `attunement_scale` in return dict
- Adds 22 unit tests in `tests/unit/test_orchestration/test_scaling_governor.py`
- Updates `test_executor_heartbeat.py` to patch the governor in dispatch-eligibility tests (isolating concerns)

## Motivation

The WOS 50-run failure produced 252 injected UoWs with 250 failures (0.8% success). Root cause: "success triggers collapse" — a clean small-scale run unlocked maximum injection with no historical Attunement evidence at that scale. The governor prevents this by capping dispatch at N/5 when no 80%-success window at the proposed scale is found in the most recent 500 terminal UoWs.

## Governor logic

1. Query registry for most recent 500 terminal UoWs (done/failed), ordered by updated_at DESC
2. Compute `attunement_scale`: largest power-of-2 window (w ≤ proposed_n) where the most recent w UoWs have ≥ 80% success rate
3. If `attunement_scale >= proposed_n`: no cap
4. If `attunement_scale < proposed_n`: cap at max(1, proposed_n // 5)
5. Override: `scaling_governor_override: true` in wos-config.json bypasses the cap (logs warning)

## Test plan

- [x] `tests/unit/test_orchestration/test_scaling_governor.py` — 22 tests, all pass
- [x] No new test regressions introduced vs. origin/main baseline
- [x] Governor fires only in `run_executor_cycle()`, not in TTL recovery path

🤖 Generated with [Claude Code](https://claude.com/claude-code)