### PR TITLE
feat: wos-execute-router daemon (Phase 1) — Issue #940

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3085,6 +3085,40 @@ except Exception as e:
         migrated=$((migrated + 1))
     fi
 
+    # Migration 90: Install lobster-wos-router systemd service (issue #940).
+    # The WOS execute router daemon routes wos_execute inbox messages without
+    # going through the dispatcher's LLM context. It polls every 30s as a
+    # persistent systemd service (Type B — always-on, not cron-direct).
+    local _m90_svc_src="$LOBSTER_DIR/services/lobster-wos-router.service"
+    local _m90_svc_dest="/etc/systemd/system/lobster-wos-router.service"
+    if [ -f "$_m90_svc_src" ] && [ ! -f "$_m90_svc_dest" ]; then
+        substep "Installing lobster-wos-router systemd service (Migration 90)..."
+        if sudo cp "$_m90_svc_src" "$_m90_svc_dest" 2>/dev/null; then
+            sudo systemctl daemon-reload 2>/dev/null || warn "Migration 90: daemon-reload failed"
+            sudo systemctl enable lobster-wos-router 2>/dev/null || warn "Migration 90: systemctl enable failed"
+            sudo systemctl start lobster-wos-router 2>/dev/null || warn "Migration 90: systemctl start failed"
+            substep "Installed and started lobster-wos-router (Migration 90)"
+            migrated=$((migrated + 1))
+        else
+            warn "Migration 90: could not copy $(_m90_svc_src) — manual install needed"
+        fi
+    elif [ -f "$_m90_svc_src" ] && [ -f "$_m90_svc_dest" ]; then
+        # Service file already installed — check if the installed copy is stale
+        if ! diff -q "$_m90_svc_src" "$_m90_svc_dest" >/dev/null 2>&1; then
+            substep "Updating lobster-wos-router service file (Migration 90)..."
+            if sudo cp "$_m90_svc_src" "$_m90_svc_dest" 2>/dev/null; then
+                sudo systemctl daemon-reload 2>/dev/null || warn "Migration 90: daemon-reload failed"
+                sudo systemctl restart lobster-wos-router 2>/dev/null || warn "Migration 90: restart failed"
+                substep "Updated lobster-wos-router service file (Migration 90)"
+                migrated=$((migrated + 1))
+            fi
+        else
+            substep "lobster-wos-router service already up to date — skipping Migration 90"
+        fi
+    else
+        substep "lobster-wos-router service source not found — skipping Migration 90"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/services/lobster-wos-router.service
+++ b/services/lobster-wos-router.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Lobster WOS Execute Router — mechanical wos_execute inbox routing daemon
+Documentation=https://github.com/dcetlin/Lobster/issues/940
+After=network.target lobster-mcp.service
+
+[Service]
+Type=simple
+User=lobster
+Group=lobster
+WorkingDirectory=/home/lobster/lobster
+Environment=LOBSTER_CONFIG_DIR=/home/lobster/lobster-config
+Environment=LOBSTER_INSTALL_DIR=/home/lobster/lobster
+Environment=LOBSTER_MESSAGES=/home/lobster/messages
+Environment=LOBSTER_WORKSPACE=/home/lobster/lobster-workspace
+Environment=LOBSTER_USER_CONFIG=/home/lobster/lobster-user-config
+EnvironmentFile=-/home/lobster/lobster/config/config.env
+EnvironmentFile=/home/lobster/lobster-config/config.env
+EnvironmentFile=-/home/lobster/lobster-config/global.env
+ExecStart=/home/lobster/lobster/.venv/bin/python /home/lobster/lobster/src/daemons/wos_execute_router.py
+Restart=on-failure
+RestartSec=15
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=lobster-wos-router
+
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/daemons/__init__.py
+++ b/src/daemons/__init__.py
@@ -1,0 +1,1 @@
+# Lobster daemons — persistent background services.

--- a/src/daemons/wos_execute_router.py
+++ b/src/daemons/wos_execute_router.py
@@ -1,0 +1,475 @@
+"""
+WOS Execute Router Daemon — Issue #940
+
+Polls the Lobster inbox every POLL_INTERVAL_SECONDS for ``wos_execute`` messages
+and routes them mechanically, with no LLM involvement.  This offloads zero-
+reasoning routing from the dispatcher's primary LLM context window.
+
+Architecture
+------------
+The daemon is a persistent systemd service.  On each poll cycle it:
+
+1. Reads all messages in the inbox directory (pure file I/O, no MCP).
+2. Filters to ``type == "wos_execute"`` client-side.
+3. For each matching message:
+   a. Claims it by moving it from inbox/ to processing/ (mark_processing).
+   b. Calls ``route_wos_message()`` — a pure function that returns a routing
+      decision dict without spawning anything.
+   c. If the decision is ``action == "spawn_subagent"``, dispatches via
+      ``_dispatch_via_claude_p()`` from ``executor.py``.
+   d. Moves the message from processing/ to processed/ (mark_processed).
+   e. On hard error: writes a system alert to inbox/ via inbox_write.py and
+      moves the message to failed/.
+4. If a ``send_reply`` action is returned (spawn-gate alert from the pure
+   router), writes a ``subagent_result`` inbox message so the dispatcher can
+   surface the alert to the user.
+
+Gates
+-----
+- ``wos-config.json`` ``execution_enabled`` gate: if False, skip routing.
+- ``MAX_AGENTS_GATE``: if active agent count >= threshold, defer by leaving
+  messages unclaimed and trying again on the next cycle.
+
+Awareness path
+--------------
+The daemon does NOT send a notification for every individual ``wos_execute``
+processed.  It writes a ``subagent_result`` inbox message only for:
+- Exception alerts (routing failure, claim failure, subprocess failure).
+- ``send_reply`` actions returned by the spawn-gate circuit-breaker in
+  ``route_wos_message``.
+
+Routine dispatch is silent — the dispatcher learns the outcome when the
+subagent calls ``write_result`` at completion.
+
+Design reference: ~/lobster-workspace/workstreams/wos/design/wos-execute-router-daemon.md
+Related issue: dcetlin/Lobster #940
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a standalone script or as an importable module
+# ---------------------------------------------------------------------------
+
+_DAEMON_FILE = Path(__file__).resolve()
+_SRC_ROOT = _DAEMON_FILE.parent.parent      # src/
+_REPO_ROOT = _SRC_ROOT.parent               # lobster/
+
+for _p in [str(_REPO_ROOT), str(_SRC_ROOT)]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# ---------------------------------------------------------------------------
+# Lazy imports from orchestration (deferred until after path setup)
+# ---------------------------------------------------------------------------
+
+from orchestration.dispatcher_handlers import route_wos_message, read_wos_config  # noqa: E402
+from orchestration.executor import _dispatch_via_claude_p  # noqa: E402
+from agents.session_store import get_active_sessions  # noqa: E402
+from utils.inbox_write import write_inbox_message  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+POLL_INTERVAL_SECONDS: int = int(os.environ.get("WOS_ROUTER_POLL_INTERVAL", "30"))
+
+# Maximum number of concurrent active agents before deferring new dispatches.
+# Mirrors the executor-heartbeat throttle logic.
+MAX_AGENTS_GATE: int = int(os.environ.get("WOS_ROUTER_MAX_AGENTS", "8"))
+
+ADMIN_CHAT_ID: int = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
+
+_MESSAGES_BASE = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+INBOX_DIR: Path = _MESSAGES_BASE / "inbox"
+PROCESSING_DIR: Path = _MESSAGES_BASE / "processing"
+PROCESSED_DIR: Path = _MESSAGES_BASE / "processed"
+FAILED_DIR: Path = _MESSAGES_BASE / "failed"
+
+_WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+LOG_FILE: Path = _WORKSPACE / "logs" / "wos-execute-router.log"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+def _configure_logging() -> None:
+    """Configure logging to both stderr and the daemon log file."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    fmt = "%(asctime)s %(levelname)s [wos-router] %(message)s"
+    datefmt = "%Y-%m-%dT%H:%M:%SZ"
+
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
+
+    try:
+        fh = logging.FileHandler(LOG_FILE)
+        fh.setFormatter(logging.Formatter(fmt, datefmt=datefmt))
+        handlers.append(fh)
+    except OSError as exc:
+        # Log file unavailable — stderr only, not fatal
+        logging.warning("wos-execute-router: could not open log file %s: %s", LOG_FILE, exc)
+
+    logging.basicConfig(level=logging.INFO, format=fmt, datefmt=datefmt, handlers=handlers)
+
+
+log = logging.getLogger("wos-execute-router")
+
+# ---------------------------------------------------------------------------
+# Signal handling — graceful shutdown on SIGTERM / SIGINT
+# ---------------------------------------------------------------------------
+
+_shutdown_requested: bool = False
+
+
+def _handle_shutdown_signal(signum: int, _frame: object) -> None:
+    global _shutdown_requested
+    log.info("Received signal %d — shutting down after current cycle", signum)
+    _shutdown_requested = True
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — inbox file I/O (no MCP dependency)
+# ---------------------------------------------------------------------------
+
+def _read_inbox_messages() -> list[dict]:
+    """
+    Return all parseable messages from the inbox directory.
+
+    Mirrors the file-read logic in inbox_server.py handle_check_inbox().
+    Returns an empty list (never raises) so a malformed file never crashes
+    the poll cycle.
+    """
+    messages: list[dict] = []
+    INBOX_DIR.mkdir(parents=True, exist_ok=True)
+
+    for f in sorted(INBOX_DIR.glob("*.json")):
+        try:
+            msg = json.loads(f.read_text(encoding="utf-8"))
+            msg["_filepath"] = str(f)
+            messages.append(msg)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    return messages
+
+
+def _filter_wos_execute(messages: list[dict]) -> list[dict]:
+    """Return only messages with type='wos_execute'."""
+    return [m for m in messages if m.get("type") == "wos_execute"]
+
+
+def _claim_message(msg: dict) -> bool:
+    """
+    Move message from inbox/ to processing/ (mark_processing equivalent).
+
+    Returns True on success, False if the message was already claimed by
+    another process (race condition) or could not be moved.
+    """
+    filepath = msg.get("_filepath")
+    if not filepath:
+        log.warning("claim: no _filepath in message %s — skipping", msg.get("id", "?"))
+        return False
+
+    src = Path(filepath)
+    if not src.exists():
+        # Already claimed by another process — expected in race conditions
+        log.debug("claim: %s no longer in inbox — already claimed", src.name)
+        return False
+
+    PROCESSING_DIR.mkdir(parents=True, exist_ok=True)
+    dest = PROCESSING_DIR / src.name
+
+    # Stamp a _processing_started_at field into the message before moving so
+    # the wos-execute-gate hook (issue #855) can verify mark_processing occurred.
+    try:
+        content = json.loads(src.read_text(encoding="utf-8"))
+        content["_processing_started_at"] = datetime.now(timezone.utc).isoformat()
+        tmp = src.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(content, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(src)
+    except OSError as exc:
+        log.warning("claim: could not stamp _processing_started_at on %s: %s", src.name, exc)
+        # Non-fatal — continue with move even if stamp failed
+
+    try:
+        src.rename(dest)
+        log.debug("claim: moved %s -> processing/", src.name)
+        return True
+    except OSError as exc:
+        log.warning("claim: could not move %s to processing/: %s", src.name, exc)
+        return False
+
+
+def _release_message_processed(message_id: str) -> None:
+    """
+    Move message from processing/ to processed/ (mark_processed equivalent).
+
+    Locates the file by message_id prefix in processing/, then renames it.
+    Logs a warning if the file cannot be found.
+    """
+    PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+
+    src = _find_in_dir(PROCESSING_DIR, message_id)
+    if src is None:
+        log.warning("mark_processed: %s not found in processing/", message_id)
+        return
+
+    dest = PROCESSED_DIR / src.name
+    try:
+        src.rename(dest)
+        log.debug("mark_processed: moved %s -> processed/", src.name)
+    except OSError as exc:
+        log.error("mark_processed: failed to move %s: %s", src.name, exc)
+
+
+def _release_message_failed(message_id: str) -> None:
+    """Move message from processing/ to failed/ on unrecoverable error."""
+    FAILED_DIR.mkdir(parents=True, exist_ok=True)
+
+    src = _find_in_dir(PROCESSING_DIR, message_id)
+    if src is None:
+        # Try inbox/ as fallback (claim may not have succeeded)
+        src = _find_in_dir(INBOX_DIR, message_id)
+    if src is None:
+        log.warning("mark_failed: %s not found in processing/ or inbox/", message_id)
+        return
+
+    dest = FAILED_DIR / src.name
+    try:
+        src.rename(dest)
+        log.debug("mark_failed: moved %s -> failed/", src.name)
+    except OSError as exc:
+        log.error("mark_failed: failed to move %s: %s", src.name, exc)
+
+
+def _find_in_dir(directory: Path, message_id: str) -> Path | None:
+    """Return the first .json file in directory whose stem starts with message_id."""
+    for f in directory.glob("*.json"):
+        if f.stem == message_id or f.name.startswith(message_id):
+            return f
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Gate helpers
+# ---------------------------------------------------------------------------
+
+def _execution_enabled() -> bool:
+    """Return True if wos-config.json has execution_enabled=true."""
+    config = read_wos_config()
+    return bool(config.get("execution_enabled", False))
+
+
+def _active_agent_count() -> int:
+    """Return the number of currently active (running/starting) agents."""
+    try:
+        sessions = get_active_sessions()
+        return len(sessions)
+    except Exception as exc:
+        log.warning("active_agent_count: could not read session store: %s — assuming 0", exc)
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Awareness path — inter-process notifications
+# ---------------------------------------------------------------------------
+
+def _write_alert(text: str) -> None:
+    """
+    Write a system alert to the inbox so the dispatcher can surface it.
+
+    Uses write_inbox_message from inbox_write.py — the same mechanism used by
+    executor-heartbeat and steward-heartbeat.  write_result is NOT used here
+    because that requires a Claude session context this daemon does not have.
+    """
+    try:
+        msg_id = write_inbox_message(
+            job_name="wos-router-alert",
+            chat_id=ADMIN_CHAT_ID,
+            text=text,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+        log.info("alert written to inbox: %s", msg_id)
+    except Exception as exc:
+        log.error("failed to write alert to inbox: %s", exc)
+
+
+def _write_send_reply_alert(text: str) -> None:
+    """
+    Write a subagent_result inbox message for a send_reply alert from
+    route_wos_message's spawn-gate circuit-breaker.
+
+    The dispatcher picks this up and surfaces it to the user.
+    """
+    _write_alert(f"[WOS spawn-gate] {text}")
+
+
+# ---------------------------------------------------------------------------
+# Core routing logic
+# ---------------------------------------------------------------------------
+
+def _route_single_message(msg: dict) -> None:
+    """
+    Route a single wos_execute message end-to-end.
+
+    Claim → route → dispatch (if spawn_subagent) → mark_processed.
+    On failure: mark_failed + write alert.
+
+    All exceptions are caught and logged — never propagated to the poll loop.
+    """
+    message_id: str = msg.get("id", "")
+    uow_id: str = msg.get("uow_id", "?")
+
+    if not message_id:
+        log.warning("route: message has no id field — skipping: %r", msg)
+        return
+
+    log.info("route: claiming wos_execute message_id=%s uow_id=%s", message_id, uow_id)
+
+    if not _claim_message(msg):
+        # Race condition — another process already claimed it; skip silently
+        log.info("route: %s already claimed — skipping", message_id)
+        return
+
+    try:
+        decision = route_wos_message(msg)
+    except Exception as exc:
+        log.error("route: route_wos_message raised for %s: %s", message_id, exc)
+        _release_message_failed(message_id)
+        _write_alert(
+            f"wos-execute-router: route_wos_message raised an exception for "
+            f"message_id={message_id} uow_id={uow_id}: {type(exc).__name__}: {exc}"
+        )
+        return
+
+    action = decision.get("action")
+
+    if action == "spawn_subagent":
+        task_id: str = decision.get("task_id", f"wos-{uow_id}")
+        prompt: str = decision.get("prompt", "")
+        # route_wos_message returns task_id as "wos-{uow_id}"; strip prefix
+        # to get the bare uow_id expected by _dispatch_via_claude_p
+        bare_uow_id = task_id.removeprefix("wos-")
+
+        log.info("route: dispatching subagent for uow_id=%s task_id=%s", uow_id, task_id)
+        try:
+            run_id = _dispatch_via_claude_p(instructions=prompt, uow_id=bare_uow_id)
+            log.info("route: dispatch succeeded run_id=%s uow_id=%s", run_id, uow_id)
+        except Exception as exc:
+            log.error("route: _dispatch_via_claude_p raised for %s: %s", uow_id, exc)
+            _release_message_failed(message_id)
+            _write_alert(
+                f"wos-execute-router: subprocess dispatch failed for "
+                f"message_id={message_id} uow_id={uow_id}: {type(exc).__name__}: {exc}"
+            )
+            return
+
+    elif action == "send_reply":
+        # Spawn-gate circuit-breaker in route_wos_message fired — surface the
+        # alert to the dispatcher via inbox
+        alert_text = decision.get("text", "spawn-gate alert (no text)")
+        log.error("route: spawn-gate alert for %s: %s", message_id, alert_text)
+        _write_send_reply_alert(alert_text)
+
+    else:
+        log.error(
+            "route: unexpected action=%r for %s — marking failed",
+            action, message_id,
+        )
+        _release_message_failed(message_id)
+        _write_alert(
+            f"wos-execute-router: unexpected routing action {action!r} for "
+            f"message_id={message_id} uow_id={uow_id}"
+        )
+        return
+
+    _release_message_processed(message_id)
+    log.info("route: completed message_id=%s uow_id=%s", message_id, uow_id)
+
+
+def run_poll_cycle() -> int:
+    """
+    Execute one poll cycle: check gates, scan inbox, route wos_execute messages.
+
+    Returns the number of messages routed (0 if gated out or no messages found).
+    This is the primary unit-testable entry point for the routing loop.
+    """
+    if not _execution_enabled():
+        log.debug("poll: execution_enabled=false — skipping")
+        return 0
+
+    active_count = _active_agent_count()
+    if active_count >= MAX_AGENTS_GATE:
+        log.info(
+            "poll: active_agents=%d >= MAX_AGENTS_GATE=%d — deferring",
+            active_count, MAX_AGENTS_GATE,
+        )
+        return 0
+
+    messages = _read_inbox_messages()
+    wos_messages = _filter_wos_execute(messages)
+
+    if not wos_messages:
+        log.debug("poll: no wos_execute messages in inbox")
+        return 0
+
+    log.info("poll: found %d wos_execute message(s)", len(wos_messages))
+
+    for msg in wos_messages:
+        if _shutdown_requested:
+            log.info("poll: shutdown requested — stopping mid-batch")
+            break
+        _route_single_message(msg)
+
+    return len(wos_messages)
+
+
+# ---------------------------------------------------------------------------
+# Daemon main loop
+# ---------------------------------------------------------------------------
+
+def run_daemon() -> None:
+    """
+    Run the routing daemon loop indefinitely.
+
+    Polls every POLL_INTERVAL_SECONDS.  Exits cleanly on SIGTERM or SIGINT.
+    Exceptions in the poll cycle are logged and the loop continues —
+    a transient error never kills the daemon.
+    """
+    signal.signal(signal.SIGTERM, _handle_shutdown_signal)
+    signal.signal(signal.SIGINT, _handle_shutdown_signal)
+
+    log.info(
+        "wos-execute-router starting: poll_interval=%ds max_agents=%d",
+        POLL_INTERVAL_SECONDS, MAX_AGENTS_GATE,
+    )
+
+    while not _shutdown_requested:
+        try:
+            run_poll_cycle()
+        except Exception as exc:
+            log.error("poll cycle raised unexpected exception: %s", exc, exc_info=True)
+
+        if _shutdown_requested:
+            break
+
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    log.info("wos-execute-router stopped")
+
+
+if __name__ == "__main__":
+    _configure_logging()
+    run_daemon()

--- a/tests/test_wos_execute_router.py
+++ b/tests/test_wos_execute_router.py
@@ -1,0 +1,566 @@
+"""
+Unit tests for src/daemons/wos_execute_router.py
+
+Tests are derived from the spec in Issue #940 and the approved design doc
+(~/lobster-workspace/workstreams/wos/design/wos-execute-router-daemon.md).
+
+Coverage:
+- execution_enabled=false gate skips routing
+- MAX_AGENTS_GATE defers when active agent count >= threshold
+- Messages without type=wos_execute are ignored
+- A valid wos_execute message is claimed, dispatched, and marked processed
+- A send_reply decision (spawn-gate alert) triggers an inbox alert but does
+  not mark the message failed
+- A dispatch exception marks the message failed and writes an alert
+- route_wos_message raising an exception marks failed and writes an alert
+- Claim race condition (file already gone) is handled gracefully
+- run_poll_cycle returns 0 when gated out
+- run_poll_cycle returns the count of wos_execute messages found
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loading helper
+# ---------------------------------------------------------------------------
+
+def _get_router_module():
+    """Import wos_execute_router with patched heavy dependencies."""
+    # The module imports orchestration and agents at module level — patch them
+    # before the import so tests stay fast and hermetic.
+    import importlib
+
+    mocks = {
+        "orchestration": MagicMock(),
+        "orchestration.dispatcher_handlers": MagicMock(),
+        "orchestration.executor": MagicMock(),
+        "agents": MagicMock(),
+        "agents.session_store": MagicMock(),
+        "utils": MagicMock(),
+        "utils.inbox_write": MagicMock(),
+    }
+    with patch.dict("sys.modules", mocks):
+        # Force reimport each test so mocks are isolated
+        mod_name = "src.daemons.wos_execute_router"
+        if mod_name in sys.modules:
+            del sys.modules[mod_name]
+
+        # Add repo root to path if needed
+        repo_root = Path(__file__).resolve().parent.parent
+        src_root = repo_root / "src"
+        for p in [str(repo_root), str(src_root)]:
+            if p not in sys.path:
+                sys.path.insert(0, p)
+
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "wos_execute_router",
+            repo_root / "src" / "daemons" / "wos_execute_router.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        # Inject mocked top-level names the module uses after import
+        mod.route_wos_message = MagicMock()
+        mod._dispatch_via_claude_p = MagicMock()
+        mod.get_active_sessions = MagicMock()
+        mod.write_inbox_message = MagicMock()
+        mod.read_wos_config = MagicMock()
+        spec.loader.exec_module(mod)
+        return mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def router(tmp_path):
+    """Return the router module with all external I/O mocked."""
+    mod = _get_router_module()
+
+    # Override directory constants to point at tmp_path
+    mod.INBOX_DIR = tmp_path / "inbox"
+    mod.PROCESSING_DIR = tmp_path / "processing"
+    mod.PROCESSED_DIR = tmp_path / "processed"
+    mod.FAILED_DIR = tmp_path / "failed"
+    mod.MAX_AGENTS_GATE = 8
+
+    # Default: execution enabled, 0 active agents
+    mod.read_wos_config.return_value = {"execution_enabled": True}
+    mod.get_active_sessions.return_value = []
+
+    return mod
+
+
+def _write_msg(directory: Path, msg: dict) -> Path:
+    """Write a message JSON file to directory, creating it if needed."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{msg['id']}.json"
+    path.write_text(json.dumps(msg), encoding="utf-8")
+    return path
+
+
+def _make_wos_execute_msg(uow_id: str = "uow-abc123") -> dict:
+    return {
+        "id": f"msg-{uow_id}",
+        "type": "wos_execute",
+        "uow_id": uow_id,
+        "instructions": "do something",
+        "output_ref": "/tmp/out.json",
+        "agent_type": "functional-engineer",
+        "source": "system",
+        "chat_id": "0",
+        "timestamp": "2026-04-25T00:00:00+00:00",
+    }
+
+
+def _make_text_msg() -> dict:
+    return {
+        "id": "msg-text-001",
+        "type": "text",
+        "text": "hello",
+        "source": "telegram",
+        "chat_id": "8075091586",
+        "timestamp": "2026-04-25T00:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: execution_enabled gate
+# ---------------------------------------------------------------------------
+
+class TestExecutionEnabledGate:
+    """run_poll_cycle skips all routing when execution_enabled is False."""
+
+    def test_skips_routing_when_disabled(self, router, tmp_path):
+        """Gate=false: no messages are claimed even if wos_execute messages exist."""
+        router.read_wos_config.return_value = {"execution_enabled": False}
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        result = router.run_poll_cycle()
+
+        assert result == 0
+        # Message must still be in inbox (not claimed)
+        assert (router.INBOX_DIR / f"{msg['id']}.json").exists()
+
+    def test_returns_zero_when_disabled(self, router):
+        """run_poll_cycle returns 0 when execution is disabled."""
+        router.read_wos_config.return_value = {"execution_enabled": False}
+        assert router.run_poll_cycle() == 0
+
+    def test_routes_when_enabled(self, router, tmp_path):
+        """Gate=true: wos_execute messages are processed."""
+        router.read_wos_config.return_value = {"execution_enabled": True}
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg['uow_id']}",
+            "prompt": "run this",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.return_value = "run-id-1"
+
+        result = router.run_poll_cycle()
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: MAX_AGENTS_GATE
+# ---------------------------------------------------------------------------
+
+class TestMaxAgentsGate:
+    """run_poll_cycle defers when active agent count >= MAX_AGENTS_GATE."""
+
+    def test_defers_when_at_threshold(self, router):
+        """Exactly MAX_AGENTS_GATE agents active: skip routing."""
+        router.get_active_sessions.return_value = [{}] * router.MAX_AGENTS_GATE
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        result = router.run_poll_cycle()
+
+        assert result == 0
+        # Message still in inbox — not claimed
+        assert (router.INBOX_DIR / f"{msg['id']}.json").exists()
+
+    def test_defers_when_above_threshold(self, router):
+        """More than MAX_AGENTS_GATE agents: skip routing."""
+        router.get_active_sessions.return_value = [{}] * (router.MAX_AGENTS_GATE + 2)
+
+        result = router.run_poll_cycle()
+        assert result == 0
+
+    def test_routes_when_below_threshold(self, router):
+        """Fewer than MAX_AGENTS_GATE agents: proceed with routing."""
+        router.get_active_sessions.return_value = [{}] * (router.MAX_AGENTS_GATE - 1)
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg['uow_id']}",
+            "prompt": "run",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.return_value = "run-id-2"
+
+        result = router.run_poll_cycle()
+        assert result == 1
+
+    def test_returns_zero_when_at_threshold(self, router):
+        router.get_active_sessions.return_value = [{}] * router.MAX_AGENTS_GATE
+        assert router.run_poll_cycle() == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: message filtering
+# ---------------------------------------------------------------------------
+
+class TestMessageFiltering:
+    """Only type=wos_execute messages are routed; others are left in inbox."""
+
+    def test_ignores_text_messages(self, router):
+        """Text messages are not claimed or routed."""
+        msg = _make_text_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        result = router.run_poll_cycle()
+
+        assert result == 0
+        assert (router.INBOX_DIR / f"{msg['id']}.json").exists()
+        router.route_wos_message.assert_not_called()
+
+    def test_routes_wos_execute_not_text(self, router):
+        """Mixed inbox: only the wos_execute message is routed."""
+        wos_msg = _make_wos_execute_msg()
+        text_msg = _make_text_msg()
+        _write_msg(router.INBOX_DIR, wos_msg)
+        _write_msg(router.INBOX_DIR, text_msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{wos_msg['uow_id']}",
+            "prompt": "run",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.return_value = "run-id-3"
+
+        result = router.run_poll_cycle()
+
+        # Only the wos_execute message counts
+        assert result == 1
+        # Text message stays in inbox
+        assert (router.INBOX_DIR / f"{text_msg['id']}.json").exists()
+
+    def test_empty_inbox_returns_zero(self, router):
+        """Empty inbox returns 0 with no errors."""
+        router.INBOX_DIR.mkdir(parents=True, exist_ok=True)
+        assert router.run_poll_cycle() == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: happy-path routing (spawn_subagent)
+# ---------------------------------------------------------------------------
+
+class TestHappyPathRouting:
+    """Valid wos_execute messages are claimed, dispatched, and marked processed."""
+
+    def test_message_moved_to_processed_after_dispatch(self, router):
+        """After successful dispatch, message is in processed/ not inbox/."""
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg['uow_id']}",
+            "prompt": "run this",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.return_value = "run-id"
+
+        router.run_poll_cycle()
+
+        # Message in processed/, not in inbox/ or failed/
+        assert not (router.INBOX_DIR / f"{msg['id']}.json").exists()
+        assert (router.PROCESSED_DIR / f"{msg['id']}.json").exists()
+
+    def test_dispatch_called_with_stripped_uow_id(self, router):
+        """_dispatch_via_claude_p receives uow_id with 'wos-' prefix stripped."""
+        uow_id = "abc-456"
+        msg = _make_wos_execute_msg(uow_id=uow_id)
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{uow_id}",
+            "prompt": "run this",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.return_value = "run-id"
+
+        router.run_poll_cycle()
+
+        # uow_id passed to _dispatch_via_claude_p must NOT have "wos-" prefix
+        call_kwargs = router._dispatch_via_claude_p.call_args
+        assert call_kwargs is not None
+        # Accept either positional or keyword argument for uow_id
+        kwargs = call_kwargs.kwargs
+        args = call_kwargs.args
+        passed_uow_id = kwargs.get("uow_id") or (args[1] if len(args) > 1 else None)
+        assert passed_uow_id == uow_id, (
+            f"Expected uow_id={uow_id!r} but got {passed_uow_id!r}. "
+            "The 'wos-' prefix must be stripped before passing to _dispatch_via_claude_p."
+        )
+
+    def test_route_wos_message_called_with_message(self, router):
+        """route_wos_message is called with the original message dict."""
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg['uow_id']}",
+            "prompt": "run",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.return_value = "run-id"
+
+        router.run_poll_cycle()
+
+        router.route_wos_message.assert_called_once()
+        called_msg = router.route_wos_message.call_args[0][0]
+        assert called_msg["id"] == msg["id"]
+        assert called_msg["type"] == "wos_execute"
+
+
+# ---------------------------------------------------------------------------
+# Tests: send_reply action (spawn-gate alert)
+# ---------------------------------------------------------------------------
+
+class TestSendReplyAlert:
+    """send_reply decision from route_wos_message triggers an inbox alert."""
+
+    def test_alert_written_on_send_reply_action(self, router):
+        """write_inbox_message is called when action=send_reply."""
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "send_reply",
+            "text": "spawn-gate alert: handler raised an error",
+            "message_type": "wos_execute",
+        }
+
+        router.run_poll_cycle()
+
+        router.write_inbox_message.assert_called_once()
+
+    def test_message_marked_processed_after_send_reply(self, router):
+        """After a send_reply alert, message moves to processed/ (not failed/)."""
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "send_reply",
+            "text": "alert text",
+            "message_type": "wos_execute",
+        }
+
+        router.run_poll_cycle()
+
+        assert (router.PROCESSED_DIR / f"{msg['id']}.json").exists()
+        assert not (router.FAILED_DIR / f"{msg['id']}.json").exists()
+
+    def test_dispatch_not_called_on_send_reply(self, router):
+        """_dispatch_via_claude_p is not called when action=send_reply."""
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "send_reply",
+            "text": "alert",
+            "message_type": "wos_execute",
+        }
+
+        router.run_poll_cycle()
+
+        router._dispatch_via_claude_p.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: dispatch failure
+# ---------------------------------------------------------------------------
+
+class TestDispatchFailure:
+    """_dispatch_via_claude_p raising moves message to failed/ and writes alert."""
+
+    def test_message_moved_to_failed_on_dispatch_error(self, router):
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg['uow_id']}",
+            "prompt": "run",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.side_effect = RuntimeError("subprocess died")
+
+        router.run_poll_cycle()
+
+        assert (router.FAILED_DIR / f"{msg['id']}.json").exists()
+        assert not (router.PROCESSED_DIR / f"{msg['id']}.json").exists()
+
+    def test_alert_written_on_dispatch_error(self, router):
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg['uow_id']}",
+            "prompt": "run",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch_via_claude_p.side_effect = RuntimeError("subprocess died")
+
+        router.run_poll_cycle()
+
+        router.write_inbox_message.assert_called_once()
+
+    def test_other_messages_continue_after_failure(self, router):
+        """A dispatch failure for one UoW does not prevent routing of the next."""
+        msg1 = _make_wos_execute_msg("uow-fail-001")
+        msg2 = _make_wos_execute_msg("uow-ok-002")
+        _write_msg(router.INBOX_DIR, msg1)
+        _write_msg(router.INBOX_DIR, msg2)
+
+        def fake_dispatch(instructions: str, uow_id: str) -> str:
+            if "fail" in uow_id:
+                raise RuntimeError("dispatch failed")
+            return "run-ok"
+
+        router.route_wos_message.side_effect = [
+            {
+                "action": "spawn_subagent",
+                "task_id": f"wos-{msg1['uow_id']}",
+                "prompt": "run",
+                "agent_type": "functional-engineer",
+                "message_type": "wos_execute",
+            },
+            {
+                "action": "spawn_subagent",
+                "task_id": f"wos-{msg2['uow_id']}",
+                "prompt": "run",
+                "agent_type": "functional-engineer",
+                "message_type": "wos_execute",
+            },
+        ]
+        router._dispatch_via_claude_p.side_effect = fake_dispatch
+
+        router.run_poll_cycle()
+
+        # msg1 failed, msg2 succeeded
+        assert (router.FAILED_DIR / f"{msg1['id']}.json").exists()
+        assert (router.PROCESSED_DIR / f"{msg2['id']}.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: route_wos_message exception
+# ---------------------------------------------------------------------------
+
+class TestRouteWosMessageException:
+    """route_wos_message raising moves message to failed/ and writes alert."""
+
+    def test_message_moved_to_failed_on_route_exception(self, router):
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.side_effect = ValueError("bad message format")
+
+        router.run_poll_cycle()
+
+        assert (router.FAILED_DIR / f"{msg['id']}.json").exists()
+
+    def test_alert_written_on_route_exception(self, router):
+        msg = _make_wos_execute_msg()
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.side_effect = ValueError("bad message format")
+
+        router.run_poll_cycle()
+
+        router.write_inbox_message.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: claim race condition
+# ---------------------------------------------------------------------------
+
+class TestClaimRaceCondition:
+    """If message disappears from inbox before claim, routing is skipped silently."""
+
+    def test_already_claimed_message_skipped_gracefully(self, router):
+        """Message removed from inbox before claim — no error, no crash."""
+        msg = _make_wos_execute_msg()
+        # Deliberately do NOT write the file — simulates a race condition where
+        # another process claimed it between check_inbox and our claim attempt
+        msg["_filepath"] = str(router.INBOX_DIR / f"{msg['id']}.json")
+
+        # Inject directly into the read result by monkeypatching _read_inbox_messages
+        with patch.object(router, "_read_inbox_messages", return_value=[msg]):
+            result = router.run_poll_cycle()
+
+        # Should not crash; dispatch never called
+        router._dispatch_via_claude_p.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _filter_wos_execute (pure function)
+# ---------------------------------------------------------------------------
+
+class TestFilterWosExecute:
+    """_filter_wos_execute is a pure filter — no side effects."""
+
+    def test_returns_only_wos_execute_messages(self):
+        mod = _get_router_module()
+        msgs = [
+            {"type": "wos_execute", "id": "a"},
+            {"type": "text", "id": "b"},
+            {"type": "subagent_notification", "id": "c"},
+            {"type": "wos_execute", "id": "d"},
+        ]
+        result = mod._filter_wos_execute(msgs)
+        assert [m["id"] for m in result] == ["a", "d"]
+
+    def test_returns_empty_for_no_matches(self):
+        mod = _get_router_module()
+        msgs = [{"type": "text"}, {"type": "callback"}]
+        assert mod._filter_wos_execute(msgs) == []
+
+    def test_returns_empty_for_empty_input(self):
+        mod = _get_router_module()
+        assert mod._filter_wos_execute([]) == []
+
+    def test_ignores_case_variation(self):
+        """Type matching is exact — 'WOS_EXECUTE' is not a match."""
+        mod = _get_router_module()
+        msgs = [{"type": "WOS_EXECUTE"}, {"type": "wos-execute"}]
+        assert mod._filter_wos_execute(msgs) == []


### PR DESCRIPTION
## Problem solved

Every `wos_execute` message currently consumes a full dispatcher reasoning turn (claim → `route_wos_message` → `mark_processed`). This is pure mechanical routing — no LLM value added — but it burns dispatcher context at a rate that grows with WOS throughput. This PR offloads that routing to a persistent daemon.

## What changed

A new always-on Python daemon (`src/daemons/wos_execute_router.py`) polls the inbox every 30 seconds, claims any `wos_execute` messages it finds, and dispatches them via `_dispatch_via_claude_p` — the same subprocess path the executor uses for CI/dev. The dispatcher's existing `wos_execute` branch is left intact (Phase 1 is additive: the daemon races to claim messages first; the dispatcher handles any it wins if the daemon is down).

**Flow before:**
```
inbox/wos_execute → dispatcher LLM turn → route_wos_message → spawn Task → mark_processed
```

**Flow after (Phase 1):**
```
inbox/wos_execute → wos-execute-router daemon (no LLM) → route_wos_message → _dispatch_via_claude_p → mark_processed
                 ↘ dispatcher (fallback if daemon didn't claim first)
```

**Key design decisions:**
- `route_wos_message` is pure — it returns a routing decision but does NOT spawn. The daemon calls `_dispatch_via_claude_p` to act on the decision (per oracle Gap 1 resolution).
- `check_inbox` has no `type` parameter — daemon filters client-side after reading the inbox directory directly (no MCP session required).
- Awareness path uses `write_inbox_message` from `inbox_write.py` (same pattern as executor-heartbeat/steward-heartbeat). `write_result` is NOT used — it requires a Claude session the daemon does not have.
- `_dispatch_via_claude_p` is synchronous; sequential dispatch is acceptable at current WOS throughput.

**Gates enforced:**
- `wos-config.json` `execution_enabled` gate: if false, skip entire cycle.
- `MAX_AGENTS_GATE=8`: if active agent count >= threshold, defer by leaving messages unclaimed.

**Functional patterns used:** pure functions (`route_wos_message`, `_filter_wos_execute`), immutable message dicts (read-only after inbox read), side effects isolated to `_claim_message`, `_release_message_*`, and `_write_alert`.

## What is NOT in this PR (Phase 1 boundary)

The dispatcher's `wos_execute` branch is NOT removed. That is Phase 2 and requires a logged ADR in `oracle/decisions.md` first (removing it is an Encoded Orientation change per the design doc). This PR is purely additive.

## New files

- `src/daemons/wos_execute_router.py` — daemon implementation
- `src/daemons/__init__.py` — package marker for the new `daemons/` directory
- `services/lobster-wos-router.service` — systemd unit (Type B, `User=lobster`, `Restart=on-failure`)
- `tests/test_wos_execute_router.py` — 26 unit tests

## Modified files

- `scripts/upgrade.sh` — Migration 90: installs/updates the systemd service on existing installs

## Tests run

- [x] `uv run pytest tests/test_wos_execute_router.py -v` — 26 passed, 0 failed
- [x] `uv run python -m py_compile src/daemons/wos_execute_router.py` — syntax clean
- [ ] Live systemd test (`systemctl start lobster-wos-router`) — blocked: requires production instance with systemd; service file structure follows the lobster-whatsapp-router.service pattern exactly

**Blocked items needing attention before merge:** none — the live systemd test is a post-merge monitoring step (watch `journalctl -u lobster-wos-router -f` after Migration 90 runs).

## Manual test

Not applicable for automated test runs. For the production install:
- Migration 90 in `upgrade.sh` installs, enables, and starts the service automatically on next `upgrade.sh` run.
- Verify with: `sudo systemctl status lobster-wos-router` and `journalctl -u lobster-wos-router -n 50`
- The daemon logs to `~/lobster-workspace/logs/wos-execute-router.log` in addition to journal.
- User-visible outcome: the dispatcher's context window stops burning on `wos_execute` routing. Verify by observing that `wos_execute` messages in the inbox are claimed by the daemon (appear in `processing/` then `processed/`) before the dispatcher's next poll cycle completes.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see Manual test above (live systemd requires production)
- [x] User-visible outcome: reduced dispatcher context burn (verifiable via monitoring post-deploy)
- [x] Side-effect audit complete: daemon polls every 30s, no flood risk; MAX_AGENTS_GATE=8 caps parallelism; failed messages go to `failed/` not discarded
- [x] External service calls: mocked in tests; production calls are file I/O only (no HTTP, no MCP)

Closes #940