### PR TITLE
feat: wire oracle_approved audit events to activate steward spiral gate

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -190,6 +190,22 @@ Also append to `~/lobster-workspace/meta/reflective-surface-queue.json`:
 
 ---
 
+## WOS Spiral Gate — emit oracle_approved audit event
+
+**When the verdict is APPROVED and a `uow_id` was provided in the task prompt:**
+
+After writing to `decisions.md` and `verdicts/pr-{number}.md`, emit an `oracle_approved` audit event to the WOS registry so the spiral gate activates. Run:
+
+```bash
+uv run ~/lobster/src/orchestration/oracle_audit.py \
+    --uow-id <uow_id> \
+    --pr-ref "PR #<number>"
+```
+
+This is a fire-and-forget call. If it fails (DB absent, UoW not found), log the error and continue — the oracle verdict delivery must not be blocked by an audit write failure.
+
+**When no `uow_id` was provided:** skip this step silently. Not all oracle reviews are for WOS UoWs.
+
 ## Completion
 
 Call `write_result`. If alignment verdict is `Questioned` or `Misaligned`, or if a premise-review item was written, set `forward=true` so the dispatcher surfaces it to the user. Otherwise `forward=false` -- findings are in the oracle files.

--- a/src/orchestration/oracle_audit.py
+++ b/src/orchestration/oracle_audit.py
@@ -1,0 +1,195 @@
+"""
+Oracle audit event writer for the WOS spiral gate (issue #810).
+
+Emits an oracle_approved audit event to the WOS registry audit_log when the
+oracle agent issues an APPROVED verdict for a WOS-linked PR.
+
+The spiral gate in steward.py reads oracle_approved entries to detect when a
+UoW has cycled through oracle review >= SPIRAL_ORACLE_PASS_THRESHOLD times.
+Without this write, _count_oracle_passes always returns 0 and the spiral gate
+is structurally correct but permanently dormant.
+
+## When to call
+
+Call emit_oracle_approved from the oracle agent (lobster-oracle.md) immediately
+after writing APPROVED to oracle/decisions.md, if a uow_id was provided in the
+task prompt. Non-WOS oracle reviews (no uow_id) are silently skipped.
+
+## Invocation from the oracle agent
+
+    uv run ~/lobster/src/orchestration/oracle_audit.py \\
+        --uow-id <uow_id> --pr-ref "<pr_ref>"
+
+Or from Python:
+
+    from orchestration.oracle_audit import emit_oracle_approved
+    emit_oracle_approved(uow_id="wos_20260423_abc123", pr_ref="PR #864")
+
+## Error handling
+
+Errors are logged but never raised. A write failure must never block the oracle
+agent's verdict delivery. The audit event is advisory — its absence leaves the
+spiral gate dormant, which is the status quo ante.
+
+## Idempotency
+
+No idempotency guard is applied. If the oracle agent writes APPROVED twice for
+the same UoW (unlikely but possible on retry), two oracle_approved entries are
+written. The steward counts all entries, so a duplicate write increments the
+spiral counter. This is acceptable — a genuine APPROVED verdict represents a
+real oracle pass, and a duplicate is rarer than a missed write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger("oracle_audit")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _default_registry_db_path() -> Path:
+    """Resolve the registry DB path using the same logic as wos_completion.py."""
+    env_override = os.environ.get("REGISTRY_DB_PATH")
+    if env_override:
+        return Path(env_override)
+    workspace = Path(
+        os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+    )
+    return workspace / "orchestration" / "registry.db"
+
+
+def emit_oracle_approved(
+    uow_id: str,
+    pr_ref: str | None = None,
+    db_path: Path | None = None,
+) -> bool:
+    """
+    Write an oracle_approved audit event to the WOS registry for the given UoW.
+
+    This activates the spiral gate in steward._count_oracle_passes, which counts
+    oracle_approved entries to detect when a UoW has cycled through oracle review
+    too many times.
+
+    Args:
+        uow_id: The WOS unit-of-work ID (e.g. "wos_20260423_abc123").
+        pr_ref: Human-readable PR reference (e.g. "PR #864"). Stored in the
+                audit entry note for traceability. Optional.
+        db_path: Override path to registry.db. If None, resolved from env.
+
+    Returns:
+        True if the event was written successfully, False otherwise.
+        Errors are logged; the caller should not raise on False.
+    """
+    if not uow_id:
+        log.debug("emit_oracle_approved: uow_id is empty — skipping")
+        return False
+
+    resolved_db_path = db_path or _default_registry_db_path()
+
+    if not resolved_db_path.exists():
+        log.debug(
+            "emit_oracle_approved: registry DB not found at %s — "
+            "skipping (no WOS install or test env)",
+            resolved_db_path,
+        )
+        return False
+
+    try:
+        from orchestration.registry import Registry
+
+        registry = Registry(resolved_db_path)
+
+        # Verify the UoW exists before writing. append_audit_log does not check
+        # existence — an audit entry for a nonexistent UoW is harmless (orphaned
+        # row) but misleading. We check explicitly so the debug log is useful.
+        uow = registry.get(uow_id)
+        if uow is None:
+            log.warning(
+                "emit_oracle_approved: UoW %r not found in registry — "
+                "oracle_approved event not written",
+                uow_id,
+            )
+            return False
+
+        entry: dict = {
+            "event": "oracle_approved",
+            "uow_id": uow_id,
+            "ts": _now_iso(),
+        }
+        if pr_ref:
+            entry["pr_ref"] = pr_ref
+
+        registry.append_audit_log(uow_id, entry)
+        log.info(
+            "emit_oracle_approved: oracle_approved written for UoW %r (pr_ref=%r)",
+            uow_id,
+            pr_ref,
+        )
+        return True
+
+    except Exception as exc:
+        log.warning(
+            "emit_oracle_approved: failed to write oracle_approved for UoW %r — %s: %s",
+            uow_id,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point — for invocation from the oracle agent via `uv run`
+# ---------------------------------------------------------------------------
+
+def _main(argv: list[str] | None = None) -> int:
+    """
+    CLI wrapper: emit an oracle_approved audit event.
+
+    Usage:
+        uv run ~/lobster/src/orchestration/oracle_audit.py \\
+            --uow-id <uow_id> --pr-ref "<pr_ref>"
+
+    Exit codes:
+        0 — event written (or silently skipped because DB absent / uow_id empty)
+        1 — write failed due to an exception (logged to stderr)
+    """
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+
+    parser = argparse.ArgumentParser(
+        description="Emit oracle_approved audit event for a WOS UoW",
+    )
+    parser.add_argument("--uow-id", required=True, help="WOS unit-of-work ID")
+    parser.add_argument(
+        "--pr-ref",
+        default=None,
+        help="Human-readable PR reference, e.g. 'PR #864'",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Override path to registry.db (default: resolved from env)",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = Path(args.db_path) if args.db_path else None
+    success = emit_oracle_approved(
+        uow_id=args.uow_id,
+        pr_ref=args.pr_ref,
+        db_path=db_path,
+    )
+    # Exit 0 even on False (DB absent / UoW not found) — these are not CLI errors.
+    # Exit 1 only if emit_oracle_approved raised, which it does not (returns False).
+    return 0 if success or True else 1  # always 0 — errors are logged, not fatal
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tests/unit/test_orchestration/test_oracle_audit.py
+++ b/tests/unit/test_orchestration/test_oracle_audit.py
@@ -1,0 +1,260 @@
+"""
+Unit tests for oracle_audit.py — emit_oracle_approved.
+
+Covers:
+- Empty uow_id → no-op (returns False, no DB write)
+- DB not found → no-op (returns False silently)
+- UoW not in registry → warning logged, returns False, no row written
+- UoW exists → oracle_approved entry written to audit_log, returns True
+- pr_ref included in entry when provided
+- pr_ref omitted from entry when not provided
+- Exception from registry → logged warning, returns False, does not raise
+- CLI: --uow-id required; writes event; exits 0
+- CLI: exits 0 even when DB absent (non-fatal)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from orchestration.oracle_audit import emit_oracle_approved, _main
+from orchestration.registry import Registry, UpsertInserted
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry(tmp_path: Path) -> tuple[Registry, str]:
+    """Create a registry and insert a single UoW, returning (registry, uow_id)."""
+    db_path = tmp_path / "registry.db"
+    registry = Registry(db_path)
+    result = registry.upsert(
+        issue_number=9910,
+        title="Oracle audit test UoW",
+        success_criteria="emit_oracle_approved writes audit entry",
+    )
+    assert isinstance(result, UpsertInserted)
+    return registry, result.id
+
+
+def _fetch_audit_entries(db_path: Path, uow_id: str) -> list[dict]:
+    """Read all audit_log rows for the given uow_id."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id ASC",
+            (uow_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def _count_oracle_approved(db_path: Path, uow_id: str) -> int:
+    """Count oracle_approved audit entries for the UoW."""
+    entries = _fetch_audit_entries(db_path, uow_id)
+    return sum(1 for e in entries if e.get("event") == "oracle_approved")
+
+
+# ---------------------------------------------------------------------------
+# Tests: emit_oracle_approved
+# ---------------------------------------------------------------------------
+
+class TestEmitOracleApprovedEmptyUowId:
+    """Empty uow_id is a silent no-op."""
+
+    def test_returns_false_for_empty_string(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "registry.db"
+        Registry(db_path)  # create DB so absence is not the reason
+        result = emit_oracle_approved(uow_id="", db_path=db_path)
+        assert result is False
+
+    def test_no_audit_entry_written_for_empty_string(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "registry.db"
+        Registry(db_path)
+        emit_oracle_approved(uow_id="", db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM audit_log WHERE event = 'oracle_approved'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 0
+
+
+class TestEmitOracleApprovedDbAbsent:
+    """When registry.db does not exist, silently return False."""
+
+    def test_returns_false_when_db_absent(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "nonexistent.db"
+        result = emit_oracle_approved(uow_id="wos_20260423_abc", db_path=db_path)
+        assert result is False
+
+    def test_does_not_raise_when_db_absent(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "nonexistent.db"
+        # Must not raise; just return False
+        try:
+            emit_oracle_approved(uow_id="wos_20260423_abc", db_path=db_path)
+        except Exception as exc:
+            pytest.fail(f"emit_oracle_approved raised unexpectedly: {exc}")
+
+
+class TestEmitOracleApprovedUowNotFound:
+    """When the UoW is not in the registry, log a warning and return False."""
+
+    def test_returns_false_for_unknown_uow(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "registry.db"
+        Registry(db_path)  # create empty registry
+        result = emit_oracle_approved(
+            uow_id="wos_does_not_exist",
+            db_path=db_path,
+        )
+        assert result is False
+
+    def test_no_audit_entry_for_unknown_uow(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "registry.db"
+        Registry(db_path)
+        emit_oracle_approved(uow_id="wos_does_not_exist", db_path=db_path)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM audit_log WHERE event = 'oracle_approved'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 0
+
+
+class TestEmitOracleApprovedSuccess:
+    """Happy path: UoW exists → oracle_approved entry written."""
+
+    def test_returns_true_when_uow_exists(self, tmp_path: Path) -> None:
+        registry, uow_id = _make_registry(tmp_path)
+        result = emit_oracle_approved(
+            uow_id=uow_id,
+            pr_ref="PR #864",
+            db_path=registry.db_path,
+        )
+        assert result is True
+
+    def test_oracle_approved_entry_written(self, tmp_path: Path) -> None:
+        registry, uow_id = _make_registry(tmp_path)
+        emit_oracle_approved(uow_id=uow_id, pr_ref="PR #864", db_path=registry.db_path)
+        assert _count_oracle_approved(registry.db_path, uow_id) == 1
+
+    def test_event_field_is_oracle_approved(self, tmp_path: Path) -> None:
+        registry, uow_id = _make_registry(tmp_path)
+        emit_oracle_approved(uow_id=uow_id, db_path=registry.db_path)
+        entries = _fetch_audit_entries(registry.db_path, uow_id)
+        oracle_entries = [e for e in entries if e.get("event") == "oracle_approved"]
+        assert len(oracle_entries) == 1
+        assert oracle_entries[0]["event"] == "oracle_approved"
+
+    def test_pr_ref_stored_in_note_when_provided(self, tmp_path: Path) -> None:
+        registry, uow_id = _make_registry(tmp_path)
+        emit_oracle_approved(uow_id=uow_id, pr_ref="PR #864", db_path=registry.db_path)
+        entries = _fetch_audit_entries(registry.db_path, uow_id)
+        oracle_entries = [e for e in entries if e.get("event") == "oracle_approved"]
+        assert len(oracle_entries) == 1
+        note_raw = oracle_entries[0].get("note") or ""
+        note = json.loads(note_raw)
+        assert note.get("pr_ref") == "PR #864"
+
+    def test_pr_ref_absent_from_note_when_not_provided(self, tmp_path: Path) -> None:
+        registry, uow_id = _make_registry(tmp_path)
+        emit_oracle_approved(uow_id=uow_id, pr_ref=None, db_path=registry.db_path)
+        entries = _fetch_audit_entries(registry.db_path, uow_id)
+        oracle_entries = [e for e in entries if e.get("event") == "oracle_approved"]
+        assert len(oracle_entries) == 1
+        note_raw = oracle_entries[0].get("note") or ""
+        note = json.loads(note_raw)
+        assert "pr_ref" not in note
+
+    def test_multiple_calls_write_multiple_entries(self, tmp_path: Path) -> None:
+        """Two APPROVED verdicts for the same UoW write two entries (spiral counter)."""
+        registry, uow_id = _make_registry(tmp_path)
+        emit_oracle_approved(uow_id=uow_id, pr_ref="PR #864", db_path=registry.db_path)
+        emit_oracle_approved(uow_id=uow_id, pr_ref="PR #867", db_path=registry.db_path)
+        assert _count_oracle_approved(registry.db_path, uow_id) == 2
+
+    def test_env_var_db_path_resolution(self, tmp_path: Path, monkeypatch) -> None:
+        """When db_path is None, REGISTRY_DB_PATH env var is used."""
+        registry, uow_id = _make_registry(tmp_path)
+        monkeypatch.setenv("REGISTRY_DB_PATH", str(registry.db_path))
+        result = emit_oracle_approved(uow_id=uow_id, pr_ref="PR #864", db_path=None)
+        assert result is True
+        assert _count_oracle_approved(registry.db_path, uow_id) == 1
+
+
+class TestEmitOracleApprovedDoesNotRaise:
+    """emit_oracle_approved must never raise, even on unexpected errors."""
+
+    def test_does_not_raise_on_corrupt_db(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "corrupt.db"
+        db_path.write_text("this is not a sqlite database")
+        try:
+            emit_oracle_approved(uow_id="wos_test", db_path=db_path)
+        except Exception as exc:
+            pytest.fail(f"emit_oracle_approved raised on corrupt DB: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI entry point (_main)
+# ---------------------------------------------------------------------------
+
+class TestCliMain:
+    """CLI invocation via _main(argv)."""
+
+    def test_requires_uow_id(self, tmp_path: Path) -> None:
+        """Missing --uow-id raises SystemExit (argparse error)."""
+        with pytest.raises(SystemExit):
+            _main(["--pr-ref", "PR #864"])
+
+    def test_exits_zero_on_success(self, tmp_path: Path) -> None:
+        registry, uow_id = _make_registry(tmp_path)
+        exit_code = _main([
+            "--uow-id", uow_id,
+            "--pr-ref", "PR #864",
+            "--db-path", str(registry.db_path),
+        ])
+        assert exit_code == 0
+
+    def test_writes_event_via_cli(self, tmp_path: Path) -> None:
+        registry, uow_id = _make_registry(tmp_path)
+        _main([
+            "--uow-id", uow_id,
+            "--pr-ref", "PR #864",
+            "--db-path", str(registry.db_path),
+        ])
+        assert _count_oracle_approved(registry.db_path, uow_id) == 1
+
+    def test_exits_zero_when_db_absent(self, tmp_path: Path) -> None:
+        """DB absent is not a CLI error — exits 0."""
+        exit_code = _main([
+            "--uow-id", "wos_test_123",
+            "--db-path", str(tmp_path / "nonexistent.db"),
+        ])
+        assert exit_code == 0
+
+    def test_exits_zero_when_uow_not_found(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "registry.db"
+        Registry(db_path)  # empty registry
+        exit_code = _main([
+            "--uow-id", "wos_does_not_exist",
+            "--db-path", str(db_path),
+        ])
+        assert exit_code == 0


### PR DESCRIPTION
## Summary

- The steward spiral gate (`_count_oracle_passes` in steward.py) has been structurally correct since PR #814 but permanently dormant: it counts `oracle_approved` entries in the WOS audit log, but no code ever wrote those entries
- This PR adds `src/orchestration/oracle_audit.py` with `emit_oracle_approved(uow_id, pr_ref)` and a CLI entry point, and updates `lobster-oracle.md` to call it after an APPROVED verdict when `uow_id` is in the task prompt
- Closes the gap documented in the steward.py NOTEs referencing issue #810

## What changed

**`src/orchestration/oracle_audit.py`** — new module:
- `emit_oracle_approved(uow_id, pr_ref, db_path)` — writes `event="oracle_approved"` to the WOS registry audit_log via `registry.append_audit_log`
- CLI: `uv run oracle_audit.py --uow-id <id> --pr-ref "PR #N"` — callable from the oracle agent via Bash
- Error handling: never raises; logs warnings on DB absent, UoW not found, or exception. Oracle verdict delivery is never blocked by an audit write failure.
- Idempotency: no guard — two APPROVED verdicts for the same UoW write two entries, which correctly increments the spiral counter

**`tests/unit/test_orchestration/test_oracle_audit.py`** — 19 tests:
- Empty uow_id → no-op (False, no DB write)
- DB absent → silent False
- UoW not found → warning, False, no row written
- Happy path: entry written, event field correct, pr_ref in note when provided, pr_ref absent from note when not provided, multiple calls write multiple entries (spiral counter), env-var DB path resolution
- Corrupt DB → no raise
- CLI: --uow-id required; exits 0 on success; exits 0 when DB absent; exits 0 when UoW not found

**`.claude/agents/lobster-oracle.md`** — add "WOS Spiral Gate" section:
- After APPROVED verdict, if `uow_id` was in the task prompt, run `uv run ~/lobster/src/orchestration/oracle_audit.py --uow-id <uow_id> --pr-ref "PR #<number>"`
- Explicitly fire-and-forget — do not block on failure
- Skip silently when no `uow_id` provided

## Test plan
- [ ] `uv run pytest tests/unit/test_orchestration/test_oracle_audit.py -v` — 19 tests pass
- [ ] Oracle agent dispatched for a WOS PR with `uow_id` in prompt → `oracle_approved` entry appears in `audit_log` after APPROVED verdict
- [ ] Oracle agent dispatched without `uow_id` (non-WOS PR) → no error, no audit entry written
- [ ] Steward spiral gate activates after 3 oracle-approved events for a UoW (existing test coverage in `test_steward_dispatch_eligibility.py` covers the gate logic; this PR wires the data it reads)

Fixes: https://github.com/dcetlin/Lobster/issues/810

🤖 Generated with [Claude Code](https://claude.com/claude-code)