### PR TITLE
chore: commit 10 LLM scheduled job systemd unit files and add Migration 87

### DIFF
--- a/docs/scheduled-jobs-golden-pattern.md
+++ b/docs/scheduled-jobs-golden-pattern.md
@@ -1,0 +1,128 @@
+# Scheduled Jobs — Golden Canonical Pattern
+
+Reference for how LLM scheduled jobs must be set up in Lobster. When adding a new recurring LLM task, follow this pattern exactly.
+
+**Related docs:** [CLAUDE.md](../CLAUDE.md) — scheduling architecture and job type distinction | [upgrade.sh](../scripts/upgrade.sh) — Migration 87 for automated install
+
+---
+
+## The Four Required Components
+
+Every LLM scheduled job (Type A) requires exactly four artifacts:
+
+### 1. systemd `.timer` file
+
+Location: `~/lobster/services/lobster-{job-name}.timer`
+
+```ini
+[Unit]
+Description={Human-readable description}
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar={systemd calendar expression}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+`Persistent=true` ensures the job fires on next boot if it was missed (e.g., system was down at scheduled time).
+
+### 2. systemd `.service` file
+
+Location: `~/lobster/services/lobster-{job-name}.service`
+
+```ini
+[Unit]
+Description={Human-readable description}
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh {job-name}
+```
+
+`Type=oneshot` is correct for LLM jobs — the service exits after the job dispatch completes.
+
+### 3. `jobs.json` entry
+
+Location: `~/lobster-workspace/scheduled-jobs/jobs.json`
+
+Managed via the `create_scheduled_job` MCP tool. The `enabled` field in jobs.json is the runtime gate — set it to `false` to pause a job without touching systemd.
+
+```json
+{
+  "name": "{job-name}",
+  "schedule": "{human-readable schedule}",
+  "enabled": true,
+  "dispatch": "systemd"
+}
+```
+
+### 4. Task definition `.md` file
+
+Location: `~/lobster-workspace/scheduled-jobs/tasks/{job-name}.md`
+
+Contains the prompt context dispatched to the LLM subagent. Managed via `create_scheduled_job` / `update_scheduled_job` MCP tools.
+
+---
+
+## Install and Enable
+
+After adding unit files to `services/`, install them:
+
+```bash
+sudo cp ~/lobster/services/lobster-{job-name}.timer /etc/systemd/system/
+sudo cp ~/lobster/services/lobster-{job-name}.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now lobster-{job-name}.timer
+```
+
+Verify with:
+
+```bash
+systemctl list-timers --all | grep lobster-{job-name}
+```
+
+---
+
+## Type C Exception (cron-direct scripts)
+
+Type C jobs (pure Python scripts with no LLM round-trip) are correctly run via cron — **not** via systemd timers. These are identified by `"dispatch": "cron-direct"` in jobs.json. Examples: `executor-heartbeat.py`, `steward-heartbeat.py`, `wos-queue-monitor.py`.
+
+**Rule: never use cron for Type A (LLM) jobs.** Cron bypasses the `list_scheduled_jobs` MCP validation and `jobs.json` enable/disable gate. Use systemd timers for all LLM-dispatched work.
+
+---
+
+## Naming Convention
+
+| Artifact | Name pattern |
+|---|---|
+| systemd timer | `lobster-{job-name}.timer` |
+| systemd service | `lobster-{job-name}.service` |
+| jobs.json key | `{job-name}` |
+| task file | `{job-name}.md` |
+| dispatch-job.sh arg | `{job-name}` |
+
+Where `{job-name}` is lowercase-hyphenated (e.g., `morning-briefing`, `pattern-candidate-sweep`).
+
+---
+
+## Jobs Migrated from Cron (issue #869)
+
+These 10 jobs were converted from cron `LOBSTER-SCHEDULED` entries to systemd timers. Their unit files live in `services/` and are installed by Migration 87 in `upgrade.sh`.
+
+| Job | Timer schedule |
+|---|---|
+| `weekly-epistemic-retro` | Sun 08:00 UTC |
+| `lobster-hygiene` | Every 3 days (1,4,7,… 06:00 UTC) |
+| `pattern-candidate-sweep` | Wed 08:00 UTC |
+| `morning-briefing` | Daily 14:00 UTC |
+| `uow-reflection` | Daily 06:30 UTC |
+| `structural-hygiene-audit` | Mar 31 12:00 UTC (annual) |
+| `upstream-sync` | Daily 08:00 and 20:00 UTC |
+| `lobster-hygiene-biweekly` | 1st and 15th 10:00 UTC |
+| `github-issue-cultivator` | Daily 06:00 UTC |
+| `wos-hourly-observation` | 06–12 UTC hourly |

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2923,6 +2923,65 @@ except Exception as e:
         substep "Migration 86: legacy wos-registry.db not present — skipping"
     fi
 
+    # Migration 87: Install systemd timer+service units for 10 LLM scheduled jobs
+    # previously run via cron (issue #869). Copies unit files from services/ in the
+    # repo to /etc/systemd/system/, then enables and starts each timer. Idempotent:
+    # skips any timer that is already installed and enabled.
+    local llm_jobs=(
+        weekly-epistemic-retro
+        lobster-hygiene
+        pattern-candidate-sweep
+        morning-briefing
+        uow-reflection
+        structural-hygiene-audit
+        upstream-sync
+        lobster-hygiene-biweekly
+        github-issue-cultivator
+        wos-hourly-observation
+    )
+    local m87_count=0
+    for job in "${llm_jobs[@]}"; do
+        local timer_name="lobster-${job}.timer"
+        local service_name="lobster-${job}.service"
+        local src_timer="$LOBSTER_DIR/services/${timer_name}"
+        local src_service="$LOBSTER_DIR/services/${service_name}"
+        local dst="/etc/systemd/system"
+
+        # Copy unit files if source exists and destination differs or is absent
+        if [ -f "$src_timer" ] && [ -f "$src_service" ]; then
+            local needs_install=false
+            if [ ! -f "$dst/$timer_name" ]; then
+                needs_install=true
+            fi
+            if $needs_install; then
+                if sudo cp "$src_timer" "$dst/$timer_name" && sudo cp "$src_service" "$dst/$service_name"; then
+                    substep "Installed $timer_name (Migration 87)"
+                    m87_count=$((m87_count + 1))
+                else
+                    warn "Could not install $timer_name — check sudo permissions"
+                    continue
+                fi
+            fi
+            # Enable and start if not already active
+            if ! systemctl is-enabled --quiet "$timer_name" 2>/dev/null; then
+                sudo systemctl daemon-reload 2>/dev/null || true
+                sudo systemctl enable --now "$timer_name" 2>/dev/null \
+                    && substep "Enabled $timer_name" \
+                    || warn "Could not enable $timer_name"
+                m87_count=$((m87_count + 1))
+            fi
+        else
+            substep "Unit file $timer_name not found in repo — skipping (run after git pull)"
+        fi
+    done
+    if [ "$m87_count" -gt 0 ]; then
+        sudo systemctl daemon-reload 2>/dev/null || true
+        success "Migration 87: installed/enabled $m87_count LLM job timer unit(s)"
+        migrated=$((migrated + m87_count))
+    else
+        substep "Migration 87: all LLM job timers already installed — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/services/lobster-github-issue-cultivator.service
+++ b/services/lobster-github-issue-cultivator.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily GitHub issue cultivator — triage and enrich open issues
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh github-issue-cultivator

--- a/services/lobster-github-issue-cultivator.timer
+++ b/services/lobster-github-issue-cultivator.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily GitHub issue cultivator — triage and enrich open issues
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-*-* 06:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-lobster-hygiene-biweekly.service
+++ b/services/lobster-lobster-hygiene-biweekly.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Biweekly lobster hygiene — extended maintenance on 1st and 15th
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh lobster-hygiene-biweekly

--- a/services/lobster-lobster-hygiene-biweekly.timer
+++ b/services/lobster-lobster-hygiene-biweekly.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Biweekly lobster hygiene — extended maintenance on 1st and 15th
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-*-01,15 10:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-lobster-hygiene.service
+++ b/services/lobster-lobster-hygiene.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Lobster hygiene — system maintenance and cleanup every 3 days
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh lobster-hygiene

--- a/services/lobster-lobster-hygiene.timer
+++ b/services/lobster-lobster-hygiene.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Lobster hygiene — system maintenance and cleanup every 3 days
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-*-1,4,7,10,13,16,19,22,25,28,31 06:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-morning-briefing.service
+++ b/services/lobster-morning-briefing.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily morning briefing — daily synthesis and priorities
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh morning-briefing

--- a/services/lobster-morning-briefing.timer
+++ b/services/lobster-morning-briefing.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily morning briefing — daily synthesis and priorities
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-*-* 14:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-pattern-candidate-sweep.service
+++ b/services/lobster-pattern-candidate-sweep.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Weekly pattern candidate sweep — identify recurring themes for IFTTT rules
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh pattern-candidate-sweep

--- a/services/lobster-pattern-candidate-sweep.timer
+++ b/services/lobster-pattern-candidate-sweep.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly pattern candidate sweep — identify recurring themes for IFTTT rules
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=Wed *-*-* 08:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-structural-hygiene-audit.service
+++ b/services/lobster-structural-hygiene-audit.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Annual structural hygiene audit — deep system structure review
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh structural-hygiene-audit

--- a/services/lobster-structural-hygiene-audit.timer
+++ b/services/lobster-structural-hygiene-audit.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Annual structural hygiene audit — deep system structure review
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-03-31 12:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-uow-reflection.service
+++ b/services/lobster-uow-reflection.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily UoW reflection — review WOS unit-of-work progress
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh uow-reflection

--- a/services/lobster-uow-reflection.timer
+++ b/services/lobster-uow-reflection.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily UoW reflection — review WOS unit-of-work progress
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-*-* 06:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-upstream-sync.service
+++ b/services/lobster-upstream-sync.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Twice-daily upstream sync — pull from upstream lobster repo
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh upstream-sync

--- a/services/lobster-upstream-sync.timer
+++ b/services/lobster-upstream-sync.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Twice-daily upstream sync — pull from upstream lobster repo
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-*-* 08,20:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-weekly-epistemic-retro.service
+++ b/services/lobster-weekly-epistemic-retro.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Weekly epistemic retro — reflect on beliefs, predictions, and learning
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh weekly-epistemic-retro

--- a/services/lobster-weekly-epistemic-retro.timer
+++ b/services/lobster-weekly-epistemic-retro.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly epistemic retro — reflect on beliefs, predictions, and learning
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=Sun *-*-* 08:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/services/lobster-wos-hourly-observation.service
+++ b/services/lobster-wos-hourly-observation.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=WOS hourly observation — monitor pipeline health 06-12 UTC
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/dispatch-job.sh wos-hourly-observation

--- a/services/lobster-wos-hourly-observation.timer
+++ b/services/lobster-wos-hourly-observation.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=WOS hourly observation — monitor pipeline health 06-12 UTC
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*-*-* 06,07,08,09,10,11,12:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What this fixes

Ten LLM scheduled jobs were migrated from cron to systemd timers (live at the OS level) by a prior audit agent, but their unit files were never committed to the repo. This meant any fresh install or upgrade.sh run on a new machine would not have these timers — they existed only on the current instance.

This PR closes that gap: the unit files are now in version control, and Migration 87 installs them automatically on upgrade.

## What changed

**20 new unit files in `services/`** (10x `.timer` + 10x `.service`) for:
- `weekly-epistemic-retro`, `lobster-hygiene`, `pattern-candidate-sweep`
- `morning-briefing`, `uow-reflection`, `structural-hygiene-audit`
- `upstream-sync`, `lobster-hygiene-biweekly`, `github-issue-cultivator`
- `wos-hourly-observation`

Each `.service` is `Type=oneshot` calling `dispatch-job.sh {job-name}`. Each `.timer` has `Persistent=true` to catch missed firings after downtime.

**Migration 87 in `upgrade.sh`**: copies unit files from `services/` to `/etc/systemd/system/`, runs `systemctl daemon-reload`, and enables each timer. Idempotent — skips any timer already installed.

**`docs/scheduled-jobs-golden-pattern.md`**: canonical four-component reference (systemd .timer, .service, jobs.json entry, task .md), naming conventions, install commands, and the Type C cron-direct exception. Mirrors the WOS golden pattern doc style.

Note: `~/lobster-workspace/CONVENTIONS.md` (runtime reference, not in repo) was also updated with a summary of this pattern — that change is outside this diff.

## What is not changed

The unit file contents are byte-for-byte identical to what is currently live on the instance. No schedule, description, or ExecStart was modified. This PR only commits them and adds the install pathway.

## Areas to review closely

- Migration 87: the `sudo cp` + `systemctl enable --now` loop. Verify it handles the already-present idempotent path correctly (checks `systemctl is-enabled` before enabling).
- The `lobster-hygiene` timer filename is `lobster-lobster-hygiene.timer` (double "lobster") — this matches what is live at `/etc/systemd/system/lobster-lobster-hygiene.timer`. Not a bug, just worth confirming the reviewer is not surprised by it.

## Tests run

- [x] Verified all 10 timers present in `systemctl list-timers --all | grep lobster` — confirmed live and active before this PR
- [x] Verified no LOBSTER-SCHEDULED cron entries remain in `crontab -l` — cron is clean
- [x] Verified unit file contents in repo match live `/etc/systemd/system/` files (copied directly from running system)
- [x] Migration 87 is idempotent by design: checks `systemctl is-enabled` and file existence before acting
- [ ] End-to-end `upgrade.sh` run on a fresh machine — not run (no second instance available); Migration 87 logic follows the same pattern as existing service migrations in the file

## Manual test

Unit files already running in production (installed by a prior agent). Presence of all 10 timers in `systemctl list-timers` output is the observable confirmation. No new behavior introduced.

User-visible outcome: N/A — infrastructure artifact commit only.

## Definition of Done

- [x] Unit tests: N/A (no test suite for shell migrations)
- [x] Integration/manual test: timers confirmed live pre-PR
- [x] User-visible outcome: N/A (infrastructure only)
- [x] Side-effect audit: Migration 87 copies and enables timers already running; no new behavior
- [x] External service calls: none

Closes #869