### PR TITLE
docs: correct steward-heartbeat dispatch type from B to C (closes #933)

### DIFF
--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -23,7 +23,7 @@ heartbeat invocation achieves finer coverage.
 Cron schedule (every 3 minutes):
     */3 * * * * cd ~/lobster && uv run scheduled-tasks/steward-heartbeat.py >> ~/lobster-workspace/scheduled-jobs/logs/steward-heartbeat.log 2>&1
 
-Type B dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+Type C dispatch: cron calls this script directly (no inbox/ message, no dispatcher
 involvement). The jobs.json enabled gate is checked at the top of main() so that
 runtime enable/disable is respected without touching cron.
 
@@ -81,7 +81,7 @@ log = logging.getLogger("steward-heartbeat")
 
 
 # ---------------------------------------------------------------------------
-# jobs.json enabled gate — Type B dispatch path
+# jobs.json enabled gate — Type C dispatch path
 # ---------------------------------------------------------------------------
 
 def _is_job_enabled(job_name: str) -> bool:
@@ -93,8 +93,8 @@ def _is_job_enabled(job_name: str) -> bool:
     - the job entry is missing
     - the file is unreadable or malformed
 
-    This mirrors the gate logic in dispatch-job.sh so Type B (cron → script)
-    jobs respect the same runtime enable/disable toggle as Type A jobs.
+    This mirrors the enabled gate pattern used by all Type C (cron-direct) scripts
+    so runtime enable/disable (e.g. "wos stop") is respected without touching cron.
     """
     workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
     jobs_file = workspace / "scheduled-jobs" / "jobs.json"


### PR DESCRIPTION
## What this changes

Issue #933 was filed to suppress steward-heartbeat from the dispatcher reasoning loop, noting it fires 20x/hour and costs LLM context per cycle.

Investigation revealed that steward-heartbeat is **already Type C / cron-direct**. It has never triggered dispatcher reasoning in the current architecture:

- `jobs.json` has `"type": "C", "dispatch": "cron-direct"` since the initial conversion
- The cron entry invokes the script directly: `uv run scheduled-tasks/steward-heartbeat.py >> .../steward-heartbeat.log`
- The script writes to `~/messages/task-outputs/`, not to `~/messages/inbox/`
- Zero `scheduled_reminder` messages for `steward-heartbeat` appear in the current inbox

The 312 processed `scheduled_reminder` messages for steward-heartbeat in the archive are historical artifacts from before the cron-direct conversion.

The only real problem this PR fixes: the script's own docstring said "Type B dispatch" (the long-running services / systemd category), which contradicts both jobs.json and the actual CLAUDE.md taxonomy. The `_is_job_enabled` comment also referenced `dispatch-job.sh`, which was retired in PR #1486.

**Before:** docstring claimed Type B, referenced dispatch-job.sh
**After:** docstring correctly says Type C, references the cron-direct pattern shared with executor-heartbeat

No behavior change. No inbox messages were being written, so nothing was suppressed — the assertion in the issue was incorrect.

## Functional patterns

Pure documentation fix — no logic changed. Immutability of the dispatch path (cron to script to log, no inbox write) is unchanged and verified.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_startup_sweep.py` — 37 passed
- [x] `uv run pytest tests/unit/test_orchestration/test_executor_heartbeat.py tests/unit/test_orchestration/test_observation_loop.py tests/unit/test_orchestration/test_heartbeat_sidecar.py` — 56 passed
- [ ] `uv run pytest tests/unit/test_orchestration/test_prescriptions_per_cycle.py` — pre-existing failure on main (patches `_default_db_path` which does not exist in the module); not introduced by this PR
- [ ] `uv run pytest tests/unit/test_dispatch_job_sh.py::TestRunJobShDisabledFlag::test_disabled_job_writes_no_inbox_message` — pre-existing failure on main; not introduced by this PR

**Blocked items needing attention before merge:** none

## Manual test

N/A — no behavior change. The script continues to run via cron and write to task-outputs/ exactly as before. Verified by inspecting crontab, jobs.json, script code, and recent task-output files.

## Definition of Done

- [x] Unit tests pass (heartbeat, observation loop, startup sweep tests — 93 passed)
- [x] Integration/manual test N/A — documentation-only change
- [x] User-visible outcome N/A — no user-visible behavior
- [x] Side-effect audit complete: no writes, no messages, no external calls changed
- [x] External service calls: none affected