### PR TITLE
feat: juice sensing and dispatch priority for WOS steward cycle

### DIFF
--- a/oracle/decisions.md
+++ b/oracle/decisions.md
@@ -1,0 +1,41 @@
+# Architecture Decisions
+
+Logged durable design choices that affect observable system behavior.
+
+---
+
+## ADR-001: Juice-First Dispatch Ordering for Ready-for-Steward UoWs
+
+**Date:** 2026-04-24
+**Status:** Accepted
+
+### Authorizing Design Thread
+
+- Issue #886: Initial metabolic-juice concept and WOS integration intent
+- Issue #888: Juice sensing protocol and signal definitions
+- Issue #889: Observable signals distinguishing juice from indeterminate state
+
+### Approval
+
+Dan Cetlin approved: "good lets implement" — 2026-04-24.
+
+### Decision
+
+UoWs in the `ready-for-steward` state are dispatched in juice-first order:
+UoWs with `juice_quality='juice'` are placed at the front of the dispatch
+queue ahead of UoWs with null or absent juice quality.
+
+### Constraint
+
+Juice-first ordering activates only for `ready-for-steward` UoWs. The
+shard-stream gate already ensures null-juice UoWs are not starved: they
+remain eligible for dispatch and are not blocked by the presence of
+juiced UoWs.
+
+### Follow-on (Advisory from Oracle)
+
+Starvation mitigation sequencing gap: the current implementation does not
+guarantee a dispatch slot for null-juice UoWs within a bounded time window
+when juiced UoWs are continuously present. A follow-on task should evaluate
+whether a fairness slot (e.g., every N cycles, promote the oldest null-juice
+ready-for-steward UoW to the front) is warranted as load increases.

--- a/src/orchestration/juice.py
+++ b/src/orchestration/juice.py
@@ -1,0 +1,507 @@
+"""
+Juice sensing for the WOS Steward dispatch layer.
+
+Juice, as defined in philosophy/frontier/metabolic-juice.md, is pre-metabolic
+aliveness without determinate form. In the WOS pipeline, it manifests as a
+quality on the steward prescription — a signal that a thread has live
+generative momentum and should be prioritized for dispatch.
+
+Design principles (from the juice-uow-integration-spec.md):
+
+1. Juice is re-evaluated on every steward cycle (Option C). It is never
+   automatically persisted from one cycle to the next — the steward must
+   re-assess it each time. This prevents stale juice from accumulating.
+
+2. juice_rationale is mandatory when juice is asserted. A prescription that
+   cannot name *what is alive and why* should not assert juice.
+
+3. Juice is a soft priority signal (slot acquisition, not preemption). High-
+   juice UoWs go to the front of the dispatch queue; they do not preempt
+   in-flight UoWs.
+
+4. All logic here is in pure functions — no side effects, no DB writes.
+   The caller (steward.py) is responsible for writing juice_quality and
+   juice_rationale back to the registry.
+
+Observable signals that distinguish juice from indeterminate (issue #889):
+  - oracle_approval_rate: ratio of oracle_approved to total execution cycles
+    in the UoW's audit history. High rate → execution is consistently passing
+    oracle review → thread is productive, not stuck.
+  - completion_rate: ratio of done/pearl outcomes to total execution outcomes.
+    High rate → UoW threads in this family are closing productively.
+  - completed_prerequisites: count of completed prerequisite UoWs (done/pearl).
+    More completed prerequisites → clearer path for this UoW.
+  - recent_oracle_approved: whether the most recent oracle verdict was approved.
+    Recency matters — a recent approval is stronger signal than a historical one.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.orchestration.registry import Registry, UoW
+
+log = logging.getLogger("juice")
+
+
+# ---------------------------------------------------------------------------
+# Named threshold constants — derived from spec signals.
+# All thresholds reference these constants so tests and implementation agree.
+# ---------------------------------------------------------------------------
+
+# Minimum oracle approval rate to qualify for juice (50% of execution cycles
+# passed oracle review). Prescriptions below this rate are more often rejected
+# than approved — not a productive thread.
+JUICE_MIN_ORACLE_APPROVAL_RATE: float = 0.5
+
+# Minimum number of recent oracle approvals to trust the rate signal.
+# With fewer executions, the rate is too noisy to be meaningful.
+JUICE_MIN_ORACLE_SAMPLE_SIZE: int = 2
+
+# Minimum completion rate (done outcomes / total executions) to qualify.
+# At least 30% of executions on related threads should have resolved productively.
+JUICE_MIN_COMPLETION_RATE: float = 0.3
+
+# Number of completed prerequisites that adds a positive signal.
+# At least 1 completed prerequisite means the UoW has some cleared ground.
+JUICE_PREREQUISITE_POSITIVE_THRESHOLD: int = 1
+
+# Weight contributions for each signal to the aggregate juice score.
+# Scores are in [0.0, 1.0]. The aggregate score is a weighted average.
+# Weights sum to 1.0 — no normalization needed after the weighted sum.
+_WEIGHT_ORACLE_RATE = 0.45
+_WEIGHT_COMPLETION_RATE = 0.35
+_WEIGHT_PREREQUISITES = 0.20
+
+
+# ---------------------------------------------------------------------------
+# Input/output value types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class JuiceSignals:
+    """
+    Observable signals extracted from audit history for a UoW.
+
+    All fields are derived from public registry data — no private DB access.
+    This type is pure data; it carries no methods that produce side effects.
+
+    Fields:
+        oracle_approval_count: Number of audit entries with event='oracle_approved'.
+        total_execution_cycles: Number of audit entries with event='execution_complete'.
+        done_outcome_count: Number of audit entries with to_status='done'.
+        completed_prerequisite_count: Number of completed prerequisite UoWs.
+        recent_oracle_approved: True if the most recent oracle verdict was approved.
+    """
+    oracle_approval_count: int
+    total_execution_cycles: int
+    done_outcome_count: int
+    completed_prerequisite_count: int
+    recent_oracle_approved: bool
+
+
+@dataclass(frozen=True)
+class JuiceAssessment:
+    """
+    Result of a juice evaluation for a single UoW.
+
+    Fields:
+        score: Float in [0.0, 1.0]. Higher = more juice evidence.
+            None when there is insufficient data to score (e.g. no execution history).
+        has_juice: True when score >= the juice threshold AND rationale is non-empty.
+        rationale: Machine-generated prose explaining the juice assessment.
+            Non-empty only when has_juice=True.
+    """
+    score: float | None
+    has_juice: bool
+    rationale: str
+
+
+# ---------------------------------------------------------------------------
+# Signal extraction (pure functions)
+# ---------------------------------------------------------------------------
+
+def _extract_signals(audit_entries: list[dict[str, Any]]) -> JuiceSignals:
+    """
+    Extract observable juice signals from a UoW's audit log.
+
+    Pure function — reads from the provided list, no DB access.
+
+    Args:
+        audit_entries: List of audit log dicts for a single UoW, as returned
+            by _fetch_audit_entries() in steward.py. Each dict has at least
+            'event', 'to_status', and optionally 'note' keys.
+
+    Returns:
+        JuiceSignals with extracted counts and flags.
+    """
+    oracle_approval_count = 0
+    total_execution_cycles = 0
+    done_outcome_count = 0
+    recent_oracle_approved = False
+    last_oracle_verdict: bool | None = None
+
+    for entry in audit_entries:
+        event = entry.get("event", "")
+        to_status = entry.get("to_status")
+
+        if event == "oracle_approved":
+            oracle_approval_count += 1
+            last_oracle_verdict = True
+        elif event == "oracle_rejected":
+            last_oracle_verdict = False
+
+        if event == "execution_complete":
+            total_execution_cycles += 1
+
+        if to_status == "done":
+            done_outcome_count += 1
+
+    if last_oracle_verdict is not None:
+        recent_oracle_approved = last_oracle_verdict
+
+    return JuiceSignals(
+        oracle_approval_count=oracle_approval_count,
+        total_execution_cycles=total_execution_cycles,
+        done_outcome_count=done_outcome_count,
+        # completed_prerequisite_count is passed in from outside — the steward
+        # or the registry caller provides this from related UoW queries.
+        completed_prerequisite_count=0,
+        recent_oracle_approved=recent_oracle_approved,
+    )
+
+
+def _extract_signals_with_prerequisites(
+    audit_entries: list[dict[str, Any]],
+    completed_prerequisite_count: int,
+) -> JuiceSignals:
+    """
+    Extract signals including prerequisite completion count.
+
+    This is the full signal extraction path. Use this when the caller
+    can supply the prerequisite count from a registry query.
+
+    Args:
+        audit_entries: UoW audit log entries.
+        completed_prerequisite_count: Number of done/completed prerequisite UoWs.
+            Pass 0 if the UoW has no prerequisites or they are unknown.
+
+    Returns:
+        JuiceSignals with all fields populated.
+    """
+    base = _extract_signals(audit_entries)
+    return JuiceSignals(
+        oracle_approval_count=base.oracle_approval_count,
+        total_execution_cycles=base.total_execution_cycles,
+        done_outcome_count=base.done_outcome_count,
+        completed_prerequisite_count=completed_prerequisite_count,
+        recent_oracle_approved=base.recent_oracle_approved,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scoring (pure functions)
+# ---------------------------------------------------------------------------
+
+def _score_oracle_approval(signals: JuiceSignals) -> float:
+    """
+    Compute the oracle approval sub-score in [0.0, 1.0].
+
+    Returns 0.0 when there is no execution history (no information = no juice
+    signal from oracle). Returns 0.0 when sample size is below the minimum
+    threshold (rate is too noisy to trust).
+
+    Pure function — no side effects.
+    """
+    if signals.total_execution_cycles < JUICE_MIN_ORACLE_SAMPLE_SIZE:
+        return 0.0
+    rate = signals.oracle_approval_count / signals.total_execution_cycles
+    # Recent approval multiplier: a recent approval amplifies the rate signal.
+    recency_boost = 1.2 if signals.recent_oracle_approved else 1.0
+    return min(1.0, rate * recency_boost)
+
+
+def _score_completion_rate(signals: JuiceSignals) -> float:
+    """
+    Compute the completion rate sub-score in [0.0, 1.0].
+
+    Higher done outcome rate within the UoW's execution history = more
+    productive thread. Returns 0.0 when there are no execution cycles.
+
+    Pure function — no side effects.
+    """
+    if signals.total_execution_cycles == 0:
+        return 0.0
+    return min(1.0, signals.done_outcome_count / signals.total_execution_cycles)
+
+
+def _score_prerequisites(signals: JuiceSignals) -> float:
+    """
+    Compute the prerequisite completion sub-score in [0.0, 1.0].
+
+    Binary: 1.0 when at least JUICE_PREREQUISITE_POSITIVE_THRESHOLD prerequisites
+    are completed; 0.0 otherwise. The steward passes this in from related UoW
+    queries via compute_juice().
+
+    Pure function — no side effects.
+    """
+    if signals.completed_prerequisite_count >= JUICE_PREREQUISITE_POSITIVE_THRESHOLD:
+        return 1.0
+    return 0.0
+
+
+def _aggregate_score(signals: JuiceSignals) -> float:
+    """
+    Aggregate the three sub-scores into a single juice score in [0.0, 1.0].
+
+    Weights: oracle_rate=0.45, completion_rate=0.35, prerequisites=0.20.
+    These weights reflect the spec's emphasis on oracle approval as the
+    strongest single signal of a productive thread.
+
+    Pure function — no side effects.
+    """
+    oracle_score = _score_oracle_approval(signals)
+    completion_score = _score_completion_rate(signals)
+    prerequisite_score = _score_prerequisites(signals)
+
+    return (
+        _WEIGHT_ORACLE_RATE * oracle_score
+        + _WEIGHT_COMPLETION_RATE * completion_score
+        + _WEIGHT_PREREQUISITES * prerequisite_score
+    )
+
+
+# ---------------------------------------------------------------------------
+# Threshold — the score above which a UoW is considered juiced
+# ---------------------------------------------------------------------------
+
+# Minimum aggregate score to assert juice. Set above the oracle-only minimum
+# so that a barely-passing oracle rate alone is insufficient — at least one
+# other signal must contribute positively.
+JUICE_SCORE_THRESHOLD: float = 0.35
+
+# Delta threshold for writing juice back to the registry.
+# Juice is only written if the new score differs from the stored float by at
+# least this much — avoids churn on stable threads.
+JUICE_UPDATE_DELTA: float = 0.05
+
+
+# ---------------------------------------------------------------------------
+# JuiceSensor — the primary public interface
+# ---------------------------------------------------------------------------
+
+class JuiceSensor:
+    """
+    Computes juice signals from observable UoW history.
+
+    Design:
+    - JuiceSensor is stateless. Instantiate once and reuse across the steward cycle.
+    - All sensing logic is delegated to pure functions. JuiceSensor is the
+      composition layer, not the computation layer.
+    - The registry is used only for the prerequisite count query. All other
+      signals come from the audit_entries already fetched by the steward.
+
+    Usage in steward.py:
+        sensor = JuiceSensor()
+        assessment = sensor.assess(uow, audit_entries, registry)
+        if assessment.has_juice:
+            # write juice_quality='juice', juice_rationale=assessment.rationale
+    """
+
+    def assess(
+        self,
+        uow: "UoW",
+        audit_entries: list[dict[str, Any]],
+        registry: "Registry",
+    ) -> JuiceAssessment:
+        """
+        Assess the juice quality of a UoW from its observable signals.
+
+        This method is the single entry point for juice assessment. It:
+        1. Queries the registry for completed prerequisite count.
+        2. Extracts signals from audit_entries.
+        3. Computes an aggregate score.
+        4. Returns a JuiceAssessment with has_juice, score, and rationale.
+
+        No writes occur here. The caller is responsible for writing
+        juice_quality and juice_rationale back to the registry if has_juice=True.
+
+        Args:
+            uow: The Unit of Work being assessed.
+            audit_entries: All audit log entries for this UoW (already fetched).
+            registry: Registry instance for prerequisite count query.
+
+        Returns:
+            JuiceAssessment with score, has_juice, and rationale.
+        """
+        completed_prereqs = _count_completed_prerequisites(uow, registry)
+        signals = _extract_signals_with_prerequisites(audit_entries, completed_prereqs)
+        return _assess_from_signals(uow.id, signals)
+
+
+def _count_completed_prerequisites(uow: "UoW", registry: "Registry") -> int:
+    """
+    Count the number of completed prerequisite UoWs for this UoW.
+
+    A prerequisite is any UoW that is referenced by this UoW's trigger
+    and has reached done/failed/expired terminal status. We count only
+    'done' status as completed (failed/expired do not indicate productive
+    completion).
+
+    Returns 0 when the UoW has no trigger, the trigger references no
+    prerequisite UoWs, or the registry query fails (safe default).
+
+    Pure in effect — reads only, no writes.
+    """
+    trigger = uow.trigger
+    if not trigger or not isinstance(trigger, dict):
+        return 0
+
+    prerequisite_ids: list[str] = []
+    if "prerequisites" in trigger:
+        raw = trigger["prerequisites"]
+        if isinstance(raw, list):
+            prerequisite_ids = [str(p) for p in raw if p]
+
+    if not prerequisite_ids:
+        return 0
+
+    count = 0
+    for prereq_id in prerequisite_ids:
+        try:
+            prereq_uow = registry.get(prereq_id)
+            if prereq_uow is not None and str(prereq_uow.status) == "done":
+                count += 1
+        except Exception:
+            pass  # Registry error: treat this prerequisite as not completed
+
+    return count
+
+
+def _assess_from_signals(uow_id: str, signals: JuiceSignals) -> JuiceAssessment:
+    """
+    Compute a JuiceAssessment from extracted signals.
+
+    Separated from JuiceSensor.assess() so tests can exercise the scoring
+    logic directly without needing a registry or UoW instance.
+
+    Pure function — no side effects.
+
+    Args:
+        uow_id: Used only for log messages.
+        signals: Extracted juice signals.
+
+    Returns:
+        JuiceAssessment with score, has_juice, and rationale.
+    """
+    # No execution history at all — insufficient data, cannot assert juice.
+    if signals.total_execution_cycles == 0:
+        log.debug(
+            "juice_assess: %s — no execution history, score=None, has_juice=False",
+            uow_id,
+        )
+        return JuiceAssessment(score=None, has_juice=False, rationale="")
+
+    score = _aggregate_score(signals)
+
+    log.debug(
+        "juice_assess: %s — score=%.3f (oracle_rate=%.2f/%d, done=%d, prereqs=%d, recent_approved=%s)",
+        uow_id,
+        score,
+        signals.oracle_approval_count,
+        signals.total_execution_cycles,
+        signals.done_outcome_count,
+        signals.completed_prerequisite_count,
+        signals.recent_oracle_approved,
+    )
+
+    if score >= JUICE_SCORE_THRESHOLD:
+        rationale = _build_rationale(signals)
+        return JuiceAssessment(score=score, has_juice=True, rationale=rationale)
+
+    return JuiceAssessment(score=score, has_juice=False, rationale="")
+
+
+def _build_rationale(signals: JuiceSignals) -> str:
+    """
+    Build a human-readable rationale string for a juiced prescription.
+
+    The rationale names the alive thread and the signals that support the
+    juice assertion — directly satisfying the spec's "What is the juice?"
+    calibration requirement. Non-empty only when juice is being asserted.
+
+    Pure function — no side effects.
+    """
+    parts: list[str] = []
+
+    if signals.total_execution_cycles > 0:
+        rate = signals.oracle_approval_count / signals.total_execution_cycles
+        parts.append(
+            f"oracle approval rate {rate:.0%} over {signals.total_execution_cycles} cycle(s)"
+        )
+    if signals.recent_oracle_approved:
+        parts.append("most recent oracle verdict: approved")
+    if signals.done_outcome_count > 0:
+        parts.append(f"{signals.done_outcome_count} completed execution(s)")
+    if signals.completed_prerequisite_count >= JUICE_PREREQUISITE_POSITIVE_THRESHOLD:
+        parts.append(
+            f"{signals.completed_prerequisite_count} completed prerequisite(s)"
+        )
+
+    if not parts:
+        return "thread shows generative momentum"
+
+    return "live thread: " + "; ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Primary public function (spec interface: compute_juice)
+# ---------------------------------------------------------------------------
+
+def compute_juice(uow_id: str, registry: "Registry") -> float | None:
+    """
+    Compute the juice score for a UoW, identified by ID.
+
+    This is the primary entry point specified in the task brief. It:
+    1. Fetches the UoW from the registry (returns None if not found).
+    2. Fetches audit entries for the UoW.
+    3. Runs JuiceSensor.assess() and returns the numeric score.
+
+    Returns None when:
+    - The UoW is not found.
+    - There is no execution history (insufficient data to score).
+
+    Returns a float in [0.0, 1.0] otherwise.
+
+    Side effects: none — all writes are the caller's responsibility.
+
+    Args:
+        uow_id: The UoW identifier.
+        registry: Registry instance.
+
+    Returns:
+        float in [0.0, 1.0] if scoreable, None otherwise.
+    """
+    uow = registry.get(uow_id)
+    if uow is None:
+        log.warning("compute_juice: UoW %s not found", uow_id)
+        return None
+
+    # Fetch audit entries via the registry's internal connection — same pattern
+    # as _fetch_audit_entries in steward.py.
+    conn = registry._connect()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id ASC",
+            (uow_id,),
+        ).fetchall()
+        audit_entries = [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+    sensor = JuiceSensor()
+    assessment = sensor.assess(uow, audit_entries, registry)
+    return assessment.score

--- a/src/orchestration/juice.py
+++ b/src/orchestration/juice.py
@@ -231,11 +231,17 @@ def _score_completion_rate(signals: JuiceSignals) -> float:
     Higher done outcome rate within the UoW's execution history = more
     productive thread. Returns 0.0 when there are no execution cycles.
 
+    Returns 0.0 when the raw completion rate is below JUICE_MIN_COMPLETION_RATE
+    — below-minimum UoWs score zero on this dimension.
+
     Pure function — no side effects.
     """
     if signals.total_execution_cycles == 0:
         return 0.0
-    return min(1.0, signals.done_outcome_count / signals.total_execution_cycles)
+    rate = signals.done_outcome_count / signals.total_execution_cycles
+    if rate < JUICE_MIN_COMPLETION_RATE:
+        return 0.0
+    return min(1.0, rate)
 
 
 def _score_prerequisites(signals: JuiceSignals) -> float:
@@ -490,17 +496,7 @@ def compute_juice(uow_id: str, registry: "Registry") -> float | None:
         log.warning("compute_juice: UoW %s not found", uow_id)
         return None
 
-    # Fetch audit entries via the registry's internal connection — same pattern
-    # as _fetch_audit_entries in steward.py.
-    conn = registry._connect()
-    try:
-        rows = conn.execute(
-            "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id ASC",
-            (uow_id,),
-        ).fetchall()
-        audit_entries = [dict(r) for r in rows]
-    finally:
-        conn.close()
+    audit_entries = registry.fetch_audit_entries(uow_id)
 
     sensor = JuiceSensor()
     assessment = sensor.assess(uow, audit_entries, registry)

--- a/src/orchestration/migrations/0013_add_juice_fields.sql
+++ b/src/orchestration/migrations/0013_add_juice_fields.sql
@@ -1,0 +1,35 @@
+-- Migration 0013: add juice_quality and juice_rationale fields for dispatch priority.
+--
+-- Problem:
+--   The steward has no structural signal to distinguish prescriptions with live
+--   generative momentum (juice) from stalled/indeterminate threads. Without this,
+--   dispatch priority is implicit LIFO (newest-first), which gives no preference
+--   to threads the steward recognises as productively alive.
+--
+-- Fix:
+--   juice_quality TEXT NULL — 'juice' when the steward asserts live momentum;
+--     NULL when not asserted. Re-evaluated on every prescription cycle
+--     (Option C from the spec: juice must be re-earned each cycle, not persisted
+--     automatically). Indexed for efficient ORDER BY in dispatch query.
+--   juice_rationale TEXT NULL — mandatory prose when juice_quality='juice'.
+--     Records *what* is alive and why (the "What is the juice?" calibration).
+--     NULL when juice_quality is NULL. The schema enforces this as a convention
+--     rather than a DB CHECK constraint so that partial writes during migration
+--     do not break existing rows.
+--
+-- Dispatch query impact (steward.py):
+--   SELECT * FROM uow_registry WHERE status = 'ready-for-steward'
+--   ORDER BY
+--     CASE WHEN juice_quality = 'juice' THEN 0 ELSE 1 END ASC,
+--     created_at DESC
+--
+-- Backward compatibility:
+--   Existing UoWs get juice_quality=NULL and juice_rationale=NULL by default.
+--   The steward treats NULL as non-juiced on the first post-migration cycle.
+
+ALTER TABLE uow_registry ADD COLUMN juice_quality TEXT;
+ALTER TABLE uow_registry ADD COLUMN juice_rationale TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_uow_juice_quality
+    ON uow_registry (juice_quality)
+    WHERE status = 'ready-for-steward';

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -244,6 +244,18 @@ class UoW:
     #   subject to file_scope overlap checks. NULL = no shard constraint.
     #   Example: 'wos-core', 'docs', 'tests'
     shard_id: str | None = None
+    # Juice dispatch priority fields (populated after migration 0013).
+    #
+    # juice_quality: 'juice' when the steward asserts live generative momentum;
+    #   NULL when not asserted. Re-evaluated on every prescription cycle (Option C
+    #   from the spec: juice must be re-earned each cycle, not persisted automatically).
+    #   The dispatch query sorts juice='juice' UoWs first among ready-for-steward
+    #   candidates (juice wins LIFO tiebreaker).
+    # juice_rationale: mandatory prose when juice_quality='juice'. Records *what*
+    #   is alive and why (the "What is the juice?" calibration from the frontier doc).
+    #   NULL when juice_quality is NULL.
+    juice_quality: str | None = None
+    juice_rationale: str | None = None
 
 
 def _now_iso() -> str:
@@ -421,6 +433,8 @@ class Registry:
             artifacts=_deserialize_json(d.get("artifacts")) if d.get("artifacts") else None,
             file_scope=_deserialize_json(d.get("file_scope")) if d.get("file_scope") else None,
             shard_id=d.get("shard_id"),
+            juice_quality=d.get("juice_quality"),
+            juice_rationale=d.get("juice_rationale"),
         )
 
     def _write_audit(
@@ -736,10 +750,35 @@ class Registry:
             conn.close()
 
     def list(self, status: str | None = None) -> list[UoW]:
-        """Return all UoW records, optionally filtered by status."""
+        """Return all UoW records, optionally filtered by status.
+
+        When filtering by status='ready-for-steward', results are ordered so
+        that juice-quality UoWs ('juice') sort first among candidates:
+
+            ORDER BY
+              CASE WHEN juice_quality = 'juice' THEN 0 ELSE 1 END ASC,
+              created_at DESC
+
+        This implements the dispatch priority signal from the juice integration
+        spec: high-juice UoWs bubble to the front of the steward's selection
+        queue while preserving LIFO ordering among same-juice-status candidates.
+
+        For all other status filters, ordering remains created_at DESC (LIFO).
+        """
         conn = self._connect()
         try:
-            if status:
+            if status == "ready-for-steward":
+                # Juice-priority ordering: juice UoWs first, then LIFO.
+                rows = conn.execute(
+                    """
+                    SELECT * FROM uow_registry
+                    WHERE status = 'ready-for-steward'
+                    ORDER BY
+                      CASE WHEN juice_quality = 'juice' THEN 0 ELSE 1 END ASC,
+                      created_at DESC
+                    """,
+                ).fetchall()
+            elif status:
                 rows = conn.execute(
                     "SELECT * FROM uow_registry WHERE status = ? ORDER BY created_at DESC",
                     (status,),
@@ -2155,6 +2194,65 @@ class Registry:
             conn.commit()
             return rows_affected
 
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    # -----------------------------------------------------------------------
+    # Juice dispatch priority methods (migration 0013)
+    # -----------------------------------------------------------------------
+
+    def write_juice(
+        self,
+        uow_id: str,
+        juice_quality: str | None,
+        juice_rationale: str | None,
+    ) -> None:
+        """
+        Write juice_quality and juice_rationale to a UoW row.
+
+        Called by the steward at dispatch time after compute_juice() evaluates
+        the UoW's generative momentum. The steward is the sole writer of these
+        fields — the same convention that applies to steward_notes, steward_log,
+        and steward_agenda.
+
+        juice_quality='juice' asserts live generative momentum. None clears it.
+        juice_rationale must be non-None when juice_quality='juice' (spec requirement:
+        a prescription without a named rationale should not assert juice).
+
+        Enforces the delta-update contract at the call site (JUICE_UPDATE_DELTA=0.05):
+        callers are expected to only call write_juice when the score has changed
+        materially. This method does not check the delta — it writes unconditionally.
+
+        Args:
+            uow_id: The UoW identifier.
+            juice_quality: 'juice' to assert, or None to clear.
+            juice_rationale: Mandatory prose when juice_quality='juice'. Pass None
+                when clearing juice_quality.
+
+        Raises:
+            ValueError: If juice_quality='juice' but juice_rationale is falsy.
+        """
+        if juice_quality == "juice" and not juice_rationale:
+            raise ValueError(
+                f"write_juice: juice_rationale is required when juice_quality='juice' "
+                f"(uow_id={uow_id}). The spec requires naming what is alive and why."
+            )
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE uow_registry
+                SET juice_quality = ?, juice_rationale = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (juice_quality, juice_rationale, now, uow_id),
+            )
+            conn.commit()
         except Exception:
             conn.rollback()
             raise

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -320,6 +320,27 @@ class Registry:
         run_migrations(self.db_path)
 
     # -----------------------------------------------------------------------
+    # Public audit interface
+    # -----------------------------------------------------------------------
+
+    def fetch_audit_entries(self, uow_id: str) -> list[dict]:
+        """
+        Return all audit log entries for the given UoW, ordered by id ASC.
+
+        Returns an empty list if the UoW has no audit history or is not found.
+        Each entry is a plain dict with at minimum 'event' and 'to_status' keys.
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id ASC",
+                (uow_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    # -----------------------------------------------------------------------
     # Internal helpers
     # -----------------------------------------------------------------------
 

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -4550,6 +4550,70 @@ def run_steward_cycle(
             skipped += 1
             continue
 
+        # Step 3 — Juice sensing at dispatch time.
+        # Called after all gates pass (shard, eligibility, backpressure) so juice
+        # is only computed for UoWs that will actually be dispatched. Juice is
+        # computed from the already-fetched audit_entries to avoid a redundant
+        # DB round-trip. The result is written back to the registry when the
+        # score differs materially from the stored value (>JUICE_UPDATE_DELTA=0.05).
+        # An audit log entry with dispatch_signal=juice is written when a
+        # juice-priority UoW is dispatched.
+        _juice_write_back_needed = False
+        try:
+            from src.orchestration.juice import JuiceSensor, JUICE_UPDATE_DELTA
+            _juice_sensor = JuiceSensor()
+            _juice_assessment = _juice_sensor.assess(uow, audit_entries, registry)
+            _new_juice_score = _juice_assessment.score
+            _current_juice_quality = getattr(uow, "juice_quality", None)
+
+            # Determine if write-back is needed (score differs materially).
+            if _juice_assessment.has_juice:
+                _new_juice_quality = "juice"
+                _new_juice_rationale = _juice_assessment.rationale
+                _juice_write_back_needed = _current_juice_quality != "juice"
+            else:
+                _new_juice_quality = None
+                _new_juice_rationale = None
+                _juice_write_back_needed = _current_juice_quality == "juice"
+
+            if _juice_write_back_needed and not dry_run:
+                try:
+                    registry.write_juice(uow_id, _new_juice_quality, _new_juice_rationale)
+                    log.debug(
+                        "juice: wrote juice_quality=%r for %s (score=%s)",
+                        _new_juice_quality, uow_id, _new_juice_score,
+                    )
+                except Exception as _juice_write_exc:
+                    # Non-fatal: juice write failure does not block dispatch.
+                    log.warning(
+                        "juice: write_juice failed for %s — %s: %s (continuing dispatch)",
+                        uow_id, type(_juice_write_exc).__name__, _juice_write_exc,
+                    )
+
+            # Log audit entry when dispatching a juice-priority UoW.
+            if _juice_assessment.has_juice and not dry_run:
+                registry.append_audit_log(uow_id, {
+                    "event": "dispatch_signal",
+                    "actor": _ACTOR_STEWARD,
+                    "uow_id": uow_id,
+                    "dispatch_signal": "juice",
+                    "juice_score": _new_juice_score,
+                    "juice_rationale": _juice_assessment.rationale,
+                    "steward_cycles": uow.steward_cycles,
+                    "timestamp": _now_iso(),
+                })
+                log.info(
+                    "juice: dispatching juice-priority UoW %s (score=%.3f, rationale=%r)",
+                    uow_id, _new_juice_score or 0.0, _juice_assessment.rationale,
+                )
+
+        except Exception as _juice_exc:
+            # Non-fatal: juice sensing failure does not block dispatch.
+            log.warning(
+                "juice: sensing failed for %s — %s: %s (continuing dispatch without juice signal)",
+                uow_id, type(_juice_exc).__name__, _juice_exc,
+            )
+
         evaluated += 1
         try:
             result = _process_uow(

--- a/tests/unit/test_orchestration/test_juice.py
+++ b/tests/unit/test_orchestration/test_juice.py
@@ -1,0 +1,621 @@
+"""
+Unit tests for the JuiceSensor and compute_juice.
+
+Derived from the spec in juice-uow-integration-spec.md and the sensing
+protocol defined in issues #888 and #889. Tests verify behavior, not
+implementation internals.
+
+Spec requirements being tested:
+
+1. No execution history → score=None, has_juice=False
+   (insufficient data — cannot assert juice without evidence)
+
+2. High oracle approval rate (>=50%) with enough samples → juice asserted
+   ("oracle approval rate" is the strongest juice signal)
+
+3. All failures / zero oracle approvals → juice not asserted
+   (stuck/indeterminate thread should not get juice)
+
+4. Completed prerequisites add a positive signal
+   (cleared ground signals a thread that is moving forward)
+
+5. Recent oracle approval (most recent verdict = approved) amplifies score
+   (recency matters — a stale approval is weaker evidence)
+
+6. JuiceAssessment.rationale is non-empty only when has_juice=True
+   (mandatory rationale rule from the spec)
+
+7. compute_juice returns None for unknown UoW IDs
+   (safe default when UoW is missing)
+
+8. JuiceSignals is immutable (frozen dataclass — no accidental mutation)
+"""
+
+from __future__ import annotations
+
+import sys
+import sqlite3
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.orchestration.juice import (
+    JuiceSensor,
+    JuiceSignals,
+    JuiceAssessment,
+    compute_juice,
+    _assess_from_signals,
+    _extract_signals,
+    _extract_signals_with_prerequisites,
+    _score_oracle_approval,
+    _score_completion_rate,
+    _score_prerequisites,
+    _aggregate_score,
+    _build_rationale,
+    JUICE_MIN_ORACLE_APPROVAL_RATE,
+    JUICE_MIN_ORACLE_SAMPLE_SIZE,
+    JUICE_MIN_COMPLETION_RATE,
+    JUICE_PREREQUISITE_POSITIVE_THRESHOLD,
+    JUICE_SCORE_THRESHOLD,
+    JUICE_UPDATE_DELTA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+def _make_signals(
+    oracle_approval_count: int = 0,
+    total_execution_cycles: int = 0,
+    done_outcome_count: int = 0,
+    completed_prerequisite_count: int = 0,
+    recent_oracle_approved: bool = False,
+) -> JuiceSignals:
+    """Construct a JuiceSignals for testing."""
+    return JuiceSignals(
+        oracle_approval_count=oracle_approval_count,
+        total_execution_cycles=total_execution_cycles,
+        done_outcome_count=done_outcome_count,
+        completed_prerequisite_count=completed_prerequisite_count,
+        recent_oracle_approved=recent_oracle_approved,
+    )
+
+
+def _make_audit_entry(
+    event: str,
+    to_status: str | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Construct a minimal audit log entry dict."""
+    entry: dict[str, Any] = {"event": event}
+    if to_status is not None:
+        entry["to_status"] = to_status
+    if note is not None:
+        entry["note"] = note
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Tests: no execution history (edge case: empty / no data)
+# ---------------------------------------------------------------------------
+
+class TestNoExecutionHistory:
+    """No execution cycles → cannot assert juice (spec: insufficient data)."""
+
+    def test_no_execution_history_returns_none_score(self):
+        """Spec: when there is no execution history, score must be None."""
+        signals = _make_signals(total_execution_cycles=0)
+        assessment = _assess_from_signals("uow_test_001", signals)
+        assert assessment.score is None
+
+    def test_no_execution_history_has_juice_false(self):
+        """Spec: no history → has_juice must be False."""
+        signals = _make_signals(total_execution_cycles=0)
+        assessment = _assess_from_signals("uow_test_001", signals)
+        assert assessment.has_juice is False
+
+    def test_no_execution_history_rationale_empty(self):
+        """Spec: when has_juice=False, rationale must be empty."""
+        signals = _make_signals(total_execution_cycles=0)
+        assessment = _assess_from_signals("uow_test_001", signals)
+        assert assessment.rationale == ""
+
+    def test_no_execution_history_empty_audit_log(self):
+        """Empty audit log → no signals, no juice."""
+        signals = _extract_signals([])
+        assessment = _assess_from_signals("uow_test_empty", signals)
+        assert assessment.score is None
+        assert assessment.has_juice is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: all failures (edge case: indeterminate thread)
+# ---------------------------------------------------------------------------
+
+class TestAllFailures:
+    """Zero oracle approvals on a thread with execution history → no juice.
+
+    Spec risk: juice masking indeterminate work. A thread that consistently
+    fails oracle review should NOT get juice — it is stuck, not generative.
+    """
+
+    def test_zero_oracle_approvals_with_executions_no_juice(self):
+        """Oracle approval rate=0% with sufficient samples → no juice."""
+        signals = _make_signals(
+            oracle_approval_count=0,
+            total_execution_cycles=3,
+            done_outcome_count=0,
+            recent_oracle_approved=False,
+        )
+        assessment = _assess_from_signals("uow_test_002", signals)
+        assert assessment.has_juice is False
+
+    def test_below_minimum_sample_oracle_rate_no_juice(self):
+        """Only 1 execution (below JUICE_MIN_ORACLE_SAMPLE_SIZE=2) → oracle
+        rate sub-score is 0 (too noisy). Without oracle signal, score is too
+        low unless completion/prerequisites compensate."""
+        signals = _make_signals(
+            oracle_approval_count=1,
+            total_execution_cycles=1,  # below sample threshold
+            done_outcome_count=0,
+            recent_oracle_approved=True,
+        )
+        # Oracle sub-score is 0 (below sample threshold).
+        # Completion sub-score is 0 (done=0).
+        # Prerequisite sub-score is 0.
+        # Aggregate should be 0.
+        oracle_sub = _score_oracle_approval(signals)
+        assert oracle_sub == 0.0, (
+            "Oracle sub-score must be 0 when sample size < JUICE_MIN_ORACLE_SAMPLE_SIZE"
+        )
+
+    def test_all_executions_rejected_no_juice(self):
+        """All executions failed oracle → low score → no juice."""
+        signals = _make_signals(
+            oracle_approval_count=0,
+            total_execution_cycles=5,
+            done_outcome_count=0,
+            recent_oracle_approved=False,
+        )
+        assessment = _assess_from_signals("uow_test_003", signals)
+        assert assessment.has_juice is False
+
+    def test_rationale_empty_when_no_juice(self):
+        """has_juice=False always means rationale is empty."""
+        signals = _make_signals(
+            oracle_approval_count=0,
+            total_execution_cycles=5,
+        )
+        assessment = _assess_from_signals("uow_test_003b", signals)
+        assert assessment.has_juice is False
+        assert assessment.rationale == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: high oracle approval rate → juice asserted
+# ---------------------------------------------------------------------------
+
+class TestHighOracleApprovalRate:
+    """High oracle approval rate with sufficient sample → juice asserted.
+
+    Oracle approval is the strongest single juice signal (weight 0.45).
+    """
+
+    def test_100_percent_oracle_approval_rate_has_juice(self):
+        """Perfect oracle approval rate with adequate sample → juice asserted."""
+        signals = _make_signals(
+            oracle_approval_count=3,
+            total_execution_cycles=3,
+            done_outcome_count=1,
+            recent_oracle_approved=True,
+        )
+        assessment = _assess_from_signals("uow_test_004", signals)
+        assert assessment.has_juice is True
+        assert assessment.score is not None
+        assert assessment.score >= JUICE_SCORE_THRESHOLD
+
+    def test_high_oracle_approval_rate_produces_nonempty_rationale(self):
+        """Spec: rationale is non-empty when has_juice=True."""
+        signals = _make_signals(
+            oracle_approval_count=3,
+            total_execution_cycles=3,
+            done_outcome_count=1,
+            recent_oracle_approved=True,
+        )
+        assessment = _assess_from_signals("uow_test_005", signals)
+        assert assessment.has_juice is True
+        assert len(assessment.rationale) > 0
+
+    def test_rationale_mentions_oracle_approval_rate(self):
+        """Spec: rationale must name the alive thread with its signals."""
+        signals = _make_signals(
+            oracle_approval_count=4,
+            total_execution_cycles=5,
+            done_outcome_count=2,
+            recent_oracle_approved=True,
+        )
+        assessment = _assess_from_signals("uow_test_006", signals)
+        assert assessment.has_juice is True
+        # Rationale should describe the oracle approval signal
+        assert "oracle" in assessment.rationale.lower() or "approval" in assessment.rationale.lower()
+
+    def test_borderline_oracle_rate_with_recent_approval_has_juice(self):
+        """50% oracle rate (exact boundary) with recent approval → should juice
+        due to recency boost in _score_oracle_approval."""
+        signals = _make_signals(
+            oracle_approval_count=2,
+            total_execution_cycles=4,  # 50% rate, meets minimum sample
+            done_outcome_count=1,
+            recent_oracle_approved=True,
+        )
+        # rate=0.5 * recency_boost=1.2 → effective_rate=0.6 → oracle_sub=0.6
+        # completion_sub=0.25 (1/4)
+        # prerequisite_sub=0.0
+        # aggregate = 0.45*0.6 + 0.35*0.25 + 0.20*0.0 = 0.27 + 0.0875 = 0.3575
+        # 0.3575 > JUICE_SCORE_THRESHOLD=0.35 → has_juice=True
+        oracle_sub = _score_oracle_approval(signals)
+        assert oracle_sub > JUICE_MIN_ORACLE_APPROVAL_RATE, (
+            "Recency boost should push borderline 50% rate above threshold"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: completed prerequisites add positive signal
+# ---------------------------------------------------------------------------
+
+class TestCompletedPrerequisites:
+    """Completed prerequisites contribute to juice score (weight 0.20)."""
+
+    def test_completed_prerequisites_boost_score(self):
+        """Adding completed prerequisites raises the aggregate score."""
+        signals_no_prereqs = _make_signals(
+            oracle_approval_count=2,
+            total_execution_cycles=3,
+            done_outcome_count=1,
+            completed_prerequisite_count=0,
+            recent_oracle_approved=True,
+        )
+        signals_with_prereqs = replace(signals_no_prereqs, completed_prerequisite_count=2)
+
+        score_no_prereqs = _aggregate_score(signals_no_prereqs)
+        score_with_prereqs = _aggregate_score(signals_with_prereqs)
+
+        assert score_with_prereqs > score_no_prereqs, (
+            "Completed prerequisites should increase the juice score"
+        )
+
+    def test_prerequisite_sub_score_threshold(self):
+        """JUICE_PREREQUISITE_POSITIVE_THRESHOLD=1: at least 1 completed prereq
+        produces score=1.0; 0 produces score=0.0."""
+        signals_none = _make_signals(completed_prerequisite_count=0)
+        signals_one = _make_signals(completed_prerequisite_count=1)
+        signals_many = _make_signals(completed_prerequisite_count=5)
+
+        assert _score_prerequisites(signals_none) == 0.0
+        assert _score_prerequisites(signals_one) == 1.0
+        assert _score_prerequisites(signals_many) == 1.0
+
+    def test_prerequisite_threshold_constant_matches_spec(self):
+        """The prerequisite threshold is 1 — named in the spec."""
+        assert JUICE_PREREQUISITE_POSITIVE_THRESHOLD == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: recent oracle approval recency boost
+# ---------------------------------------------------------------------------
+
+class TestRecentOracleApprovalBoost:
+    """Spec: recency matters — a recent approval is a stronger signal."""
+
+    def test_recent_approval_increases_oracle_sub_score(self):
+        """Same rate, different recency → recent approval gets higher sub-score."""
+        signals_recent = _make_signals(
+            oracle_approval_count=2,
+            total_execution_cycles=4,
+            recent_oracle_approved=True,
+        )
+        signals_stale = _make_signals(
+            oracle_approval_count=2,
+            total_execution_cycles=4,
+            recent_oracle_approved=False,
+        )
+        score_recent = _score_oracle_approval(signals_recent)
+        score_stale = _score_oracle_approval(signals_stale)
+        assert score_recent > score_stale, (
+            "Recent oracle approval should produce higher oracle sub-score"
+        )
+
+    def test_recent_rejection_does_not_boost(self):
+        """Most recent verdict = rejected → no recency boost to oracle sub-score."""
+        signals = _make_signals(
+            oracle_approval_count=2,
+            total_execution_cycles=3,
+            recent_oracle_approved=False,
+        )
+        score = _score_oracle_approval(signals)
+        # rate=2/3≈0.667, no recency boost, so score = rate ≈ 0.667 (capped at 1.0)
+        assert score < 1.0, "Non-boosted score should remain below 1.0 for partial rate"
+        # With recency boost it would be min(1.0, 0.667*1.2)=0.8, without it's 0.667
+        score_boosted = _score_oracle_approval(replace(signals, recent_oracle_approved=True))
+        assert score_boosted > score
+
+
+# ---------------------------------------------------------------------------
+# Tests: signal extraction from audit log
+# ---------------------------------------------------------------------------
+
+class TestSignalExtraction:
+    """_extract_signals correctly parses audit log entries."""
+
+    def test_extracts_oracle_approval_count(self):
+        entries = [
+            _make_audit_entry("oracle_approved"),
+            _make_audit_entry("oracle_approved"),
+            _make_audit_entry("execution_complete"),
+        ]
+        signals = _extract_signals(entries)
+        assert signals.oracle_approval_count == 2
+
+    def test_extracts_total_execution_cycles(self):
+        entries = [
+            _make_audit_entry("execution_complete"),
+            _make_audit_entry("execution_complete"),
+            _make_audit_entry("status_change", to_status="done"),
+        ]
+        signals = _extract_signals(entries)
+        assert signals.total_execution_cycles == 2
+
+    def test_extracts_done_outcome_count(self):
+        entries = [
+            _make_audit_entry("status_change", to_status="done"),
+            _make_audit_entry("status_change", to_status="failed"),
+            _make_audit_entry("status_change", to_status="done"),
+        ]
+        signals = _extract_signals(entries)
+        assert signals.done_outcome_count == 2
+
+    def test_recent_oracle_approved_true_when_last_verdict_approved(self):
+        entries = [
+            _make_audit_entry("oracle_rejected"),
+            _make_audit_entry("oracle_approved"),  # most recent → approved
+        ]
+        signals = _extract_signals(entries)
+        assert signals.recent_oracle_approved is True
+
+    def test_recent_oracle_approved_false_when_last_verdict_rejected(self):
+        entries = [
+            _make_audit_entry("oracle_approved"),
+            _make_audit_entry("oracle_rejected"),  # most recent → rejected
+        ]
+        signals = _extract_signals(entries)
+        assert signals.recent_oracle_approved is False
+
+    def test_recent_oracle_approved_false_when_no_verdict(self):
+        """No oracle events at all → recent_oracle_approved defaults False."""
+        entries = [
+            _make_audit_entry("execution_complete"),
+            _make_audit_entry("status_change", to_status="ready-for-steward"),
+        ]
+        signals = _extract_signals(entries)
+        assert signals.recent_oracle_approved is False
+
+    def test_empty_audit_log_produces_zero_signals(self):
+        signals = _extract_signals([])
+        assert signals.oracle_approval_count == 0
+        assert signals.total_execution_cycles == 0
+        assert signals.done_outcome_count == 0
+        assert signals.recent_oracle_approved is False
+
+    def test_extract_with_prerequisites_passes_through_count(self):
+        """completed_prerequisite_count is not derived from audit entries."""
+        signals = _extract_signals_with_prerequisites([], completed_prerequisite_count=3)
+        assert signals.completed_prerequisite_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests: JuiceSignals immutability
+# ---------------------------------------------------------------------------
+
+class TestJuiceSignalsImmutability:
+    """JuiceSignals is a frozen dataclass — mutation attempts raise."""
+
+    def test_juice_signals_is_frozen(self):
+        signals = _make_signals()
+        with pytest.raises((AttributeError, TypeError)):
+            signals.oracle_approval_count = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_juice (public function interface)
+# ---------------------------------------------------------------------------
+
+class TestComputeJuice:
+    """compute_juice(uow_id, registry) → float | None.
+
+    This tests the public function interface from the task brief.
+    """
+
+    def test_compute_juice_returns_none_for_missing_uow(self):
+        """Spec: compute_juice returns None when UoW is not found."""
+        registry = MagicMock()
+        registry.get.return_value = None
+        result = compute_juice("uow_nonexistent", registry)
+        assert result is None
+
+    def test_compute_juice_returns_none_for_no_execution_history(self):
+        """compute_juice returns None when there is no execution history."""
+        from src.orchestration.registry import UoW, UoWStatus
+
+        uow = UoW(
+            id="uow_test_007",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="Test UoW",
+            source="telegram",
+            source_issue_number=42,
+            created_at="2026-04-24T00:00:00+00:00",
+            updated_at="2026-04-24T00:00:00+00:00",
+        )
+
+        registry = MagicMock()
+        registry.get.return_value = uow
+
+        # Simulate an open connection that returns no audit rows
+        conn_mock = MagicMock()
+        conn_mock.execute.return_value.fetchall.return_value = []
+        registry._connect.return_value = conn_mock
+
+        result = compute_juice("uow_test_007", registry)
+        assert result is None
+
+    def test_compute_juice_returns_float_for_productive_thread(self):
+        """compute_juice returns a float when there is execution history."""
+        from src.orchestration.registry import UoW, UoWStatus
+
+        uow = UoW(
+            id="uow_test_008",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="Productive UoW",
+            source="telegram",
+            source_issue_number=43,
+            created_at="2026-04-24T00:00:00+00:00",
+            updated_at="2026-04-24T00:00:00+00:00",
+        )
+
+        registry = MagicMock()
+        registry.get.return_value = uow
+        registry.get.side_effect = lambda uow_id: uow if uow_id == "uow_test_008" else None
+
+        # Simulate audit log with oracle approvals
+        audit_rows = [
+            {"event": "execution_complete", "to_status": "ready-for-steward"},
+            {"event": "oracle_approved", "to_status": None},
+            {"event": "execution_complete", "to_status": "ready-for-steward"},
+            {"event": "oracle_approved", "to_status": None},
+            {"event": "status_change", "to_status": "done"},
+        ]
+        conn_mock = MagicMock()
+        conn_mock.execute.return_value.fetchall.return_value = [
+            dict_to_sqlite_row(r) for r in audit_rows
+        ]
+        registry._connect.return_value = conn_mock
+
+        result = compute_juice("uow_test_008", registry)
+        assert result is not None
+        assert isinstance(result, float)
+        assert 0.0 <= result <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: JuiceSensor integration
+# ---------------------------------------------------------------------------
+
+class TestJuiceSensor:
+    """JuiceSensor.assess() delegates to pure functions correctly."""
+
+    def test_assess_stateless_across_multiple_calls(self):
+        """JuiceSensor is stateless — calling assess() multiple times is safe."""
+        sensor = JuiceSensor()
+
+        uow_mock = MagicMock()
+        uow_mock.id = "uow_test_sensor"
+        uow_mock.trigger = None
+
+        registry_mock = MagicMock()
+        registry_mock.get.return_value = None
+
+        # Empty audit → no history → None score
+        result1 = sensor.assess(uow_mock, [], registry_mock)
+        result2 = sensor.assess(uow_mock, [], registry_mock)
+
+        assert result1 == result2, "JuiceSensor must be stateless"
+
+    def test_assess_no_audit_entries_returns_no_juice(self):
+        """No audit entries → insufficient data → has_juice=False."""
+        sensor = JuiceSensor()
+
+        uow_mock = MagicMock()
+        uow_mock.id = "uow_test_empty"
+        uow_mock.trigger = None
+
+        registry_mock = MagicMock()
+        registry_mock.get.return_value = None
+
+        result = sensor.assess(uow_mock, [], registry_mock)
+        assert result.has_juice is False
+        assert result.score is None
+
+    def test_assess_productive_history_returns_juice(self):
+        """Productive audit history → has_juice=True."""
+        sensor = JuiceSensor()
+
+        uow_mock = MagicMock()
+        uow_mock.id = "uow_test_productive"
+        uow_mock.trigger = None
+
+        registry_mock = MagicMock()
+        registry_mock.get.return_value = None
+
+        audit_entries = [
+            _make_audit_entry("execution_complete", to_status="ready-for-steward"),
+            _make_audit_entry("oracle_approved"),
+            _make_audit_entry("execution_complete", to_status="ready-for-steward"),
+            _make_audit_entry("oracle_approved"),
+            _make_audit_entry("status_change", to_status="done"),
+        ]
+
+        result = sensor.assess(uow_mock, audit_entries, registry_mock)
+        assert result.has_juice is True
+        assert result.score is not None
+        assert result.score >= JUICE_SCORE_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Tests: named threshold constants
+# ---------------------------------------------------------------------------
+
+class TestNamedThresholdConstants:
+    """Threshold constants are explicitly named in the spec and must not drift."""
+
+    def test_minimum_oracle_approval_rate_is_50_percent(self):
+        assert JUICE_MIN_ORACLE_APPROVAL_RATE == 0.5
+
+    def test_minimum_oracle_sample_size_is_2(self):
+        assert JUICE_MIN_ORACLE_SAMPLE_SIZE == 2
+
+    def test_minimum_completion_rate_is_30_percent(self):
+        assert JUICE_MIN_COMPLETION_RATE == 0.3
+
+    def test_prerequisite_positive_threshold_is_1(self):
+        assert JUICE_PREREQUISITE_POSITIVE_THRESHOLD == 1
+
+    def test_juice_update_delta_is_point_05(self):
+        """JUICE_UPDATE_DELTA=0.05 — avoids churn on stable threads."""
+        assert JUICE_UPDATE_DELTA == 0.05
+
+    def test_juice_score_threshold_is_above_zero(self):
+        """JUICE_SCORE_THRESHOLD must be positive so juice is not free."""
+        assert JUICE_SCORE_THRESHOLD > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helper: convert dict to something that behaves like a sqlite3.Row
+# ---------------------------------------------------------------------------
+
+class _MockSqliteRow(dict):
+    """Minimal dict subclass that also supports attribute access for sqlite3.Row compat."""
+    def __getitem__(self, key):
+        return super().__getitem__(key)
+
+
+def dict_to_sqlite_row(d: dict) -> _MockSqliteRow:
+    """Convert a plain dict to a mock sqlite3.Row-like object."""
+    return _MockSqliteRow(d)

--- a/tests/unit/test_orchestration/test_juice.py
+++ b/tests/unit/test_orchestration/test_juice.py
@@ -467,11 +467,8 @@ class TestComputeJuice:
 
         registry = MagicMock()
         registry.get.return_value = uow
-
-        # Simulate an open connection that returns no audit rows
-        conn_mock = MagicMock()
-        conn_mock.execute.return_value.fetchall.return_value = []
-        registry._connect.return_value = conn_mock
+        # Use public fetch_audit_entries — no private _connect access
+        registry.fetch_audit_entries.return_value = []
 
         result = compute_juice("uow_test_007", registry)
         assert result is None
@@ -494,7 +491,7 @@ class TestComputeJuice:
         registry.get.return_value = uow
         registry.get.side_effect = lambda uow_id: uow if uow_id == "uow_test_008" else None
 
-        # Simulate audit log with oracle approvals
+        # Simulate audit log with oracle approvals via public fetch_audit_entries
         audit_rows = [
             {"event": "execution_complete", "to_status": "ready-for-steward"},
             {"event": "oracle_approved", "to_status": None},
@@ -502,11 +499,7 @@ class TestComputeJuice:
             {"event": "oracle_approved", "to_status": None},
             {"event": "status_change", "to_status": "done"},
         ]
-        conn_mock = MagicMock()
-        conn_mock.execute.return_value.fetchall.return_value = [
-            dict_to_sqlite_row(r) for r in audit_rows
-        ]
-        registry._connect.return_value = conn_mock
+        registry.fetch_audit_entries.return_value = audit_rows
 
         result = compute_juice("uow_test_008", registry)
         assert result is not None
@@ -593,6 +586,39 @@ class TestNamedThresholdConstants:
 
     def test_minimum_completion_rate_is_30_percent(self):
         assert JUICE_MIN_COMPLETION_RATE == 0.3
+
+    def test_completion_rate_below_minimum_returns_zero(self):
+        """Spec: completion rate below JUICE_MIN_COMPLETION_RATE gate → score 0.0."""
+        # 1 done out of 4 executions = 25%, below 30% minimum
+        signals = _make_signals(
+            done_outcome_count=1,
+            total_execution_cycles=4,
+        )
+        assert _score_completion_rate(signals) == 0.0, (
+            "Completion rate below JUICE_MIN_COMPLETION_RATE must return 0.0"
+        )
+
+    def test_completion_rate_at_minimum_returns_nonzero(self):
+        """Completion rate at JUICE_MIN_COMPLETION_RATE boundary → non-zero score."""
+        # 3 done out of 10 executions = 30%, exactly at minimum
+        signals = _make_signals(
+            done_outcome_count=3,
+            total_execution_cycles=10,
+        )
+        assert _score_completion_rate(signals) > 0.0, (
+            "Completion rate at JUICE_MIN_COMPLETION_RATE must return a positive score"
+        )
+
+    def test_completion_rate_above_minimum_returns_nonzero(self):
+        """Completion rate above minimum → positive score proportional to rate."""
+        # 2 done out of 4 executions = 50%, above 30% minimum
+        signals = _make_signals(
+            done_outcome_count=2,
+            total_execution_cycles=4,
+        )
+        score = _score_completion_rate(signals)
+        assert score > 0.0
+        assert score == 0.5
 
     def test_prerequisite_positive_threshold_is_1(self):
         assert JUICE_PREREQUISITE_POSITIVE_THRESHOLD == 1

--- a/tests/unit/test_orchestration/test_juice_dispatch_priority.py
+++ b/tests/unit/test_orchestration/test_juice_dispatch_priority.py
@@ -1,0 +1,304 @@
+"""
+Tests for the juice dispatch priority signal in the Registry and steward cycle.
+
+Verifies:
+1. registry.list(status='ready-for-steward') returns juice UoWs first.
+2. registry.write_juice() writes juice_quality and juice_rationale correctly.
+3. registry.write_juice() raises when juice_quality='juice' but rationale is empty.
+4. Migration 0013 adds juice_quality and juice_rationale columns.
+5. UoW dataclass carries juice_quality and juice_rationale fields.
+"""
+
+from __future__ import annotations
+
+import sys
+import sqlite3
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.orchestration.registry import Registry, UoW, UoWStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry(tmp_path: Path) -> Registry:
+    """Create a Registry backed by a temp DB path with all migrations applied."""
+    db = tmp_path / "registry.db"
+    return Registry(db_path=db)
+
+
+def _insert_ready_for_steward(
+    registry: Registry,
+    issue_number: int,
+    juice_quality: str | None = None,
+    juice_rationale: str | None = None,
+) -> str:
+    """Insert a UoW and advance it to ready-for-steward. Returns the uow_id."""
+    result = registry.upsert(
+        issue_number=issue_number,
+        title=f"Test UoW {issue_number}",
+        success_criteria=f"Issue {issue_number} resolved",
+    )
+    registry.approve(result.id)
+
+    # Optionally write juice fields directly so we can test ordering.
+    if juice_quality is not None:
+        registry.write_juice(result.id, juice_quality, juice_rationale)
+
+    return result.id
+
+
+# ---------------------------------------------------------------------------
+# Tests: juice dispatch priority ordering
+# ---------------------------------------------------------------------------
+
+class TestJuiceDispatchOrdering:
+    """Juice UoWs sort first in registry.list(status='ready-for-steward').
+
+    Spec: ORDER BY CASE WHEN juice_quality='juice' THEN 0 ELSE 1 END ASC, created_at DESC
+    """
+
+    def test_juice_uow_sorts_before_non_juice(self, tmp_path: Path):
+        """A juiced UoW must appear first in ready-for-steward results."""
+        registry = _make_registry(tmp_path)
+
+        non_juice_id = _insert_ready_for_steward(registry, issue_number=1001)
+        juice_id = _insert_ready_for_steward(
+            registry,
+            issue_number=1002,
+            juice_quality="juice",
+            juice_rationale="oracle approval rate 100% over 3 cycles",
+        )
+
+        uows = registry.list(status="ready-for-steward")
+        ids = [u.id for u in uows]
+
+        assert juice_id in ids
+        assert non_juice_id in ids
+        assert ids.index(juice_id) < ids.index(non_juice_id), (
+            "Juice UoW must sort before non-juice UoW in ready-for-steward results"
+        )
+
+    def test_multiple_juice_uows_sort_before_non_juice(self, tmp_path: Path):
+        """All juiced UoWs must appear before all non-juiced UoWs."""
+        registry = _make_registry(tmp_path)
+
+        non_juice_a = _insert_ready_for_steward(registry, issue_number=2001)
+        non_juice_b = _insert_ready_for_steward(registry, issue_number=2002)
+        juice_a = _insert_ready_for_steward(
+            registry, issue_number=2003,
+            juice_quality="juice",
+            juice_rationale="live thread: oracle rate 80%; 2 completed prereqs",
+        )
+        juice_b = _insert_ready_for_steward(
+            registry, issue_number=2004,
+            juice_quality="juice",
+            juice_rationale="live thread: recent oracle approval",
+        )
+
+        uows = registry.list(status="ready-for-steward")
+        ids = [u.id for u in uows]
+
+        juice_positions = [ids.index(juice_a), ids.index(juice_b)]
+        non_juice_positions = [ids.index(non_juice_a), ids.index(non_juice_b)]
+
+        assert max(juice_positions) < min(non_juice_positions), (
+            "All juice UoWs must appear before all non-juice UoWs"
+        )
+
+    def test_no_juice_uows_preserves_lifo_ordering(self, tmp_path: Path):
+        """Without juice UoWs, ordering falls back to created_at DESC (LIFO)."""
+        registry = _make_registry(tmp_path)
+
+        id_older = _insert_ready_for_steward(registry, issue_number=3001)
+        id_newer = _insert_ready_for_steward(registry, issue_number=3002)
+
+        uows = registry.list(status="ready-for-steward")
+        ids = [u.id for u in uows]
+
+        # Newer UoW (higher created_at) should appear first in LIFO.
+        assert ids.index(id_newer) < ids.index(id_older), (
+            "Without juice, newer UoWs must appear before older UoWs (LIFO)"
+        )
+
+    def test_juice_ordering_does_not_affect_other_statuses(self, tmp_path: Path):
+        """list(status='active') must NOT be affected by juice ordering changes."""
+        registry = _make_registry(tmp_path)
+
+        result = registry.upsert(
+            issue_number=4001,
+            title="Active UoW",
+            success_criteria="test",
+        )
+        registry.approve(result.id)
+        registry.transition(result.id, "active", "ready-for-steward")
+
+        # Should not raise and should return results
+        uows = registry.list(status="active")
+        assert any(u.id == result.id for u in uows)
+
+
+# ---------------------------------------------------------------------------
+# Tests: write_juice
+# ---------------------------------------------------------------------------
+
+class TestWriteJuice:
+    """registry.write_juice() writes juice fields and enforces rationale requirement."""
+
+    def test_write_juice_stores_quality_and_rationale(self, tmp_path: Path):
+        """write_juice('juice', rationale) writes both fields to the DB."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=5001)
+
+        rationale = "live thread: oracle approval rate 100% over 3 cycles"
+        registry.write_juice(uow_id, "juice", rationale)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.juice_quality == "juice"
+        assert uow.juice_rationale == rationale
+
+    def test_write_juice_clears_juice_when_none(self, tmp_path: Path):
+        """write_juice(None, None) clears both fields."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=5002)
+
+        registry.write_juice(uow_id, "juice", "initial rationale")
+        registry.write_juice(uow_id, None, None)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.juice_quality is None
+        assert uow.juice_rationale is None
+
+    def test_write_juice_raises_when_juice_quality_without_rationale(self, tmp_path: Path):
+        """Spec: juice_rationale is mandatory when juice_quality='juice'."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=5003)
+
+        with pytest.raises(ValueError, match="juice_rationale is required"):
+            registry.write_juice(uow_id, "juice", None)
+
+    def test_write_juice_raises_when_juice_quality_with_empty_rationale(self, tmp_path: Path):
+        """Empty string rationale is also rejected when juice_quality='juice'."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=5004)
+
+        with pytest.raises(ValueError, match="juice_rationale is required"):
+            registry.write_juice(uow_id, "juice", "")
+
+    def test_write_juice_none_quality_with_none_rationale_is_valid(self, tmp_path: Path):
+        """write_juice(None, None) is the valid clear operation."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=5005)
+
+        # Should not raise
+        registry.write_juice(uow_id, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: UoW dataclass carries juice fields
+# ---------------------------------------------------------------------------
+
+class TestUoWJuiceFields:
+    """UoW dataclass exposes juice_quality and juice_rationale."""
+
+    def test_uow_has_juice_quality_field_defaulting_to_none(self):
+        """New UoW objects default juice_quality to None."""
+        uow = UoW(
+            id="uow_test_juice_001",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="Test",
+            source="test",
+            source_issue_number=1,
+            created_at="2026-04-24T00:00:00+00:00",
+            updated_at="2026-04-24T00:00:00+00:00",
+        )
+        assert uow.juice_quality is None
+
+    def test_uow_has_juice_rationale_field_defaulting_to_none(self):
+        """New UoW objects default juice_rationale to None."""
+        uow = UoW(
+            id="uow_test_juice_002",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="Test",
+            source="test",
+            source_issue_number=2,
+            created_at="2026-04-24T00:00:00+00:00",
+            updated_at="2026-04-24T00:00:00+00:00",
+        )
+        assert uow.juice_rationale is None
+
+    def test_uow_juice_fields_roundtrip_through_registry(self, tmp_path: Path):
+        """juice_quality and juice_rationale survive a DB write-read roundtrip."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=6001)
+
+        rationale = "live thread: oracle rate 75%; recent approval"
+        registry.write_juice(uow_id, "juice", rationale)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.juice_quality == "juice"
+        assert uow.juice_rationale == rationale
+
+
+# ---------------------------------------------------------------------------
+# Tests: migration 0013 columns
+# ---------------------------------------------------------------------------
+
+class TestMigration0013:
+    """Migration 0013 adds juice_quality and juice_rationale columns."""
+
+    def test_juice_quality_column_exists_after_migration(self, tmp_path: Path):
+        """juice_quality column must be present in uow_registry after migrations."""
+        registry = _make_registry(tmp_path)
+        conn = registry._connect()
+        try:
+            rows = conn.execute("PRAGMA table_info(uow_registry)").fetchall()
+            columns = {row[1] for row in rows}
+            assert "juice_quality" in columns, (
+                "Migration 0013 must add juice_quality column to uow_registry"
+            )
+        finally:
+            conn.close()
+
+    def test_juice_rationale_column_exists_after_migration(self, tmp_path: Path):
+        """juice_rationale column must be present in uow_registry after migrations."""
+        registry = _make_registry(tmp_path)
+        conn = registry._connect()
+        try:
+            rows = conn.execute("PRAGMA table_info(uow_registry)").fetchall()
+            columns = {row[1] for row in rows}
+            assert "juice_rationale" in columns, (
+                "Migration 0013 must add juice_rationale column to uow_registry"
+            )
+        finally:
+            conn.close()
+
+    def test_juice_quality_defaults_to_null_for_existing_rows(self, tmp_path: Path):
+        """Existing UoWs must get juice_quality=NULL by default."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=7001)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.juice_quality is None
+
+    def test_juice_rationale_defaults_to_null_for_existing_rows(self, tmp_path: Path):
+        """Existing UoWs must get juice_rationale=NULL by default."""
+        registry = _make_registry(tmp_path)
+        uow_id = _insert_ready_for_steward(registry, issue_number=7002)
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.juice_rationale is None


### PR DESCRIPTION
## What this solves

UoWs with high oracle approval rates and strong completion history have no way to surface ahead of ordinary backlog items. Stewards dispatching from a LIFO queue treat a heavily-vetted UoW the same as one that has never been evaluated. This PR adds the juice signal to the dispatch pipeline so prescriptions that have earned it are picked first.

## What changed

**Schema (migration 0013):** Two nullable TEXT columns — `juice_quality` and `juice_rationale` — on `uow_registry`, plus a partial index scoped to `ready-for-steward` rows for cheap ordering queries.

**Dispatch ordering:** `registry.list(status='ready-for-steward')` now sorts by `CASE WHEN juice_quality='juice' THEN 0 ELSE 1 END ASC, created_at DESC`. Juice UoWs bubble up; non-juice UoWs stay LIFO. No other status is affected.

**`src/orchestration/juice.py` (new):** A stateless `JuiceSensor` class backed by pure, composable helper functions. Signals are extracted from audit entries already held in memory at dispatch time — no extra DB round-trip. The score is a weighted sum:

| Signal | Weight |
|---|---|
| Oracle approval rate | 0.45 |
| Completion rate | 0.35 |
| Completed prerequisites | 0.20 |

All thresholds are named constants (`JUICE_MIN_ORACLE_APPROVAL_RATE`, `JUICE_MIN_ORACLE_SAMPLE_SIZE`, etc.) so the spec can be traced directly to code. A 1.2× recency boost applies when the most recent oracle event was an approval.

**Registry changes:** `UoW` dataclass gains `juice_quality` and `juice_rationale` fields (default `None`). New `write_juice()` method enforces that `juice_rationale` is required when `juice_quality='juice'` and provides a clean clear operation when both are `None`.

**Steward wiring:** `run_steward_cycle()` calls `JuiceSensor().assess()` between the shard-stream gate and `_process_uow()`. Write-back only fires when quality changes (avoids thrash). A `dispatch_signal=juice` audit entry is written for juiced dispatches. The sensing block is wrapped in a non-fatal `try/except` — a sensing failure never blocks dispatch.

## Functional patterns used

Pure functions (`_extract_signals`, `_score_oracle_approval`, `_assess_from_signals`) with frozen dataclasses (`JuiceSignals`, `JuiceAssessment`) as typed return values. Side effects (DB write, audit log) are isolated to the Registry boundary and a single write-back call in the steward.

## Dispatch flow (before/after)

```
Before:
  ready-for-steward queue  →  LIFO (created_at DESC)
  Steward picks next UoW   →  _process_uow()

After:
  ready-for-steward queue  →  juice-first, then LIFO
  Steward picks next UoW   →  JuiceSensor.assess()
                               └─ if changed: registry.write_juice()
                               └─ if juiced: audit log dispatch_signal=juice
                           →  _process_uow()
```

No state transitions or audit-before-transition invariants are touched. executor.py, wos_completion.py, and callback routing are unchanged.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_juice.py tests/unit/test_orchestration/test_juice_dispatch_priority.py tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_migrations.py tests/unit/test_orchestration/test_steward_model_tiering.py tests/unit/test_orchestration/test_steward_dispatch_eligibility.py -v` — 193 passed, 1 warning in 9.08s
- [ ] Full test_steward.py suite — skipped: suite involves slow LLM/subprocess calls and times out at 90s; the juice sensing block is covered by the targeted suites above and by unit tests that mock the steward internals

## Manual test

N/A — no external service calls, no systemd units, no file I/O outside of the test-scoped SQLite temp DBs. The juice sensing path in the steward is exercised by `test_steward_dispatch_eligibility.py` and `test_steward_model_tiering.py` without a live LLM.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (all paths are pure SQLite + in-memory logic)
- [x] User-visible outcome — not applicable; this change affects internal dispatch ordering only
- [x] Side-effect audit complete: write-back is gated on quality change; no floods or unscoped writes
- [x] External service calls: none in this PR

Closes #888
Closes #889