### PR TITLE
docs(wos): remove stale NOTEs claiming spiral gate is non-functional

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2244,10 +2244,10 @@ def _count_oracle_passes(audit_entries: list[dict]) -> int:
     Each oracle_approved entry represents one complete oracle pass that
     returned APPROVED for this UoW. Used by the Spiral pattern detector.
 
-    NOTE: oracle_pass_count will always be 0 until the oracle agent integration
-    writes event="oracle_approved" to the UoW audit log. The spiral gate is
-    structurally correct but non-functional until that write is wired.
-    See: https://github.com/dcetlin/Lobster/issues/810
+    oracle_approved events are written by oracle_audit.emit_oracle_approved()
+    after the oracle agent issues an APPROVED verdict for a WOS-linked PR.
+    The oracle agent calls oracle_audit.py (CLI) fire-and-forget after writing
+    to oracle/verdicts/pr-{number}.md. See src/orchestration/oracle_audit.py.
 
     Pure function — reads only audit_entries; no side effects.
     """
@@ -2288,10 +2288,8 @@ def _check_dispatch_eligibility(
     Pure function — no side effects, no DB writes.
     """
     # Spiral check (highest precedence)
-    # NOTE: oracle_pass_count will always be 0 until the oracle agent integration
-    # writes event="oracle_approved" to the UoW audit log. The spiral gate is
-    # structurally correct but non-functional until that write is wired.
-    # See: https://github.com/dcetlin/Lobster/issues/810
+    # oracle_approved events are written by the oracle agent via oracle_audit.py
+    # after each APPROVED verdict for a WOS-linked PR. See oracle_audit.py.
     oracle_passes = _count_oracle_passes(audit_entries)
     if oracle_passes >= SPIRAL_ORACLE_PASS_THRESHOLD:
         log.debug(


### PR DESCRIPTION
## Summary

PR #865 wired `oracle_approved` event writes to the WOS registry, activating the steward spiral gate. However, it left behind two NOTE comments in `steward.py` that still warned the spiral gate was "structurally correct but non-functional until that write is wired." Those comments were accurate before #865 and false after it.

This PR removes the stale NOTEs and replaces them with accurate pointers to where the write actually happens: `oracle_audit.emit_oracle_approved()` called by the oracle agent after each APPROVED verdict.

**What was wrong:** A reader of `_count_oracle_passes()` or `_check_dispatch_eligibility()` would see warnings that the gate does not work, leading to wasted investigation or duplicate implementation attempts. (This PR was triggered by exactly that confusion.)

**No behavior change.** Only docstring/comment text updated.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_dispatch_eligibility.py tests/unit/test_orchestration/test_oracle_audit.py -v` — 48 passed, 0 failed

## Manual test
N/A — comment-only change with no behavioral effect.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (comment-only change)
- [x] User-visible outcome — N/A (no user-facing behavior)
- [x] Side-effect audit — N/A (no side effects)
- [x] External service calls — none