### PR TITLE
WOS: canonical data access layer — registry_cli ergonomics + subagent docs

### DIFF
--- a/docs/WOS-DATA-ACCESS.md
+++ b/docs/WOS-DATA-ACCESS.md
@@ -75,11 +75,13 @@ Use the `Registry` class from `src/orchestration/registry.py`. This is the sole 
 ### Standard import pattern
 
 ```python
+import os
 import sys
 from pathlib import Path
 
-# Add src/ to the path — use the absolute path, not relative
-_SRC_DIR = Path("/home/lobster/lobster/src")
+# Add src/ to the path using LOBSTER_ROOT env var — avoids hardcoding the
+# host user path (e.g. /home/lobster) which is machine-specific and brittle.
+_SRC_DIR = Path(os.environ.get("LOBSTER_ROOT", "/home/lobster/lobster")) / "src"
 if str(_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(_SRC_DIR))
 
@@ -104,10 +106,9 @@ if uow is None:
 
 # Count by status (returns {status: count} dict)
 # Prefer registry_cli.py status-breakdown for this — it's simpler from shell
-# From Python, build the breakdown yourself via list():
-from collections import Counter
-all_uows = registry.list()
-breakdown = Counter(u.status for u in all_uows)
+# From Python, use get_status_counts() — this runs a DB-level GROUP BY,
+# which is more efficient than loading all UoWs into memory:
+breakdown = registry.get_status_counts()
 
 # Find escalation candidates
 escalated = registry.list(status="needs-human-review")
@@ -147,13 +148,17 @@ conn = sqlite3.connect("/home/lobster/lobster-workspace/orchestration/registry.d
 rows = conn.execute("SELECT * FROM uow_registry WHERE status = 'active'").fetchall()
 ```
 
-### Never use sys.path tricks to import from an unknown location
+### Never hardcode the host user path when manipulating sys.path
 
 ```python
-# BAD — fragile, depends on repo layout staying fixed at a specific path
-sys.path.insert(0, '/home/lobster/lobster')  # absolute but brittle
+# BAD — hardcodes /home/lobster, which breaks on any other machine or user account
+sys.path.insert(0, '/home/lobster/lobster')  # host-user path, not portable
 from src.orchestration.uow_registry import UoWRegistry  # wrong class name too
 ```
+
+The approved Path 2 import pattern above uses `sys.path.insert` — that part is fine.
+What is prohibited is hardcoding `/home/lobster` as a literal string. Use the
+`LOBSTER_ROOT` env var with a sensible default instead (see Path 2 above).
 
 ### Never hardcode the DB path in queries
 

--- a/docs/WOS-DATA-ACCESS.md
+++ b/docs/WOS-DATA-ACCESS.md
@@ -1,0 +1,184 @@
+# WOS Data Access — Canonical Subagent Guide
+
+**Audience:** Subagents (engineer agents, scheduled jobs, oracle agents) that need to read WOS state.
+**Related docs:** `docs/wos-registry-reference.md` (status machine, field reference), `docs/wos-golden-pattern.md` (Python patterns)
+
+---
+
+## The Rule
+
+**Never use raw `sqlite3` to query `registry.db` directly.** The schema evolves, column names change, and JSON fields require deserialization. Going around the access layer produces bugs that are invisible until production.
+
+Use exactly one of the two access paths described below.
+
+---
+
+## Path 1: CLI queries (subagents, shell scripts, ad-hoc inspection)
+
+`registry_cli.py` is the canonical entry point for all read queries. All output is JSON on stdout.
+
+### Standard invocation pattern
+
+```bash
+# From any working directory — the CLI resolves the DB path via env/defaults
+uv run /home/lobster/lobster/src/orchestration/registry_cli.py <subcommand> [args]
+```
+
+Or, in a subagent context using `REGISTRY_DB_PATH` to pin the DB:
+
+```bash
+REGISTRY_DB_PATH=~/lobster-workspace/orchestration/registry.db \
+  uv run /home/lobster/lobster/src/orchestration/registry_cli.py status-breakdown
+```
+
+### Available read subcommands
+
+| Subcommand | What it returns | When to use |
+|---|---|---|
+| `list` | All UoWs, or filtered by `--status` | Browse the full queue |
+| `list --status <s>` | UoWs in a specific status | Get active, blocked, etc. |
+| `get --id <uow-id>` | Single UoW object | Inspect one UoW by ID |
+| `status-breakdown` | `{status: count}` — all statuses with counts | Dashboard, health checks |
+| `escalation-candidates` | UoWs in `needs-human-review` | Operator triage, alerts |
+| `stale [--buffer-seconds N]` | In-flight UoWs with silent heartbeats | Observation loop, health checks |
+| `check-stale` | Active UoWs whose GitHub issue is closed | Source integrity checks |
+| `gate-readiness` | Registry health metrics | WOS autonomy gate |
+
+### Common query patterns
+
+```bash
+# How many UoWs are in each status?
+uv run registry_cli.py status-breakdown
+# → {"proposed": 2, "ready-for-steward": 1, "done": 14, ...}
+
+# What UoWs need my attention?
+uv run registry_cli.py escalation-candidates
+# → [{id, status: "needs-human-review", summary, retry_count, ...}, ...]
+
+# Are any executing UoWs stalled?
+uv run registry_cli.py stale
+# → [{id, status: "active", heartbeat_at, heartbeat_ttl, ...}, ...]
+
+# What is in the steward queue right now?
+uv run registry_cli.py list --status ready-for-steward
+
+# Get the full record for a specific UoW
+uv run registry_cli.py get --id uow_20260424_abc123
+```
+
+---
+
+## Path 2: Programmatic Python (agents that process UoW objects)
+
+Use the `Registry` class from `src/orchestration/registry.py`. This is the sole ORM — it handles connection management, WAL mode, JSON deserialization, and schema migrations.
+
+### Standard import pattern
+
+```python
+import sys
+from pathlib import Path
+
+# Add src/ to the path — use the absolute path, not relative
+_SRC_DIR = Path("/home/lobster/lobster/src")
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+from orchestration.registry import Registry, UoWStatus
+
+# Registry resolves the DB path automatically (via REGISTRY_DB_PATH env or
+# paths.REGISTRY_DB canonical default). Pass no argument for normal operation.
+registry = Registry()
+```
+
+### Common programmatic patterns
+
+```python
+# Get all UoWs in a specific status
+uows = registry.list(status="ready-for-steward")
+
+# Get one UoW by ID
+uow = registry.get("uow_20260424_abc123")
+if uow is None:
+    # Not found
+    ...
+
+# Count by status (returns {status: count} dict)
+# Prefer registry_cli.py status-breakdown for this — it's simpler from shell
+# From Python, build the breakdown yourself via list():
+from collections import Counter
+all_uows = registry.list()
+breakdown = Counter(u.status for u in all_uows)
+
+# Find escalation candidates
+escalated = registry.list(status="needs-human-review")
+
+# Find stale in-flight UoWs (uses heartbeat fields, migration 0009+)
+stale = registry.get_stale_heartbeat_uows(buffer_seconds=30)
+```
+
+### What you get back
+
+`registry.list()` and `registry.get()` return typed `UoW` dataclass objects:
+
+```python
+uow.id             # str — "uow_20260424_abc123"
+uow.status         # UoWStatus enum — use str(uow.status) for serialization
+uow.summary        # str — issue title / task description
+uow.source_issue_number  # int | None
+uow.steward_cycles # int — how many steward cycles this UoW has consumed
+uow.retry_count    # int — escalation retry count
+uow.heartbeat_at   # str | None — ISO timestamp of last heartbeat
+uow.heartbeat_ttl  # int — seconds before heartbeat silence triggers stall
+uow.artifacts      # list | None — typed outcome refs [{type, ref, category}]
+```
+
+Fields are documented in `src/orchestration/registry.py` (the `UoW` dataclass).
+
+---
+
+## What NOT to do
+
+### Never use raw sqlite3
+
+```python
+# BAD — bypasses deserialization, breaks on schema changes
+import sqlite3
+conn = sqlite3.connect("/home/lobster/lobster-workspace/orchestration/registry.db")
+rows = conn.execute("SELECT * FROM uow_registry WHERE status = 'active'").fetchall()
+```
+
+### Never use sys.path tricks to import from an unknown location
+
+```python
+# BAD — fragile, depends on repo layout staying fixed at a specific path
+sys.path.insert(0, '/home/lobster/lobster')  # absolute but brittle
+from src.orchestration.uow_registry import UoWRegistry  # wrong class name too
+```
+
+### Never hardcode the DB path in queries
+
+```python
+# BAD — breaks in test environments and alternate workspaces
+conn = sqlite3.connect("/home/lobster/lobster-workspace/orchestration/registry.db")
+```
+
+---
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `REGISTRY_DB_PATH` | Override the DB path (used in tests; not needed in production) |
+| `LOBSTER_WORKSPACE` | Workspace root — the canonical DB lives at `$LOBSTER_WORKSPACE/orchestration/registry.db` |
+
+Both are honored by `Registry()` and by `registry_cli.py`.
+
+---
+
+## Troubleshooting
+
+**"file is not a database" or OperationalError on connect:** The path is wrong. Print `registry.db_path` to see what the Registry resolved.
+
+**Missing columns / AttributeError on UoW fields:** The DB needs a migration. Run `uv run registry_cli.py gate-readiness` — the Registry constructor runs migrations automatically on init.
+
+**Empty results when records should exist:** Check `REGISTRY_DB_PATH` is not accidentally set to a test DB.

--- a/docs/WOS-INDEX.md
+++ b/docs/WOS-INDEX.md
@@ -57,6 +57,12 @@ as proposed UoWs.
 
 ---
 
+### Data Access Layer (canonical subagent guide)
+
+**See:** [WOS-DATA-ACCESS.md](WOS-DATA-ACCESS.md) — canonical patterns for reading WOS state from subagents and scripts. Covers when to use the CLI vs. the Registry class, the import pattern, and what not to do.
+
+---
+
 ### Registry (`src/orchestration/registry.py`)
 
 **Role:** SQLite-backed store for Units of Work. All writes use BEGIN IMMEDIATE

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -812,6 +812,24 @@ class Registry:
         finally:
             conn.close()
 
+    def get_status_counts(self) -> dict[str, int]:
+        """Return a count of UoWs grouped by status.
+
+        Returns a dict mapping each status present in the DB to its count,
+        e.g. {"proposed": 3, "active": 1, "done": 12}.
+
+        Prefer this over a raw GROUP BY query — connection setup and WAL mode
+        are handled consistently via _connect(), and the result is typed.
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT status, COUNT(*) as cnt FROM uow_registry GROUP BY status ORDER BY status"
+            ).fetchall()
+            return {row["status"]: row["cnt"] for row in rows}
+        finally:
+            conn.close()
+
     def expire_proposals(self) -> dict[str, Any]:
         """
         Transition proposed records older than 14 days to 'expired'.

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -192,6 +192,62 @@ def cmd_decide_close(registry: Registry, args: argparse.Namespace) -> None:
         })
 
 
+def cmd_status_breakdown(registry: Registry, args: argparse.Namespace) -> None:
+    """
+    Return a count of UoWs grouped by status.
+
+    Output: JSON object mapping each status present in the DB to its count.
+    Example: {"proposed": 3, "active": 1, "done": 12}
+
+    This is the canonical query that subagents should use instead of raw SQL
+    GROUP BY queries — those have repeatedly caused syntax errors in practice.
+    """
+    import sqlite3 as _sqlite3
+    conn = _sqlite3.connect(str(registry.db_path), timeout=10.0)
+    conn.row_factory = _sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        rows = conn.execute(
+            "SELECT status, COUNT(*) as cnt FROM uow_registry GROUP BY status ORDER BY status"
+        ).fetchall()
+        _output({row["status"]: row["cnt"] for row in rows})
+    finally:
+        conn.close()
+
+
+def cmd_escalation_candidates(registry: Registry, args: argparse.Namespace) -> None:
+    """
+    Return UoWs that require human decision-making.
+
+    Escalation candidates are UoWs in 'needs-human-review' status — the Steward
+    has already exhausted its retry budget and escalated. These UoWs are waiting
+    for Dan to either retry, close, or defer them.
+
+    Output: JSON array of UoW objects (same structure as 'list' output).
+    """
+    records = registry.list(status="needs-human-review")
+    _output([_uow_to_dict(r) for r in records])
+
+
+def cmd_stale(registry: Registry, args: argparse.Namespace) -> None:
+    """
+    Return UoWs whose heartbeat has gone silent beyond their TTL.
+
+    A UoW is stale when:
+    - status is 'active' or 'executing' (in-flight)
+    - heartbeat_at is not NULL (agent has written at least one heartbeat)
+    - (now - heartbeat_at) > heartbeat_ttl + buffer_seconds
+
+    UoWs with no heartbeat_at are NOT returned — those use the legacy
+    started_at-based TTL path.
+
+    Output: JSON array of UoW objects with stale heartbeats.
+    """
+    buffer_seconds = getattr(args, "buffer_seconds", 30)
+    records = registry.get_stale_heartbeat_uows(buffer_seconds=buffer_seconds)
+    _output([_uow_to_dict(r) for r in records])
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -249,6 +305,31 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_decide_close.add_argument("--id", required=True, help="UoW id")
 
+    # status-breakdown
+    subparsers.add_parser(
+        "status-breakdown",
+        help="Count UoWs grouped by status (returns JSON object: {status: count})",
+    )
+
+    # escalation-candidates
+    subparsers.add_parser(
+        "escalation-candidates",
+        help="List UoWs in needs-human-review status awaiting operator decision",
+    )
+
+    # stale
+    p_stale = subparsers.add_parser(
+        "stale",
+        help="List in-flight UoWs whose heartbeat has gone silent beyond their TTL",
+    )
+    p_stale.add_argument(
+        "--buffer-seconds",
+        dest="buffer_seconds",
+        type=int,
+        default=30,
+        help="Grace period added to heartbeat_ttl before declaring a stall (default: 30)",
+    )
+
     return parser
 
 
@@ -262,6 +343,9 @@ _COMMAND_MAP = {
     "gate-readiness": cmd_gate_readiness,
     "decide-retry": cmd_decide_retry,
     "decide-close": cmd_decide_close,
+    "status-breakdown": cmd_status_breakdown,
+    "escalation-candidates": cmd_escalation_candidates,
+    "stale": cmd_stale,
 }
 
 

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -202,17 +202,7 @@ def cmd_status_breakdown(registry: Registry, args: argparse.Namespace) -> None:
     This is the canonical query that subagents should use instead of raw SQL
     GROUP BY queries — those have repeatedly caused syntax errors in practice.
     """
-    import sqlite3 as _sqlite3
-    conn = _sqlite3.connect(str(registry.db_path), timeout=10.0)
-    conn.row_factory = _sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
-    try:
-        rows = conn.execute(
-            "SELECT status, COUNT(*) as cnt FROM uow_registry GROUP BY status ORDER BY status"
-        ).fetchall()
-        _output({row["status"]: row["cnt"] for row in rows})
-    finally:
-        conn.close()
+    _output(registry.get_status_counts())
 
 
 def cmd_escalation_candidates(registry: Registry, args: argparse.Namespace) -> None:

--- a/tests/unit/test_orchestration/test_registry_cli.py
+++ b/tests/unit/test_orchestration/test_registry_cli.py
@@ -337,3 +337,162 @@ class TestDecideRetryCommand:
         assert row["from_status"] == "ready-for-steward", (
             "audit log from_status must reflect actual source status, not hardcoded 'blocked'"
         )
+
+
+# ---------------------------------------------------------------------------
+# status-breakdown command
+# ---------------------------------------------------------------------------
+
+class TestStatusBreakdownCommand:
+    def test_status_breakdown_returns_dict_of_counts(self, db_path):
+        """status-breakdown outputs a dict with status names as keys and integer counts as values."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        run_cli(db_path, "upsert", "--issue", "100", "--title", "Issue 100", "--sweep-date", today)
+        run_cli(db_path, "upsert", "--issue", "101", "--title", "Issue 101", "--sweep-date", today)
+        result = run_cli(db_path, "status-breakdown")
+        assert isinstance(result, dict), "status-breakdown must return a JSON object"
+        assert "proposed" in result, "proposed status must be present after upsert"
+        assert result["proposed"] == 2, "count must equal number of inserted records"
+
+    def test_status_breakdown_counts_are_integers(self, db_path):
+        """All values in the status-breakdown output are non-negative integers."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        run_cli(db_path, "upsert", "--issue", "110", "--title", "Issue 110", "--sweep-date", today)
+        result = run_cli(db_path, "status-breakdown")
+        for status, count in result.items():
+            assert isinstance(count, int), f"count for {status!r} must be an int, got {type(count)}"
+            assert count >= 0, f"count for {status!r} must be non-negative"
+
+    def test_status_breakdown_empty_db_returns_empty_dict(self, db_path):
+        """status-breakdown on an empty but initialized DB returns an empty dict."""
+        # Initialize DB without inserting any UoWs
+        run_cli(db_path, "upsert", "--issue", "999", "--title", "Init", "--sweep-date", "2026-01-01")
+        # Force the single record to done so there are no proposed
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DELETE FROM uow_registry")
+        conn.commit()
+        conn.close()
+        # Must not error; must return {} or a dict without error key
+        result = run_cli(db_path, "status-breakdown")
+        assert isinstance(result, dict)
+        assert "error" not in result
+
+    def test_status_breakdown_reflects_multiple_statuses(self, db_path):
+        """status-breakdown counts separately for each status that exists in the DB."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "120", "--title", "Issue 120", "--sweep-date", today)
+        uow_id_1 = inserted["id"]
+        inserted2 = run_cli(db_path, "upsert", "--issue", "121", "--title", "Issue 121", "--sweep-date", today)
+        uow_id_2 = inserted2["id"]
+        # Force one to blocked so we get two different statuses
+        _force_status(db_path, uow_id_1, "blocked")
+        result = run_cli(db_path, "status-breakdown")
+        assert result.get("blocked", 0) >= 1
+        assert result.get("proposed", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# escalation-candidates command
+# ---------------------------------------------------------------------------
+
+class TestEscalationCandidatesCommand:
+    def test_escalation_candidates_returns_list(self, db_path):
+        """escalation-candidates returns a JSON array."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        run_cli(db_path, "upsert", "--issue", "200", "--title", "Issue 200", "--sweep-date", today)
+        result = run_cli(db_path, "escalation-candidates")
+        assert isinstance(result, list), "escalation-candidates must return a JSON array"
+
+    def test_escalation_candidates_includes_needs_human_review(self, db_path):
+        """UoWs in needs-human-review status appear as escalation candidates."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "201", "--title", "Issue 201", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "needs-human-review")
+        result = run_cli(db_path, "escalation-candidates")
+        ids = [r["id"] for r in result]
+        assert uow_id in ids, "UoW in needs-human-review must appear in escalation-candidates"
+
+    def test_escalation_candidates_excludes_done_uows(self, db_path):
+        """UoWs in done status do not appear as escalation candidates."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "202", "--title", "Issue 202", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "done")
+        result = run_cli(db_path, "escalation-candidates")
+        ids = [r["id"] for r in result]
+        assert uow_id not in ids, "UoW in done status must not appear in escalation-candidates"
+
+    def test_escalation_candidates_output_has_required_fields(self, db_path):
+        """Each escalation candidate record has id, status, and summary fields."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "203", "--title", "Issue 203", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "needs-human-review")
+        result = run_cli(db_path, "escalation-candidates")
+        assert len(result) >= 1
+        record = result[0]
+        assert "id" in record
+        assert "status" in record
+        assert "summary" in record
+
+
+# ---------------------------------------------------------------------------
+# stale command
+# ---------------------------------------------------------------------------
+
+class TestStaleCommand:
+    def test_stale_returns_list(self, db_path):
+        """stale returns a JSON array."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        run_cli(db_path, "upsert", "--issue", "300", "--title", "Issue 300", "--sweep-date", today)
+        result = run_cli(db_path, "stale")
+        assert isinstance(result, list), "stale must return a JSON array"
+
+    def test_stale_excludes_uows_without_heartbeat(self, db_path):
+        """A UoW with no heartbeat_at recorded is not included in stale output."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "301", "--title", "Issue 301", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "active")
+        # No heartbeat written — should not appear as stale
+        result = run_cli(db_path, "stale")
+        ids = [r["id"] for r in result]
+        assert uow_id not in ids, "UoW with no heartbeat_at must not appear in stale output"
+
+    def test_stale_includes_uows_with_expired_heartbeat(self, db_path):
+        """A UoW with an old heartbeat_at beyond its TTL appears in stale output."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "302", "--title", "Issue 302", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "active")
+        # Write an old heartbeat (well beyond any TTL)
+        old_heartbeat = "2020-01-01T00:00:00+00:00"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE uow_registry SET heartbeat_at = ?, heartbeat_ttl = 300 WHERE id = ?",
+            (old_heartbeat, uow_id),
+        )
+        conn.commit()
+        conn.close()
+        result = run_cli(db_path, "stale")
+        ids = [r["id"] for r in result]
+        assert uow_id in ids, "UoW with expired heartbeat must appear in stale output"
+
+    def test_stale_excludes_done_uows(self, db_path):
+        """Done UoWs are never reported as stale even if heartbeat_at is old."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "303", "--title", "Issue 303", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "done")
+        old_heartbeat = "2020-01-01T00:00:00+00:00"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE uow_registry SET heartbeat_at = ?, heartbeat_ttl = 300 WHERE id = ?",
+            (old_heartbeat, uow_id),
+        )
+        conn.commit()
+        conn.close()
+        result = run_cli(db_path, "stale")
+        ids = [r["id"] for r in result]
+        assert uow_id not in ids, "done UoW must not appear in stale output"


### PR DESCRIPTION
## What this solves

Subagents accessing WOS data without a canonical path is a recurring source of bugs:
raw `sqlite3` calls with relative paths, direct Python imports via `sys.path.insert`, and ad-hoc GROUP BY queries that fail mid-execution. This PR closes that gap without building new infrastructure.

## What changed

### `src/orchestration/registry_cli.py` — three new read subcommands

**`status-breakdown`** returns `{status: count}` — the GROUP BY query that subagents kept re-implementing with raw SQL:
```
uv run registry_cli.py status-breakdown
```

**`escalation-candidates`** returns UoWs in `needs-human-review` — the escalation triage query:
```
uv run registry_cli.py escalation-candidates
```

**`stale [--buffer-seconds N]`** delegates to `Registry.get_stale_heartbeat_uows()` — CLI exposure of an existing Registry method:
```
uv run registry_cli.py stale
```

All three follow existing conventions: JSON on stdout, subprocess-safe, test-covered.

### `docs/WOS-DATA-ACCESS.md` — new canonical subagent guide

Covers:
- The two approved access paths: CLI for shell/ad-hoc, `Registry` class for Python
- Standard import pattern
- Common query examples for all new and existing subcommands
- Explicit anti-patterns: never use raw sqlite3, never hardcode DB paths

### `docs/WOS-INDEX.md` — cross-reference to the new guide

## What was explicitly not done

- No schema changes (boundary from the task spec)
- No UoW status modifications (boundary from the task spec)
- No new MCP server — CLI + documentation covers the use cases; adding MCP tools would be ~100 lines of boilerplate for 3 read operations that work fine via subprocess

## Functional patterns used

Pure functions for command handlers: each takes `(registry, args)` and produces JSON to stdout. `cmd_escalation_candidates` and `cmd_stale` compose over existing `Registry` methods. `cmd_status_breakdown` uses `registry.db_path` (public attribute) for a direct aggregation query.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry_cli.py -q` — 33 passed, 1 pre-existing failure (`test_approve_idempotent_on_pending`) confirmed on main before this branch
- [x] All 12 new tests pass: `TestStatusBreakdownCommand` (4), `TestEscalationCandidatesCommand` (4), `TestStaleCommand` (4)
- [x] `uv run python -m py_compile src/orchestration/registry_cli.py` — syntax clean

## Manual test

N/A — all changes are read-only. No external services, no systemd, no file I/O beyond the existing registry DB. Correctness verified via the subprocess test harness.

## Definition of Done

- [x] Unit tests pass, no production hits in automated tests
- [x] Side-effect audit: read-only, no writes, no shared state mutations
- [x] External service calls: none