### PR TITLE
fix: load instructions from artifact for wos_execute messages (Issue #922)

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -590,6 +590,28 @@ def handle_steward_trigger(uow_id: str) -> dict[str, Any]:
     }
 
 
+def _load_instructions_from_artifact(uow_id: str) -> str:
+    """
+    Load prescribed instructions from the WorkflowArtifact file for uow_id.
+
+    Called by route_wos_message when the wos_execute inbox message does not
+    embed an 'instructions' field (test/manual invocations).
+    Raises ValueError with a descriptive message if the artifact is missing
+    or malformed — this is caught by the spawn-gate and surfaced as a send_reply
+    alert rather than a raw KeyError.
+    """
+    from .workflow_artifact import artifact_path, from_frontmatter
+    path = artifact_path(uow_id)
+    if not path.exists():
+        raise ValueError(
+            f"wos_execute message has no 'instructions' field and artifact file "
+            f"not found at {path} for uow_id={uow_id!r}"
+        )
+    text = path.read_text(encoding="utf-8")
+    artifact = from_frontmatter(text)
+    return artifact["instructions"]
+
+
 def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
     """
     Route an inbox message whose `type` is listed in WOS_MESSAGE_TYPE_DISPATCH.
@@ -665,7 +687,7 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
     try:
         if msg_type == "wos_execute":
             uow_id: str = msg["uow_id"]
-            instructions: str = msg["instructions"]
+            instructions: str = msg.get("instructions") or _load_instructions_from_artifact(uow_id)
             # output_ref may be supplied by the Executor, or derived from uow_id
             output_ref: str = msg.get(
                 "output_ref",

--- a/tests/unit/test_orchestration/test_dispatcher_integration.py
+++ b/tests/unit/test_orchestration/test_dispatcher_integration.py
@@ -752,6 +752,86 @@ class TestRouteWosMessageSpawnGate:
 
 
 # ---------------------------------------------------------------------------
+# route_wos_message artifact-fallback tests — issue #922
+#
+# These tests verify that route_wos_message handles wos_execute messages that
+# do NOT carry an 'instructions' field (test/manual invocations). The fix
+# adds _load_instructions_from_artifact as a fallback path so a minimal
+# {"type":"wos_execute","uow_id":"x","chat_id":"1"} dict no longer raises
+# KeyError but instead loads instructions from the WorkflowArtifact on disk.
+# ---------------------------------------------------------------------------
+
+class TestRouteWosMessageArtifactFallback:
+    """route_wos_message must handle wos_execute messages without 'instructions'."""
+
+    _ARTIFACT_CONTENT = (
+        '---json\n'
+        '{"uow_id":"test-uow","executor_type":"functional-engineer","constraints":[],"prescribed_skills":[]}\n'
+        '---\n'
+        'Do the thing.\n'
+    )
+
+    def test_inline_instructions_used_when_present(self):
+        """When 'instructions' is in the message, it is used directly without artifact lookup."""
+        msg = {
+            "type": "wos_execute",
+            "uow_id": "test-uow",
+            "chat_id": 8075091586,
+            "instructions": "Inline instructions here.",
+        }
+        result = route_wos_message(msg)
+        assert result["action"] == "spawn_subagent", (
+            "route_wos_message with inline instructions must return spawn_subagent"
+        )
+        assert "Inline instructions here." in result["prompt"]
+
+    def test_artifact_fallback_when_instructions_absent(self, tmp_path, monkeypatch):
+        """When 'instructions' is absent, instructions are loaded from the artifact file."""
+        artifact_file = tmp_path / "test-uow-fallback.md"
+        artifact_file.write_text(self._ARTIFACT_CONTENT, encoding="utf-8")
+
+        import src.orchestration.workflow_artifact as wa
+        monkeypatch.setattr(wa, "artifact_path", lambda uow_id: artifact_file)
+
+        msg = {
+            "type": "wos_execute",
+            "uow_id": "test-uow-fallback",
+            "chat_id": 8075091586,
+        }
+        result = route_wos_message(msg)
+        assert result["action"] == "spawn_subagent", (
+            "route_wos_message without instructions field must fall back to artifact "
+            "and return spawn_subagent when artifact exists"
+        )
+        assert "Do the thing." in result["prompt"]
+
+    def test_missing_artifact_returns_send_reply_with_alert(self, tmp_path, monkeypatch):
+        """When 'instructions' is absent and artifact is missing, spawn-gate returns send_reply."""
+        nonexistent = tmp_path / "no-such-artifact.md"
+        # Do not create the file — it should not exist
+
+        import src.orchestration.workflow_artifact as wa
+        monkeypatch.setattr(wa, "artifact_path", lambda uow_id: nonexistent)
+
+        msg = {
+            "type": "wos_execute",
+            "uow_id": "uow-missing-artifact",
+            "chat_id": 8075091586,
+        }
+        result = route_wos_message(msg)
+        assert result["action"] == "send_reply", (
+            "route_wos_message must return send_reply (spawn-gate) when instructions "
+            "field is absent and artifact file does not exist"
+        )
+        assert "spawn-gate alert" in result["text"], (
+            "send_reply result must contain 'spawn-gate alert'"
+        )
+        assert "instructions" in result["text"], (
+            "send_reply result must mention 'instructions' so the alert is actionable"
+        )
+
+
+# ---------------------------------------------------------------------------
 # decide_retry / decide_close callback handler tests — issue #901
 #
 # These tests verify that tapping the "Retry" or "Close" buttons on a


### PR DESCRIPTION
## Summary

Fixes a `KeyError` that occurred on every `wos_execute` routing call because bare dict access assumed the inbox message carries an `instructions` field — but `wos_execute` inbox messages only carry `type`, `uow_id`, and `chat_id`.

- Adds `_load_instructions_from_artifact` helper to `dispatcher_handlers.py` that loads instructions from the `WorkflowArtifact` file when the `instructions` field is absent from the message dict
- `route_wos_message` now calls this helper instead of accessing `msg['instructions']` directly
- Adds 3 new unit tests: inline instructions path, artifact fallback path, and missing-artifact spawn-gate path

## Why this is needed

`wos_execute` messages are written to the inbox with only `type`, `uow_id`, and `chat_id`. The instructions live in the `WorkflowArtifact` file on disk. The original code did `msg['instructions']` which raised `KeyError` every time a real `wos_execute` message was processed, silently breaking WOS dispatch.

## Test plan

- [x] `uv run pytest tests/unit/test_orchestration/test_dispatcher_integration.py -x -q` — 99 passed

Closes #922