### PR TITLE
perf(#934): cap active-sessions prefix to 5 entries with overflow summary

### DIFF
--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -868,12 +868,20 @@ def _elapsed_minutes_str(elapsed_seconds: int | None) -> str:
     return f"{minutes}m ago"
 
 
+_ACTIVE_SESSIONS_DISPLAY_CAP = 5
+
+
 def format_active_sessions_block(sessions: list[dict]) -> str:
     """Format a list of active sessions as a compact context block.
 
     Distinguishes user-facing agents from system agents (chat_id=0 or None).
     System agents are background tasks (scheduled jobs, startup-catchup, etc.)
     that do not correspond to a user conversation in the IDE panel.
+
+    Renders at most _ACTIVE_SESSIONS_DISPLAY_CAP entries (user sessions first,
+    then system). When the total exceeds the cap, a trailing "...and N more"
+    line is appended so the dispatcher knows the full count without paying the
+    per-token cost of every entry.
 
     Produces output like:
         [1 agent running, 1 system]
@@ -899,8 +907,13 @@ def format_active_sessions_block(sessions: list[dict]) -> str:
         header += f", {system_count} {sys_label}"
     header += "]"
 
+    all_sessions = user_sessions + system_sessions
+    total = len(all_sessions)
+    displayed = all_sessions[:_ACTIVE_SESSIONS_DISPLAY_CAP]
+    hidden = total - len(displayed)
+
     lines = [header]
-    for s in user_sessions + system_sessions:
+    for s in displayed:
         agent_type = s.get("agent_type") or "agent"
         desc = s.get("description", "")
         # Truncate long descriptions
@@ -912,6 +925,10 @@ def format_active_sessions_block(sessions: list[dict]) -> str:
             lines.append(f'- {agent_type}: "{desc}" (system, {elapsed})')
         else:
             lines.append(f'- {agent_type}: "{desc}" (chat: {chat_id}, {elapsed})')
+
+    if hidden > 0:
+        lines.append(f"...and {hidden} more")
+
     return "\n".join(lines)
 
 

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -379,6 +379,41 @@ def test_format_only_system_agents():
     assert "(system," in result
 
 
+def test_format_active_sessions_block_cap():
+    """When more than _ACTIVE_SESSIONS_DISPLAY_CAP sessions exist, only cap entries are shown with a trailing '...and N more' line."""
+    cap = session_store._ACTIVE_SESSIONS_DISPLAY_CAP
+    # Build cap+2 sessions (all user-facing)
+    sessions = [
+        {"agent_type": "subagent", "description": f"Task {i}",
+         "chat_id": "8075091586", "elapsed_seconds": i * 60, "id": str(i)}
+        for i in range(cap + 2)
+    ]
+    result = session_store.format_active_sessions_block(sessions)
+    lines = result.splitlines()
+    # Header + cap detail lines + 1 overflow line
+    assert len(lines) == cap + 2, f"Expected {cap + 2} lines, got {len(lines)}: {result!r}"
+    assert lines[-1] == "...and 2 more"
+    # Entries beyond cap must not appear
+    for i in range(cap):
+        assert f"Task {i}" in result
+    for i in range(cap, cap + 2):
+        assert f"Task {i}" not in result
+
+
+def test_format_active_sessions_block_at_cap():
+    """When exactly _ACTIVE_SESSIONS_DISPLAY_CAP sessions exist, no overflow line is added."""
+    cap = session_store._ACTIVE_SESSIONS_DISPLAY_CAP
+    sessions = [
+        {"agent_type": "subagent", "description": f"Task {i}",
+         "chat_id": "8075091586", "elapsed_seconds": i * 60, "id": str(i)}
+        for i in range(cap)
+    ]
+    result = session_store.format_active_sessions_block(sessions)
+    assert "...and" not in result
+    lines = result.splitlines()
+    assert len(lines) == cap + 1  # header + cap entries
+
+
 # ---------------------------------------------------------------------------
 # Test: tracker.py adapter compatibility
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Caps `format_active_sessions_block` output to 5 entries (user sessions first, then system), with a trailing `...and N more` line when concurrency exceeds the cap
- Adds module-level `_ACTIVE_SESSIONS_DISPLAY_CAP = 5` constant so the limit is tunable in one place
- Adds two new test cases: cap enforcement and exact-cap boundary (no spurious overflow line)

## Motivation

The active-sessions prefix is prepended to every `wait_for_messages` response. With 5+ concurrent agents the block grows to 150-300 tokens per call. At 96 WFM calls/hour that's up to 29K tokens/hour consumed solely by the sessions prefix. This change makes the cost O(1) with respect to agent count.

Closes #934.

## Test plan

- [ ] `uv run pytest tests/test_agent_sessions.py` passes (42 tests)
- [ ] Verify `...and N more` appears only when total > 5
- [ ] Verify header still shows true total count (unaffected by cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)