### PR TITLE
feat(wos): populate UoW artifacts field from write_result payload

### DIFF
--- a/src/orchestration/migrations/0011_add_artifacts_column.sql
+++ b/src/orchestration/migrations/0011_add_artifacts_column.sql
@@ -1,0 +1,18 @@
+-- Migration 0011: add artifacts column for outcome_refs extracted from write_result payloads.
+--
+-- Problem:
+--   When a WOS subagent calls write_result, the completion text often contains
+--   references to PRs, issues, and files produced during execution. These refs
+--   were previously extracted only into the result.json file (via _enrich_result_file),
+--   making them invisible to the registry-level steward and retrospective queries.
+--
+-- Fix:
+--   Add artifacts TEXT NULL to uow_registry. Stores a JSON array of typed ref objects
+--   extracted from the write_result payload at completion time. Schema per item:
+--     {type: "pr"|"issue"|"file"|"commit", ref: str, category: str, description?: str}
+--
+-- Backward compatibility:
+--   Existing UoWs get artifacts=NULL by default (treated as empty list by readers).
+--   Populated forward-only: only UoWs completed after this migration receive refs.
+
+ALTER TABLE uow_registry ADD COLUMN artifacts TEXT NULL;

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -226,6 +226,11 @@ class UoW:
     #   Incremented each time the steward re-dispatches after a failed execution.
     #   When retry_count >= MAX_RETRIES, escalates to needs-human-review.
     retry_count: int = 0
+    # artifacts: typed outcome refs extracted from write_result payload (migration 0011).
+    #   JSON array of {type, ref, category, description?} objects. NULL until populated.
+    #   Populated by wos_completion.py after successful UoW completion.
+    #   Types: "pr", "issue", "file", "commit".
+    artifacts: list | None = None
 
 
 def _now_iso() -> str:
@@ -400,6 +405,7 @@ class Registry:
             heartbeat_at=d.get("heartbeat_at"),
             heartbeat_ttl=d.get("heartbeat_ttl") or 300,
             retry_count=d.get("retry_count") or 0,
+            artifacts=_deserialize_json(d.get("artifacts")) if d.get("artifacts") else None,
         )
 
     def _write_audit(
@@ -1459,6 +1465,43 @@ class Registry:
             conn.execute(
                 "UPDATE uow_registry SET status = 'ready-for-steward', updated_at = ? WHERE id = ?",
                 (now, uow_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def update_artifacts(self, uow_id: str, artifacts: list) -> None:
+        """
+        Store extracted outcome refs in the registry artifacts field for a UoW.
+
+        Called by wos_completion.py after extracting artifact refs from the
+        write_result payload. Overwrites any existing value — the list is derived
+        fresh from result_text each time and replacement is idempotent.
+
+        No-op when:
+        - artifacts is empty (no refs were extracted — avoids noisy NULL→'[]' writes)
+        - uow_id does not exist in the registry (graceful skip)
+
+        Non-transactional: this is an advisory enrichment. If it fails, the UoW
+        transition already succeeded. Callers must not rely on this field for
+        correctness — only for observability and steward queries.
+
+        Args:
+            uow_id: The WOS unit-of-work ID.
+            artifacts: List of typed ref dicts. Each item has at minimum:
+                       {type: str, ref: str, category: str}.
+        """
+        if not artifacts:
+            return
+
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE uow_registry SET artifacts = ?, updated_at = ? WHERE id = ?",
+                (json.dumps(artifacts), _now_iso(), uow_id),
             )
             conn.commit()
         except Exception:

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -82,6 +82,103 @@ _PR_REF_RE = re.compile(r"PR\s*#(\d+)", re.IGNORECASE)
 _ISSUE_REF_RE = re.compile(r"issue\s*#(\d+)", re.IGNORECASE)
 _FILE_PATH_RE = re.compile(r"(~/[^\s,;\"']+\.(?:md|json|py|sh|txt|yaml|yml))")
 
+#: Patterns for typed outcome_refs extraction (issue #880).
+#: PR: explicit "PR #N", "pull request #N", or GitHub pull URL.
+_OUTCOME_PR_RE = re.compile(
+    r"(?:pull\s+request|PR)\s*#(\d+)|/pull/(\d+)",
+    re.IGNORECASE,
+)
+#: Issue: "issue #N", "closes #N", "fixes #N".
+_OUTCOME_ISSUE_RE = re.compile(
+    r"(?:issue|closes|fixes)\s*#(\d+)",
+    re.IGNORECASE,
+)
+#: Commit SHA: 7–40 hex chars, word-bounded, not inside a URL path segment.
+#: Conservative: must be preceded/followed by whitespace or punctuation to
+#: avoid false positives in file content and hex color codes.
+_OUTCOME_COMMIT_RE = re.compile(r"(?<![/\w])([0-9a-f]{7,40})(?![/\w])")
+#: File path: absolute-looking or home-relative paths with recognized extensions.
+_OUTCOME_FILE_RE = re.compile(
+    r"(?:^|[\s(,])([~/][^\s,;\"']+\.(?:py|md|yaml|yml|json|sh|txt))",
+    re.MULTILINE,
+)
+
+#: Words that are very unlikely to be commit SHAs (common English hex-looking words).
+_SHA_DENYLIST = frozenset({"dead", "beef", "cafe", "babe", "face", "fade"})
+
+
+def _is_plausible_sha(candidate: str) -> bool:
+    """
+    Return True when candidate looks like a git commit SHA.
+
+    A plausible SHA:
+    - Is 7–40 lowercase hex characters.
+    - Is not in the SHA denylist (common false-positive hex words).
+    - Is not all-digit (would be mistaken for a number).
+
+    Pure function — no I/O.
+    """
+    if candidate.lower() in _SHA_DENYLIST:
+        return False
+    if candidate.isdigit():
+        return False
+    return True
+
+
+def _extract_outcome_refs(text: str, repo: str = "dcetlin/Lobster") -> list[dict]:
+    """
+    Extract typed outcome refs from agent result text for storage in the registry.
+
+    Pure function — no side effects.
+
+    Returns a list of typed ref dicts matching the issue #880 schema:
+      [{type: "pr"|"issue"|"file"|"commit", ref: str, category: str}]
+
+    Classification heuristics:
+    - PR refs   → category "pearl" (a merged PR is a concrete deliverable)
+    - Issue refs → category "seed"  (a filed issue is a future-value pointer)
+    - File refs  → category "pearl" (a committed file is a concrete artifact)
+    - Commit SHAs → category "pearl" (a merged commit is a concrete deliverable)
+
+    Deduplication: each (type, ref) pair appears at most once.
+
+    Args:
+        text: The result_text string from the write_result call.
+        repo: The GitHub repo slug used to qualify PR and issue refs.
+    """
+    seen: set[tuple[str, str]] = set()
+    refs: list[dict] = []
+
+    def _add(ref_type: str, ref: str, category: str) -> None:
+        key = (ref_type, ref)
+        if key not in seen:
+            seen.add(key)
+            refs.append({"type": ref_type, "ref": ref, "category": category})
+
+    # PR refs
+    for m in _OUTCOME_PR_RE.finditer(text):
+        number = m.group(1) or m.group(2)
+        _add("pr", f"{repo}#{number}", "pearl")
+
+    # Issue refs
+    for m in _OUTCOME_ISSUE_RE.finditer(text):
+        number = m.group(1)
+        _add("issue", f"{repo}#{number}", "seed")
+
+    # File paths
+    for m in _OUTCOME_FILE_RE.finditer(text):
+        path = m.group(1).strip()
+        _add("file", path, "pearl")
+
+    # Commit SHAs — only when text explicitly contains "commit" nearby to reduce noise
+    if re.search(r"\bcommit\b", text, re.IGNORECASE):
+        for m in _OUTCOME_COMMIT_RE.finditer(text):
+            sha = m.group(1).lower()
+            if _is_plausible_sha(sha):
+                _add("commit", sha, "pearl")
+
+    return refs
+
 
 def _extract_artifact_refs(text: str) -> dict:
     """
@@ -93,6 +190,9 @@ def _extract_artifact_refs(text: str) -> dict:
     - "pr_numbers": list of int PR numbers found (e.g. [42, 99])
     - "issue_numbers": list of int issue numbers found (e.g. [123])
     - "file_paths": list of str file paths found (e.g. ["~/lobster-workspace/foo.md"])
+
+    Note: _extract_outcome_refs provides the typed list form used for the registry
+    artifacts field (issue #880). This function is retained for result.json enrichment.
     """
     pr_numbers = [int(m) for m in _PR_REF_RE.findall(text)]
     issue_numbers = [int(m) for m in _ISSUE_REF_RE.findall(text)]
@@ -674,6 +774,32 @@ def maybe_complete_wos_uow(
                 log.warning(
                     "maybe_complete_wos_uow: result file enrichment failed for UoW %r — %s: %s",
                     uow_id, type(enrich_exc).__name__, enrich_exc,
+                )
+
+        # Registry artifact population (issue #880): extract typed outcome refs from
+        # result_text and store them in the registry artifacts field so the steward
+        # and retrospective job can traverse the causal chain without reading result files.
+        # Non-fatal — artifact extraction must never block the UoW transition.
+        if result_text:
+            try:
+                repo = os.environ.get("LOBSTER_WOS_REPO", "dcetlin/Lobster")
+                outcome_refs = _extract_outcome_refs(result_text, repo=repo)
+                if outcome_refs:
+                    registry.update_artifacts(uow_id, outcome_refs)
+                    log.info(
+                        "maybe_complete_wos_uow: artifacts extracted for UoW %r: %s",
+                        uow_id,
+                        outcome_refs,
+                    )
+                else:
+                    log.debug(
+                        "maybe_complete_wos_uow: no artifact refs found in result_text for UoW %r",
+                        uow_id,
+                    )
+            except Exception as artifacts_exc:
+                log.warning(
+                    "maybe_complete_wos_uow: artifact extraction failed for UoW %r — %s: %s",
+                    uow_id, type(artifacts_exc).__name__, artifacts_exc,
                 )
 
         # Close-out protocol: post a structured comment to the source GitHub issue.

--- a/tests/unit/test_orchestration/test_wos_completion.py
+++ b/tests/unit/test_orchestration/test_wos_completion.py
@@ -38,7 +38,10 @@ from orchestration.wos_completion import (
     WRITE_RESULT_SUCCESS_STATUS,
     _backpropagate_result_to_output_file,
     _build_closeout_comment,
+    _extract_artifact_refs,
     _extract_github_issue,
+    _extract_outcome_refs,
+    _is_plausible_sha,
     classify_uow_output,
     maybe_complete_wos_uow,
 )
@@ -911,3 +914,329 @@ class TestBackpropagateResultToOutputFile:
         assert payload["uow_id"] == uow_id
         assert payload["outcome"] == "complete"
         assert payload["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# _is_plausible_sha — pure function
+# ---------------------------------------------------------------------------
+
+class TestIsPlausibleSha:
+    """Behavioral tests for the SHA plausibility filter."""
+
+    def test_valid_short_sha_is_plausible(self) -> None:
+        assert _is_plausible_sha("a1b2c3d") is True
+
+    def test_valid_full_sha_is_plausible(self) -> None:
+        assert _is_plausible_sha("abc123def456789012345678901234567890abcd") is True
+
+    def test_all_digits_is_not_plausible(self) -> None:
+        # Pure digits would be mistaken for a PR/issue number
+        assert _is_plausible_sha("1234567") is False
+
+    def test_deny_listed_word_dead_is_not_plausible(self) -> None:
+        assert _is_plausible_sha("dead") is False
+
+    def test_deny_listed_word_beef_is_not_plausible(self) -> None:
+        assert _is_plausible_sha("beef") is False
+
+    def test_deny_listed_word_cafe_is_not_plausible(self) -> None:
+        assert _is_plausible_sha("cafe") is False
+
+    def test_mixed_hex_not_in_denylist_is_plausible(self) -> None:
+        assert _is_plausible_sha("d34db33f") is True
+
+
+# ---------------------------------------------------------------------------
+# _extract_outcome_refs — pure function, typed ref extraction (issue #880)
+# ---------------------------------------------------------------------------
+
+#: Named constant anchoring the minimum ref set expected from a PR-mention text.
+_RESULT_TEXT_WITH_PR = "PR #42 opened on dcetlin/Lobster. Closes #880."
+_RESULT_TEXT_WITH_URL_PR = "https://github.com/dcetlin/Lobster/pull/99 was merged."
+_RESULT_TEXT_WITH_COMMIT = "commit abc1234 was merged to main."
+_RESULT_TEXT_WITH_FILE = "wrote ~/lobster-workspace/foo.py as output."
+_RESULT_TEXT_EMPTY = ""
+
+
+class TestExtractOutcomeRefs:
+    """
+    Behavioral tests for _extract_outcome_refs — typed provenance ref extraction.
+
+    All tests operate on the public behavior (returned list contents) and treat
+    the regex internals as implementation details.
+    """
+
+    def test_pr_mention_produces_pr_ref_with_pearl_category(self) -> None:
+        refs = _extract_outcome_refs(_RESULT_TEXT_WITH_PR, repo="dcetlin/Lobster")
+        pr_refs = [r for r in refs if r["type"] == "pr"]
+        assert len(pr_refs) >= 1, "PR mention must produce at least one pr ref"
+        assert pr_refs[0]["category"] == "pearl", "PR refs must be categorized as pearl"
+        assert "dcetlin/Lobster#42" in [r["ref"] for r in pr_refs]
+
+    def test_pr_url_produces_pr_ref(self) -> None:
+        refs = _extract_outcome_refs(_RESULT_TEXT_WITH_URL_PR, repo="dcetlin/Lobster")
+        pr_refs = [r for r in refs if r["type"] == "pr"]
+        assert any("99" in r["ref"] for r in pr_refs), (
+            "GitHub pull URL must produce a pr ref containing the PR number"
+        )
+
+    def test_closes_keyword_produces_issue_ref_with_seed_category(self) -> None:
+        refs = _extract_outcome_refs(_RESULT_TEXT_WITH_PR, repo="dcetlin/Lobster")
+        issue_refs = [r for r in refs if r["type"] == "issue"]
+        assert len(issue_refs) >= 1, "'Closes #N' must produce an issue ref"
+        assert issue_refs[0]["category"] == "seed", "Issue refs must be categorized as seed"
+        assert "dcetlin/Lobster#880" in [r["ref"] for r in issue_refs]
+
+    def test_file_path_produces_file_ref_with_pearl_category(self) -> None:
+        refs = _extract_outcome_refs(_RESULT_TEXT_WITH_FILE, repo="dcetlin/Lobster")
+        file_refs = [r for r in refs if r["type"] == "file"]
+        assert len(file_refs) >= 1, "File path mention must produce a file ref"
+        assert file_refs[0]["category"] == "pearl", "File refs must be categorized as pearl"
+        assert any("foo.py" in r["ref"] for r in file_refs)
+
+    def test_commit_sha_with_commit_keyword_produces_commit_ref(self) -> None:
+        refs = _extract_outcome_refs(_RESULT_TEXT_WITH_COMMIT, repo="dcetlin/Lobster")
+        commit_refs = [r for r in refs if r["type"] == "commit"]
+        assert len(commit_refs) >= 1, "commit SHA + 'commit' keyword must produce a commit ref"
+        assert commit_refs[0]["category"] == "pearl", "Commit refs must be categorized as pearl"
+
+    def test_commit_sha_without_commit_keyword_is_not_extracted(self) -> None:
+        # SHA-looking strings without "commit" nearby must not be extracted
+        # to avoid false positives in arbitrary hex content.
+        text = "Hash value: abc1234ef5 in the output."
+        refs = _extract_outcome_refs(text, repo="dcetlin/Lobster")
+        commit_refs = [r for r in refs if r["type"] == "commit"]
+        assert len(commit_refs) == 0, (
+            "SHA-looking strings without 'commit' keyword must not produce commit refs"
+        )
+
+    def test_empty_text_produces_no_refs(self) -> None:
+        refs = _extract_outcome_refs(_RESULT_TEXT_EMPTY, repo="dcetlin/Lobster")
+        assert refs == [], "Empty result text must produce an empty ref list"
+
+    def test_deduplication_prevents_duplicate_refs(self) -> None:
+        # Mentioning the same PR twice must produce exactly one ref
+        text = "PR #42 opened. See also PR #42 for details."
+        refs = _extract_outcome_refs(text, repo="dcetlin/Lobster")
+        pr_refs = [r for r in refs if r["type"] == "pr" and "42" in r["ref"]]
+        assert len(pr_refs) == 1, (
+            f"Duplicate PR mention must produce exactly one ref, got {len(pr_refs)}"
+        )
+
+    def test_repo_slug_is_used_in_ref_string(self) -> None:
+        text = "PR #7 opened."
+        refs = _extract_outcome_refs(text, repo="myorg/myrepo")
+        pr_refs = [r for r in refs if r["type"] == "pr"]
+        assert any("myorg/myrepo#7" in r["ref"] for r in pr_refs), (
+            "repo slug must be embedded in pr ref string"
+        )
+
+    def test_fixes_keyword_produces_issue_ref(self) -> None:
+        text = "Fixes #123 — bug corrected."
+        refs = _extract_outcome_refs(text, repo="dcetlin/Lobster")
+        issue_refs = [r for r in refs if r["type"] == "issue"]
+        assert any("123" in r["ref"] for r in issue_refs), (
+            "'Fixes #N' must produce an issue ref"
+        )
+
+    def test_all_ref_dicts_have_required_keys(self) -> None:
+        """Every ref dict must carry type, ref, and category — no partial objects."""
+        text = "PR #1 opened. Closes #2. Wrote ~/foo.py."
+        refs = _extract_outcome_refs(text, repo="dcetlin/Lobster")
+        for ref in refs:
+            assert "type" in ref, f"ref missing 'type': {ref}"
+            assert "ref" in ref, f"ref missing 'ref': {ref}"
+            assert "category" in ref, f"ref missing 'category': {ref}"
+
+
+# ---------------------------------------------------------------------------
+# Registry.update_artifacts — DB write (integration with in-memory DB)
+# ---------------------------------------------------------------------------
+
+class TestRegistryUpdateArtifacts:
+    """
+    Behavioral tests for Registry.update_artifacts.
+
+    Tests write to a real SQLite DB in tmp_path to verify the column is
+    written and readable via Registry.get().
+    """
+
+    def _create_uow(self, registry: Registry) -> str:
+        """Insert a UoW and return its ID."""
+        result = registry.upsert(
+            issue_number=9900,
+            title="Artifacts test UoW",
+            success_criteria="artifacts populated",
+        )
+        assert isinstance(result, UpsertInserted)
+        return result.id
+
+    def test_artifacts_stored_in_registry_after_update(self, tmp_path: Path) -> None:
+        """
+        After update_artifacts, registry.get() must return a UoW with the artifacts
+        field populated matching what was written.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id = self._create_uow(registry)
+
+        artifacts = [
+            {"type": "pr", "ref": "dcetlin/Lobster#42", "category": "pearl"},
+            {"type": "issue", "ref": "dcetlin/Lobster#880", "category": "seed"},
+        ]
+        registry.update_artifacts(uow_id, artifacts)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.artifacts is not None, "artifacts must be populated after update_artifacts"
+        assert len(uow.artifacts) == 2
+        assert uow.artifacts[0]["type"] == "pr"
+        assert uow.artifacts[1]["type"] == "issue"
+
+    def test_empty_artifacts_list_does_not_write(self, tmp_path: Path) -> None:
+        """
+        Calling update_artifacts with an empty list must be a no-op — the artifacts
+        column must remain NULL (no noisy NULL→'[]' writes).
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id = self._create_uow(registry)
+
+        registry.update_artifacts(uow_id, [])
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.artifacts is None, (
+            "Empty artifacts list must leave the column NULL — no write must occur"
+        )
+
+    def test_artifacts_overwritten_on_second_call(self, tmp_path: Path) -> None:
+        """
+        Calling update_artifacts twice must overwrite the first value with the second.
+        The field is derived fresh from result_text each time; replacement is idempotent.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id = self._create_uow(registry)
+
+        first = [{"type": "pr", "ref": "dcetlin/Lobster#1", "category": "pearl"}]
+        second = [{"type": "issue", "ref": "dcetlin/Lobster#2", "category": "seed"}]
+        registry.update_artifacts(uow_id, first)
+        registry.update_artifacts(uow_id, second)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.artifacts is not None
+        assert uow.artifacts[0]["type"] == "issue", (
+            "Second call to update_artifacts must overwrite the first value"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: artifacts populated from write_result via maybe_complete_wos_uow
+# ---------------------------------------------------------------------------
+
+#: Expected artifact count for a result_text mentioning both a PR and an issue.
+EXPECTED_ARTIFACT_COUNT_PR_AND_ISSUE = 2
+
+
+class TestArtifactPopulationEndToEnd:
+    """
+    End-to-end tests verifying that maybe_complete_wos_uow extracts artifacts
+    from result_text and populates the registry artifacts field.
+    """
+
+    def test_artifacts_populated_when_result_mentions_pr_and_issue(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        When result_text mentions a PR and an issue, both refs must appear in
+        the registry artifacts field after maybe_complete_wos_uow completes.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id = _seed_uow_at_status(registry, "executing", output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+        result_text = "PR #42 opened. Closes #880."
+
+        with patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {
+                 "REGISTRY_DB_PATH": str(db_path),
+                 "LOBSTER_WOS_REPO": "dcetlin/Lobster",
+             }):
+            maybe_complete_wos_uow(task_id, WRITE_RESULT_SUCCESS_STATUS, result_text=result_text)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.artifacts is not None, (
+            "artifacts must be populated after write_result with PR/issue mentions"
+        )
+        assert len(uow.artifacts) >= EXPECTED_ARTIFACT_COUNT_PR_AND_ISSUE, (
+            f"Expected at least {EXPECTED_ARTIFACT_COUNT_PR_AND_ISSUE} artifact refs "
+            f"(PR #42 + issue #880), got {len(uow.artifacts)}: {uow.artifacts}"
+        )
+        types_found = {r["type"] for r in uow.artifacts}
+        assert "pr" in types_found, "PR ref must be present in artifacts"
+        assert "issue" in types_found, "Issue ref must be present in artifacts"
+
+    def test_artifacts_not_set_when_result_text_is_empty(self, tmp_path: Path) -> None:
+        """
+        When result_text is empty (subagent sent no meaningful output), the registry
+        artifacts field must remain NULL — no noisy empty-list write.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id = _seed_uow_at_status(registry, "executing", output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        with patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {
+                 "REGISTRY_DB_PATH": str(db_path),
+                 "LOBSTER_WOS_REPO": "dcetlin/Lobster",
+             }):
+            maybe_complete_wos_uow(task_id, WRITE_RESULT_SUCCESS_STATUS, result_text=None)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.artifacts is None, (
+            "artifacts must remain NULL when result_text is empty — no noisy write"
+        )
+
+    def test_uow_still_transitions_when_artifact_extraction_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        If artifact extraction raises an exception (e.g. corrupt text, import error),
+        the UoW must still transition to ready-for-steward — artifact enrichment is
+        non-fatal by design.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id = _seed_uow_at_status(registry, "executing", output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        with patch("orchestration.wos_completion._extract_outcome_refs",
+                   side_effect=RuntimeError("simulated extraction failure")), \
+             patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {
+                 "REGISTRY_DB_PATH": str(db_path),
+                 "LOBSTER_WOS_REPO": "dcetlin/Lobster",
+             }):
+            maybe_complete_wos_uow(
+                task_id, WRITE_RESULT_SUCCESS_STATUS, result_text="PR #1 opened."
+            )
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.status == UoWStatus.READY_FOR_STEWARD, (
+            "UoW must reach ready-for-steward even when artifact extraction fails"
+        )


### PR DESCRIPTION
## What problem does this solve?

Before this change, when a WOS subagent completed work and called `write_result`, the provenance of that work was invisible to the registry. A subagent might report "PR #42 opened, closes #880" but the registry only recorded `status = ready-for-steward` — no structured pointer to what was produced. The steward and retrospective job had to parse result files (or skip the causal chain entirely) to answer "which seeds were consumed this week?" and "which UoWs produced PRs?"

This change makes the causal chain traversable from the registry, without file I/O.

## What changed

**Registry schema (migration 0011):** adds `artifacts TEXT NULL` to `uow_registry`. Stores a JSON array of typed ref objects.

**`_extract_outcome_refs(text, repo)` — pure function:** extracts typed refs from write_result text:
- `pr`: `PR #N`, `pull request #N`, or `/pull/N` URLs → category `pearl`
- `issue`: `issue #N`, `closes #N`, `fixes #N` → category `seed`
- `file`: home-relative paths (`.py`, `.md`, `.yaml`, `.json`, etc.) → category `pearl`
- `commit`: 7–40 hex SHA preceded by the word "commit" → category `pearl`

SHA extraction is keyword-gated (`commit` must appear near the hex string) to avoid false positives in file content. A denylist (`dead`, `beef`, `cafe`, `babe`, `face`, `fade`) filters common English hex-looking words.

**`Registry.update_artifacts(uow_id, artifacts)`:** writes the ref list to the `artifacts` column. No-op on empty list (avoids noisy `NULL→'[]'` writes). Idempotent on repeat calls.

**`maybe_complete_wos_uow` (wos_completion.py):** after backprop and result file enrichment, calls `_extract_outcome_refs` then `registry.update_artifacts`. Non-fatal — artifact extraction failure is logged and swallowed; the UoW transition already succeeded before this point.

## Before/after flow

```
write_result arrives
      |
      +-- complete_uow() [registry: executing -> ready-for-steward]
      |
      +-- _backpropagate_result_to_output_file()  [file I/O]
      |
      +-- _enrich_result_file()  [file I/O: adds summary + refs to result.json]
      |
      +-- _extract_outcome_refs() + update_artifacts()  [NEW: registry write]
      |      ^ extracts typed {type, ref, category} list from result_text
      |      ^ non-fatal: failure logged, transition not blocked
      |
      +-- _post_closeout_comment_if_github()  [gh subprocess]
      |
      +-- _stamp_issue_on_completion()  [gh subprocess]
```

The `artifacts` field is now populated at the registry layer, making it queryable without touching the filesystem.

## What was not changed

- The `write_result` MCP tool interface is unchanged.
- The result.json enrichment path (`_enrich_result_file`) is unchanged — it continues to write `refs` to the result file. The registry artifacts field is additive.
- No historical UoWs are backfilled (forward-only).

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py -v` — 69 passed, 0 failed (includes 24 new tests)
- [x] Pre-existing test suite check: wos_dashboard (7 failures) and executor/steward tests (import errors) confirmed pre-existing on base branch before any changes
- [ ] Live integration test — not applicable: change is purely registry-internal; no Telegram output, no external service calls, no systemd or cron changes

## Manual test

N/A — this change writes to the SQLite registry only. No external services, no Telegram output, no systemd/cron. Unit tests exercise the DB write path against real SQLite in `tmp_path`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (see above)
- [x] User-visible outcome verified — N/A: this is a registry enrichment, not a user-facing change
- [x] Side-effect audit complete: only writes to `uow_registry.artifacts` for completing UoWs; no floods, no mass sends, no unintended volume
- [x] External service calls: none introduced

Closes #880.