### PR TITLE
fix(memory): filter health probe events from vector memory writes

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -8783,6 +8783,32 @@ CANONICAL_DIR = _USER_CONFIG / "memory" / "canonical"
 HANDOFF_PATH = CANONICAL_DIR / "handoff.md"
 
 
+
+# ---------------------------------------------------------------------------
+# Memory ingestion filter — noise event exclusion
+#
+# These event types are pure operational noise for semantic retrieval.
+# health_check fires ~380 times/day (health-check-v3 every 4 min).
+# Exclude them before any embedding computation or DB insertion.
+# ---------------------------------------------------------------------------
+MEMORY_EXCLUDED_TYPES: frozenset[str] = frozenset({
+    "health_check",      # canonical type written by health-check-v3.sh and daily-health-check.sh
+    "health_probe",      # forward-compat alias in case producers adopt this name
+    "cron_heartbeat",    # executor/steward heartbeat noise
+})
+MEMORY_EXCLUDED_SUBTYPES: frozenset[str] = frozenset({
+    "health_check",      # subtype variant from some producers
+})
+
+
+def _should_skip_memory_write(event_type: str, event_subtype: str | None) -> bool:
+    """Return True if this event should be silently dropped from memory ingestion."""
+    return (
+        event_type in MEMORY_EXCLUDED_TYPES
+        or (event_subtype is not None and event_subtype in MEMORY_EXCLUDED_SUBTYPES)
+    )
+
+
 async def handle_memory_store(arguments: dict[str, Any]) -> list[TextContent]:
     """Store an event in memory."""
     if _memory_provider is None:
@@ -8791,6 +8817,16 @@ async def handle_memory_store(arguments: dict[str, Any]) -> list[TextContent]:
     content = arguments.get("content", "")
     if not content:
         return [TextContent(type="text", text="Error: content is required.")]
+
+    # Filter gate: drop operational noise events before embedding or DB write.
+    event_type = arguments.get("type", "note")
+    event_subtype = arguments.get("subtype")
+    if _should_skip_memory_write(event_type, event_subtype):
+        log.debug(
+            "memory_store: skipping noise event (type=%r, subtype=%r)",
+            event_type, event_subtype,
+        )
+        return [TextContent(type="text", text=f"Skipped: event type '{event_type}' is excluded from memory ingestion.")]
 
     from memory.provider import VALENCE_VALUES
     raw_valence = arguments.get("valence", "neutral")


### PR DESCRIPTION
## Summary

- Adds `_should_skip_memory_write()` filter gate in `handle_memory_store` that drops events before any embedding computation or DB insertion
- Excluded types: `health_check` (canonical, written by health-check-v3.sh and daily-health-check.sh), `health_probe` (forward-compat alias), `cron_heartbeat` (executor/steward heartbeat noise)
- Excluded subtypes: `health_check`
- health-check-v3 fires every 4 minutes (~380 writes/day eliminated)
- Filter returns a `Skipped:` response so callers can confirm the gate fired without an error

## Verification

- Confirmed actual event schema: health-check-v3.sh writes `type="health_check"` with `metadata={"tags": ["health_probe"]}` — filter matches on type
- Checked that `handle_memory_store` is the single MCP entry point for all vector DB writes (add_rule and record_mirroring_instance use internal paths not affected)
- All 48 memory unit tests pass (`tests/unit/test_memory.py`)

## Test plan

- [ ] Confirm `memory_store` called with `type=health_check` returns `Skipped:` message without DB write
- [ ] Confirm `memory_store` called with `type=note` or `type=message` still writes normally
- [ ] Observe reduced noise in `memory_recent` output after health-check-v3 next fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)