### PR TITLE
fix(wos): back-propagate write_result text to executor output file (#867)

### DIFF
--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -191,6 +191,123 @@ def _enrich_result_file(output_ref: str, result_text: str | None) -> None:
         )
 
 # ---------------------------------------------------------------------------
+# Back-propagation — write result text to executor output file (issue #867)
+# ---------------------------------------------------------------------------
+
+def _backpropagate_result_to_output_file(
+    uow_id: str,
+    output_ref: str,
+    result_text: str | None,
+) -> None:
+    """
+    Write the write_result payload to the executor output file when none exists.
+
+    Problem (issue #867): when a WOS subagent calls write_result, the result
+    text is stored in the MCP/session layer but the executor output file
+    ({output_ref}.result.json) is never updated. The Steward reads that file to
+    determine completion, so UoWs whose subagents did not explicitly write a
+    result file are classified as 'outcome_unverifiable'.
+
+    Fix: when maybe_complete_wos_uow fires (write_result confirmed), check
+    whether {output_ref}.result.json already exists. If not, write a minimal
+    conforming result file so the Steward can verify the outcome.
+
+    The result file schema follows executor-contract.md:
+    - uow_id: the UoW ID (validated by the Steward before reading other fields)
+    - outcome: "complete" (write_result status="success" implies success)
+    - success: true
+    - reason: the write_result text (truncated to 500 chars)
+    - executor_id: "write_result_backprop" (identifies this synthetic record)
+
+    Also writes result_text to the primary output_ref path when that file is
+    missing or empty (sentinel-only), so agent-status.sh and the steward have
+    human-readable content to display.
+
+    Non-fatal: failures are logged and swallowed — back-propagation must never
+    block the UoW transition or cause write_result to fail.
+
+    Args:
+        uow_id: The WOS unit-of-work ID.
+        output_ref: The output_ref path for this UoW (absolute path).
+        result_text: The text field from the write_result call. May be None or empty.
+    """
+    if not output_ref:
+        return
+
+    try:
+        import json as _json
+        import tempfile as _tempfile
+
+        p = Path(output_ref)
+        # Derive result.json path — mirrors executor._result_json_path
+        if p.suffix:
+            result_path = p.with_suffix(".result.json")
+        else:
+            result_path = Path(str(p) + ".result.json")
+
+        if result_path.exists():
+            # Already present — _enrich_result_file will add summary/refs
+            log.debug(
+                "_backpropagate_result_to_output_file: result file already exists at %s — skipping",
+                result_path,
+            )
+            return
+
+        # Write a minimal conforming result.json
+        reason = (result_text or "").strip()[:500] or "completed via write_result"
+        payload = {
+            "uow_id": uow_id,
+            "outcome": "complete",
+            "success": True,
+            "reason": reason,
+            "executor_id": "write_result_backprop",
+        }
+
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write: tmp → rename so the Steward never reads a partial file
+        tmp_fd, tmp_name = _tempfile.mkstemp(
+            dir=result_path.parent,
+            prefix=f".{result_path.name}.backprop.",
+            suffix=".json",
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write(_json.dumps(payload, indent=2))
+            tmp_path.rename(result_path)
+            log.info(
+                "_backpropagate_result_to_output_file: wrote result.json for UoW %r at %s",
+                uow_id,
+                result_path,
+            )
+        except Exception:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+        # Also write result_text to the primary output_ref when it is missing
+        # or still a sentinel (zero-byte file written by the executor to guard
+        # against crashed_output_ref_missing detection).
+        if result_text:
+            primary = p
+            if not primary.exists() or primary.stat().st_size == 0:
+                primary.parent.mkdir(parents=True, exist_ok=True)
+                primary.write_text(result_text, encoding="utf-8")
+                log.info(
+                    "_backpropagate_result_to_output_file: wrote result_text to primary output %s",
+                    primary,
+                )
+
+    except Exception as exc:
+        log.warning(
+            "_backpropagate_result_to_output_file: failed for UoW %r — %s: %s",
+            uow_id, type(exc).__name__, exc,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Output classification — pure function
 # ---------------------------------------------------------------------------
 
@@ -541,6 +658,12 @@ def maybe_complete_wos_uow(
             "(execution_complete written on write_result confirmation)",
             uow_id,
         )
+
+        # Back-propagation (issue #867): write result_text to the executor output
+        # file when the subagent did not write one itself. Must run BEFORE
+        # _enrich_result_file so the file exists for enrichment to update.
+        if output_ref:
+            _backpropagate_result_to_output_file(uow_id, output_ref, result_text)
 
         # Enrich result file with summary + extracted artifact refs from agent output.
         # Non-fatal — enrichment failure never blocks the UoW transition.

--- a/tests/unit/test_orchestration/test_wos_completion.py
+++ b/tests/unit/test_orchestration/test_wos_completion.py
@@ -36,6 +36,7 @@ if str(_SRC) not in sys.path:
 from orchestration.wos_completion import (
     WOS_TASK_ID_PREFIX,
     WRITE_RESULT_SUCCESS_STATUS,
+    _backpropagate_result_to_output_file,
     _build_closeout_comment,
     _extract_github_issue,
     classify_uow_output,
@@ -757,3 +758,156 @@ class TestCloseoutProtocolIntegration:
         assert any("77" in str(call) for call in close_calls), (
             f"gh issue close must target issue 77. Close calls observed: {close_calls}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Back-propagation — issue #867
+# ---------------------------------------------------------------------------
+
+class TestBackpropagateResultToOutputFile:
+    """
+    Unit tests for _backpropagate_result_to_output_file (issue #867).
+
+    This function writes a minimal conforming result.json when the subagent
+    did not write one, so the Steward can verify UoW completion.
+    """
+
+    def test_writes_result_json_when_missing(self, tmp_path: Path) -> None:
+        """
+        When no result.json exists, a conforming file must be written with
+        outcome='complete', success=True, and the uow_id matching the UoW.
+        """
+        output_ref = str(tmp_path / "abc123.json")
+        result_text = "Opened PR #42 on dcetlin/Lobster."
+
+        _backpropagate_result_to_output_file("abc123", output_ref, result_text)
+
+        result_path = tmp_path / "abc123.result.json"
+        assert result_path.exists(), "result.json must be created by back-propagation"
+        payload = json.loads(result_path.read_text())
+        assert payload["uow_id"] == "abc123"
+        assert payload["outcome"] == "complete"
+        assert payload["success"] is True
+        assert payload["executor_id"] == "write_result_backprop"
+        assert result_text[:500] in payload.get("reason", "")
+
+    def test_does_not_overwrite_existing_result_json(self, tmp_path: Path) -> None:
+        """
+        When result.json already exists (written by the subagent), back-propagation
+        must leave it untouched — the existing file has higher fidelity.
+        """
+        output_ref = str(tmp_path / "abc456.json")
+        result_path = tmp_path / "abc456.result.json"
+        original_payload = {
+            "uow_id": "abc456",
+            "outcome": "partial",
+            "success": False,
+            "reason": "only 3 of 5 steps completed",
+        }
+        result_path.write_text(json.dumps(original_payload))
+
+        _backpropagate_result_to_output_file("abc456", output_ref, "some text")
+
+        payload = json.loads(result_path.read_text())
+        assert payload == original_payload, (
+            "_backpropagate_result_to_output_file must not overwrite an existing result file"
+        )
+
+    def test_no_op_when_output_ref_is_empty(self, tmp_path: Path) -> None:
+        """
+        When output_ref is empty, the function must return silently without writing
+        any result.json or primary output file.
+        """
+        # The function must not write any result file — verify no .result.json is created
+        result_path = tmp_path / "abc789.result.json"
+        primary_path = tmp_path / "abc789.json"
+        _backpropagate_result_to_output_file("abc789", "", "some text")
+        assert not result_path.exists(), "No result.json must be written for empty output_ref"
+        assert not primary_path.exists(), "No primary output must be written for empty output_ref"
+
+    def test_writes_result_text_to_primary_output_when_missing(self, tmp_path: Path) -> None:
+        """
+        When the primary output_ref file is missing (never written, not even a
+        sentinel), the result_text must be written there so agent-status.sh
+        has human-readable content.
+        """
+        output_ref = str(tmp_path / "abc999.json")
+        result_text = "Task completed — no changes needed."
+
+        _backpropagate_result_to_output_file("abc999", output_ref, result_text)
+
+        primary_path = tmp_path / "abc999.json"
+        assert primary_path.exists(), "Primary output file must be written when missing"
+        assert primary_path.read_text() == result_text
+
+    def test_writes_result_text_to_primary_output_when_sentinel_zero_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The executor writes a zero-byte sentinel to output_ref at dispatch time
+        to guard against crashed_output_ref_missing detection. Back-propagation
+        must overwrite it with the actual result text.
+        """
+        output_ref = str(tmp_path / "sentinel.json")
+        sentinel_path = tmp_path / "sentinel.json"
+        sentinel_path.write_text("")  # zero-byte sentinel
+        result_text = "Work done."
+
+        _backpropagate_result_to_output_file("sentinel", output_ref, result_text)
+
+        assert sentinel_path.read_text() == result_text, (
+            "Zero-byte sentinel must be replaced by result_text"
+        )
+
+    def test_result_json_conforms_to_executor_contract(self, tmp_path: Path) -> None:
+        """
+        The synthetic result.json must contain all required fields from
+        executor-contract.md: uow_id, outcome, success. Optional fields
+        (reason, executor_id) improve observability but are not contractually
+        required here — this test validates required fields only.
+        """
+        output_ref = str(tmp_path / "contract_uow.json")
+        _backpropagate_result_to_output_file("contract_uow", output_ref, "Done.")
+
+        result_path = tmp_path / "contract_uow.result.json"
+        payload = json.loads(result_path.read_text())
+        assert "uow_id" in payload, "result.json must have uow_id"
+        assert "outcome" in payload, "result.json must have outcome"
+        assert "success" in payload, "result.json must have success"
+
+    def test_maybe_complete_wos_uow_writes_result_json_via_backprop(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        End-to-end: when a WOS subagent calls write_result and no result.json
+        exists, maybe_complete_wos_uow must create one via back-propagation
+        so the Steward can verify completion.
+        """
+        import sqlite3
+
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id = _seed_uow_at_status(registry, "executing", output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+        result_text = "PR #55 opened."
+
+        with patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            maybe_complete_wos_uow(task_id, WRITE_RESULT_SUCCESS_STATUS, result_text=result_text)
+
+        uow = registry.get(uow_id)
+        output_ref = uow.output_ref
+        assert output_ref, "UoW must have output_ref after execution"
+
+        result_path = Path(output_ref).with_suffix(".result.json")
+        assert result_path.exists(), (
+            "result.json must be created by back-propagation when the subagent "
+            "did not write one itself"
+        )
+        payload = json.loads(result_path.read_text())
+        assert payload["uow_id"] == uow_id
+        assert payload["outcome"] == "complete"
+        assert payload["success"] is True


### PR DESCRIPTION
## Summary

- Adds `_backpropagate_result_to_output_file()` in `wos_completion.py` — when `maybe_complete_wos_uow` fires (write_result confirmed) and no `{output_ref}.result.json` exists, writes a minimal conforming record (`outcome=complete`, `success=true`, write_result text as `reason`, `executor_id=write_result_backprop`)
- Also writes `result_text` to the primary `output_ref` when it is absent or a zero-byte sentinel, so `agent-status.sh` has human-readable content
- Must run before `_enrich_result_file()` so enrichment has a file to update; ordering enforced in `maybe_complete_wos_uow`
- Non-fatal: failures are logged and swallowed — `write_result` is never blocked by back-propagation errors

## Root cause

87/90 "completed" UoWs showed `outcome_unverifiable` because subagents called `write_result` (stored in the MCP/session layer) but never wrote the executor output file the Steward reads to determine completion. The 3 verifiable completions were exceptions where subagents explicitly wrote the file themselves.

## What was not changed

- Registry schema — no new columns added
- Executor dispatch path
- Any file outside `wos_completion.py` and its test file

## Test plan

- [x] 45 unit tests pass (38 pre-existing + 7 new for `_backpropagate_result_to_output_file`)
- [x] New test `test_maybe_complete_wos_uow_writes_result_json_via_backprop` exercises the full end-to-end path from `maybe_complete_wos_uow` through back-propagation
- [x] Existing behavior (do not overwrite a subagent-written result file) verified by `test_does_not_overwrite_existing_result_json`

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)