### PR TITLE
feat: WOS pipeline fixes — dynamic burst batch, sweep schedule, result enrichment, legacy DB

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -93,17 +93,42 @@ def _is_job_enabled(job_name: str) -> bool:
 
 
 def _warn_if_legacy_registry_exists() -> None:
-    """Log a warning if the deprecated legacy registry path exists and is non-empty."""
+    """Log a warning if the deprecated legacy registry path exists and is non-empty.
+
+    The canonical registry lives at ~/lobster-workspace/orchestration/registry.db.
+    The legacy path (data/wos-registry.db) is removed by upgrade.sh Migration 86
+    when its uow_registry table is empty. This function fires only if the file
+    survived migration (non-empty or migration not yet run).
+    """
     workspace = Path(os.environ.get(
         "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
     ))
     legacy_path = workspace / "data" / "wos-registry.db"
-    if legacy_path.exists() and legacy_path.stat().st_size > 0:
+    if not legacy_path.exists():
+        return
+    size = legacy_path.stat().st_size
+    if size == 0:
+        # Zero-byte file — safe to ignore; Migration 86 handles non-zero files.
+        return
+    # Count UoWs to distinguish an empty-schema file from one with actual data.
+    try:
+        import sqlite3
+        conn = sqlite3.connect(str(legacy_path), timeout=5.0)
+        uow_count = conn.execute("SELECT COUNT(*) FROM uow_registry").fetchone()[0]
+        conn.close()
+    except Exception:
+        uow_count = -1
+    if uow_count == 0:
+        log.info(
+            "Legacy registry DB at %s exists (%d bytes) but has 0 UoWs — "
+            "run upgrade.sh to apply Migration 86 and remove it.",
+            legacy_path, size,
+        )
+    else:
         log.warning(
-            "Legacy registry DB at %s exists and is non-empty (%d bytes). "
-            "Canonical path is %s. Investigate and remove the legacy file.",
-            legacy_path,
-            legacy_path.stat().st_size,
+            "Legacy registry DB at %s exists and is non-empty (%d bytes, %d UoWs). "
+            "Canonical path is %s. Run upgrade.sh (Migration 86) to safely relocate.",
+            legacy_path, size, uow_count,
             workspace / "orchestration" / "registry.db",
         )
 

--- a/scheduled-tasks/garden-caretaker.py
+++ b/scheduled-tasks/garden-caretaker.py
@@ -2,7 +2,7 @@
 """
 GardenCaretaker Heartbeat — cron-driven scan-and-tend cycle for WOS registry.
 
-Runs every 15 minutes. On each invocation:
+Runs every 2 hours. On each invocation:
 1. Checks the enabled gate in jobs.json (Type C job — cron-direct dispatch).
 2. Instantiates GardenCaretaker with the GitHubIssueSource for dcetlin/Lobster.
 3. Calls run_reconciliation_cycle() — which runs scan() then tend() in sequence.
@@ -13,8 +13,8 @@ a single infrastructure polling loop. This is a Type C job (pure Python script
 invoked directly by cron — no inbox message written, no LLM round-trip). The
 enabled gate in jobs.json controls runtime enable/disable without touching cron.
 
-Cron schedule (every 15 minutes):
-    */15 * * * * cd $HOME && uv run ~/lobster/scheduled-tasks/garden-caretaker.py >> ~/lobster-workspace/logs/garden-caretaker.log 2>&1
+Cron schedule (every 2 hours — was every 15 minutes before migration d12):
+    0 */2 * * * cd $HOME && uv run ~/lobster/scheduled-tasks/garden-caretaker.py >> ~/lobster-workspace/logs/garden-caretaker.log 2>&1
 
 Run standalone:
     uv run ~/lobster/scheduled-tasks/garden-caretaker.py [--dry-run]

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -216,17 +216,42 @@ def _utc_now() -> datetime:
 
 
 def _warn_if_legacy_registry_exists() -> None:
-    """Log a warning if the deprecated legacy registry path exists and is non-empty."""
+    """Log a warning if the deprecated legacy registry path exists and is non-empty.
+
+    The canonical registry lives at ~/lobster-workspace/orchestration/registry.db.
+    The legacy path (data/wos-registry.db) is removed by upgrade.sh Migration 86
+    when its uow_registry table is empty. This function fires only if the file
+    survived migration (non-empty or migration not yet run).
+    """
     workspace = Path(os.environ.get(
         "LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"
     ))
     legacy_path = workspace / "data" / "wos-registry.db"
-    if legacy_path.exists() and legacy_path.stat().st_size > 0:
+    if not legacy_path.exists():
+        return
+    size = legacy_path.stat().st_size
+    if size == 0:
+        # Zero-byte file — safe to ignore; Migration 86 handles non-zero files.
+        return
+    # Count UoWs to distinguish an empty-schema file from one with actual data.
+    try:
+        import sqlite3
+        conn = sqlite3.connect(str(legacy_path), timeout=5.0)
+        uow_count = conn.execute("SELECT COUNT(*) FROM uow_registry").fetchone()[0]
+        conn.close()
+    except Exception:
+        uow_count = -1
+    if uow_count == 0:
+        log.info(
+            "Legacy registry DB at %s exists (%d bytes) but has 0 UoWs — "
+            "run upgrade.sh to apply Migration 86 and remove it.",
+            legacy_path, size,
+        )
+    else:
         log.warning(
-            "Legacy registry DB at %s exists and is non-empty (%d bytes). "
-            "Canonical path is %s. Investigate and remove the legacy file.",
-            legacy_path,
-            legacy_path.stat().st_size,
+            "Legacy registry DB at %s exists and is non-empty (%d bytes, %d UoWs). "
+            "Canonical path is %s. Run upgrade.sh (Migration 86) to safely relocate.",
+            legacy_path, size, uow_count,
             workspace / "orchestration" / "registry.db",
         )
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2890,6 +2890,39 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "oracle/verdicts/ already exists — skipping Migration 85"
     fi
 
+    # Migration 86: Remove legacy wos-registry.db if it contains no UoWs.
+    # The canonical registry moved to ~/lobster-workspace/orchestration/registry.db.
+    # The legacy file at ~/lobster-workspace/data/wos-registry.db is safe to remove
+    # when its uow_registry table is empty (migrated installs have 0 rows there).
+    # A non-empty file is left in place with a renamed .obsolete suffix to prevent
+    # accidental data loss; the operator should inspect it manually.
+    local legacy_db="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/data/wos-registry.db"
+    if [ -f "$legacy_db" ]; then
+        local uow_count
+        uow_count=$(python3 -c "
+import sqlite3, sys
+try:
+    conn = sqlite3.connect('$legacy_db')
+    n = conn.execute('SELECT COUNT(*) FROM uow_registry').fetchone()[0]
+    print(n)
+except Exception as e:
+    print(-1)
+" 2>/dev/null)
+        if [ "$uow_count" = "0" ]; then
+            rm -f "$legacy_db"
+            substep "Migration 86: removed empty legacy wos-registry.db (0 UoWs)"
+            migrated=$((migrated + 1))
+        elif [ "$uow_count" = "-1" ]; then
+            substep "Migration 86: could not read legacy wos-registry.db — skipping"
+        else
+            mv "$legacy_db" "${legacy_db}.obsolete"
+            substep "Migration 86: legacy wos-registry.db has $uow_count UoWs — renamed to .obsolete, inspect manually"
+            migrated=$((migrated + 1))
+        fi
+    else
+        substep "Migration 86: legacy wos-registry.db not present — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/scripts/user-update.sh
+++ b/scripts/user-update.sh
@@ -874,3 +874,24 @@ LEARNINGS_PROPOSALS_TASK
         substep "learnings-proposals crontab entry already present"
     fi
 
+    # d12: Update garden-caretaker cron schedule from every 15 minutes to every 2 hours.
+    # The 15-minute sweep caused bulk germination of 150+ UoWs at once when GitHub issues
+    # were scanned on every cycle. A 2-hour cadence spreads the load without losing coverage.
+    local GC_MARKER="# LOBSTER-GARDEN-CARETAKER"
+    local GC_OLD_SCHEDULE="*/15 \* \* \* \*"
+    local GC_NEW_SCHEDULE="0 \*/2 \* \* \*"
+    if crontab -l 2>/dev/null | grep -q "$GC_MARKER"; then
+        if crontab -l 2>/dev/null | grep "$GC_MARKER" | grep -q "^\*/15"; then
+            # Remove old 15-min entry and add new 2-hour entry
+            "$LOBSTER_DIR/scripts/cron-manage.sh" remove "$GC_MARKER"
+            "$LOBSTER_DIR/scripts/cron-manage.sh" add "$GC_MARKER" \
+                "0 */2 * * * cd \$HOME && uv run $LOBSTER_DIR/scheduled-tasks/garden-caretaker.py >> $WORKSPACE_DIR/logs/garden-caretaker.log 2>&1 $GC_MARKER"
+            substep "Updated garden-caretaker cron: every 15 min → every 2 hours (d12)"
+            migrated=$((migrated + 1))
+        else
+            substep "garden-caretaker cron already updated — skipping d12"
+        fi
+    else
+        substep "garden-caretaker cron entry not found — skipping d12"
+    fi
+

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2201,9 +2201,28 @@ SPIRAL_ORACLE_PASS_THRESHOLD: int = 3
 # Source: oracle/patterns.md §dead-end — "failed or blocked state ≥2 times"
 DEAD_END_FAILURE_THRESHOLD: int = 2
 
-# Burst: throttle to this many UoWs per cycle when burst is detected
-# Source: oracle/patterns.md §burst — "batch into groups of 3"
+# Burst: throttle to this many UoWs per cycle when burst is detected.
+# Default is 3 (oracle/patterns.md §burst — "batch into groups of 3").
+# When queue depth exceeds thresholds, a larger batch size is used to drain
+# faster without losing the throttle protection.
 BURST_BATCH_SIZE: int = 3
+
+
+def _dynamic_burst_batch_size(queue_depth: int) -> int:
+    """Return the appropriate BURST_BATCH_SIZE given the current queue depth.
+
+    Thresholds (applied in order, first match wins):
+    - queue_depth > 50  → batch size 15
+    - queue_depth > 20  → batch size 8
+    - default           → BURST_BATCH_SIZE (3)
+
+    Pure function — no side effects.
+    """
+    if queue_depth > 50:
+        return 15
+    if queue_depth > 20:
+        return 8
+    return BURST_BATCH_SIZE
 
 # Burst: hard lower bound for the baseline queue depth used in spike detection.
 # Queue depths at or above 2x this value are treated as a burst.
@@ -4203,6 +4222,14 @@ def run_steward_cycle(
     # Captured once before the loop so all per-UoW checks see the same depth value.
     _queue_depth = len(uows)
 
+    # Dynamic batch size: scale up when queue is deep so bursts drain faster.
+    _effective_burst_batch_size = _dynamic_burst_batch_size(_queue_depth)
+    if _effective_burst_batch_size != BURST_BATCH_SIZE:
+        log.info(
+            "Steward cycle: dynamic burst batch size=%d (queue_depth=%d, default=%d)",
+            _effective_burst_batch_size, _queue_depth, BURST_BATCH_SIZE,
+        )
+
     evaluated = 0
     prescribed = 0
     done = 0
@@ -4305,20 +4332,20 @@ def run_steward_cycle(
         # dead-end, and burst patterns before committing to a prescription cycle.
         _eligibility = _check_dispatch_eligibility(uow, audit_entries, _queue_depth)
         if _eligibility == "throttle":
-            if throttle_count < BURST_BATCH_SIZE:
+            if throttle_count < _effective_burst_batch_size:
                 # Within the allowed burst batch — dispatch normally and count it.
                 throttle_count += 1
                 log.debug(
                     "dispatch_eligibility: uow_id=%s throttle allowed "
                     "(throttle_count=%d/%d)",
-                    uow_id, throttle_count, BURST_BATCH_SIZE,
+                    uow_id, throttle_count, _effective_burst_batch_size,
                 )
             else:
-                # Beyond BURST_BATCH_SIZE for this cycle — skip.
+                # Beyond _effective_burst_batch_size for this cycle — skip.
                 log.info(
                     "dispatch_eligibility: uow_id=%s skipped — pattern=throttle "
-                    "(throttle_count=%d >= BURST_BATCH_SIZE=%d)",
-                    uow_id, throttle_count, BURST_BATCH_SIZE,
+                    "(throttle_count=%d >= burst_batch_size=%d)",
+                    uow_id, throttle_count, _effective_burst_batch_size,
                 )
                 if not dry_run:
                     registry.append_audit_log(uow_id, {

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -45,6 +45,126 @@ WRITE_RESULT_SUCCESS_STATUS = "success"
 _GITHUB_ISSUE_SOURCE_RE = re.compile(r"^github:issue/(\d+)$")
 
 # ---------------------------------------------------------------------------
+# Result file enrichment — summary + artifact extraction
+# ---------------------------------------------------------------------------
+
+#: Maximum characters to capture from result_text as the summary field.
+_RESULT_SUMMARY_MAX_CHARS: int = 300
+
+#: Regex patterns for extracting artifact references from agent output.
+_PR_REF_RE = re.compile(r"PR\s*#(\d+)", re.IGNORECASE)
+_ISSUE_REF_RE = re.compile(r"issue\s*#(\d+)", re.IGNORECASE)
+_FILE_PATH_RE = re.compile(r"(~/[^\s,;\"']+\.(?:md|json|py|sh|txt|yaml|yml))")
+
+
+def _extract_artifact_refs(text: str) -> dict:
+    """
+    Extract PR numbers, issue numbers, and file paths from agent output text.
+
+    Pure function — no side effects.
+
+    Returns a dict with keys:
+    - "pr_numbers": list of int PR numbers found (e.g. [42, 99])
+    - "issue_numbers": list of int issue numbers found (e.g. [123])
+    - "file_paths": list of str file paths found (e.g. ["~/lobster-workspace/foo.md"])
+    """
+    pr_numbers = [int(m) for m in _PR_REF_RE.findall(text)]
+    issue_numbers = [int(m) for m in _ISSUE_REF_RE.findall(text)]
+    file_paths = _FILE_PATH_RE.findall(text)
+    return {
+        "pr_numbers": pr_numbers,
+        "issue_numbers": issue_numbers,
+        "file_paths": file_paths,
+    }
+
+
+def _enrich_result_file(output_ref: str, result_text: str | None) -> None:
+    """
+    Read the existing result.json at output_ref, add 'summary' and 'refs' fields,
+    and rewrite it atomically.
+
+    Called after a successful UoW completion (outcome=complete) to capture:
+    - summary: first _RESULT_SUMMARY_MAX_CHARS chars of result_text
+    - refs: extracted PR numbers, issue numbers, and file paths from result_text
+
+    No-op when:
+    - result_text is None or empty
+    - result file does not exist (subagent skipped result_writer)
+    - result file is unreadable or not valid JSON
+
+    Side effects are isolated to this function. Failures are logged and swallowed
+    — result file enrichment must never block the UoW transition.
+    """
+    if not result_text:
+        return
+
+    # Derive result file path (mirrors result_writer._result_json_path)
+    p = Path(os.path.expanduser(output_ref))
+    if p.suffix:
+        result_path = p.with_suffix(".result.json")
+    else:
+        result_path = Path(str(p) + ".result.json")
+
+    if not result_path.exists():
+        log.debug(
+            "_enrich_result_file: result file not found at %s — skipping enrichment",
+            result_path,
+        )
+        return
+
+    try:
+        import json
+        import tempfile
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        log.warning(
+            "_enrich_result_file: could not read result file %s — %s: %s",
+            result_path, type(exc).__name__, exc,
+        )
+        return
+
+    try:
+        import json
+        import tempfile
+
+        summary = result_text[:_RESULT_SUMMARY_MAX_CHARS]
+        refs = _extract_artifact_refs(result_text)
+
+        # Only add fields not already present (subagent may have set summary itself)
+        if "summary" not in payload:
+            payload["summary"] = summary
+        if "refs" not in payload and any(refs.values()):
+            payload["refs"] = refs
+
+        # Atomic rewrite
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            dir=result_path.parent,
+            prefix=f".{result_path.name}.enrich.",
+            suffix=".json",
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, indent=2))
+            tmp_path.rename(result_path)
+            log.debug(
+                "_enrich_result_file: enriched %s (summary_len=%d, refs=%s)",
+                result_path, len(summary), refs,
+            )
+        except Exception:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    except Exception as exc:
+        log.warning(
+            "_enrich_result_file: failed to enrich result file %s — %s: %s",
+            result_path, type(exc).__name__, exc,
+        )
+
+# ---------------------------------------------------------------------------
 # Output classification — pure function
 # ---------------------------------------------------------------------------
 
@@ -347,6 +467,17 @@ def maybe_complete_wos_uow(
             "(execution_complete written on write_result confirmation)",
             uow_id,
         )
+
+        # Enrich result file with summary + extracted artifact refs from agent output.
+        # Non-fatal — enrichment failure never blocks the UoW transition.
+        if output_ref:
+            try:
+                _enrich_result_file(output_ref, result_text)
+            except Exception as enrich_exc:
+                log.warning(
+                    "maybe_complete_wos_uow: result file enrichment failed for UoW %r — %s: %s",
+                    uow_id, type(enrich_exc).__name__, enrich_exc,
+                )
 
         # Close-out protocol: post a structured comment to the source GitHub issue.
         # Non-GitHub sources are silently skipped. Comment failure is non-fatal.


### PR DESCRIPTION
## Summary

- **Fix 1 — Dynamic BURST_BATCH_SIZE** (`src/orchestration/steward.py`): Added `_dynamic_burst_batch_size(queue_depth)` which returns 15 when depth>50, 8 when depth>20, and the default 3 otherwise. The steward cycle computes this once before the dispatch loop so deep queues drain faster without losing burst protection.

- **Fix 2 — Spread sweep schedule** (`scheduled-tasks/garden-caretaker.py`, `scripts/user-update.sh`): Garden-caretaker sweep schedule changed from every 15 minutes to every 2 hours via migration d12. The 15-minute cadence caused bulk germination of 150+ UoWs at once. A 2-hour cadence spreads the load without losing coverage.

- **Fix 3 — Result file enrichment** (`src/orchestration/wos_completion.py`): After a successful UoW completion, `_enrich_result_file()` reads the existing result.json and adds a `summary` field (first 300 chars of agent output) and a `refs` field (extracted PR numbers, issue numbers, file paths via regex). Enrichment is non-fatal and never blocks the UoW transition.

- **Fix 4 — Legacy wos-registry.db warning** (`scheduled-tasks/steward-heartbeat.py`, `scheduled-tasks/executor-heartbeat.py`, `scripts/upgrade.sh`): `_warn_if_legacy_registry_exists()` now checks the UoW count in the legacy file before warning. A file with 0 UoWs logs INFO instead of WARNING and directs the operator to run upgrade.sh. Migration 86 in upgrade.sh safely removes the legacy file when it has 0 UoWs, or renames it to `.obsolete` when it contains actual data.

## Test plan

- [x] Ran `uv run pytest tests/unit/test_orchestration/test_wos_completion.py tests/unit/test_result_writer.py tests/unit/test_orchestration/test_garden_caretaker.py` — 115 passed
- [ ] The pre-existing `src.ooda` import error prevents steward unit tests from running — unrelated to this PR (no new test failures introduced)
- [ ] Verify d12 migration updates garden-caretaker cron from `*/15` to `0 */2` on the target instance by running `upgrade.sh` after merge
- [ ] Verify Migration 86 removes `~/lobster-workspace/data/wos-registry.db` (0 UoWs confirmed) on the target instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)