### PR TITLE
fix(steward): short-circuit executing_orphan to failed instead of retry

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -941,6 +941,12 @@ def _determine_reentry_posture(
             return "crashed_no_output"
         return "execution_failed"
     elif classification == _CLASSIFICATION_ORPHAN:
+        # executing_orphan is a distinct orphan sub-type: the executor claimed the
+        # UoW and dispatched the subagent, but write_result was never called.
+        # Preserve this classification so the 4b-orphan guard in _process_uow can
+        # short-circuit to fail_uow rather than re-dispatching.
+        if return_reason == "executing_orphan":
+            return "executing_orphan"
         return "executor_orphan"
     else:
         # Fall back to audit event inspection
@@ -3729,6 +3735,42 @@ def _process_uow(
             artifact_dir=artifact_dir,
         )
         return Done(uow_id=uow_id)
+
+    # 4b-orphan: executing_orphan short-circuit.
+    # A UoW whose subagent exited without calling write_result should not be
+    # retried — the retry loop cannot fix a subagent that systematically skips
+    # the result contract. Mark failed immediately so the Steward does not
+    # re-dispatch into an infinite loop.
+    if reentry_posture == "executing_orphan":
+        orphan_reason = "executing_orphan: subagent exited without calling write_result"
+        orphan_log_entry = {
+            "event": "executing_orphan_failed",
+            "uow_id": uow_id,
+            "steward_cycles": cycles,
+            "reason": orphan_reason,
+            "timestamp": _now_iso(),
+        }
+        current_log_str = _append_steward_log_entry(registry, uow_id, current_log_str, orphan_log_entry)
+        if not dry_run:
+            _write_steward_fields(registry, uow_id, steward_log=current_log_str)
+            registry.append_audit_log(uow_id, {
+                "event": "executing_orphan_failed",
+                "actor": _ACTOR_STEWARD,
+                "uow_id": uow_id,
+                "steward_cycles": cycles,
+                "reason": orphan_reason,
+                "timestamp": _now_iso(),
+            })
+            registry.fail_uow(uow_id, orphan_reason)
+        _append_cycle_trace(
+            uow_id=uow_id,
+            cycle_num=cycles,
+            subagent_excerpt=_read_output_ref(uow.output_ref),
+            return_reason=return_reason or "",
+            next_action="failed",
+            artifact_dir=artifact_dir,
+        )
+        return Surfaced(uow_id=uow_id, condition="executing_orphan")
 
     # 4c: Prescribe another Executor pass
     # executor-contract.md Steward Interpretation Table: `partial` and `failed`

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -930,6 +930,9 @@ def _determine_reentry_posture(
     if return_reason == "executor_orphan":
         return "executor_orphan"
 
+    if return_reason == "executing_orphan":
+        return "executing_orphan"
+
     classification = _RETURN_REASON_CLASSIFICATIONS.get(return_reason or "", None)
 
     if classification == _CLASSIFICATION_NORMAL:
@@ -941,12 +944,6 @@ def _determine_reentry_posture(
             return "crashed_no_output"
         return "execution_failed"
     elif classification == _CLASSIFICATION_ORPHAN:
-        # executing_orphan is a distinct orphan sub-type: the executor claimed the
-        # UoW and dispatched the subagent, but write_result was never called.
-        # Preserve this classification so the 4b-orphan guard in _process_uow can
-        # short-circuit to fail_uow rather than re-dispatching.
-        if return_reason == "executing_orphan":
-            return "executing_orphan"
         return "executor_orphan"
     else:
         # Fall back to audit event inspection

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -4533,3 +4533,110 @@ class TestParseWorkflowArtifact:
         result = steward._parse_workflow_artifact(raw)
 
         assert result["success_criteria_check"] == "Check that status: done appears in output"
+
+
+# ---------------------------------------------------------------------------
+# Test: executing_orphan short-circuit (4b-orphan guard)
+# ---------------------------------------------------------------------------
+
+class TestExecutingOrphanShortCircuit:
+    """
+    A UoW whose subagent exited without calling write_result is detected by
+    startup_sweep as executing_orphan. The steward must mark it failed immediately
+    rather than re-dispatching — the retry loop cannot fix a subagent that
+    systematically skips the result contract.
+    """
+
+    EXECUTING_ORPHAN_AUDIT_ENTRY = {
+        "event": "startup_sweep",
+        "classification": "executing_orphan",
+        "prior_status": "executing",
+    }
+
+    def test_executing_orphan_marks_failed_not_retried(self, db_path, registry, tmp_path):
+        """executing_orphan posture → fail_uow called, no transition to ready-for-executor."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            output_ref=None,
+            audit_log_entries=[self.EXECUTING_ORPHAN_AUDIT_ENTRY],
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+        )
+
+        uow = _get_uow(db_path, uow_id)
+        assert uow["status"] == "failed", (
+            f"executing_orphan must be marked failed immediately, not retried. "
+            f"Got status: {uow['status']}"
+        )
+
+    def test_executing_orphan_does_not_transition_to_ready_for_executor(self, db_path, registry, tmp_path):
+        """executing_orphan posture must never transition to ready-for-executor."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            output_ref=None,
+            audit_log_entries=[self.EXECUTING_ORPHAN_AUDIT_ENTRY],
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+        )
+
+        uow = _get_uow(db_path, uow_id)
+        assert uow["status"] != "ready-for-executor", (
+            "executing_orphan must not be re-dispatched to executor — "
+            f"got status: {uow['status']}"
+        )
+
+    def test_executing_orphan_returns_surfaced_with_condition(self, db_path, registry, tmp_path):
+        """_process_uow returns Surfaced(condition='executing_orphan') for this posture."""
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=1,
+            output_ref=None,
+            audit_log_entries=[self.EXECUTING_ORPHAN_AUDIT_ENTRY],
+        )
+        conn.close()
+
+        result = steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+        )
+
+        # run_steward_cycle returns a StewardCycleResult; check that the UoW
+        # outcome was recorded — the simplest signal is the failed status above.
+        # Additionally verify that the executing_orphan_failed event appears in audit_log.
+        entries = _audit_entries(db_path, uow_id)
+        orphan_events = [e for e in entries if e.get("event") == "executing_orphan_failed"]
+        assert orphan_events, (
+            "executing_orphan_failed audit event must be written when short-circuit fires; "
+            f"audit entries: {entries}"
+        )


### PR DESCRIPTION
## Problem

When a functional-engineer subagent exits with code 0 without calling `write_result`, the UoW gets stuck in `executing`. The startup sweep detects it as `executing_orphan` after 630s. The steward then re-prescribes and re-dispatches — but nothing about retrying fixes a subagent that systematically skips the result contract. The loop repeats until `MAX_RETRIES = 3` is exhausted and the UoW escalates to `needs-human-review` (sometimes after 30+ minutes of wasted dispatch cycles).

The root cause has two parts:

1. `_determine_reentry_posture` collapses `executing_orphan` into the generic `executor_orphan` path because both share `_CLASSIFICATION_ORPHAN` in the return-reason table. The `executing_orphan` label is lost before `_process_uow` can act on it.

2. Even if the posture were preserved, `_process_uow` had no short-circuit for it — it would fall through to the 4c retry-cap block and re-prescribe.

## Fix

**`_determine_reentry_posture`** (pure function): add an explicit check for `return_reason == "executing_orphan"` inside the `_CLASSIFICATION_ORPHAN` branch. `executor_orphan` (executor never claimed) and `executing_orphan` (executor claimed and dispatched, but `write_result` never called) are semantically distinct and require different handling downstream.

**`_process_uow` (4b-orphan guard)**: after the `is_complete` check (4b) and before the `cycles > 0` retry-cap check (4c), add:

```
if reentry_posture == "executing_orphan":
    → log executing_orphan_failed event
    → registry.fail_uow(uow_id, reason)
    → return Surfaced(condition="executing_orphan")
```

This makes the failure immediate and explicit rather than letting MAX_RETRIES absorb it silently.

## Before / After Flow

```
Before:
  executing (TTL expired)
    → startup_sweep classifies executing_orphan
    → _most_recent_return_reason returns "executing_orphan"
    → _determine_reentry_posture: executing_orphan ∈ _CLASSIFICATION_ORPHAN → "executor_orphan"
    → _process_uow: no guard, falls to 4c
    → re-prescribes → re-dispatches → subagent exits 0 again → loop
    → after 3 retries: needs-human-review

After:
  executing (TTL expired)
    → startup_sweep classifies executing_orphan
    → _most_recent_return_reason returns "executing_orphan"
    → _determine_reentry_posture: "executing_orphan" preserved (new check)
    → _process_uow: 4b-orphan guard fires
    → fail_uow immediately → done, no retry
```

## Out of scope

- `executor_orphan` behavior is unchanged (executor never claimed — different recovery path)
- `diagnosing_orphan` is unchanged
- `MAX_RETRIES` constant is unchanged
- No other orphan classifications are touched

## Functional patterns

Pure-function diagnosis (`_determine_reentry_posture`, `_diagnose_uow`) remains pure. The guard in `_process_uow` is a new early-exit branch that follows the same pattern as the existing stuck-condition and is_complete branches.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -k "orphan" -v` — 7 passed, 0 failed (includes 3 new tests for `TestExecutingOrphanShortCircuit` and 4 pre-existing executor_orphan tests)
- [x] `uv run pytest tests/unit/test_orchestration/ -q` — 1369 passed; 9 failed, all pre-existing on `main` (confirmed by running the same tests against `main` before this branch)

Pre-existing failures (not introduced by this PR):
- `test_executor_subprocess.py::TestHappyPath::test_instructions_are_passed_to_dispatcher`
- `test_prescriptions_per_cycle.py::TestPrescriptionsTaskOutput::test_task_output_includes_prescription_count`
- `test_steward.py::TestModuleConstants::test_bootup_candidate_gate_constant_exists`
- `test_steward.py::TestSelectExecutorType` (3 tests)
- `test_steward_execution_gate.py::TestStewardExecutionGate` (2 tests)
- `test_registry_cli.py::TestApproveCommand::test_approve_idempotent_on_pending`

## Manual test

N/A — this change is entirely internal to the steward's decision logic. No external service calls, no file I/O outside of the test DB fixtures, no Telegram output.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure logic change, fully covered by unit tests)
- [x] User-visible outcome — N/A (internal steward routing change)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #911
WOS-UoW: uow_20260424_694809