### PR TITLE
docs(wos): integrate metabolic primitives as typed stock in architecture diagram

### DIFF
--- a/docs/wos-pipeline-architecture-20260422.md
+++ b/docs/wos-pipeline-architecture-20260422.md
@@ -136,6 +136,33 @@ flowchart TD
     ORACLE_VERDICT -->|NEEDS_CHANGES| FIX
     FIX --> SUBAGENT
     MERGE --> DONE
+
+    subgraph METABOLIC ["Metabolic Output Layer (outcome_refs — Issue #880)"]
+        OREFS["outcome_refs\n[{type, ref, category}]\nwritten by subagent in write_result\nprovenance carrier — makes stock traversable"]
+
+        PEARL["Pearl\noutcome_category: pearl\nTyped stock with address\n(PR URL, file path, doc link)"]
+        SEED["Seed\noutcome_category: seed\nTyped stock with address\n(GitHub Issue URL)"]
+        HEAT["Heat\noutcome_category: heat\nEnergy with log entry\n(no downstream stock)"]
+        SHIT["Shit\noutcome_category: shit\nEnergy with log entry\n(no downstream stock)"]
+
+        PEARL_OUT["Artifact delivered\nSystem state changes\nObservable in repo / docs"]
+        SEED_ISSUE["New Issue filed\n(ref in outcome_refs)"]
+        SEED_UOW["New UoW\n(via Cultivator on next cycle)"]
+        HEAT_LOG["Log entry only\nWork done, no artifact\n(healthy no-op)"]
+        SHIT_LOG["Waste account entry\nFuture cleanup work\n(stale notes, accumulation)"]
+    end
+
+    RESULT --> OREFS
+    OREFS -->|category=pearl| PEARL
+    OREFS -->|category=seed| SEED
+    OREFS -->|category=heat| HEAT
+    OREFS -->|category=shit| SHIT
+    PEARL --> PEARL_OUT
+    SEED --> SEED_ISSUE
+    SEED_ISSUE --> SEED_UOW
+    SEED_UOW -.->|generative loop| GH
+    HEAT --> HEAT_LOG
+    SHIT --> SHIT_LOG
 ```
 
 ---
@@ -240,6 +267,8 @@ The `sequential` posture (assigned by the routing classifier for seed-type work)
 
 ### 6. Lifecycle stages — seed, pearl, heat, and shit
 
+See also: the **Metabolic Output Layer** subgraph in the Pipeline Flowchart above, and the Outcome Categories table below. The formal `outcome_refs` schema is specified in [Issue #880](https://github.com/dcetlin/Lobster/issues/880).
+
 WOS uses two complementary vocabularies for lifecycle:
 
 **Biological vocabulary (design/philosophy register):**
@@ -304,12 +333,18 @@ The parallel to the pipeline diagram: WOS has the cycles (the heartbeats, the sw
 
 ## Outcome Categories (write_result metabolic tags)
 
-| Category | Meaning |
-|----------|---------|
-| `seed` | Intentional investment in future capability (infra fixes, tooling, instrumentation) |
-| `pearl` | Direct high-value output (bugs caught, frameworks encoded, analysis acted on) |
-| `heat` | Pure dissipation, no residue (empty checks, healthy no-ops) |
-| `shit` | Organic waste that persists and must be processed (stale notes, unread accumulation) |
+Spec: [Issue #880](https://github.com/dcetlin/Lobster/issues/880) — `outcome_refs` schema and traversal contract.
+
+The metabolic primitives are **typed stock** that move through flows after UoW execution. Seeds and pearls carry addresses (refs) that make them machine-traceable; heat and shit are energy expenditure with log entries only — no downstream stock is created.
+
+| Category | Stock type | `outcome_refs` required? | Downstream flow |
+|----------|------------|--------------------------|-----------------|
+| `pearl` | Artifact delivered | Yes — PR URL, file path, or doc link | System state changes; observable in repo/docs |
+| `seed` | Future work spawned | Yes — GitHub Issue URL | New Issue → New UoW via Cultivator (generative loop) |
+| `heat` | Pure dissipation | No | Log entry only; no artifact, no issue |
+| `shit` | Organic waste | No | Waste account entry; signals future cleanup work |
+
+**Key principle:** seeds and pearls are stock with addresses (refs); heat and shit are energy with logs (no downstream stock).
 
 ## UoW Lifecycle States
 

--- a/docs/wos-pipeline-architecture-20260422.md
+++ b/docs/wos-pipeline-architecture-20260422.md
@@ -89,7 +89,7 @@ flowchart TD
     LOBSTER["Lobster Dispatcher\npicks up wos_execute message\non next cycle (~seconds)"]
     SUBAGENT["Register-Appropriate Subagent\nfunctional-engineer / frontier-writer / design-review\nexecutes UoW\nstate: active → executing"]
     RESULT["result.json + trace.json written\noutcome: complete / partial / failed / blocked\nstate: executing → ready-for-steward"]
-    ORACLE["Oracle Review\noracle/\nPR diff reviewed by oracle agent\nverdict written to oracle/decisions.md"]
+    ORACLE["Oracle Review\noracle/verdicts/\nPR diff reviewed by oracle agent\nverdict written to oracle/verdicts/pr-NNN.md"]
     ORACLE_VERDICT{Verdict?}
     MERGE["Merge Agent\nmerges PR\nstate: → done"]
     FIX["Fix Agent\naddresses NEEDS_CHANGES"]
@@ -173,7 +173,7 @@ The WOS pipeline contains several explicit feedback loops:
 
 1. **Steward re-prescription loop** — After a subagent writes `result.json`, the UoW transitions to `ready-for-steward`. The Steward re-evaluates success criteria; if unsatisfied, it re-prescribes and the UoW cycles back through the executor. This is the primary loop for iterative-convergent UoWs.
 
-2. **Oracle → fix → re-oracle loop** — For code UoWs that open a PR: oracle agent reviews the diff, writes a verdict to `oracle/decisions.md`. A NEEDS_CHANGES verdict dispatches a fix agent which opens a new PR revision; the oracle re-runs. This loop repeats until APPROVED.
+2. **Oracle → fix → re-oracle loop** — For code UoWs that open a PR: oracle agent reviews the diff, writes a verdict to `oracle/verdicts/pr-NNN.md`. A NEEDS_CHANGES verdict dispatches a fix agent which opens a new PR revision; the oracle re-runs. This loop repeats until APPROVED.
 
 3. **Heartbeat stall detection loop** — The steward's observation loop checks `active` UoWs every 3 minutes. If `heartbeat_at` has been silent for more than `heartbeat_ttl` seconds (default: 300s), the UoW is transitioned back to `ready-for-steward` for re-diagnosis. The executor heartbeat retains a 24h TTL orphan safety net (`recover_ttl_exceeded_uows`) as a last-resort backstop for UoWs that somehow evade the observation loop, but it is no longer the primary stall detection mechanism.
 
@@ -308,7 +308,7 @@ The parallel to the pipeline diagram: WOS has the cycles (the heartbeats, the sw
 | **Executor Heartbeat** | `scheduled-tasks/executor-heartbeat.py` | Every 3 min via cron (+90s offset). Checks `wos-config.json` execution gate, runs orphan safety net (`recover_ttl_exceeded_uows`, 24h threshold — Phase 1, always), then recovery-dispatches ready UoWs missed by the primary event-driven path (Phase 2). Primary stall detection is the steward's heartbeat observation loop, not this component. |
 | **Executor** | `src/orchestration/executor.py` | Performs the 6-step atomic claim sequence (optimistic lock on `ready-for-executor` → `active`). Primary path: writes `wos_execute` inbox message and returns immediately (async/event-driven). Legacy path: `claude -p` subprocess (CI/dev). |
 | **Register-Appropriate Subagent** | Dispatched by Lobster | functional-engineer (code), frontier-writer (philosophical synthesis), design-review (human-judgment analysis). Executes the UoW, writes `result.json` and `trace.json`. |
-| **Oracle** | `oracle/` | Reviews PR diffs and writes APPROVED / NEEDS_CHANGES verdicts to `oracle/decisions.md`. PR Merge Gate requires an APPROVED verdict before merge. |
+| **Oracle** | `oracle/verdicts/` | Reviews PR diffs and writes APPROVED / NEEDS_CHANGES verdicts to `oracle/verdicts/pr-NNN.md`. PR Merge Gate requires an APPROVED verdict before merge. |
 | **Steward** | `src/orchestration/steward.py` | Evaluates completed UoWs against success criteria, diagnoses failures, re-prescribes, or surfaces to Dan. The only component authorized to mark a UoW `done`. |
 
 ---


### PR DESCRIPTION
Adds the metabolic output layer to the WOS pipeline architecture diagram, and corrects a stale oracle path that PR #875 deprecated.

**What changed (diagram only — no code):**
- Pearl/seed/heat/shit represented as typed stock lanes with outcome_refs as the carrier
- Seeds shown as stock that flows into new Issues → new UoWs (generative loop)
- Pearls shown as stock that delivers observable system state change
- Heat and shit shown as energy with logs but no downstream stock
- Oracle path updated in 3 places: `oracle/decisions.md` → `oracle/verdicts/pr-NNN.md` (per PR #875)
- Issue #880 (outcome_refs spec) referenced as formal design anchor
- Workstream README updated with metabolic stock model note

**Why this PR replaces #882:** Branch `feat/system-retrospective-2026-04-23` was used for #878 (squash-merged), so git showed that branch's full history vs main — making #882 appear to include the assessment doc and smell-patterns.yaml from #878. This clean branch contains only the two diagram commits.

**Oracle gap fixed:** `decisions.md` references in the Mermaid ORACLE node, the loop description, and the component table all updated to `oracle/verdicts/pr-NNN.md`.

Closes/supersedes #882.

## Tests run
- [ ] No automated tests — docs-only change (diagram and markdown only, no code)

## Manual test
N/A — this change is entirely internal documentation. No systemd, cron, external services, file I/O, or DB schema affected.

## Definition of Done
- [x] Unit tests pass — N/A (docs only)
- [x] Integration/manual test — N/A (docs only)
- [x] User-visible outcome — N/A (no user-visible behavior changed)
- [x] Side-effect audit — no side effects possible (markdown file only)
- [x] External service calls — none

🤖 Generated with [Claude Code](https://claude.ai/claude-code)