### PR TITLE
feat(wos): consolidate escalation notifications for shared-cause failure waves

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -3403,6 +3403,110 @@ def _default_notify_dan_early_warning(
 # Escalation notification (retry cap reached)
 # ---------------------------------------------------------------------------
 
+# Consolidation threshold: when this many or more UoWs escalate within a single
+# heartbeat cycle (same return_reason), suppress individual notifications and
+# emit one consolidated signal instead.
+#
+# Rationale: a session-end event can kill N executing agents simultaneously,
+# producing N independent "retry cap exceeded" escalations that share a single
+# root cause. Below this threshold, individual messages are more informative.
+# At or above: a consolidated message is less noisy and more actionable.
+#
+# Spec: architectural-proposal-20260426.md §Category 4 / §3
+ESCALATION_CONSOLIDATION_THRESHOLD: int = 3
+
+
+@dataclass(frozen=True)
+class EscalationRecord:
+    """
+    Carries the UoW and its return_reason at the point of retry-cap escalation.
+
+    Accumulated per heartbeat cycle in run_steward_cycle. When the cycle ends,
+    the count determines whether individual or consolidated notification fires.
+    """
+    uow: UoW
+    return_reason: str | None
+
+
+def _build_consolidated_escalation_text(records: list[EscalationRecord]) -> str:
+    """
+    Build a human-readable summary for a batch of same-cycle escalations.
+
+    Pure function — no side effects, no I/O.
+
+    Returns a multi-line string naming the count, the cause(s), and each UoW ID.
+    When all records share one return_reason, the cause is stated as the shared
+    cause. When multiple causes are present, each is listed.
+    """
+    count = len(records)
+    causes = sorted({r.return_reason or "unknown" for r in records})
+    cause_str = causes[0] if len(causes) == 1 else ", ".join(causes)
+
+    uow_lines = "\n".join(
+        f"  - {r.uow.id} ({(r.uow.summary or '')[:80].strip()})"
+        for r in records
+    )
+    return (
+        f"WOS: {count} UoWs escalated to needs-human-review in the same heartbeat cycle.\n\n"
+        f"Shared cause: {cause_str}\n\n"
+        f"Affected UoWs ({count}):\n{uow_lines}\n\n"
+        f"This is likely a single infrastructure event (e.g. session-end killing multiple "
+        f"executing agents), not {count} independent work failures.\n\n"
+        f"To act on all: 'retry <uow_id>' or 'close <uow_id>' for each.\n"
+        f"(Button handlers are a follow-on — text commands are the current interface.)"
+    )
+
+
+def _send_consolidated_escalation_notification(records: list[EscalationRecord]) -> None:
+    """
+    Send a single consolidated Telegram notification covering all UoWs that
+    escalated within the same heartbeat cycle.
+
+    Writes one JSON file to ~/messages/inbox/ instead of N individual files.
+    Called by run_steward_cycle when len(pending_escalations) >= ESCALATION_CONSOLIDATION_THRESHOLD.
+    """
+    chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", _DAN_CHAT_ID)
+    count = len(records)
+    causes = sorted({r.return_reason or "unknown" for r in records})
+    uow_ids = [r.uow.id for r in records]
+
+    log.warning(
+        "WOS ESCALATION (consolidated): %d UoWs escalated in same cycle "
+        "— cause(s): %s — sending one consolidated notification",
+        count, ", ".join(causes),
+    )
+
+    msg_id = str(uuid.uuid4())
+    text = _build_consolidated_escalation_text(records)
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "chat_id": chat_id,
+        "text": text,
+        "timestamp": time.time(),
+        "metadata": {
+            "type": "wos_surface",
+            "condition": "retry_cap_consolidated",
+            "escalation_count": count,
+            "causes": causes,
+            "uow_ids": uow_ids,
+        },
+    }
+    inbox_dir = Path(os.path.expanduser("~/messages/inbox"))
+    try:
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        (inbox_dir / f"{msg_id}.json").write_text(
+            json.dumps(msg, indent=2), encoding="utf-8"
+        )
+        log.info(
+            "WOS consolidated escalation message written to inbox: %s "
+            "(%d UoWs, cause=%s)",
+            msg_id, count, ", ".join(causes),
+        )
+    except OSError as e:
+        log.error("Failed to write WOS consolidated escalation message to inbox: %s", e)
+
+
 def _send_escalation_notification(uow: UoW) -> None:
     """
     Send a Telegram notification to Dan when a UoW has exhausted MAX_RETRIES
@@ -3485,6 +3589,7 @@ def _process_uow(
     notify_dan_early_warning: Callable | None = None,
     llm_prescriber: Callable[..., LLMPrescription | None] | None = _llm_prescribe,
     inline_executor: Callable[[str], Any] | None = None,
+    escalation_notifier: Callable[[UoW], None] | None = None,
 ) -> StewardOutcome:
     """
     Process a single UoW through the full diagnosis + prescribe/close/surface cycle.
@@ -3501,6 +3606,10 @@ def _process_uow(
             The Executor's optimistic lock protects against double-execution if a
             concurrent heartbeat fires between the transition and the inline call.
             Defaults to None (no inline dispatch — heartbeat remains the dispatch path).
+        escalation_notifier: Callable(uow) invoked when the retry cap is exceeded.
+            Defaults to _send_escalation_notification (immediate individual notification).
+            run_steward_cycle injects a collector that accumulates escalations for
+            end-of-cycle consolidation. Tests may inject a no-op or a recorder.
     """
     uow_id = uow.id
     cycles = uow.steward_cycles
@@ -3824,7 +3933,13 @@ def _process_uow(
                     "timestamp": _now_iso(),
                 })
                 registry.transition(uow_id, _STATUS_NEEDS_HUMAN_REVIEW, _STATUS_DIAGNOSING)
-            _send_escalation_notification(uow)
+            # Route through injected notifier when provided (consolidation path),
+            # or fall back to individual notification (default / test path).
+            # Gated on not dry_run: notifications are side effects; dry_run must
+            # not write to inbox or accumulate the collector.
+            if not dry_run:
+                _effective_notifier = escalation_notifier or _send_escalation_notification
+                _effective_notifier(uow)
             _append_cycle_trace(
                 uow_id=uow_id,
                 cycle_num=cycles,
@@ -4415,6 +4530,18 @@ def run_steward_cycle(
     shard_blocked = 0
     considered_ids = []
 
+    # Per-cycle escalation collector for shared-cause consolidation.
+    # Accumulates (uow, return_reason) tuples during the loop. After the loop,
+    # if count >= ESCALATION_CONSOLIDATION_THRESHOLD: one consolidated notification.
+    # Otherwise: individual notification per UoW.
+    # In dry_run mode: no notifications are sent regardless.
+    _pending_escalations: list[EscalationRecord] = []
+
+    def _collect_escalation(uow: UoW) -> None:
+        """Collector injected as escalation_notifier — defers notification to end of cycle."""
+        _return_reason = _most_recent_return_reason(_fetch_audit_entries(registry, uow.id))
+        _pending_escalations.append(EscalationRecord(uow=uow, return_reason=_return_reason))
+
     # Shard-stream parallel dispatch gate — fetch once before the loop.
     # _executing_uows is updated within the loop as UoWs are prescribed
     # so that subsequent candidates in the same cycle see the updated
@@ -4679,6 +4806,7 @@ def run_steward_cycle(
                 notify_dan_early_warning=notify_dan_early_warning,
                 llm_prescriber=llm_prescriber,
                 inline_executor=inline_executor,
+                escalation_notifier=None if dry_run else _collect_escalation,
             )
         except Exception:
             log.exception("Steward: unhandled error processing UoW %s — skipping", uow_id)
@@ -4707,6 +4835,26 @@ def run_steward_cycle(
                 wait_for_trace += 1
             case _:
                 skipped += 1
+
+    # Post-loop: dispatch escalation notifications.
+    # Individual UoW transitions to needs-human-review have already been written
+    # inside _process_uow. Only the notification layer is consolidated here.
+    if _pending_escalations and not dry_run:
+        if len(_pending_escalations) >= ESCALATION_CONSOLIDATION_THRESHOLD:
+            log.info(
+                "Steward cycle: consolidating %d escalations (threshold=%d) "
+                "— sending one consolidated notification",
+                len(_pending_escalations), ESCALATION_CONSOLIDATION_THRESHOLD,
+            )
+            _send_consolidated_escalation_notification(_pending_escalations)
+        else:
+            log.info(
+                "Steward cycle: %d escalations below threshold=%d "
+                "— sending individual notifications",
+                len(_pending_escalations), ESCALATION_CONSOLIDATION_THRESHOLD,
+            )
+            for _rec in _pending_escalations:
+                _send_escalation_notification(_rec.uow)
 
     return CycleResult(
         evaluated=evaluated,

--- a/tests/ooda/test_escalation_consolidation.py
+++ b/tests/ooda/test_escalation_consolidation.py
@@ -1,0 +1,603 @@
+"""
+tests/ooda/test_escalation_consolidation.py
+
+Unit tests for shared-cause escalation consolidation.
+
+Spec (architectural-proposal-20260426.md §Category 4 / §3):
+  - When N UoWs escalate within the same heartbeat cycle, all via the same
+    return_reason, produce ONE consolidated Telegram notification rather than N
+    individual ones.
+  - Individual UoW records still transition to needs-human-review; only the
+    notification layer is consolidated.
+  - The consolidation threshold is ESCALATION_CONSOLIDATION_THRESHOLD. At or
+    above that count: one consolidated message. Below: individual messages per UoW.
+  - The consolidated message must include: count of affected UoWs, the shared
+    return_reason, and each UoW's ID.
+
+Coverage:
+- ESCALATION_CONSOLIDATION_THRESHOLD constant is exported from steward.
+- _build_consolidated_escalation_text: pure function, no side effects.
+  - Returns a string mentioning the count and the shared cause.
+  - Includes each UoW ID in the output.
+  - Works correctly at exactly the threshold boundary.
+- _send_consolidated_escalation_notification: writes one inbox JSON file.
+- run_steward_cycle: when >= ESCALATION_CONSOLIDATION_THRESHOLD UoWs escalate
+  in the same cycle, only ONE inbox notification is written (not N).
+- run_steward_cycle: when < ESCALATION_CONSOLIDATION_THRESHOLD UoWs escalate,
+  individual notifications are written per UoW.
+- All individual UoW records transition to needs-human-review regardless of
+  whether notification is consolidated.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.orchestration.steward import (
+    ESCALATION_CONSOLIDATION_THRESHOLD,
+    MAX_RETRIES,
+    _build_consolidated_escalation_text,
+    _send_consolidated_escalation_notification,
+    EscalationRecord,
+    run_steward_cycle,
+)
+from src.orchestration.registry import Registry, UoW, UoWStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+_ISSUE_COUNTER: list[int] = [1000]  # mutable singleton to generate unique issue numbers
+
+
+def _make_uow_at_retry_cap(
+    conn: sqlite3.Connection,
+    uow_id: str | None = None,
+    return_reason: str = "executor_orphan",
+    summary: str = "Test UoW",
+) -> str:
+    """
+    Insert a UoW at the retry cap boundary (retry_count == MAX_RETRIES,
+    steward_cycles > 0, with a prior execution_complete audit entry for the
+    given return_reason).
+    Returns the uow_id.
+    """
+    if uow_id is None:
+        uow_id = f"uow_test_{uuid.uuid4().hex[:6]}"
+    now = _now_iso()
+    # Each UoW needs a unique (source_issue_number, sweep_date) due to the DB constraint.
+    # Use a monotonically incrementing issue number and a unique date suffix.
+    _ISSUE_COUNTER[0] += 1
+    issue_num = _ISSUE_COUNTER[0]
+    sweep_date = f"2026-{(issue_num % 12) + 1:02d}-{(issue_num % 28) + 1:02d}"
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+            (id, type, source, source_issue_number, sweep_date, status, posture,
+             created_at, updated_at, summary, output_ref, steward_cycles, lifetime_cycles,
+             retry_count, success_criteria, register, route_evidence, trigger,
+             steward_agenda, steward_log)
+        VALUES (?, 'executable', ?, ?, ?, ?, 'solo',
+                ?, ?, ?, NULL, ?, ?, ?, ?, 'operational', '{}', '{"type": "immediate"}',
+                NULL, NULL)
+        """,
+        (
+            uow_id,
+            f"github:issue/{issue_num}",
+            issue_num,
+            sweep_date,
+            "ready-for-steward",
+            now, now,
+            summary,
+            MAX_RETRIES + 1,  # steward_cycles > 0 → re-dispatch path
+            MAX_RETRIES + 1,  # lifetime_cycles
+            MAX_RETRIES,      # retry_count == MAX_RETRIES → cap exceeded on next increment
+            "Output exists",
+        ),
+    )
+    # Audit entry that makes _most_recent_return_reason return our return_reason
+    conn.execute(
+        """
+        INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            now, uow_id, "execution_complete",
+            "active", "ready-for-steward", "executor",
+            json.dumps({"event": "execution_complete", "return_reason": return_reason}),
+        ),
+    )
+    conn.commit()
+    return uow_id
+
+
+def _get_uow_status(conn: sqlite3.Connection, uow_id: str) -> str | None:
+    row = conn.execute(
+        "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+    ).fetchone()
+    return row["status"] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path) -> Registry:
+    return Registry(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Test: constant exists and has expected value
+# ---------------------------------------------------------------------------
+
+class TestEscalationConsolidationThreshold:
+    def test_threshold_is_exported(self):
+        """ESCALATION_CONSOLIDATION_THRESHOLD must be exported from steward."""
+        assert ESCALATION_CONSOLIDATION_THRESHOLD is not None
+
+    def test_threshold_is_at_least_two(self):
+        """
+        Threshold must be >= 2. A threshold of 1 would consolidate every single
+        escalation, defeating the purpose.
+        """
+        assert ESCALATION_CONSOLIDATION_THRESHOLD >= 2
+
+    def test_threshold_is_an_integer(self):
+        assert isinstance(ESCALATION_CONSOLIDATION_THRESHOLD, int)
+
+
+# ---------------------------------------------------------------------------
+# Test: EscalationRecord dataclass
+# ---------------------------------------------------------------------------
+
+class TestEscalationRecord:
+    def test_escalation_record_carries_uow_and_return_reason(self):
+        """EscalationRecord must hold a UoW and a return_reason string."""
+        uow = UoW(
+            id="uow_test_abc123",
+            status=UoWStatus.DIAGNOSING,
+            summary="Some work",
+            source="github:issue/1",
+            source_issue_number=1,
+            created_at=_now_iso(),
+            updated_at=_now_iso(),
+        )
+        rec = EscalationRecord(uow=uow, return_reason="executor_orphan")
+        assert rec.uow is uow
+        assert rec.return_reason == "executor_orphan"
+
+
+# ---------------------------------------------------------------------------
+# Test: _build_consolidated_escalation_text (pure function)
+# ---------------------------------------------------------------------------
+
+class TestBuildConsolidatedEscalationText:
+    def _make_records(self, count: int, return_reason: str = "executor_orphan") -> list[EscalationRecord]:
+        records = []
+        for i in range(count):
+            uow = UoW(
+                id=f"uow_test_{i:04d}",
+                status=UoWStatus.NEEDS_HUMAN_REVIEW,
+                summary=f"Work item {i}",
+                source="github:issue/1",
+                source_issue_number=1,
+                created_at=_now_iso(),
+                updated_at=_now_iso(),
+            )
+            records.append(EscalationRecord(uow=uow, return_reason=return_reason))
+        return records
+
+    def test_output_mentions_count(self):
+        """Consolidated text must state the number of affected UoWs."""
+        records = self._make_records(5)
+        text = _build_consolidated_escalation_text(records)
+        assert "5" in text
+
+    def test_output_mentions_shared_cause(self):
+        """Consolidated text must name the shared return_reason."""
+        records = self._make_records(3, return_reason="executor_orphan")
+        text = _build_consolidated_escalation_text(records)
+        assert "executor_orphan" in text
+
+    def test_output_includes_each_uow_id(self):
+        """Consolidated text must include every affected UoW ID."""
+        records = self._make_records(4)
+        text = _build_consolidated_escalation_text(records)
+        for rec in records:
+            assert rec.uow.id in text, f"Expected {rec.uow.id} in consolidated text"
+
+    def test_pure_function_no_side_effects(self, tmp_path):
+        """
+        _build_consolidated_escalation_text must not write files, write to DB,
+        or produce observable side effects. Called twice with the same input,
+        it must return the same output.
+        """
+        records = self._make_records(3)
+        text1 = _build_consolidated_escalation_text(records)
+        text2 = _build_consolidated_escalation_text(records)
+        assert text1 == text2
+
+    def test_at_threshold_boundary(self):
+        """Text generation works at exactly ESCALATION_CONSOLIDATION_THRESHOLD records."""
+        records = self._make_records(ESCALATION_CONSOLIDATION_THRESHOLD)
+        text = _build_consolidated_escalation_text(records)
+        assert str(ESCALATION_CONSOLIDATION_THRESHOLD) in text
+
+    def test_heterogeneous_return_reasons_listed(self):
+        """
+        When records have different return_reasons (mixed-cause wave), each cause
+        should appear in the consolidated text or the text should clearly reflect
+        the mixed nature.
+        """
+        uow_a = UoW(
+            id="uow_a", status=UoWStatus.NEEDS_HUMAN_REVIEW,
+            summary="A", source="github:issue/1", source_issue_number=1,
+            created_at=_now_iso(), updated_at=_now_iso(),
+        )
+        uow_b = UoW(
+            id="uow_b", status=UoWStatus.NEEDS_HUMAN_REVIEW,
+            summary="B", source="github:issue/2", source_issue_number=2,
+            created_at=_now_iso(), updated_at=_now_iso(),
+        )
+        records = [
+            EscalationRecord(uow=uow_a, return_reason="executor_orphan"),
+            EscalationRecord(uow=uow_b, return_reason="executing_orphan"),
+        ]
+        text = _build_consolidated_escalation_text(records)
+        # Should list both IDs regardless of cause grouping
+        assert "uow_a" in text
+        assert "uow_b" in text
+
+
+# ---------------------------------------------------------------------------
+# Test: _send_consolidated_escalation_notification writes one inbox file
+# ---------------------------------------------------------------------------
+
+class TestSendConsolidatedEscalationNotification:
+    def _make_records(self, count: int, return_reason: str = "executor_orphan") -> list[EscalationRecord]:
+        records = []
+        for i in range(count):
+            uow = UoW(
+                id=f"uow_test_{i:04d}",
+                status=UoWStatus.NEEDS_HUMAN_REVIEW,
+                summary=f"Work item {i}",
+                source="github:issue/1",
+                source_issue_number=1,
+                created_at=_now_iso(),
+                updated_at=_now_iso(),
+            )
+            records.append(EscalationRecord(uow=uow, return_reason=return_reason))
+        return records
+
+    def test_writes_exactly_one_inbox_file(self, tmp_path):
+        """
+        _send_consolidated_escalation_notification must write exactly one JSON
+        file to the inbox directory, regardless of how many UoWs are in the batch.
+        """
+        fake_inbox = tmp_path / "inbox"
+        fake_inbox.mkdir()
+        records = self._make_records(5)
+
+        with patch("src.orchestration.steward.Path") as mock_path_cls:
+            real_path = Path
+
+            def path_side_effect(*args):
+                if args and "messages/inbox" in str(args[0] if args else ""):
+                    return fake_inbox
+                return real_path(*args)
+
+            mock_path_cls.side_effect = path_side_effect
+            _send_consolidated_escalation_notification(records)
+
+        written = list(fake_inbox.glob("*.json"))
+        assert len(written) == 1, (
+            f"Expected exactly 1 inbox file, got {len(written)}"
+        )
+
+    def test_inbox_file_has_correct_metadata(self, tmp_path):
+        """
+        The written inbox file must have metadata indicating it is a consolidated
+        escalation signal, not an individual one.
+        """
+        fake_inbox = tmp_path / "inbox"
+        fake_inbox.mkdir()
+        records = self._make_records(3, return_reason="executor_orphan")
+
+        with patch("src.orchestration.steward.Path") as mock_path_cls:
+            real_path = Path
+
+            def path_side_effect(*args):
+                if args and "messages/inbox" in str(args[0] if args else ""):
+                    return fake_inbox
+                return real_path(*args)
+
+            mock_path_cls.side_effect = path_side_effect
+            _send_consolidated_escalation_notification(records)
+
+        written = list(fake_inbox.glob("*.json"))
+        assert written
+        data = json.loads(written[0].read_text())
+        metadata = data.get("metadata", {})
+        assert metadata.get("condition") == "retry_cap_consolidated"
+        assert metadata.get("escalation_count") == 3
+
+
+# ---------------------------------------------------------------------------
+# Test: run_steward_cycle consolidation behavior
+# ---------------------------------------------------------------------------
+
+class TestRunStewardCycleConsolidation:
+    """
+    Integration-level tests that run the full Steward cycle against a test
+    registry and verify the notification behavior at the cycle level.
+    """
+
+    def _make_uow_at_cap(
+        self,
+        conn: sqlite3.Connection,
+        return_reason: str = "executor_orphan",
+        summary: str = "Test UoW",
+    ) -> str:
+        return _make_uow_at_retry_cap(conn, return_reason=return_reason, summary=summary)
+
+    def test_individual_notifications_below_threshold(self, db_path, registry, tmp_path):
+        """
+        When fewer than ESCALATION_CONSOLIDATION_THRESHOLD UoWs hit the retry cap
+        in a single cycle, each should trigger its own individual notification.
+        """
+        count = ESCALATION_CONSOLIDATION_THRESHOLD - 1
+        conn = _open_db(db_path)
+        uow_ids = [
+            self._make_uow_at_cap(conn, return_reason="executor_orphan")
+            for _ in range(count)
+        ]
+        conn.close()
+
+        individual_calls = []
+        consolidated_calls = []
+
+        def fake_notify_dan(uow, condition, **kwargs):
+            pass
+
+        def fake_llm_prescriber(uow_arg, reentry_posture, completion_gap, issue_body=""):
+            from src.orchestration.steward import LLMPrescription
+            return LLMPrescription(
+                instructions="do something",
+                success_criteria_check="output exists",
+                estimated_cycles=1,
+            )
+
+        with (
+            patch("src.orchestration.steward._send_escalation_notification") as mock_individual,
+            patch("src.orchestration.steward._send_consolidated_escalation_notification") as mock_consolidated,
+        ):
+            run_steward_cycle(
+                registry=registry,
+                dry_run=False,
+                artifact_dir=tmp_path,
+                notify_dan=fake_notify_dan,
+                llm_prescriber=fake_llm_prescriber,
+            )
+
+        # Individual escalation must have been called once per UoW
+        assert mock_individual.call_count == count, (
+            f"Expected {count} individual escalation calls, got {mock_individual.call_count}"
+        )
+        # Consolidated must NOT have been called
+        assert mock_consolidated.call_count == 0, (
+            f"Consolidated notification must not fire below threshold, "
+            f"got {mock_consolidated.call_count} calls"
+        )
+
+    def test_consolidated_notification_at_threshold(self, db_path, registry, tmp_path):
+        """
+        When exactly ESCALATION_CONSOLIDATION_THRESHOLD UoWs hit the retry cap
+        in the same cycle, ONE consolidated notification is sent and zero individual
+        notifications are sent.
+        """
+        count = ESCALATION_CONSOLIDATION_THRESHOLD
+        conn = _open_db(db_path)
+        uow_ids = [
+            self._make_uow_at_cap(conn, return_reason="executor_orphan")
+            for _ in range(count)
+        ]
+        conn.close()
+
+        def fake_notify_dan(uow, condition, **kwargs):
+            pass
+
+        def fake_llm_prescriber(uow_arg, reentry_posture, completion_gap, issue_body=""):
+            from src.orchestration.steward import LLMPrescription
+            return LLMPrescription(
+                instructions="do something",
+                success_criteria_check="output exists",
+                estimated_cycles=1,
+            )
+
+        with (
+            patch("src.orchestration.steward._send_escalation_notification") as mock_individual,
+            patch("src.orchestration.steward._send_consolidated_escalation_notification") as mock_consolidated,
+        ):
+            run_steward_cycle(
+                registry=registry,
+                dry_run=False,
+                artifact_dir=tmp_path,
+                notify_dan=fake_notify_dan,
+                llm_prescriber=fake_llm_prescriber,
+            )
+
+        # Individual escalation must NOT have been called
+        assert mock_individual.call_count == 0, (
+            f"Individual escalation must be suppressed when consolidating, "
+            f"got {mock_individual.call_count} calls"
+        )
+        # Exactly one consolidated call
+        assert mock_consolidated.call_count == 1, (
+            f"Expected 1 consolidated escalation call, got {mock_consolidated.call_count}"
+        )
+
+    def test_consolidated_notification_above_threshold(self, db_path, registry, tmp_path):
+        """
+        When more than ESCALATION_CONSOLIDATION_THRESHOLD UoWs escalate, still
+        ONE consolidated notification (not multiple consolidated or hybrid).
+        """
+        count = ESCALATION_CONSOLIDATION_THRESHOLD + 4
+        conn = _open_db(db_path)
+        for _ in range(count):
+            self._make_uow_at_cap(conn, return_reason="executor_orphan")
+        conn.close()
+
+        def fake_notify_dan(uow, condition, **kwargs):
+            pass
+
+        def fake_llm_prescriber(uow_arg, reentry_posture, completion_gap, issue_body=""):
+            from src.orchestration.steward import LLMPrescription
+            return LLMPrescription(
+                instructions="do something",
+                success_criteria_check="output exists",
+                estimated_cycles=1,
+            )
+
+        with (
+            patch("src.orchestration.steward._send_escalation_notification") as mock_individual,
+            patch("src.orchestration.steward._send_consolidated_escalation_notification") as mock_consolidated,
+        ):
+            run_steward_cycle(
+                registry=registry,
+                dry_run=False,
+                artifact_dir=tmp_path,
+                notify_dan=fake_notify_dan,
+                llm_prescriber=fake_llm_prescriber,
+            )
+
+        assert mock_individual.call_count == 0, (
+            f"No individual notifications when above threshold, "
+            f"got {mock_individual.call_count}"
+        )
+        assert mock_consolidated.call_count == 1, (
+            f"Expected exactly 1 consolidated notification, got {mock_consolidated.call_count}"
+        )
+
+    def test_all_uows_transition_to_needs_human_review_regardless_of_consolidation(
+        self, db_path, registry, tmp_path
+    ):
+        """
+        Whether notification is individual or consolidated, every UoW that hits
+        the retry cap must transition to needs-human-review in the registry.
+        Individual records must not be suppressed — only the notification is consolidated.
+        """
+        count = ESCALATION_CONSOLIDATION_THRESHOLD + 2
+        conn = _open_db(db_path)
+        uow_ids = [
+            self._make_uow_at_cap(conn, return_reason="executor_orphan")
+            for _ in range(count)
+        ]
+        conn.close()
+
+        def fake_notify_dan(uow, condition, **kwargs):
+            pass
+
+        def fake_llm_prescriber(uow_arg, reentry_posture, completion_gap, issue_body=""):
+            from src.orchestration.steward import LLMPrescription
+            return LLMPrescription(
+                instructions="do something",
+                success_criteria_check="output exists",
+                estimated_cycles=1,
+            )
+
+        with (
+            patch("src.orchestration.steward._send_escalation_notification"),
+            patch("src.orchestration.steward._send_consolidated_escalation_notification"),
+        ):
+            run_steward_cycle(
+                registry=registry,
+                dry_run=False,
+                artifact_dir=tmp_path,
+                notify_dan=fake_notify_dan,
+                llm_prescriber=fake_llm_prescriber,
+            )
+
+        conn2 = _open_db(db_path)
+        for uow_id in uow_ids:
+            status = _get_uow_status(conn2, uow_id)
+            assert status == "needs-human-review", (
+                f"UoW {uow_id} must be in needs-human-review, got {status!r}"
+            )
+        conn2.close()
+
+    def test_dry_run_does_not_send_any_notification(self, db_path, registry, tmp_path):
+        """
+        In dry_run mode, no notifications of any kind should be sent —
+        neither individual nor consolidated.
+        """
+        count = ESCALATION_CONSOLIDATION_THRESHOLD + 2
+        conn = _open_db(db_path)
+        for _ in range(count):
+            self._make_uow_at_cap(conn, return_reason="executor_orphan")
+        conn.close()
+
+        def fake_notify_dan(uow, condition, **kwargs):
+            pass
+
+        def fake_llm_prescriber(uow_arg, reentry_posture, completion_gap, issue_body=""):
+            from src.orchestration.steward import LLMPrescription
+            return LLMPrescription(
+                instructions="do something",
+                success_criteria_check="output exists",
+                estimated_cycles=1,
+            )
+
+        with (
+            patch("src.orchestration.steward._send_escalation_notification") as mock_individual,
+            patch("src.orchestration.steward._send_consolidated_escalation_notification") as mock_consolidated,
+        ):
+            run_steward_cycle(
+                registry=registry,
+                dry_run=True,
+                artifact_dir=tmp_path,
+                notify_dan=fake_notify_dan,
+                llm_prescriber=fake_llm_prescriber,
+            )
+
+        assert mock_individual.call_count == 0, (
+            f"No individual notifications in dry_run, got {mock_individual.call_count}"
+        )
+        assert mock_consolidated.call_count == 0, (
+            f"No consolidated notifications in dry_run, got {mock_consolidated.call_count}"
+        )


### PR DESCRIPTION
## What problem does this solve

When a session ends and kills multiple executing WOS agents simultaneously, the Steward fires N independent \"UoW needs human review\" Telegram notifications — one per UoW — despite all of them sharing a single root cause (executor_orphan from the same session-end event). The 19-UoW failure cohort from 2026-04-26 triggered exactly this: 19 separate \"retry cap exceeded\" messages where one consolidated signal was the correct response.

This is pure notification noise. Each individual message implies an independent decision point, when the actual situation is one infrastructure event that requires one triage decision.

## What changes

The Steward's escalation path now detects when multiple UoWs hit the retry cap within the same heartbeat cycle and consolidates them into a single notification.

**New exports from `steward.py`:**
- `ESCALATION_CONSOLIDATION_THRESHOLD = 3` — at or above this many escalations per cycle, consolidate.
- `EscalationRecord(uow, return_reason)` — carries data for one escalation in the batch.
- `_build_consolidated_escalation_text(records)` — pure function, no side effects, returns a human-readable summary: count, shared cause, and each UoW ID.
- `_send_consolidated_escalation_notification(records)` — writes one inbox JSON with `condition: "retry_cap_consolidated"` and `escalation_count` in metadata.

**Changes to `_process_uow`:**
- New injectable `escalation_notifier` parameter (default: `_send_escalation_notification`). `run_steward_cycle` injects a per-cycle collector closure instead of the default.
- The notification call is now gated on `not dry_run`. Previously the individual notification fired even in dry_run mode — this was a latent bug exposed by the new tests.

**Changes to `run_steward_cycle`:**
- A per-cycle `_pending_escalations: list[EscalationRecord]` accumulator is created before the UoW loop.
- `_collect_escalation` closure is injected as `escalation_notifier` for each `_process_uow` call.
- After the loop: if `len(_pending_escalations) >= ESCALATION_CONSOLIDATION_THRESHOLD`, call `_send_consolidated_escalation_notification` once. Otherwise, call `_send_escalation_notification` per UoW.

**What is not changed:**
- Individual UoW records still transition to `needs-human-review` in the registry — the data model is untouched.
- Retry accounting is unchanged (separate PR per the architectural proposal).
- trace.json is unchanged (separate PR).
- The `ESCALATION_CONSOLIDATION_THRESHOLD` is per-cycle, not per time window — the heartbeat cycle boundary is the consolidation window.

## Flow before/after

**Before:**
```
session-end kills 19 agents
       ↓
steward heartbeat cycle
  for each of 19 UoWs:
    retry_cap_exceeded → needs-human-review
    _send_escalation_notification(uow)   ← 19 inbox messages
                                         ← 19 Telegram notifications
```

**After:**
```
session-end kills 19 agents
       ↓
steward heartbeat cycle
  for each of 19 UoWs:
    retry_cap_exceeded → needs-human-review
    _collect_escalation(uow)             ← accumulates in _pending_escalations
  end of cycle:
  if len(_pending_escalations) >= 3:
    _send_consolidated_escalation_notification(all 19)   ← 1 inbox message
                                                         ← 1 Telegram notification
```

**Below threshold (< 3 escalations):** individual notifications fire per UoW, unchanged behavior.

## Tests run

- [x] `uv run pytest tests/ooda/test_escalation_consolidation.py` — 17 passed, 0 failed (new tests)
- [x] `uv run pytest tests/ooda/test_retry_cap.py` — 9 passed, 0 failed (regression: existing retry cap tests)
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_dispatch_eligibility.py tests/unit/test_orchestration/test_steward_model_tiering.py tests/ooda/` — 91 passed, 0 failed
- [x] `uv run python -c "import py_compile; py_compile.compile('src/orchestration/steward.py', doraise=True)"` — syntax OK

## Manual test

N/A — this change is entirely internal to the escalation notification path. It does not touch systemd, cron, external services, DB schema, or file I/O outside the existing inbox-write pattern. The inbox-write behavior is tested by `TestSendConsolidatedEscalationNotification`. The user-visible outcome (receiving 1 Telegram notification instead of 19) cannot be self-verified without a live session-kill event.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, change is internal notification routing
- [ ] User-visible outcome verified — blocked: requires production session-kill event to observe. The change is correctly implemented and tested at the unit level.
- [x] Side-effect audit: no floods (fewer messages, not more), no unscoped writes, no unintended volume. The change reduces notification volume.
- [x] External service calls: inbox-write is mocked in tests; no direct Telegram API calls.

## Areas to review closely

1. The `not dry_run` gate added to the notification call in `_process_uow` — this fixes a latent bug where `_send_escalation_notification` fired in dry_run mode. Confirm this is the correct behavior (consistent with all other side-effecting calls in the retry cap block).
2. The `_collect_escalation` closure captures `registry` and calls `_fetch_audit_entries` to re-read `return_reason` from the DB after the fact. This is a second DB round-trip per escalating UoW. The alternative (passing `return_reason` through `_process_uow`'s return value) would require a new `Surfaced` variant — the current approach is simpler and the DB cost is bounded to escalating UoWs only (not every UoW in the cycle).
3. The consolidation is per-cycle (same heartbeat invocation), not per time window. This is simpler and avoids a DB query, but means escalations arriving in adjacent cycles are not consolidated. Given the failure mode (session-kill kills all in-flight at once), same-cycle is the correct window.

Relates to: architectural-proposal-20260426.md §Category 4 / §3

🤖 Generated with [Claude Code](https://claude.com/claude-code)