### PR TITLE
feat(wos): add route_callback_message for compaction-resilient callback dispatch (issue #901)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -439,7 +439,7 @@ Always pass correct `source` to `send_reply`.
 4. "delete-confirm-no-<slug>": send_reply "Deletion discarded."
 5. "job-confirm-yes-<name>": retrieve parked job from memory, Task(lobster-generalist), send_reply "Job dispatched."
 6. "job-confirm-no-<name>": send_reply "Job cancelled."
-7. data.startswith("decide_retry:") or data.startswith("decide_close:"): result = route_callback_message(msg) from src.orchestration.dispatcher_handlers — import and call this function; it returns {"action": "send_reply", "text": <result>, "chat_id": <chat_id>, "handled": True}. Send the reply: send_reply(chat_id=result["chat_id"], text=result["text"], source=source, reply_to_message_id=msg.get("original_telegram_message_id")). This is the compaction-resilient path.
+7. call route_callback_message(msg) — from src.orchestration.dispatcher_handlers import route_callback_message; result = route_callback_message(msg). If result["handled"] is True: send_reply(chat_id=result["chat_id"], text=result["text"], source=source, reply_to_message_id=msg.get("original_telegram_message_id")); mark_processed(message_id); done. If result["handled"] is False: fall through to step 8.
 8. else: send_reply f"Unknown callback: {data}"
 9. mark_processed(message_id)
 ```

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -439,10 +439,9 @@ Always pass correct `source` to `send_reply`.
 4. "delete-confirm-no-<slug>": send_reply "Deletion discarded."
 5. "job-confirm-yes-<name>": retrieve parked job from memory, Task(lobster-generalist), send_reply "Job dispatched."
 6. "job-confirm-no-<name>": send_reply "Job cancelled."
-7. data.startswith("decide_retry:"): uow_id = data[len("decide_retry:"):]; import sys; sys.path.insert(0, "/home/lobster/lobster"); from src.orchestration.registry import Registry; from src.orchestration.paths import REGISTRY_DB; from src.orchestration.dispatcher_handlers import handle_decide_retry; registry = Registry(REGISTRY_DB); reply = handle_decide_retry(uow_id, registry=registry); send_reply(chat_id=chat_id, text=reply, source=source, reply_to_message_id=msg.get("original_telegram_message_id"))
-8. data.startswith("decide_close:"): uow_id = data[len("decide_close:"):]; import sys; sys.path.insert(0, "/home/lobster/lobster"); from src.orchestration.registry import Registry; from src.orchestration.paths import REGISTRY_DB; from src.orchestration.dispatcher_handlers import handle_decide_close; registry = Registry(REGISTRY_DB); reply = handle_decide_close(uow_id, registry=registry); send_reply(chat_id=chat_id, text=reply, source=source, reply_to_message_id=msg.get("original_telegram_message_id"))
-9. else: send_reply f"Unknown callback: {data}"
-10. mark_processed(message_id)
+7. data.startswith("decide_retry:") or data.startswith("decide_close:"): result = route_callback_message(msg) from src.orchestration.dispatcher_handlers — import and call this function; it returns {"action": "send_reply", "text": <result>, "chat_id": <chat_id>, "handled": True}. Send the reply: send_reply(chat_id=result["chat_id"], text=result["text"], source=source, reply_to_message_id=msg.get("original_telegram_message_id")). This is the compaction-resilient path.
+8. else: send_reply f"Unknown callback: {data}"
+9. mark_processed(message_id)
 ```
 
 ### Telegram-specific

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -15,6 +15,7 @@ The dispatcher calls these handlers when it recognizes:
   decide retry <uow-id>                → handle_decide_retry(uow_id, registry)
   decide close <uow-id>                → handle_decide_close(uow_id, registry)
   type: "wos_execute"                  → handle_wos_execute(uow_id, instructions, output_ref)
+  type: "callback" (decide_retry/close)→ route_callback_message(msg)
 
 ## Compaction-resilient dispatch
 
@@ -632,3 +633,101 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
 
     # Unreachable given the guard above, but satisfies exhaustiveness checkers
     raise ValueError(f"route_wos_message: no branch for type {msg_type!r}")
+
+
+# ---------------------------------------------------------------------------
+# Compaction-resilient callback dispatch
+#
+# The dispatcher calls route_callback_message(msg) for type="callback" messages
+# instead of relying on prose instructions that may not survive context compaction.
+#
+# Dispatcher integration (add to main loop):
+#
+#     from src.orchestration.dispatcher_handlers import route_callback_message
+#
+#     if msg.get("type") == "callback":
+#         result = route_callback_message(msg)
+#         # result["action"] tells the dispatcher what to do:
+#         #   "send_reply" → send result["text"] to result["chat_id"]
+#         # mark_processed(message_id) after sending the reply
+# ---------------------------------------------------------------------------
+
+#: Callback data prefixes that this router handles.
+CALLBACK_DATA_HANDLERS: frozenset[str] = frozenset({
+    "decide_retry:",
+    "decide_close:",
+})
+
+
+def route_callback_message(msg: dict[str, Any], *, registry: "Registry | None" = None) -> dict[str, Any]:
+    """
+    Route a ``type: "callback"`` inbox message from an inline keyboard button press.
+
+    This is the compaction-resilient entry point for callback routing.  The
+    dispatcher should import and call this function rather than relying on prose
+    boot instructions that can be lost under context compaction.
+
+    Currently handles:
+    - ``decide_retry:<uow_id>`` — retry a blocked UoW (calls ``handle_decide_retry``)
+    - ``decide_close:<uow_id>`` — close a blocked UoW (calls ``handle_decide_close``)
+
+    All other callback_data values fall through to an "unknown callback" reply,
+    which lets the dispatcher handle other callback types (job-confirm, delete-confirm,
+    etc.) via its existing prose routing logic.
+
+    Args:
+        msg: The raw inbox message dict.  Must contain ``callback_data`` and
+             ``chat_id``.
+        registry: Optional Registry instance.  If omitted, a default Registry()
+             is constructed (uses the production DB path).  Pass an explicit
+             instance in tests to use a temp DB.
+
+    Returns:
+        A dict with:
+
+        ``action`` (str):
+            Always ``"send_reply"`` — the dispatcher must call send_reply.
+
+        ``text`` (str):
+            The reply text to send to the user.
+
+        ``chat_id`` (int | str):
+            The chat to reply to (echoed from ``msg["chat_id"]``).
+
+        ``handled`` (bool):
+            ``True`` if callback_data matched a known WOS pattern;
+            ``False`` if the dispatcher should fall through to its own
+            handling (e.g. job-confirm-yes, delete-confirm-yes).
+
+    Example dispatcher integration::
+
+        from src.orchestration.dispatcher_handlers import route_callback_message
+
+        if msg.get("type") == "callback":
+            result = route_callback_message(msg)
+            if result["handled"]:
+                send_reply(chat_id=result["chat_id"], text=result["text"],
+                           message_id=message_id)
+            else:
+                # fall through to prose-based job-confirm / delete-confirm logic
+                ...
+    """
+    from .registry import Registry  # local import to keep module importable without DB
+
+    data: str = msg.get("callback_data", "")
+    chat_id = msg.get("chat_id")
+
+    if data.startswith("decide_retry:"):
+        uow_id = data[len("decide_retry:"):]
+        reg = registry if registry is not None else Registry()
+        text = handle_decide_retry(uow_id, registry=reg)
+        return {"action": "send_reply", "text": text, "chat_id": chat_id, "handled": True}
+
+    if data.startswith("decide_close:"):
+        uow_id = data[len("decide_close:"):]
+        reg = registry if registry is not None else Registry()
+        text = handle_decide_close(uow_id, registry=reg)
+        return {"action": "send_reply", "text": text, "chat_id": chat_id, "handled": True}
+
+    # Not a WOS callback — signal the dispatcher to use its own handling
+    return {"action": "send_reply", "text": f"Unknown callback: {data}", "chat_id": chat_id, "handled": False}

--- a/tests/unit/test_orchestration/test_dispatcher_integration.py
+++ b/tests/unit/test_orchestration/test_dispatcher_integration.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 import pytest
 
-from src.orchestration.dispatcher_handlers import handle_approve, handle_confirm, handle_decide, handle_decide_defer, handle_wos_execute, handle_wos_status, handle_wos_unblock, route_wos_message, WOS_MESSAGE_TYPE_DISPATCH
+from src.orchestration.dispatcher_handlers import handle_approve, handle_confirm, handle_decide, handle_decide_defer, handle_wos_execute, handle_wos_status, handle_wos_unblock, route_wos_message, route_callback_message, CALLBACK_DATA_HANDLERS, WOS_MESSAGE_TYPE_DISPATCH
 
 
 @pytest.fixture
@@ -729,3 +729,103 @@ class TestDecideCallbackParseRoundtrip:
             assert parsed == uow_id, (
                 f"UoW ID with hyphens must survive round-trip through {prefix!r}"
             )
+
+
+class TestRouteCallbackMessage:
+    """Tests for route_callback_message — compaction-resilient callback dispatch."""
+
+    def test_decide_retry_returns_send_reply_action(self, registry):
+        """decide_retry callback returns action='send_reply'."""
+        uow_id = registry.upsert(
+            issue_number=901, title="Retry callback test", sweep_date="2026-04-24",
+            success_criteria="Test."
+        ).id
+        registry.set_status_direct(uow_id, "blocked")
+        msg = {"callback_data": f"decide_retry:{uow_id}", "chat_id": 12345}
+        result = route_callback_message(msg, registry=registry)
+        assert result["action"] == "send_reply"
+
+    def test_decide_retry_returns_handled_true(self, registry):
+        """decide_retry callback sets handled=True."""
+        uow_id = registry.upsert(
+            issue_number=901, title="Retry handled test", sweep_date="2026-04-24",
+            success_criteria="Test."
+        ).id
+        registry.set_status_direct(uow_id, "blocked")
+        msg = {"callback_data": f"decide_retry:{uow_id}", "chat_id": 12345}
+        result = route_callback_message(msg, registry=registry)
+        assert result["handled"] is True
+
+    def test_decide_retry_echoes_chat_id(self, registry):
+        """route_callback_message echoes chat_id from the message."""
+        uow_id = registry.upsert(
+            issue_number=901, title="ChatId echo test", sweep_date="2026-04-24",
+            success_criteria="Test."
+        ).id
+        registry.set_status_direct(uow_id, "blocked")
+        msg = {"callback_data": f"decide_retry:{uow_id}", "chat_id": 99999}
+        result = route_callback_message(msg, registry=registry)
+        assert result["chat_id"] == 99999
+
+    def test_decide_retry_transitions_blocked_uow(self, registry):
+        """decide_retry callback transitions a blocked UoW to ready-for-steward."""
+        uow_id = registry.upsert(
+            issue_number=901, title="Retry transition test", sweep_date="2026-04-24",
+            success_criteria="Test."
+        ).id
+        registry.set_status_direct(uow_id, "blocked")
+        msg = {"callback_data": f"decide_retry:{uow_id}", "chat_id": 12345}
+        route_callback_message(msg, registry=registry)
+        uow = registry.get(uow_id)
+        assert uow.status == "ready-for-steward"
+
+    def test_decide_close_returns_send_reply_action(self, registry):
+        """decide_close callback returns action='send_reply'."""
+        uow_id = registry.upsert(
+            issue_number=901, title="Close callback test", sweep_date="2026-04-24",
+            success_criteria="Test."
+        ).id
+        registry.set_status_direct(uow_id, "blocked")
+        msg = {"callback_data": f"decide_close:{uow_id}", "chat_id": 12345}
+        result = route_callback_message(msg, registry=registry)
+        assert result["action"] == "send_reply"
+
+    def test_decide_close_returns_handled_true(self, registry):
+        """decide_close callback sets handled=True."""
+        uow_id = registry.upsert(
+            issue_number=901, title="Close handled test", sweep_date="2026-04-24",
+            success_criteria="Test."
+        ).id
+        registry.set_status_direct(uow_id, "blocked")
+        msg = {"callback_data": f"decide_close:{uow_id}", "chat_id": 12345}
+        result = route_callback_message(msg, registry=registry)
+        assert result["handled"] is True
+
+    def test_decide_close_transitions_blocked_to_failed(self, registry):
+        """decide_close callback transitions a blocked UoW to failed."""
+        uow_id = registry.upsert(
+            issue_number=901, title="Close transition test", sweep_date="2026-04-24",
+            success_criteria="Test."
+        ).id
+        registry.set_status_direct(uow_id, "blocked")
+        msg = {"callback_data": f"decide_close:{uow_id}", "chat_id": 12345}
+        route_callback_message(msg, registry=registry)
+        uow = registry.get(uow_id)
+        assert uow.status == "failed"
+
+    def test_unknown_callback_returns_handled_false(self):
+        """Non-WOS callbacks return handled=False so dispatcher can handle them."""
+        msg = {"callback_data": "job-confirm-yes-some-job", "chat_id": 12345}
+        result = route_callback_message(msg)
+        assert result["handled"] is False
+
+    def test_unknown_callback_returns_send_reply_action(self):
+        """Unknown callbacks still return action='send_reply'."""
+        msg = {"callback_data": "delete-confirm-no-some-slug", "chat_id": 12345}
+        result = route_callback_message(msg)
+        assert result["action"] == "send_reply"
+
+    def test_callback_data_handlers_contains_expected_prefixes(self):
+        """CALLBACK_DATA_HANDLERS contains the two WOS prefixes."""
+        assert "decide_retry:" in CALLBACK_DATA_HANDLERS
+        assert "decide_close:" in CALLBACK_DATA_HANDLERS


### PR DESCRIPTION
## Summary

- Adds `route_callback_message(msg, *, registry=None)` to `dispatcher_handlers.py` — a Python function that handles `decide_retry:<uow_id>` and `decide_close:<uow_id>` inline button callbacks directly, calling the existing pure handlers (`handle_decide_retry` / `handle_decide_close`)
- Returns `{"action": "send_reply", "text": ..., "chat_id": ..., "handled": bool}` where `handled=False` signals non-WOS callbacks to fall through to existing prose routing
- Adds `CALLBACK_DATA_HANDLERS` frozenset documenting handled prefixes
- Updates `sys.dispatcher.bootup.md` to replace prose steps 7-8 with a single instruction to call `route_callback_message` — a Python import that survives compaction, unlike prose

## Why this PR exists

The prior fix (commit 6bdf068) wired the buttons via prose in the dispatcher bootup. Prose is lost under context compaction. After compaction, the buttons become dead again. This PR applies the same compaction-resilient pattern as `route_wos_message` / `WOS_MESSAGE_TYPE_DISPATCH` (issue #856) to callback routing.

## Test plan

- [ ] 10 new tests in `TestRouteCallbackMessage` cover: status transitions (retry → ready-for-steward, close → failed), `handled` flag, `chat_id` echo, unknown callback fallthrough (`handled=False`)
- [ ] All 81 previously-passing dispatcher integration tests still pass
- [ ] Pre-existing failure (`test_is_bootup_candidate_gate_active_reflects_flag`) is due to missing `src.ooda` module, unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)