### PR TITLE
fix(tests): add session-scoped LOBSTER_INBOX_DIR isolation fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,21 @@ Do NOT add per-test mocks for:
     FAILED_DIR, CONFIG_DIR, AUDIO_DIR, SENT_DIR, SENT_REPLIES_DIR,
     TASK_REPLIED_DIR, TASKS_FILE, TASK_OUTPUTS_DIR, BISQUE_OUTBOX_DIR,
     SCHEDULED_JOBS_DIR, SCHEDULED_JOBS_FILE, SCHEDULED_TASKS_TASKS_DIR,
-    SCHEDULED_TASKS_LOGS_DIR, LOG_DIR
+    SCHEDULED_TASKS_LOGS_DIR, LOG_DIR, LOBSTER_INBOX_DIR (env var)
 
 These are all redirected automatically.
+
+LOBSTER_INBOX_DIR isolation
+----------------------------
+The ``isolate_lobster_inbox_dir`` fixture (autouse=True, session-scoped) sets the
+``LOBSTER_INBOX_DIR`` environment variable to a temporary directory for the entire
+test session.  This prevents any code that reads ``LOBSTER_INBOX_DIR`` at call time
+(e.g. ``_write_steward_trigger()`` in wos_completion.py) from writing to the live
+``~/messages/inbox/`` directory.
+
+Issue #915: without this fixture, tests that trigger the executing → ready-for-steward
+transition write ghost ``steward_trigger`` messages to the live inbox.  82 such messages
+were written across 5 pytest runs on 2026-04-24 before this guard was added.
 """
 
 import asyncio
@@ -243,6 +255,44 @@ def isolate_executor_outputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     outputs_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("WOS_OUTPUTS_DIR", str(outputs_dir))
     return outputs_dir
+
+
+@pytest.fixture(autouse=True, scope="session")
+def isolate_lobster_inbox_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Redirect LOBSTER_INBOX_DIR to a temporary directory for the entire test session.
+
+    Any code that writes to the inbox by reading LOBSTER_INBOX_DIR from the
+    environment at call time (e.g. ``_write_steward_trigger()`` in wos_completion.py)
+    will write to this temp directory instead of the live ~/messages/inbox/.
+
+    The fixture creates the standard inbox subdirectory layout that production code
+    may expect:
+        <tmp>/inbox/
+        <tmp>/processing/
+        <tmp>/processed/
+        <tmp>/failed/
+
+    Restores (or unsets) the original env var value after the session ends.
+
+    See: Issue #915 — 82 ghost steward_trigger messages written to live inbox during
+    5 pytest runs because tests only patched REGISTRY_DB_PATH, not LOBSTER_INBOX_DIR.
+    """
+    # Create a session-level temp directory so it persists across all tests.
+    session_tmp = tmp_path_factory.mktemp("lobster_inbox_session", numbered=True)
+
+    for subdir in ("inbox", "processing", "processed", "failed"):
+        (session_tmp / subdir).mkdir(parents=True, exist_ok=True)
+
+    original_value = os.environ.get("LOBSTER_INBOX_DIR")
+    os.environ["LOBSTER_INBOX_DIR"] = str(session_tmp)
+
+    yield session_tmp
+
+    # Restore: unset if it wasn't set before, otherwise put the original back.
+    if original_value is None:
+        os.environ.pop("LOBSTER_INBOX_DIR", None)
+    else:
+        os.environ["LOBSTER_INBOX_DIR"] = original_value
 
 
 # =============================================================================


### PR DESCRIPTION
## What problem this solves

`_write_steward_trigger()` (introduced in the `feature/issue-912-wos-drain-fix` branch) reads `LOBSTER_INBOX_DIR` from the environment at call time. Tests that trigger the `executing → ready-for-steward` transition only patched `REGISTRY_DB_PATH` — not `LOBSTER_INBOX_DIR`. Result: 82 ghost `steward_trigger` messages were written to the live `~/messages/inbox/` across 5 pytest runs before this guard was added.

This is the same class of production path leak that the existing `isolate_executor_outputs` fixture addresses for `WOS_OUTPUTS_DIR`.

## What changed

Added `isolate_lobster_inbox_dir` to `tests/conftest.py`:

- `autouse=True`, `scope="session"` — applies to every test without opt-in
- Creates a temp directory with the standard inbox subdirectory layout (`inbox/`, `processing/`, `processed/`, `failed/`)
- Sets `LOBSTER_INBOX_DIR` to the temp path before any test runs
- Restores the original env var value (or unsets it) after the session

The fixture is session-scoped rather than per-test because `_write_steward_trigger()` reads the env var at call time — a fresh directory per session is sufficient to prevent production writes, and session scope avoids creating hundreds of throwaway directories.

## Functional patterns

The fixture is a pure setup/teardown boundary: it isolates the side-effecting `os.environ` mutation, yields an immutable path value to callers who need it, and restores state cleanly via the generator protocol.

## Coverage gap note

`_write_steward_trigger()` does not yet exist in `main` — it lives in `feature/issue-912-wos-drain-fix` (PR #913). This PR merges first so that when #913 is rebased onto main, the inbox guard is already in place. Tests that specifically test `_write_steward_trigger` behavior correctly do their own per-test `LOBSTER_INBOX_DIR` patching — this fixture is a belt-and-suspenders guard for tests that call `maybe_complete_wos_uow` without explicitly thinking about the inbox side effect.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py -q` — 69 passed, 0 failed
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_attunement.py -x -q` — pre-existing failures only (`src.ooda` missing, ordering-sensitive bisque test); no new failures introduced by this fixture

## Manual test

N/A — this change is entirely internal to the test harness. It does not touch production code paths, external services, or runtime state.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (test-only change)
- [x] User-visible outcome — N/A
- [x] Side-effect audit: fixture only mutates `os.environ` within the test session; restores original value on teardown

Closes #915