### PR TITLE
fix: separate metabolic taxonomy from issue lifecycle — seed UoW closes issue

### DIFF
--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -413,10 +413,19 @@ def _stamp_issue_on_completion(
     gh_bin: str = "gh",
 ) -> None:
     """
-    Call the appropriate lifecycle stamp based on output classification.
+    Call stamp_issue_complete for any successful UoW completion.
 
-    pearl / heat → stamp_issue_complete (closes the issue — verified done)
-    seed          → stamp_issue_unverifiable (leaves open — no artifact trail)
+    The source issue is closed regardless of metabolic classification
+    (pearl, heat, or seed). A seed UoW — one that filed a follow-up — still
+    addressed the source issue and should close it. The metabolic category
+    is recorded in the separate close-out comment posted by
+    _post_closeout_comment_if_github; it does not drive lifecycle decisions.
+
+    stamp_issue_unverifiable is NOT called here. That function is reserved
+    for future cases where a UoW completes but cannot be verified (no artifact
+    trail AND no subagent confirmation). All write_result=success paths call
+    stamp_issue_complete unconditionally.
+
     Non-GitHub sources or missing issue_number → no-op.
     Import or gh failures are non-fatal.
     """
@@ -427,29 +436,16 @@ def _stamp_issue_on_completion(
     repo, _ = parsed
     _import_lifecycle()
 
-    classification = classify_uow_output(output_ref, result_text)
     summary = (result_text or "").strip()[:200]
 
-    if classification in ("pearl", "heat"):
-        if _stamp_issue_complete_fn is not None:
-            _stamp_issue_complete_fn(issue_number, uow_id, summary, repo=repo, gh_bin=gh_bin)
-        else:
-            log.debug(
-                "wos_completion: _stamp_issue_on_completion skipped for %s#%d "
-                "(lifecycle module not available)",
-                repo, issue_number,
-            )
+    if _stamp_issue_complete_fn is not None:
+        _stamp_issue_complete_fn(issue_number, uow_id, summary, repo=repo, gh_bin=gh_bin)
     else:
-        # "seed" — conservative default: artifact has potential future value
-        # but is not yet a verified deliverable. Leave the issue open.
-        if _stamp_issue_unverifiable_fn is not None:
-            _stamp_issue_unverifiable_fn(issue_number, uow_id, repo=repo, gh_bin=gh_bin)
-        else:
-            log.debug(
-                "wos_completion: _stamp_issue_on_completion (unverifiable) skipped for %s#%d "
-                "(lifecycle module not available)",
-                repo, issue_number,
-            )
+        log.debug(
+            "wos_completion: _stamp_issue_on_completion skipped for %s#%d "
+            "(lifecycle module not available)",
+            repo, issue_number,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/orchestration/wos_issue_lifecycle.py
+++ b/src/orchestration/wos_issue_lifecycle.py
@@ -302,7 +302,13 @@ def stamp_issue_complete(
     gh_bin: str = "gh",
 ) -> bool:
     """
-    Stamp a GitHub issue as completed after a successful (pearl) UoW.
+    Stamp a GitHub issue as completed after a successful UoW execution.
+
+    Called for any successful UoW outcome — pearl, heat, or seed. The
+    lifecycle decision (close the issue) is orthogonal to the metabolic
+    taxonomy (what was produced). Any successful completion means the
+    source issue was addressed; the metabolic category is recorded
+    separately in the close-out comment posted by wos_completion.py.
 
     Steps:
     1. Remove wos:executing label from the issue.
@@ -345,7 +351,7 @@ def stamp_issue_complete(
         truncated_summary = summary[:200] + ("…" if len(summary) > 200 else "")
         comment_body = (
             f"## WOS UoW Complete — {uow_id}\n"
-            f"**Outcome:** pearl (verified artifact)\n"
+            f"**Outcome:** successful completion\n"
             f"**Summary:** {truncated_summary}\n"
             f"This issue was closed automatically by the Work Orchestration System."
         )

--- a/tests/unit/test_orchestration/test_wos_completion.py
+++ b/tests/unit/test_orchestration/test_wos_completion.py
@@ -700,3 +700,60 @@ class TestCloseoutProtocolIntegration:
             f"result_text mentioning a PR must produce 'pearl' classification in the "
             f"close-out comment. Got close-out comment body:\n{closeout_body}"
         )
+
+    def test_seed_classified_result_closes_issue(self, tmp_path: Path) -> None:
+        """
+        A UoW whose result_text classifies as 'seed' (the default — no PR mention,
+        no heat signals) must still close the source GitHub issue.
+
+        Rationale: metabolic classification (seed/pearl/heat) describes what the UoW
+        PRODUCED, not whether the source issue was ADDRESSED. A seed UoW that filed a
+        follow-up absolutely addressed the source issue. Lifecycle decisions must be
+        driven by completion status (success vs fail), not by output category.
+
+        Before this fix, seed-classified results called stamp_issue_unverifiable,
+        leaving the issue OPEN. This test confirms the corrected behavior: any
+        successful completion triggers stamp_issue_complete (which closes the issue).
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id = self._seed_uow_with_source(
+            registry, output_dir, source="github:issue/77", issue_number=77
+        )
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        close_calls: list[list[str]] = []
+
+        def _capture_run(cmd, **kwargs):
+            # Track 'gh issue close' calls
+            if "close" in cmd:
+                close_calls.append(list(cmd))
+            return MagicMock(returncode=0)
+
+        # result_text has no PR mention and no heat signals → classifies as 'seed'
+        seed_result_text = "Filed follow-up issue #88 for remaining work."
+
+        with patch("orchestration.wos_completion.subprocess.run", side_effect=_capture_run), \
+             patch.dict(os.environ, {
+                 "REGISTRY_DB_PATH": str(db_path),
+                 "LOBSTER_WOS_REPO": "dcetlin/Lobster",
+             }):
+            maybe_complete_wos_uow(
+                task_id,
+                WRITE_RESULT_SUCCESS_STATUS,
+                result_text=seed_result_text,
+            )
+
+        # The source issue must be closed regardless of seed classification.
+        assert len(close_calls) >= 1, (
+            "A seed-classified UoW must still close the source GitHub issue. "
+            "Metabolic category (seed/pearl/heat) does not determine whether the "
+            "issue was addressed — completion status does."
+        )
+        # Confirm the close targeted the correct issue number
+        assert any("77" in str(call) for call in close_calls), (
+            f"gh issue close must target issue 77. Close calls observed: {close_calls}"
+        )

--- a/tests/unit/test_orchestration/test_wos_issue_lifecycle.py
+++ b/tests/unit/test_orchestration/test_wos_issue_lifecycle.py
@@ -244,7 +244,7 @@ class TestStampIssueExecuting:
 # ---------------------------------------------------------------------------
 
 class TestStampIssueComplete:
-    """Tests for the UoW-completion (pearl) lifecycle stamp."""
+    """Tests for the UoW-completion lifecycle stamp (called for any successful outcome)."""
 
     def test_success_path_removes_label_closes_and_comments(self) -> None:
         """
@@ -276,6 +276,38 @@ class TestStampIssueComplete:
         comment_args = mock_run.call_args_list[2][0][0]
         assert "issue" in comment_args
         assert "comment" in comment_args
+
+    def test_comment_body_says_successful_completion_not_pearl(self) -> None:
+        """
+        stamp_issue_complete is now called for all successful outcomes (pearl,
+        heat, seed). The comment body must say 'successful completion' — not
+        'pearl (verified artifact)' — because metabolic category is not what
+        drives lifecycle decisions.
+        """
+        remove_label_result = _make_completed_process(returncode=0)
+        close_result = _make_completed_process(returncode=0)
+        comment_result = _make_completed_process(returncode=0)
+
+        captured_body: list[str] = []
+
+        def _capture(cmd, **kwargs):
+            if "--body" in cmd:
+                captured_body.append(cmd[cmd.index("--body") + 1])
+            return _make_completed_process(returncode=0)
+
+        with patch("subprocess.run", side_effect=_capture):
+            stamp_issue_complete(_TEST_ISSUE, _TEST_UOW_ID, _TEST_SUMMARY, repo=_TEST_REPO)
+
+        assert len(captured_body) == 1, "Expected exactly one comment"
+        body = captured_body[0]
+        assert "successful completion" in body, (
+            "Comment body must say 'successful completion' — not pearl-specific language. "
+            f"Got: {body!r}"
+        )
+        assert "pearl" not in body, (
+            "Comment body must not mention 'pearl' — metabolic category does not drive "
+            f"lifecycle decisions. Got: {body!r}"
+        )
 
     def test_already_closed_issue_returns_true_gracefully(self) -> None:
         """


### PR DESCRIPTION
## What this fixes

PR #876 introduced `wos_issue_lifecycle.py`, but shipped with a design error that conflated two orthogonal axes:

1. **Metabolic taxonomy** (seed/pearl/heat) — what a UoW *produced*. Recorded for observability.
2. **Issue lifecycle** — was the source issue addressed? Binary. Driven by completion status alone.

The bug: `_stamp_issue_on_completion` in `wos_completion.py` called `stamp_issue_unverifiable` (leaves issue OPEN) for seed-classified results. A seed UoW — one that filed a follow-up — absolutely addressed the source issue. Leaving it open was wrong.

## Before / after

```
Before (broken):
  write_result=success, classify → pearl/heat  → stamp_issue_complete   (closes issue) ✓
  write_result=success, classify → seed        → stamp_issue_unverifiable (leaves OPEN) ✗

After (correct):
  write_result=success, any classification     → stamp_issue_complete   (closes issue) ✓
  write_result=error / fail_uow               → stamp_issue_failed      (leaves OPEN) ✓
```

The metabolic category (pearl/heat/seed) still flows into the separate close-out comment posted by `_post_closeout_comment_if_github` for observability. It no longer drives lifecycle decisions.

## Changes

**`wos_completion.py`**: `_stamp_issue_on_completion` removes the `classification in ("pearl", "heat")` branch. All successful completions call `stamp_issue_complete` unconditionally. `stamp_issue_unverifiable` is no longer called from this path — it is reserved for future cases with no artifact trail and no subagent confirmation.

**`wos_issue_lifecycle.py`**: `stamp_issue_complete` docstring and comment body updated. "Outcome: pearl (verified artifact)" → "Outcome: successful completion" because the function is no longer pearl-specific. The metabolic category is an input to the close-out comment builder, not a label stamped on the lifecycle comment.

**Tests added:**
- `test_comment_body_says_successful_completion_not_pearl` — verifies the lifecycle comment body no longer embeds a metabolic category label
- `test_seed_classified_result_closes_issue` — end-to-end: seed result_text → `maybe_complete_wos_uow` → `stamp_issue_complete` → `gh issue close` confirms the issue is closed

## Functional patterns

Pure functions unchanged (`classify_uow_output`, `_build_closeout_comment`). Side effects isolated to `_stamp_issue_on_completion` and the `_stamp_*` leaf functions. No new dependencies added.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_issue_lifecycle.py` — 19 passed, 0 failed (1 new test added)
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py` — 38 passed, 0 failed (1 new test added)
- [x] Combined with germinator, garden_caretaker, routing_classifier: 159 passed, 0 failed

## Manual test
N/A — no systemd, cron, or DB schema changes. All GitHub interactions are through the gh CLI, mocked in tests.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure gh CLI side effects, fully mocked in tests)
- [x] User-visible outcome: GitHub issues sourced from seed-classified UoWs will now close automatically on successful completion, consistent with pearl/heat behavior
- [x] Side-effect audit: no floods, no loops, bounded gh CLI calls per lifecycle event
- [x] External service calls: mocked via subprocess.run patch in all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)