### PR TITLE
fix(wos-executor): rename stdout= to output= in CalledProcessError constructors

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -1072,8 +1072,8 @@ def _dispatch_via_claude_p(instructions: str, uow_id: str) -> str:
         raise subprocess.CalledProcessError(
             error.exit_code or 1,
             error.command,
+            output=error.stdout,
             stderr=error.stderr,
-            stdout=error.stdout,
         )
 
     return run_id
@@ -1200,8 +1200,8 @@ def _dispatch_via_stub(register_name: str, instructions: str, uow_id: str) -> st
         raise subprocess.CalledProcessError(
             error.exit_code or 1,
             error.command,
+            output=error.stdout,
             stderr=error.stderr,
-            stdout=error.stdout,
         )
 
     return run_id


### PR DESCRIPTION
## What problem does this solve?

When `_dispatch_via_claude_p` or `_dispatch_via_stub` encounters a subprocess failure, both functions re-raise a `CalledProcessError` to propagate the failure to callers. The construction used `stdout=error.stdout` — but `stdout` is not a valid constructor keyword argument for `CalledProcessError.__init__(returncode, cmd, output=None, stderr=None)`. The valid parameter name is `output`.

This caused the router daemon to crash with:

```
TypeError: CalledProcessError.__init__() got an unexpected keyword argument 'stdout'
```

The TypeError replaced the original subprocess error in the exception chain, making the actual dispatch failure invisible in logs. Observed for `uow_20260425_639b91`.

## What changed

Renamed `stdout=` to `output=` in two `CalledProcessError(...)` constructor calls in `executor.py`:
- `_dispatch_via_claude_p` (line ~1072)
- `_dispatch_via_stub` (line ~1200)

No other changes. The PR #954 PATH fix (`_build_claude_env` with `~/.local/bin` prepend) and error-capture surfacing pattern are already in place at both call sites — this PR only fixes the invalid kwarg.

## Functional patterns

Pure fix — no side effects introduced. The `CalledProcessError` instance is constructed immutably and re-raised; the `.stdout` attribute (which `output=` populates) is already accessed by the PR #954 handler at the exception catch site.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_executor_failure_fixes.py tests/test_wos_execute_router.py -v` — 35 passed, 0 failed

## Manual test

N/A — this change is entirely internal. The fix prevents a constructor TypeError from masking subprocess failures; no Telegram output or external service calls are affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, internal only
- [x] User-visible outcome verified — N/A, no user-visible output from this path
- [x] Side-effect audit complete: fix removes an unhandled exception; no new side effects
- [x] External service calls: none touched