### PR TITLE
fix: use PathSelection StrEnum in shard_dispatch.py (Issue #926)

### DIFF
--- a/oracle/golden-patterns.md
+++ b/oracle/golden-patterns.md
@@ -160,6 +160,24 @@ Applied in WOS Phase 2 design (2026-03-30):
 
 ---
 
+### [2026-04-25] Pattern: full-repo grep as precondition for dead-code removal
+
+**Three rules, all required:**
+
+**Rule 1 — Dead-code removal requires a full-repo grep across ALL Python files.** Searching only `src/` is insufficient. The required scope is: `src/`, `.claude/`, `scripts/`, `tests/`, `scheduled-tasks/`, `hooks/`. A grep limited to `src/` can miss imports in heartbeat scripts, scheduled tasks, hooks, and agent definitions that live outside the main package tree.
+
+**Rule 2 — Run `grep -r 'module_name' ~/lobster/ --include='*.py'` and verify zero matches before filing any dead-code removal issue.** The grep must return zero results across the entire repo. Do not grep a subdirectory and extrapolate — the full repo command is the gate.
+
+**Rule 3 — A single grep hit anywhere in the repo is sufficient to block removal.** One import in `scheduled-tasks/steward-heartbeat.py` or `hooks/` is as binding as ten imports in `src/`. Location outside `src/` does not make the usage less real.
+
+**Why these rules together.** Issue #197 filed `dispatcher_handlers.py` for removal based on a grep scoped to `src/` and `.claude/`. The file was actively imported in `steward.py`, `shard_dispatch.py`, and `inbox_server.py` — files that were never searched. The failure mode is: an incomplete search produces a false "no usages" result, the issue is filed and acted on, and a live import breaks. All three rules exist to make that failure structurally impossible: the scope rule covers the search perimeter, the command rule makes the gate explicit, and the single-hit rule prevents rationalization ("it's only in a script, probably safe to remove").
+
+**Where it applies in this codebase:** `src/orchestration/dispatcher_handlers.py` — issue #197 closed as "not planned" after the routing agent discovered the three live imports during WOS executor implementation (2026-04-25).
+
+**Reuse guidance:** Before filing any issue to remove or rename a Python module, run: `grep -r '<module_filename_without_extension>' ~/lobster/ --include='*.py'`. If any results appear, the module is not dead code — stop. If no results appear, the module is safe to remove. This command is the gate, not a judgment call about whether the usages are "important."
+
+---
+
 *Entries should be added when: (1) an oracle decision receives an "Alignment verdict: Confirmed" with notable quality findings; (2) a negentropic sweep identifies an "undernamed gem" in the golden patterns section; (3) a reflection-systems review names a structural win specific to this codebase.*
 
 ---

--- a/oracle/golden-patterns.md
+++ b/oracle/golden-patterns.md
@@ -292,3 +292,9 @@ StartupSweepResult = _sweep_mod.StartupSweepResult
 **Where it applies:** Every file addition, every module split, every directory reorganization. The question "is the right home unambiguous?" is a pre-commit check, not a post-hoc audit.
 
 **Reuse guidance:** Before adding any file: (1) state the home in one sentence using only the directory and file name; (2) ask if someone new would agree without being told; (3) if no — restructure. Before renaming or moving anything: check whether existing references to the old location would mislead rather than break (breaks are loud; misdirection is silent). The goal is a repo where organizational structure never generates a question that requires a human to answer.
+
+**Documentation is not a fix:** The urge to write a comment or README saying "X lives in Y" is a signal the structure failed, not a solution. Document the why; never the where. If you need to explain where something lives, the location is wrong.
+
+**No split canonical homes:** If something could plausibly live in two places, that ambiguity is the structural problem. Pick one, encode the convention. The existence of a reasonable second option means the first isn't obvious enough.
+
+**Grounded in:** Single Source of Truth (one authoritative home; duplication is structural debt); Principle of Least Surprise (contributors find things where they expect, not where they were convenient to place); self-documenting structure (the repo layout answers "where does X live?" without external documentation).

--- a/oracle/golden-patterns.md
+++ b/oracle/golden-patterns.md
@@ -276,3 +276,19 @@ StartupSweepResult = _sweep_mod.StartupSweepResult
 **Where it appears:** `compact-catchup.md` Phase 3 (step 14) and `nightly-consolidation.md` step 3, both updated in PR #892. The "Stable Context" section is the designated slow section in both agents.
 
 **Reuse guidance:** Apply whenever a memory file is shared between multiple agents using an overwrite pattern. Identify the sections by update rate: (1) fast-moving sections (current work, recent decisions, active threads) — re-synthesize each run; (2) slow-moving sections (contacts, infra, long-term goals) — carry forward verbatim. Name the slow section explicitly in the file's structure and in the agent instructions. Require that both agents use the same section names and the same carry-forward rule — asymmetric rules between agents produce structural variation in the file that downstream readers must handle.
+
+---
+
+### [2026-04-25] Principle: canonical placement must be obvious from first encounter
+
+**Principle:** The right home for any file, module, or definition must be unambiguous without interpretation. If you add something and the correct location is not immediately obvious to someone reading the repo for the first time, the organizational structure has failed — not the reader. When you're about to add something, ask: "Is the right home for this unambiguous?" If the answer requires judgment, context, or familiarity with history, restructure first. Never add to a structure that would require explanation.
+
+**The anti-pattern:** Placing a file "close enough" to where it belongs and relying on contributors to figure out the intent. This compounds. One ambiguous placement generates a second ambiguous reference to the first, then a third that mirrors the second. The confusion isn't localized — it propagates forward and creates friction in every future decision made in its vicinity.
+
+**The staleness problem is the same problem:** A file that used to be canonical and no longer is — because its function moved, its name no longer matches its contents, or its location was never updated when the surrounding structure changed — is not just dead weight. It is active misdirection. A stale canonical home is worse than no canonical home because it answers the question "where does X live?" with the wrong answer confidently.
+
+**The test:** Could a new contributor, given only the repo structure and file names, land on this file without help? If not, the structure owes them a correction — not documentation explaining the deviation.
+
+**Where it applies:** Every file addition, every module split, every directory reorganization. The question "is the right home unambiguous?" is a pre-commit check, not a post-hoc audit.
+
+**Reuse guidance:** Before adding any file: (1) state the home in one sentence using only the directory and file name; (2) ask if someone new would agree without being told; (3) if no — restructure. Before renaming or moving anything: check whether existing references to the old location would mislead rather than break (breaks are loud; misdirection is silent). The goal is a repo where organizational structure never generates a question that requires a human to answer.

--- a/oracle/golden-patterns.md
+++ b/oracle/golden-patterns.md
@@ -142,6 +142,24 @@ Applied in WOS Phase 2 design (2026-03-30):
 
 ---
 
+### [2026-04-24] Pattern: StrEnum constants in all enum-backed SQL and routing logic
+
+**Three rules, all required:**
+
+**Rule 1 — Always use StrEnum constants in SQL.** Raw string literals for enum-backed DB columns are forbidden. Import and use the enum; never write the string value directly in a query. `WHERE status = 'active'` is a latent bug; `WHERE status = UoWStatus.ACTIVE` is correct. A grep for the enum class surfaces all usages; a grep for the raw string catches some of them and misses others.
+
+**Rule 2 — New modules must import enums at definition time.** When writing a new module that uses status/type values from a shared enum, import the enum before writing any code that uses those values. "Not in scope mentally" is not an excuse — the enum exists for type safety and maintainability. The correct pattern: import statement at the top of the file, then use the imported constant. The incorrect pattern: discover the value by looking at an existing string in another file and copy it as a literal.
+
+**Rule 3 — PathSelection/type discriminators get StrEnum.** Any function that returns one of N fixed string choices (path selection, strategy names, mode strings) should define a StrEnum. Naked string returns have no place in internal routing logic. `StrEnum` values compare equal to their string counterparts, so the migration is backward-compatible: callers doing `if path == 'fast'` continue to work without changes.
+
+**Why these rules together.** The three failure modes are related: raw SQL strings, raw literals in new modules, and naked routing returns are all the same underlying pattern — a value with a finite domain is being managed as an unbounded string. The fix is always the same: find the enum (or define one), import it, use it.
+
+**Where these apply in this codebase:** PR #904 introduced `list_executing()` with raw SQL literals despite the surrounding `registry.py` using `UoWStatus` consistently (issue #925). `shard_dispatch.py`'s `select_path()` returns `'fast'`/`'thorough'` with no StrEnum backing (issue #926). Both are filed for fix.
+
+**Reuse guidance:** Before committing any SQL query that filters on a status/type column, run: does the value being compared have an enum in this codebase? If yes, use it. Before merging any module that returns one of N fixed string choices, ask: should this be a StrEnum? The answer is almost always yes.
+
+---
+
 *Entries should be added when: (1) an oracle decision receives an "Alignment verdict: Confirmed" with notable quality findings; (2) a negentropic sweep identifies an "undernamed gem" in the golden patterns section; (3) a reflection-systems review names a structural win specific to this codebase.*
 
 ---

--- a/oracle/verdicts/archive/pr-924.md
+++ b/oracle/verdicts/archive/pr-924.md
@@ -1,0 +1,183 @@
+VERDICT: APPROVED
+PR: 924
+Round: 2
+
+## Round 2 — 2026-04-24
+
+### Prior gap tracking
+
+**Gap 1 (Round 1): Unreachable guard in `_determine_reentry_posture`** — ADDRESSED.
+
+The round 1 gap required an explicit early-return for `executing_orphan` before the classification lookup, analogous to the existing `executor_orphan` early-return at line 930. The round 2 fix (commit 9c87cc61) adds exactly that:
+
+```python
+if return_reason == "executing_orphan":
+    return "executing_orphan"
+```
+
+placed between the existing `executor_orphan` early-return and the classification lookup. The now-redundant inner check inside `elif classification == _CLASSIFICATION_ORPHAN:` was cleanly removed. The fix is the minimal change the gap required.
+
+---
+
+### Stage 1: Vision Alignment (locked from Round 1)
+
+The adversarial prior — this implementation is solving the wrong problem or forecloses better paths — is not confirmed. `executing_orphan` UoWs being looped through retry cycles rather than failed immediately is a real failure mode in the WOS execution pipeline. Hardening the steward's classification response to a known unrecoverable orphan class is consistent with `principle-1` (Proactive resilience over reactive recovery). The round 1 alignment finding holds: the fix is solving the right problem at the right layer.
+
+From learnings.md (PR #891): "the consumer-vs-producer pattern requires distinguishing individual non-conformance from universal infrastructure gap." This pattern constrained my analysis: the `executing_orphan` case is per-UoW non-conformance (a specific subagent exited without calling `write_result`), not a universal infrastructure gap — so the steward consumer layer is the correct fix site. The pattern confirmed rather than questioned the approach.
+
+**Alignment verdict: Confirmed.**
+
+---
+
+### Stage 2: Quality Review (Round 2)
+
+#### Fix placement and correctness
+
+The round 2 fix is placed correctly. The function `_determine_reentry_posture` now has three early-return guards before the classification lookup:
+
+1. `if not audit_entries: return "first_execution"`
+2. `if return_reason == "executor_orphan": return "executor_orphan"` (existing)
+3. `if return_reason == "executing_orphan": return "executing_orphan"` (new)
+
+This pattern is consistent, minimal, and does not depend on `executing_orphan` being present in `_RETURN_REASON_CLASSIFICATIONS`. The classification table does contain `"executing_orphan": _CLASSIFICATION_ORPHAN` (added in PR #858), but the early-return fires before the table lookup, making the fix robust regardless of the table's contents.
+
+#### Test verification
+
+The three `TestExecutingOrphanShortCircuit` tests were run against the branch code and all pass:
+
+- `test_executing_orphan_marks_failed_not_retried` — verifies status == "failed"
+- `test_executing_orphan_does_not_transition_to_ready_for_executor` — verifies status != "ready-for-executor"
+- `test_executing_orphan_returns_surfaced_with_condition` — verifies `executing_orphan_failed` audit event is written
+
+The tests exercise the real execution path: `_make_uow_row` stores the entire entry dict as the `note` column (via `json.dumps(entry)`), so `_most_recent_return_reason` reads the `note` JSON and finds `classification: "executing_orphan"`, returning it as `return_reason`. The early-return fires. The 4b-orphan guard in `_process_uow` fires. The UoW is marked failed. The tests verify what they claim to verify.
+
+An additional regression run of all 11 orphan-related tests (`-k "orphan or Orphan or reentry or Reentry"`) shows 11 passed with no failures.
+
+#### `_CLASSIFICATION_ORPHAN` branch side-effect check
+
+The `_CLASSIFICATION_ORPHAN` branch (`elif classification == _CLASSIFICATION_ORPHAN: return "executor_orphan"`) now handles only `diagnosing_orphan` (the only `_CLASSIFICATION_ORPHAN` classification not caught by the two early-returns). Behavior for `diagnosing_orphan` is unchanged: it falls through to the classification lookup, gets `_CLASSIFICATION_ORPHAN`, and returns `"executor_orphan"`. No regression.
+
+#### Encoded Orientation check (constraint-3)
+
+This PR changes steward decision-making logic: `executing_orphan` now short-circuits to `fail_uow` rather than being re-prescribed. This is a behavioral default change. Prior logged decision: issue #911 documents the root cause and intended fix. Vision anchor: `principle-1` (Proactive resilience over reactive recovery) and WOS execution pipeline reliability work in `vision.yaml current_focus.this_week.primary`. Both are present and sufficient. Constraint-3 is satisfied.
+
+#### Note on round 1 analysis
+
+Round 1 stated that `executing_orphan` was not in `_RETURN_REASON_CLASSIFICATIONS`, making the `_CLASSIFICATION_ORPHAN` branch unreachable. This was incorrect: `executing_orphan` was added to the classification table in PR #858 (commit 7ce2dab9), which was merged to main before the round 1 PR branch was cut. The classification table on main had the entry; the round 1 diff showed no addition of it; the oracle reading the diff missed the pre-existing table state.
+
+The practical consequence: the round 1 guard (inside `_CLASSIFICATION_ORPHAN` branch) would have been reachable. The round 1 NEEDS_CHANGES verdict required a fix that was structurally cleaner than the original approach (early-return pattern matches `executor_orphan`) but the original inner check would also have been functionally correct. The round 2 fix improves structural clarity and is the correct canonical form regardless. The round 1 analysis error does not affect the round 2 verdict — the fix is correct and the tests verify the path end-to-end.
+
+---
+
+**VERDICT: APPROVED**
+
+---
+
+## Round 1 — 2026-04-24
+
+### Stage 1: Vision Alignment
+
+**Formed before reading the implementation. Locked — does not change after Stage 2.**
+
+The theory of change for this PR: `executing_orphan` UoWs are being looped through retry cycles because the `executing_orphan` label is collapsed into the generic `executor_orphan` path in `_determine_reentry_posture`, and no short-circuit exists even if the label were preserved. The fix adds (a) label preservation in the classification function and (b) a new early-exit guard in `_process_uow`.
+
+The adversarial prior I hold entering any review: this is solving the wrong problem, or solving the right problem in a direction that forecloses better paths.
+
+The named failure pattern most relevant here is from learnings.md (PR #607): "Recovery gate tolerating an open executor contract gap inverts principle-1 — fix the contract at the producer, not the consumer." This pattern constrained my Stage 1 analysis by forcing me to ask whether the correct fix is to harden the subagent result contract (producer) rather than add a new failure path in the steward (consumer).
+
+Assessment: the pattern does not apply here. The producer-side gap (subagent exits 0 without calling `write_result`) is not structurally preventable at the consumer's boundary — LLM-spawned subagents can fail arbitrarily. The steward's classification system exists precisely as the authoritative downstream determinant when the handshake breaks. Failing-immediately on a recognized unrecoverable orphan class is the correct consumer-side response. The fix is not tolerating a contract gap; it is enforcing a consequence for a known unrecoverable failure mode. The PR is solving the right problem.
+
+**Alignment verdict: Confirmed.**
+
+---
+
+### Stage 2: Quality Review
+
+#### Critical defect: the new guard in `_determine_reentry_posture` is unreachable
+
+The PR adds this guard inside the `_CLASSIFICATION_ORPHAN` branch:
+
+```python
+elif classification == _CLASSIFICATION_ORPHAN:
+    if return_reason == "executing_orphan":
+        return "executing_orphan"
+    return "executor_orphan"
+```
+
+For this branch to execute, `classification` must equal `_CLASSIFICATION_ORPHAN`. `classification` is set by:
+
+```python
+classification = _RETURN_REASON_CLASSIFICATIONS.get(return_reason or "", None)
+```
+
+`_RETURN_REASON_CLASSIFICATIONS` maps `executor_orphan` and `diagnosing_orphan` to `_CLASSIFICATION_ORPHAN`. It does NOT contain `executing_orphan`. So when `return_reason == "executing_orphan"`, `classification` is `None`, not `_CLASSIFICATION_ORPHAN`. The `elif classification == _CLASSIFICATION_ORPHAN:` branch never fires. The new check inside it is dead code.
+
+The function falls into the audit inspection fallback. The audit inspection's `startup_sweep` handler reads `clf = data.get("classification", "")` and finds `"executing_orphan"`, but there is no handler for it (only `executor_orphan` and `diagnosing_orphan` are handled). The loop exits without returning. `_determine_reentry_posture` returns `"first_execution"`.
+
+With `reentry_posture == "first_execution"`, the 4b-orphan guard `if reentry_posture == "executing_orphan":` in `_process_uow` never fires. The UoW is re-prescribed and dispatched to `ready-for-executor`, not failed.
+
+The root-cause diagnosis is correct (label collapse is the issue). The fix location in `_determine_reentry_posture` is correct (this is where the label must be preserved). But the fix code is placed in a branch that never executes for `executing_orphan`.
+
+#### Why the existing pattern works for `executor_orphan`
+
+`executor_orphan` is handled via an explicit early-return at line 901:
+
+```python
+if return_reason == "executor_orphan":
+    return "executor_orphan"
+```
+
+This fires before the classification lookup, so it bypasses the `_RETURN_REASON_CLASSIFICATIONS` table entirely. `executing_orphan` needs the same treatment. The fix must add:
+
+```python
+if return_reason == "executing_orphan":
+    return "executing_orphan"
+```
+
+as an early-return check analogous to line 901, OR add `"executing_orphan": _CLASSIFICATION_ORPHAN` to `_RETURN_REASON_CLASSIFICATIONS` so the classification lookup finds it. The early-return approach is the minimal fix that matches the existing pattern.
+
+#### Test analysis
+
+The three new tests (`TestExecutingOrphanShortCircuit`) are structurally correct in intent but are presently testing dead code — they pass only if there is another path that coincidentally produces the expected result, or they do not actually pass in the PR branch. Given the code path analysis above, `test_executing_orphan_marks_failed_not_retried` should fail because the UoW ends up re-prescribed (not failed). If the engineer reports 7 passed, either: (a) the tests are exercising a path I cannot see in the diff, or (b) there is an interaction with the LLM prescriber mock that incidentally fails the UoW. Either way, the tests do not verify what they claim to verify because the guard they test (`if reentry_posture == "executing_orphan":`) is unreachable.
+
+#### Side-effect audit on `executor_orphan` and `diagnosing_orphan`
+
+The new code does not touch lines 901, 912-915, or 935-938. `executor_orphan` still returns via the line-901 early-return. `diagnosing_orphan` still returns via the audit inspection path. Both paths are unchanged. No side effects on these two classifications.
+
+#### 4b-orphan guard placement
+
+The placement of the 4b-orphan guard in `_process_uow` — after the `is_complete` check (original 4b) and before the 4c prescription block — is correct. If the `reentry_posture` were correctly set to `"executing_orphan"`, the guard would fire at the right point in the decision tree.
+
+#### Encoded Orientation check (constraint-3)
+
+This PR changes steward decision-making logic (short-circuit to `fail_uow` for a recognized orphan class). This is a behavioral default change. A prior logged decision exists: issue #911 documents the root cause and the intended fix. The vision anchor is `principle-1` (Proactive resilience over reactive recovery) and the WOS execution pipeline reliability work documented in `vision.yaml current_focus.this_week.primary`. The prior and anchor are sufficient. If the fix were correctly implemented, constraint-3 would be satisfied.
+
+#### Stale `_posture_prediction` comment
+
+The engineer correctly notes this is cosmetic and out of scope. For completeness: once `executing_orphan` is correctly routed, `_posture_prediction` will fall into `case _:` with a generic message rather than a specific prediction. This is a minor documentation gap but not a correctness issue.
+
+---
+
+### NEEDS_CHANGES — Required fix
+
+**Gap 1: Unreachable guard in `_determine_reentry_posture`**
+
+The new `if return_reason == "executing_orphan": return "executing_orphan"` check is inside `elif classification == _CLASSIFICATION_ORPHAN:`, which never fires because `executing_orphan` is not in `_RETURN_REASON_CLASSIFICATIONS`. The guard is dead code.
+
+Required resolution (one of):
+- (a) Add an explicit early-return before the classification lookup, analogous to the existing line-901 check for `executor_orphan`:
+  ```python
+  if return_reason == "executing_orphan":
+      return "executing_orphan"
+  ```
+  This should be placed alongside (or immediately after) the existing `executor_orphan` early-return.
+- (b) Add `"executing_orphan": _CLASSIFICATION_ORPHAN` to `_RETURN_REASON_CLASSIFICATIONS`, making the classification lookup find it and route into the `_CLASSIFICATION_ORPHAN` branch where the new check lives.
+
+Either option is sufficient. Option (a) is the minimal change consistent with the existing pattern.
+
+After this fix, verify that:
+- `_determine_reentry_posture(audit_entries, "executing_orphan")` returns `"executing_orphan"` in a direct unit test or the existing test exercise
+- `test_executing_orphan_marks_failed_not_retried` asserts `status == "failed"` and passes because the 4b-orphan guard now fires
+- `test_executing_orphan_returns_surfaced_with_condition` finds the `executing_orphan_failed` audit event
+
+Resolution contract: this gap is addressed when the guard is reachable and the three new tests verify the actual execution path, not a coincidental or unreachable one.

--- a/oracle/verdicts/archive/pr-930.md
+++ b/oracle/verdicts/archive/pr-930.md
@@ -1,0 +1,77 @@
+VERDICT: APPROVED
+PR: 930
+Round: 1
+
+---
+
+## Stage 1 — Vision Alignment (formed before reading implementation)
+
+**Adversarial prior:** This implementation is solving the wrong problem, or solving the right problem in a direction that forecloses better paths.
+
+**What the work claims to serve:** Closing a structural gap in the PR Merge Gate: the hook existed but had a soft exit for missing verdicts, meaning the gate was only functional for the NEEDS_CHANGES case. A PR with no oracle review at all could still merge.
+
+**Theory of change test:** For this work to be the right path, the existing advisory gate would need to be materially failing — PRs merging without oracle review because the hook's exit-0 for missing verdicts created a real bypass route. The PR Merge Gate is in the Tier-1 Gate Register. The gate's own golden-patterns.md entry (advisory-to-hook promotion, 2026-04-22) names compaction-vulnerability as the primary hazard. A hook that exits 0 for missing verdicts is not compaction-vulnerable — it's just incomplete. The hook was incomplete by design at PR #825 ("pre-oracle or infrastructure" carve-out), and this PR removes that carve-out.
+
+**Cheaper test:** There is no cheaper test. The question "does a missing verdict produce a hard block?" is directly testable only by changing the exit code.
+
+**What this forecloses:** The carve-out path for pre-oracle or infrastructure PRs. This is the right thing to foreclose — the carve-out was a soft guarantee, not a structural one. If a PR genuinely should bypass oracle review (infrastructure, pre-oracle), the correct mechanism is not "no verdict file" but "a verdict file with a documented reason." The gate does not foreclose that path; it requires it be explicit.
+
+**Opportunity cost:** Negligible. This is a single-function behavioral change with no architectural surface. The delta from the current codebase is small and the domain (hook enforcement) is stable.
+
+**Encoded Orientation check (constraint-3):** This PR changes a behavioral default in an existing hook — from warn+allow to hard-block for missing verdicts. This is an Encoded Orientation change. The check requires: (a) a prior logged decision exists, and (b) the change is traceable to a vision.yaml anchor.
+
+(a) Prior: The original hook (PR #825) is the prior logged decision. Golden-patterns.md documents PR #825 as oracle-approved under the "advisory-to-hook promotion" pattern (2026-04-22). The current PR tightens an existing Encoded Orientation rather than adding a new one. The PR description states Dan explicitly approved making the check hard. The oracle verdict for PR #930 serves as the formal logged record for this tightening, consistent with learnings.md PR #914 pattern ("Dan-authored... provides stronger substantive authorization... The oracle verdict for the reversing PR serves as the logged prior going forward"). This is the same class of authorization.
+
+(b) Vision.yaml anchor: `principle-1` (proactive resilience over reactive recovery) and the Tier-1 Gate Register entry for PR Merge Gate in CLAUDE.md. The gate's stated purpose — prevent merging without oracle approval — is structurally aligned with `principle-1`'s statement that "structural prevention is preferred over better correction mechanisms." A warn+allow exit is a correction mechanism; a hard block is structural prevention. The vision anchor is real, not inferable.
+
+**Alignment verdict: Confirmed.** This work serves a real structural gap in the oracle enforcement chain. The adversarial prior was not confirmed.
+
+---
+
+## Stage 2 — Quality Review
+
+### What the diff does
+
+**`hooks/pr-merge-gate.py`:** The APPROVED check is moved before the None check. Both the None path and the non-APPROVED path now exit 2. The docstring and exit-code comments are updated to match.
+
+**Logic verification (implementor concern #1 — reordering):** The after-state is:
+1. `if verdict == 'APPROVED': sys.exit(0)` — fast path, exit 0
+2. `if verdict is None:` → print BLOCKED, exit 2
+3. Fall-through (NEEDS_CHANGES or UNKNOWN) → print BLOCKED, exit 2
+
+Both None and non-APPROVED produce exit 2. The reordering is safe and correct. The hot path is now APPROVED → exit immediately without evaluating the None check, which is a minor efficiency improvement. No logic error introduced.
+
+**`.claude/sys.subagent.bootup.md`:** The stale reference to `oracle/decisions.md` as the manual verification step for PR merges is replaced with a description of the mechanical enforcement. This is a correct canonicalization — the file on disk (pre-PR) says "also verify oracle approval in ~/lobster/oracle/decisions.md per the PR Merge Gate in CLAUDE.md." The PR replaces it with "the hook does this automatically; do not try to bypass it." The replacement is accurate and removes an instruction that invited manual workarounds.
+
+**`tests/unit/test_hooks/test_pr_merge_gate.py`:** 19 tests in three classes. The test design correctly separates:
+- `TestExtractPrNumber`: pure function, 6 cases including URL form, no-number, non-merge command
+- `TestFindOracleVerdict`: pure function with tmp_path fixtures, 6 cases including UNKNOWN first line, legacy decisions.md path
+- `TestHookExitCodes`: integration contract via `_run_gate_logic` helper, 7 cases
+
+**Test isolation (implementor concern #2):** Tests patch `VERDICTS_DIR` and `DECISIONS_FILE` as module globals after load. The `_load_module_functions` helper feeds a non-Bash payload to trigger the immediate `sys.exit(0)` at module top-level, then re-binds stdin. This avoids the anti-pattern described in learnings.md PR #839 (module-level constant frozen at import time) because `VERDICTS_DIR` and `DECISIONS_FILE` are `Path` objects computed at module scope but accessed by name in the functions — patching the module globals after load is correct here since the functions reference the module-level names, not captured values.
+
+**`_run_gate_logic` helper:** This function re-implements the hook's top-level logic in the test file. This is the "inline test copy of a production function" pattern from learnings.md PR #848, which carries synchronization debt. However, the function is 15 lines and exactly mirrors the top-level script body (which is itself about 15 lines). The production script is not a function that can be called directly — it is a module-level script that exits. The copy is structurally necessary and the logic is simple enough that drift is unlikely. The PR description acknowledges the test structure explicitly. This is acceptable; the risk is low given the simplicity of the logic being duplicated.
+
+**The critical behavioral case — missing verdict now blocks:** `test_missing_oracle_entry_hard_blocks` directly verifies the PR's stated behavioral change: empty verdicts directory, no decisions.md, result is EXIT_BLOCK (2). This test would have failed against the pre-PR code (which would return EXIT_ALLOW). The test is correctly specced.
+
+**Failure modes:**
+- Archive directory: `oracle/verdicts/archive/` contains merged PR verdicts. The hook looks for `oracle/verdicts/pr-{N}.md`. An archived verdict at `oracle/verdicts/archive/pr-{N}.md` is not found by `find_oracle_verdict` — the hook would hard-block. This is the existing behavior from PR #825; the PR does not change it. The Merge Gate documentation says "move file to oracle/verdicts/archive/pr-{number}.md" as a post-merge step, so the verdict file is present pre-merge and archived post-merge. No regression here.
+- YAML frontmatter: If an APPROVED verdict file has YAML frontmatter prepended (as the oracle instructions specify for document reviews), the first line would be `---` not `VERDICT: APPROVED`. For oracle PR verdicts, the instructions say first line must be exactly `VERDICT: APPROVED` — the oracle protocol does not prepend frontmatter to PR verdict files. The test `_make_verdict_file` correctly writes the verdict first line as the actual first line. No issue here for PR verdicts.
+
+**Migration 82 note:** Migration 82 in upgrade.sh registers the hook but does not update its behavior. The behavioral change (exit 2 for missing verdict) is in the hook file itself and takes effect immediately on any instance where the hook is already registered. New installs get Migration 82 (registration) plus the updated hook file. No migration gap.
+
+**Pre-existing test failure:** `test_disabled_job_writes_no_inbox_message` fails on both main and branch equally. Not introduced by this PR; not a concern for this review.
+
+### What this makes easier / harder
+
+Easier: The merge gate is now structurally complete. No PR can merge without an oracle verdict file — the implementation of the gate now matches its stated intent. Future agents do not need to remember "missing verdict = allow" as a special case.
+
+Harder: Infrastructure PRs or "pre-oracle" PRs that used to slide through on the warning now require explicit oracle review or a verdict file with a documented rationale. This is the correct hardening — the exception carve-out was an escape hatch that eroded the gate's structural guarantee.
+
+### Patterns introduced
+
+The test helper `_run_gate_logic` introduces a module-level script copy pattern. Per the discussion above, this is acceptable for this use case but should not propagate to more complex hook scripts where the logic divergence risk is higher.
+
+### Summary
+
+The implementation is correct, the test coverage is complete for the behavioral cases, and the Encoded Orientation check passes with a real vision.yaml anchor and a substantive prior (PR #825 + Dan's explicit approval). The single concern (inline test copy) is acceptable given the scope. No gaps requiring changes.

--- a/src/ooda/fast_thorough_selector.py
+++ b/src/ooda/fast_thorough_selector.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import logging
 
+from src.orchestration.shard_dispatch import PathSelection
+
 log = logging.getLogger(__name__)
 
 
@@ -71,7 +73,7 @@ def cite_basis(context: dict) -> str | None:
     return None
 
 
-def select_path(context: dict) -> str:
+def select_path(context: dict) -> PathSelection:
     """
     Select the routing path for an OODA loop decision: "fast" or "thorough".
 
@@ -107,7 +109,7 @@ def select_path(context: dict) -> str:
             context.get("stakes", "<unknown>"),
             basis,
         )
-        return "fast"
+        return PathSelection.FAST
 
     log.info(
         "[fast-thorough-selector] Thorough Path selected | "
@@ -117,4 +119,4 @@ def select_path(context: dict) -> str:
         context.get("vision_anchor"),
         len(context.get("prior_decisions", [])),
     )
-    return "thorough"
+    return PathSelection.THOROUGH

--- a/src/orchestration/shard_dispatch.py
+++ b/src/orchestration/shard_dispatch.py
@@ -42,7 +42,13 @@ Named constants
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Sequence
+
+
+class PathSelection(StrEnum):
+    FAST = "fast"
+    THOROUGH = "thorough"
 
 # Default cap: two non-overlapping UoWs may run in parallel before any
 # Attunement evidence exists at higher concurrency.

--- a/tests/ooda/test_fast_thorough_selector.py
+++ b/tests/ooda/test_fast_thorough_selector.py
@@ -15,6 +15,7 @@ Coverage:
 import pytest
 
 from src.ooda.fast_thorough_selector import cite_basis, select_path
+from src.orchestration.shard_dispatch import PathSelection
 
 
 # ---------------------------------------------------------------------------
@@ -30,7 +31,7 @@ class TestSelectPath:
             "prior_decisions": [],
             "vision_anchor": "vision.core.fundamental_intent",
         }
-        assert select_path(ctx) == "fast"
+        assert select_path(ctx) == PathSelection.FAST
 
     def test_fast_path_prior_decision_same_class_low_stakes(self):
         """Fast Path when prior decision of same class exists and stakes low."""
@@ -42,7 +43,7 @@ class TestSelectPath:
             ],
             "vision_anchor": None,
         }
-        assert select_path(ctx) == "fast"
+        assert select_path(ctx) == PathSelection.FAST
 
     def test_thorough_path_no_anchor_no_prior(self):
         """Thorough Path when no anchor and no prior decision."""
@@ -52,7 +53,7 @@ class TestSelectPath:
             "prior_decisions": [],
             "vision_anchor": None,
         }
-        assert select_path(ctx) == "thorough"
+        assert select_path(ctx) == PathSelection.THOROUGH
 
     def test_thorough_path_high_stakes_even_with_anchor(self):
         """Thorough Path when stakes are high even if vision anchor exists."""
@@ -62,7 +63,7 @@ class TestSelectPath:
             "prior_decisions": [],
             "vision_anchor": "vision.core.inviolable_constraints",
         }
-        assert select_path(ctx) == "thorough"
+        assert select_path(ctx) == PathSelection.THOROUGH
 
     def test_thorough_path_high_stakes_with_prior(self):
         """Thorough Path when stakes high even with matching prior decision."""
@@ -74,7 +75,7 @@ class TestSelectPath:
             ],
             "vision_anchor": None,
         }
-        assert select_path(ctx) == "thorough"
+        assert select_path(ctx) == PathSelection.THOROUGH
 
     def test_fast_path_prior_decision_no_explicit_id(self):
         """Fast Path with prior decision that has no explicit ID uses synthetic ref."""
@@ -86,7 +87,7 @@ class TestSelectPath:
             ],
             "vision_anchor": None,
         }
-        assert select_path(ctx) == "fast"
+        assert select_path(ctx) == PathSelection.FAST
 
     def test_thorough_path_prior_different_class(self):
         """Thorough Path when prior decision exists but is a different class."""
@@ -98,7 +99,7 @@ class TestSelectPath:
             ],
             "vision_anchor": None,
         }
-        assert select_path(ctx) == "thorough"
+        assert select_path(ctx) == PathSelection.THOROUGH
 
     def test_fast_path_prefers_vision_anchor_over_prior(self):
         """When both anchor and prior exist (low stakes), Fast Path is selected."""
@@ -110,7 +111,7 @@ class TestSelectPath:
             ],
             "vision_anchor": "vision.active_project.phase_intent",
         }
-        assert select_path(ctx) == "fast"
+        assert select_path(ctx) == PathSelection.FAST
 
     def test_empty_string_anchor_treated_as_absent(self):
         """An empty string vision_anchor is treated as absent (Thorough Path)."""
@@ -120,7 +121,7 @@ class TestSelectPath:
             "prior_decisions": [],
             "vision_anchor": "",
         }
-        assert select_path(ctx) == "thorough"
+        assert select_path(ctx) == PathSelection.THOROUGH
 
     def test_whitespace_only_anchor_treated_as_absent(self):
         """A whitespace-only vision_anchor is treated as absent (Thorough Path)."""
@@ -130,7 +131,7 @@ class TestSelectPath:
             "prior_decisions": [],
             "vision_anchor": "   ",
         }
-        assert select_path(ctx) == "thorough"
+        assert select_path(ctx) == PathSelection.THOROUGH
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ooda/test_fast_thorough_selector.py
+++ b/tests/ooda/test_fast_thorough_selector.py
@@ -209,3 +209,17 @@ class TestCiteBasis:
         basis = cite_basis(ctx)
         # Vision anchor should take precedence
         assert basis == "vision.active_project.phase_intent"
+
+
+# ---------------------------------------------------------------------------
+# PathSelection backward-compatibility
+# ---------------------------------------------------------------------------
+
+class TestPathSelectionBackwardCompat:
+    def test_fast_equals_raw_string(self):
+        """PathSelection.FAST == 'fast' — StrEnum backward-compat guarantee."""
+        assert PathSelection.FAST == "fast"
+
+    def test_thorough_equals_raw_string(self):
+        """PathSelection.THOROUGH == 'thorough' — StrEnum backward-compat guarantee."""
+        assert PathSelection.THOROUGH == "thorough"


### PR DESCRIPTION
## Summary

**Stated scope (Issue #926): PathSelection StrEnum enforcement**

- Defines \`PathSelection(StrEnum)\` with \`FAST = "fast"\` and \`THOROUGH = "thorough"\` in \`shard_dispatch.py\`
- Updates \`select_path()\` in \`fast_thorough_selector.py\` to return \`PathSelection\` instead of a raw string
- Updates all test assertions in \`test_fast_thorough_selector.py\` to use \`PathSelection.FAST\` / \`PathSelection.THOROUGH\`
- Adds two explicit backward-compat assertions: \`assert PathSelection.FAST == "fast"\` and \`assert PathSelection.THOROUGH == "thorough"\`

\`StrEnum\` ensures backward-compatibility: \`PathSelection.FAST == "fast"\` is \`True\`, so no callers that compare against magic strings are broken.

**Oracle housekeeping (acceptable per oracle verdict pr-931 Round 1)**

- \`oracle/golden-patterns.md\`: two new entries — StrEnum-constants pattern ([2026-04-24]) and canonicality principle ([2026-04-25]) and dead-code grep rule ([2026-04-25])
- \`oracle/verdicts/archive/pr-924.md\`: archive of pr-924 (executing_orphan short-circuit) post-merge
- \`oracle/verdicts/archive/pr-930.md\`: archive of pr-930 (oracle hard-block) post-merge

These housekeeping files were present in the branch before the StrEnum fix was added and are carried forward here.

Closes #926

## Test plan
- [x] All 18 \`test_fast_thorough_selector.py\` tests pass (\`uv run pytest tests/ooda/test_fast_thorough_selector.py\`)
- [x] All 36 \`test_shard_dispatch.py\` tests pass (\`uv run pytest tests/unit/test_orchestration/test_shard_dispatch.py\`)
- [x] \`PathSelection.FAST == "fast"\` and \`PathSelection.THOROUGH == "thorough"\` verified by explicit test assertions (TestPathSelectionBackwardCompat)
- [x] No steward.py or dispatcher_handlers.py changes in diff — branch rebased onto origin/main, duplicate commits dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)