### PR TITLE
fix(registry): use UoWStatus enum in list_executing() SQL (Issue #925)

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1156,9 +1156,14 @@ class Registry:
             rows = conn.execute(
                 """
                 SELECT * FROM uow_registry
-                WHERE status IN ('active', 'executing', 'ready-for-executor')
+                WHERE status IN (?, ?, ?)
                 ORDER BY updated_at DESC
-                """
+                """,
+                (
+                    UoWStatus.ACTIVE.value,
+                    UoWStatus.EXECUTING.value,
+                    UoWStatus.READY_FOR_EXECUTOR.value,
+                ),
             ).fetchall()
             return [self._row_to_uow(r) for r in rows]
         finally:


### PR DESCRIPTION
## Summary

- Replaces three raw string literals ('active', 'executing', 'ready-for-executor') in `list_executing()`'s WHERE clause with parameterised placeholders bound to `UoWStatus` enum values
- Makes `list_executing()` consistent with the rest of `registry.py`
- Ensures any future enum value change is caught at a single definition point rather than scattered across raw strings

Closes #925

## Test plan
- [ ] Verify `list_executing()` returns same results as before with enum-bound parameters
- [ ] Confirm no raw string literals remain in the WHERE clause of `list_executing()`
- [ ] Check that `UoWStatus` enum values match the string literals they replace ('active', 'executing', 'ready-for-executor')

🤖 Generated with [Claude Code](https://claude.com/claude-code)