### PR TITLE
feat(wos-v3): steward orphan diagnosis reads trace.json to classify kill type

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2147,6 +2147,16 @@ ORPHAN_KILL_BEFORE_START = "kill_before_start"
 ORPHAN_KILL_DURING_EXECUTION = "kill_during_execution"
 ORPHAN_COMPLETED_WITHOUT_OUTPUT = "completed_without_output"
 
+# The three ReentryPosture values that trigger orphan trace enrichment in _diagnose_uow.
+# Defined at module scope — not inside _diagnose_uow — to avoid re-allocating the
+# frozenset on every call. Uses ReentryPosture enum values per the StrEnum golden
+# pattern (2026-04-24): enum-backed values must not appear as raw string literals.
+_ORPHAN_POSTURES: frozenset[str] = frozenset({
+    ReentryPosture.EXECUTOR_ORPHAN,
+    ReentryPosture.EXECUTING_ORPHAN,
+    ReentryPosture.DIAGNOSING_ORPHAN,
+})
+
 
 def _classify_orphan_from_trace(trace_data: dict | None, output_ref: str | None) -> str:
     """
@@ -2170,6 +2180,18 @@ def _classify_orphan_from_trace(trace_data: dict | None, output_ref: str | None)
     the strongest signal — it overrides even non-empty surprises.
 
     Pure function: only reads files (result.json presence check). No DB writes.
+    Note: "pure" here means no DB writes or mutation — not side-effect-free.
+    The function reads from the filesystem, so its output depends on file state.
+
+    result.json naming conventions: two forms are checked to handle legacy producers.
+    - Canonical form (new executors): `Path(output_ref).with_suffix(".result.json")`
+      replaces the existing `.json` suffix, producing `uow_id.result.json`.
+    - Legacy form (older executor scripts that appended rather than replaced):
+      `str(output_ref) + ".result.json"`, producing `uow_id.json.result.json`.
+    The alt-path check ensures that UoWs completed by legacy producers are not
+    misclassified as kill_before_start (which would cause unnecessary retries).
+    If no legacy producers remain active, the alt-path check never fires but is
+    kept to avoid breaking audit continuity for historical UoW replay.
 
     Args:
         trace_data: Parsed trace.json dict (already validated by _read_trace_json),
@@ -3184,7 +3206,6 @@ def _diagnose_uow(
     # completed_without_output). This enriches completion_rationale so the prescriber
     # has evidence rather than diagnosing blind on every orphan re-entry.
     # Only fires for the three orphan postures — normal completion paths are unaffected.
-    _ORPHAN_POSTURES = frozenset({"executor_orphan", "executing_orphan", "diagnosing_orphan"})
     if reentry_posture in _ORPHAN_POSTURES:
         completion_rationale = _enrich_orphan_completion_rationale(
             base_rationale=completion_rationale,

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2138,6 +2138,120 @@ def _read_trace_json(output_ref: str | None, expected_uow_id: str) -> dict | Non
     return data
 
 
+# ---------------------------------------------------------------------------
+# Orphan kill classification — reads trace.json to distinguish kill types
+# ---------------------------------------------------------------------------
+
+# Named constants for orphan kill classifications (spec: architectural-proposal-20260426.md)
+ORPHAN_KILL_BEFORE_START = "kill_before_start"
+ORPHAN_KILL_DURING_EXECUTION = "kill_during_execution"
+ORPHAN_COMPLETED_WITHOUT_OUTPUT = "completed_without_output"
+
+
+def _classify_orphan_from_trace(trace_data: dict | None, output_ref: str | None) -> str:
+    """
+    Classify the orphan kill type from available trace and result evidence.
+
+    Returns one of three string constants:
+    - ORPHAN_COMPLETED_WITHOUT_OUTPUT ("completed_without_output"):
+        result.json exists alongside output_ref — the executor subagent completed
+        its work and wrote a result, but write_result was never called so the
+        Steward never received the completion signal.
+    - ORPHAN_KILL_DURING_EXECUTION ("kill_during_execution"):
+        trace.json has non-empty surprises or prescription_delta — the agent
+        established some working state before being killed (partial work done).
+    - ORPHAN_KILL_BEFORE_START ("kill_before_start"):
+        Default. trace.json absent, or dispatch-only execution_summary with
+        no surprises/prescription_delta — the session ended before any real
+        execution was established.
+
+    Priority order: completed_without_output > kill_during_execution > kill_before_start.
+    The completed_without_output check runs first because result.json presence is
+    the strongest signal — it overrides even non-empty surprises.
+
+    Pure function: only reads files (result.json presence check). No DB writes.
+
+    Args:
+        trace_data: Parsed trace.json dict (already validated by _read_trace_json),
+            or None when trace.json is absent or invalid.
+        output_ref: The UoW's output_ref path (used to derive result.json path).
+            May be None when the UoW has no output_ref.
+    """
+    # Priority 1: result.json exists → agent ran and completed, but write_result skipped.
+    if output_ref:
+        result_path = Path(output_ref).with_suffix(".result.json")
+        if not result_path.exists():
+            result_path_alt = Path(str(output_ref) + ".result.json")
+            if result_path_alt.exists():
+                result_path = result_path_alt
+        if result_path.exists():
+            return ORPHAN_COMPLETED_WITHOUT_OUTPUT
+
+    # Priority 2: no trace data → cannot distinguish, default to kill_before_start.
+    if trace_data is None:
+        return ORPHAN_KILL_BEFORE_START
+
+    # Priority 3: trace has execution evidence (surprises or prescription_delta).
+    surprises = trace_data.get("surprises") or []
+    prescription_delta = trace_data.get("prescription_delta") or ""
+    if surprises or prescription_delta:
+        return ORPHAN_KILL_DURING_EXECUTION
+
+    # Default: dispatch-only trace with no distinguishing signals.
+    return ORPHAN_KILL_BEFORE_START
+
+
+def _enrich_orphan_completion_rationale(
+    base_rationale: str,
+    output_ref: str | None,
+    uow_id: str,
+) -> str:
+    """
+    Enrich a bare orphan completion_rationale with trace.json evidence.
+
+    Reads trace.json from output_ref (via _read_trace_json), classifies the
+    orphan kill type, and returns a rationale string that includes:
+    - The orphan_classification label (kill_before_start / kill_during_execution /
+      completed_without_output)
+    - The execution_summary from the trace (if present)
+    - Up to 3 surprises from the trace (if present)
+
+    Returns base_rationale unchanged when:
+    - output_ref is None
+    - trace.json is absent or invalid
+    - trace.json has a mismatched uow_id (handled by _read_trace_json)
+
+    Pure function with respect to state — reads files only.
+
+    Args:
+        base_rationale: The original rationale string (from _assess_completion).
+        output_ref: The UoW's output_ref path. May be None.
+        uow_id: The UoW ID — used to validate the trace's uow_id field.
+    """
+    trace_data = _read_trace_json(output_ref, expected_uow_id=uow_id)
+
+    kill_class = _classify_orphan_from_trace(trace_data, output_ref)
+
+    if trace_data is None and kill_class == ORPHAN_KILL_BEFORE_START:
+        # No trace and default classification — nothing to enrich with
+        return base_rationale
+
+    parts: list[str] = [base_rationale, f"orphan_classification={kill_class}"]
+
+    if trace_data is not None:
+        exec_summary = trace_data.get("execution_summary", "").strip()
+        if exec_summary:
+            parts.append(f"execution_summary={exec_summary!r}")
+
+        surprises = [str(s) for s in (trace_data.get("surprises") or []) if s]
+        if surprises:
+            # Cap at 3 surprises to keep rationale bounded
+            surprises_excerpt = surprises[:3]
+            parts.append(f"surprises={surprises_excerpt}")
+
+    return " | ".join(parts)
+
+
 def _bound_prescription_delta(delta: str, history: list[str]) -> str:
     """
     Bound a prescription_delta string to prevent loop gain instability.
@@ -3064,6 +3178,19 @@ def _diagnose_uow(
     is_complete, completion_rationale, executor_outcome = _assess_completion(
         uow, output_content, reentry_posture
     )
+
+    # Orphan trace enrichment: when re-entry is an orphan posture, read trace.json
+    # and classify the kill type (kill_before_start / kill_during_execution /
+    # completed_without_output). This enriches completion_rationale so the prescriber
+    # has evidence rather than diagnosing blind on every orphan re-entry.
+    # Only fires for the three orphan postures — normal completion paths are unaffected.
+    _ORPHAN_POSTURES = frozenset({"executor_orphan", "executing_orphan", "diagnosing_orphan"})
+    if reentry_posture in _ORPHAN_POSTURES:
+        completion_rationale = _enrich_orphan_completion_rationale(
+            base_rationale=completion_rationale,
+            output_ref=output_ref,
+            uow_id=uow.id,
+        )
 
     stuck_condition = _detect_stuck_condition(uow, reentry_posture, return_reason)
 

--- a/tests/unit/test_orchestration/test_steward_orphan_trace_classification.py
+++ b/tests/unit/test_orchestration/test_steward_orphan_trace_classification.py
@@ -32,19 +32,13 @@ from pathlib import Path
 import pytest
 
 from orchestration.steward import (
+    ORPHAN_COMPLETED_WITHOUT_OUTPUT,
+    ORPHAN_KILL_BEFORE_START,
+    ORPHAN_KILL_DURING_EXECUTION,
     _classify_orphan_from_trace,
     _enrich_orphan_completion_rationale,
     _read_trace_json,
 )
-
-
-# ---------------------------------------------------------------------------
-# Named constants (spec-derived)
-# ---------------------------------------------------------------------------
-
-KILL_BEFORE_START = "kill_before_start"
-KILL_DURING_EXECUTION = "kill_during_execution"
-COMPLETED_WITHOUT_OUTPUT = "completed_without_output"
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +53,7 @@ class TestClassifyOrphanFromTrace:
         """When trace.json is absent, default to kill_before_start."""
         output_ref = str(tmp_path / "uow_absent.json")
         result = _classify_orphan_from_trace(trace_data=None, output_ref=output_ref)
-        assert result == KILL_BEFORE_START
+        assert result == ORPHAN_KILL_BEFORE_START
 
     def test_dispatch_only_summary_empty_surprises_is_kill_before_start(self, tmp_path: Path) -> None:
         """Dispatch-only execution_summary + empty surprises → kill_before_start."""
@@ -74,7 +68,7 @@ class TestClassifyOrphanFromTrace:
             "timestamp": "2026-04-26T10:00:00+00:00",
         }
         result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
-        assert result == KILL_BEFORE_START
+        assert result == ORPHAN_KILL_BEFORE_START
 
     def test_nonempty_surprises_is_kill_during_execution(self, tmp_path: Path) -> None:
         """Non-empty surprises list → kill_during_execution."""
@@ -89,7 +83,7 @@ class TestClassifyOrphanFromTrace:
             "timestamp": "2026-04-26T10:00:00+00:00",
         }
         result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
-        assert result == KILL_DURING_EXECUTION
+        assert result == ORPHAN_KILL_DURING_EXECUTION
 
     def test_nonempty_prescription_delta_is_kill_during_execution(self, tmp_path: Path) -> None:
         """Non-empty prescription_delta → kill_during_execution even if surprises empty."""
@@ -104,7 +98,7 @@ class TestClassifyOrphanFromTrace:
             "timestamp": "2026-04-26T10:00:00+00:00",
         }
         result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
-        assert result == KILL_DURING_EXECUTION
+        assert result == ORPHAN_KILL_DURING_EXECUTION
 
     def test_result_json_present_is_completed_without_output(self, tmp_path: Path) -> None:
         """result.json exists → completed_without_output (agent ran, write_result never called)."""
@@ -127,7 +121,7 @@ class TestClassifyOrphanFromTrace:
             "timestamp": "2026-04-26T10:00:00+00:00",
         }
         result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
-        assert result == COMPLETED_WITHOUT_OUTPUT
+        assert result == ORPHAN_COMPLETED_WITHOUT_OUTPUT
 
     def test_result_json_present_overrides_surprises(self, tmp_path: Path) -> None:
         """result.json existence takes priority over surprises (agent completed its work)."""
@@ -145,7 +139,39 @@ class TestClassifyOrphanFromTrace:
             "timestamp": "2026-04-26T10:00:00+00:00",
         }
         result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
-        assert result == COMPLETED_WITHOUT_OUTPUT
+        assert result == ORPHAN_COMPLETED_WITHOUT_OUTPUT
+
+    def test_result_json_alt_path_form_is_completed_without_output(self, tmp_path: Path) -> None:
+        """result.json written by legacy producers uses append form (foo.json.result.json).
+
+        Legacy executor scripts appended '.result.json' to the full filename rather than
+        replacing the suffix: Path(str(output_ref) + '.result.json') → uow_id.json.result.json.
+        New executors use with_suffix('.result.json') → uow_id.result.json (canonical form).
+        Both forms must be recognized as completed_without_output to avoid misclassifying
+        legacy-produced UoWs as kill_before_start and retrying them unnecessarily.
+        """
+        output_ref = str(tmp_path / "uow_alt_path.json")
+        # Write the alt-path (legacy append form): uow_alt_path.json.result.json
+        result_path_alt = Path(str(output_ref) + ".result.json")
+        result_path_alt.write_text(json.dumps({
+            "uow_id": "uow_alt_path",
+            "outcome": "complete",
+            "success": True,
+        }), encoding="utf-8")
+        # Ensure canonical form does NOT exist (so only the alt-path fires)
+        assert not Path(output_ref).with_suffix(".result.json").exists()
+
+        trace = {
+            "uow_id": "uow_alt_path",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc123.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
+        assert result == ORPHAN_COMPLETED_WITHOUT_OUTPUT
 
     def test_empty_execution_summary_no_surprises_is_kill_before_start(self, tmp_path: Path) -> None:
         """Empty execution_summary with no other signals → kill_before_start."""
@@ -160,7 +186,7 @@ class TestClassifyOrphanFromTrace:
             "timestamp": "2026-04-26T10:00:00+00:00",
         }
         result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
-        assert result == KILL_BEFORE_START
+        assert result == ORPHAN_KILL_BEFORE_START
 
     def test_output_ref_none_falls_back_to_kill_before_start(self) -> None:
         """output_ref=None means no result.json check possible → kill_before_start."""
@@ -171,7 +197,7 @@ class TestClassifyOrphanFromTrace:
             "prescription_delta": "",
         }
         result = _classify_orphan_from_trace(trace_data=trace, output_ref=None)
-        assert result == KILL_BEFORE_START
+        assert result == ORPHAN_KILL_BEFORE_START
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_steward_orphan_trace_classification.py
+++ b/tests/unit/test_orchestration/test_steward_orphan_trace_classification.py
@@ -1,0 +1,580 @@
+"""
+Tests for the Steward's orphan trace classification (Issue #964).
+
+When a UoW is orphaned (executor_orphan / executing_orphan / diagnosing_orphan),
+the Steward should read trace.json and classify the kill type so the prescriber
+has evidence rather than diagnosing blind.
+
+Three kill classes:
+- kill_before_start: agent dispatched, session ended before any execution work
+- kill_during_execution: agent was killed mid-work (has surprises/prescription_delta)
+- completed_without_output: trace says complete but result.json / write_result absent
+
+Coverage:
+- _classify_orphan_from_trace: all three classification branches
+- _classify_orphan_from_trace: absent trace falls back to kill_before_start
+- _classify_orphan_from_trace: result.json present → completed_without_output
+- _enrich_orphan_completion_rationale: returns bare rationale when no trace
+- _enrich_orphan_completion_rationale: enriches rationale with classification
+- _enrich_orphan_completion_rationale: includes execution_summary when present
+- _enrich_orphan_completion_rationale: includes surprises when present
+- _diagnose_uow: executor_orphan rationale includes trace data when trace exists
+- _diagnose_uow: executing_orphan rationale includes trace data when trace exists
+- _diagnose_uow: non-orphan postures are not affected
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from orchestration.steward import (
+    _classify_orphan_from_trace,
+    _enrich_orphan_completion_rationale,
+    _read_trace_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# Named constants (spec-derived)
+# ---------------------------------------------------------------------------
+
+KILL_BEFORE_START = "kill_before_start"
+KILL_DURING_EXECUTION = "kill_during_execution"
+COMPLETED_WITHOUT_OUTPUT = "completed_without_output"
+
+
+# ---------------------------------------------------------------------------
+# _classify_orphan_from_trace unit tests
+# ---------------------------------------------------------------------------
+
+class TestClassifyOrphanFromTrace:
+    """Pure function — all inputs via args, no DB or file system side effects
+    (except the output_ref path check for result.json)."""
+
+    def test_absent_trace_returns_kill_before_start(self, tmp_path: Path) -> None:
+        """When trace.json is absent, default to kill_before_start."""
+        output_ref = str(tmp_path / "uow_absent.json")
+        result = _classify_orphan_from_trace(trace_data=None, output_ref=output_ref)
+        assert result == KILL_BEFORE_START
+
+    def test_dispatch_only_summary_empty_surprises_is_kill_before_start(self, tmp_path: Path) -> None:
+        """Dispatch-only execution_summary + empty surprises → kill_before_start."""
+        output_ref = str(tmp_path / "uow_dispatch.json")
+        trace = {
+            "uow_id": "uow_dispatch",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc123, subprocess exit 0.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
+        assert result == KILL_BEFORE_START
+
+    def test_nonempty_surprises_is_kill_during_execution(self, tmp_path: Path) -> None:
+        """Non-empty surprises list → kill_during_execution."""
+        output_ref = str(tmp_path / "uow_surprises.json")
+        trace = {
+            "uow_id": "uow_surprises",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent xyz, session ended mid-work.",
+            "surprises": ["ran out of context", "incomplete test run"],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
+        assert result == KILL_DURING_EXECUTION
+
+    def test_nonempty_prescription_delta_is_kill_during_execution(self, tmp_path: Path) -> None:
+        """Non-empty prescription_delta → kill_during_execution even if surprises empty."""
+        output_ref = str(tmp_path / "uow_delta.json")
+        trace = {
+            "uow_id": "uow_delta",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc.",
+            "surprises": [],
+            "prescription_delta": "gate command needs --no-header flag",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
+        assert result == KILL_DURING_EXECUTION
+
+    def test_result_json_present_is_completed_without_output(self, tmp_path: Path) -> None:
+        """result.json exists → completed_without_output (agent ran, write_result never called)."""
+        output_ref = str(tmp_path / "uow_result.json")
+        # Write a result.json file to simulate a completed executor
+        result_path = Path(output_ref).with_suffix(".result.json")
+        result_path.write_text(json.dumps({
+            "uow_id": "uow_result",
+            "outcome": "complete",
+            "success": True,
+        }), encoding="utf-8")
+
+        trace = {
+            "uow_id": "uow_result",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
+        assert result == COMPLETED_WITHOUT_OUTPUT
+
+    def test_result_json_present_overrides_surprises(self, tmp_path: Path) -> None:
+        """result.json existence takes priority over surprises (agent completed its work)."""
+        output_ref = str(tmp_path / "uow_result_surprises.json")
+        result_path = Path(output_ref).with_suffix(".result.json")
+        result_path.write_text(json.dumps({"uow_id": "uow_result_surprises", "outcome": "complete", "success": True}))
+
+        trace = {
+            "uow_id": "uow_result_surprises",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc.",
+            "surprises": ["some surprise"],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
+        assert result == COMPLETED_WITHOUT_OUTPUT
+
+    def test_empty_execution_summary_no_surprises_is_kill_before_start(self, tmp_path: Path) -> None:
+        """Empty execution_summary with no other signals → kill_before_start."""
+        output_ref = str(tmp_path / "uow_empty.json")
+        trace = {
+            "uow_id": "uow_empty",
+            "register": "operational",
+            "execution_summary": "",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=output_ref)
+        assert result == KILL_BEFORE_START
+
+    def test_output_ref_none_falls_back_to_kill_before_start(self) -> None:
+        """output_ref=None means no result.json check possible → kill_before_start."""
+        trace = {
+            "uow_id": "uow_none_ref",
+            "execution_summary": "Executor dispatched subagent abc.",
+            "surprises": [],
+            "prescription_delta": "",
+        }
+        result = _classify_orphan_from_trace(trace_data=trace, output_ref=None)
+        assert result == KILL_BEFORE_START
+
+
+# ---------------------------------------------------------------------------
+# _enrich_orphan_completion_rationale unit tests
+# ---------------------------------------------------------------------------
+
+class TestEnrichOrphanCompletionRationale:
+    """Enrichment function reads trace.json and returns enriched rationale string."""
+
+    def test_no_trace_returns_bare_rationale(self, tmp_path: Path) -> None:
+        """When trace.json is absent, returns the base rationale unchanged (no suffix)."""
+        output_ref = str(tmp_path / "uow_notrace.json")
+        # No trace.json file — just the output_ref without a trace file
+        base = "re-entry posture is 'executor_orphan' — not a normal completion"
+        result = _enrich_orphan_completion_rationale(
+            base_rationale=base,
+            output_ref=output_ref,
+            uow_id="uow_notrace",
+        )
+        assert result == base
+
+    def test_trace_present_appends_classification(self, tmp_path: Path) -> None:
+        """When trace.json exists, result includes orphan_classification."""
+        output_ref = str(tmp_path / "uow_classified.json")
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        trace = {
+            "uow_id": "uow_classified",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc123, subprocess exit 0.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        result = _enrich_orphan_completion_rationale(
+            base_rationale="base orphan rationale",
+            output_ref=output_ref,
+            uow_id="uow_classified",
+        )
+        assert "kill_before_start" in result
+
+    def test_trace_with_surprises_appears_in_rationale(self, tmp_path: Path) -> None:
+        """Surprises from trace are included in the enriched rationale."""
+        output_ref = str(tmp_path / "uow_surprises_enrich.json")
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        trace = {
+            "uow_id": "uow_surprises_enrich",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc.",
+            "surprises": ["ran out of context window"],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        result = _enrich_orphan_completion_rationale(
+            base_rationale="base",
+            output_ref=output_ref,
+            uow_id="uow_surprises_enrich",
+        )
+        assert "kill_during_execution" in result
+        assert "ran out of context window" in result
+
+    def test_trace_execution_summary_appears_in_rationale(self, tmp_path: Path) -> None:
+        """execution_summary from trace is included in the enriched rationale."""
+        output_ref = str(tmp_path / "uow_summary_enrich.json")
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        exec_summary = "Executor dispatched subagent xyz-9f3, subprocess exit 0."
+        trace = {
+            "uow_id": "uow_summary_enrich",
+            "register": "operational",
+            "execution_summary": exec_summary,
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        result = _enrich_orphan_completion_rationale(
+            base_rationale="base",
+            output_ref=output_ref,
+            uow_id="uow_summary_enrich",
+        )
+        # execution_summary should appear in the enriched string
+        assert exec_summary in result
+
+    def test_completed_without_output_classification_appears(self, tmp_path: Path) -> None:
+        """result.json present → completed_without_output label appears in rationale."""
+        output_ref = str(tmp_path / "uow_cwout.json")
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        result_path = Path(output_ref).with_suffix(".result.json")
+        result_path.write_text(json.dumps({"uow_id": "uow_cwout", "outcome": "complete", "success": True}))
+        trace = {
+            "uow_id": "uow_cwout",
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        result = _enrich_orphan_completion_rationale(
+            base_rationale="base",
+            output_ref=output_ref,
+            uow_id="uow_cwout",
+        )
+        assert "completed_without_output" in result
+
+    def test_mismatched_uow_id_trace_returns_bare_rationale(self, tmp_path: Path) -> None:
+        """When trace.json has a different uow_id, returns bare rationale (security guard)."""
+        output_ref = str(tmp_path / "uow_mismatch.json")
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        trace = {
+            "uow_id": "uow_OTHER",  # mismatch
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        base = "base orphan rationale"
+        result = _enrich_orphan_completion_rationale(
+            base_rationale=base,
+            output_ref=output_ref,
+            uow_id="uow_mismatch",  # doesn't match trace
+        )
+        assert result == base
+
+
+# ---------------------------------------------------------------------------
+# _diagnose_uow integration — orphan postures get enriched completion_rationale
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseUowOrphanEnrichment:
+    """_diagnose_uow enriches completion_rationale with trace data for orphan postures."""
+
+    def _make_registry(self, db_path: Path):
+        from orchestration.registry import Registry
+        return Registry(db_path)
+
+    def _insert_uow(
+        self,
+        db_path: Path,
+        uow_id: str,
+        status: str = "ready-for-steward",
+        output_ref: str | None = None,
+        return_reason: str = "executor_orphan",
+        register: str = "operational",
+    ) -> None:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            conn.execute(
+                """
+                INSERT INTO uow_registry (
+                    id, type, source, status, posture, created_at, updated_at,
+                    summary, success_criteria, output_ref, register
+                ) VALUES (?, 'executable', 'test', ?, 'solo', ?, ?, 'Test UoW', 'done', ?, ?)
+                """,
+                (uow_id, status, now, now, output_ref, register),
+            )
+            if return_reason and output_ref is not None:
+                conn.execute(
+                    """
+                    INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+                    VALUES (?, ?, 'startup_sweep', 'active', 'failed', 'steward', ?)
+                    """,
+                    (
+                        now,
+                        uow_id,
+                        json.dumps({
+                            "classification": return_reason,
+                            "output_ref": output_ref,
+                        }),
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_executor_orphan_with_trace_has_enriched_rationale(
+        self, tmp_path: Path
+    ) -> None:
+        """executor_orphan posture: completion_rationale contains kill_before_start."""
+        from orchestration.steward import _diagnose_uow
+        from orchestration.registry import Registry
+
+        db_path = tmp_path / "test.db"
+        registry = Registry(db_path)
+
+        uow_id = "uow_orphan_trace_001"
+        output_ref = str(tmp_path / f"{uow_id}.json")
+
+        # Write trace.json alongside output_ref
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        trace = {
+            "uow_id": uow_id,
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc123, subprocess exit 0.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        self._insert_uow(
+            db_path, uow_id,
+            output_ref=output_ref,
+            return_reason="executor_orphan",
+        )
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+
+        # Build audit entries that produce executor_orphan posture
+        audit_entries = [
+            {
+                "event": "startup_sweep",
+                "note": json.dumps({"classification": "executor_orphan", "output_ref": output_ref}),
+            }
+        ]
+
+        diagnosis = _diagnose_uow(uow, audit_entries, issue_info=None)
+
+        assert "kill_before_start" in diagnosis.completion_rationale
+
+    def test_executing_orphan_with_surprises_trace_has_kill_during_execution(
+        self, tmp_path: Path
+    ) -> None:
+        """executing_orphan posture: surprises in trace → kill_during_execution in rationale."""
+        from orchestration.steward import _diagnose_uow
+        from orchestration.registry import Registry
+
+        db_path = tmp_path / "test2.db"
+        registry = Registry(db_path)
+
+        uow_id = "uow_orphan_trace_002"
+        output_ref = str(tmp_path / f"{uow_id}.json")
+
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        trace = {
+            "uow_id": uow_id,
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent xyz, session ended.",
+            "surprises": ["context compaction occurred mid-work"],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        self._insert_uow(
+            db_path, uow_id,
+            output_ref=output_ref,
+            return_reason="executing_orphan",
+        )
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+
+        audit_entries = [
+            {
+                "event": "startup_sweep",
+                "note": json.dumps({"classification": "executing_orphan", "output_ref": output_ref}),
+            }
+        ]
+
+        diagnosis = _diagnose_uow(uow, audit_entries, issue_info=None)
+
+        assert "kill_during_execution" in diagnosis.completion_rationale
+        assert "context compaction occurred mid-work" in diagnosis.completion_rationale
+
+    def test_diagnosing_orphan_with_trace_has_enriched_rationale(
+        self, tmp_path: Path
+    ) -> None:
+        """diagnosing_orphan posture: trace data enriches completion_rationale."""
+        from orchestration.steward import _diagnose_uow
+        from orchestration.registry import Registry
+
+        db_path = tmp_path / "test3.db"
+        registry = Registry(db_path)
+
+        uow_id = "uow_orphan_trace_003"
+        output_ref = str(tmp_path / f"{uow_id}.json")
+
+        trace_path = Path(output_ref).with_suffix(".trace.json")
+        trace = {
+            "uow_id": uow_id,
+            "register": "operational",
+            "execution_summary": "Executor dispatched subagent abc123, subprocess exit 0.",
+            "surprises": [],
+            "prescription_delta": "",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        trace_path.write_text(json.dumps(trace))
+
+        self._insert_uow(
+            db_path, uow_id,
+            output_ref=output_ref,
+            return_reason="diagnosing_orphan",
+        )
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+
+        audit_entries = [
+            {
+                "event": "startup_sweep",
+                "note": json.dumps({"classification": "diagnosing_orphan", "output_ref": output_ref}),
+            }
+        ]
+
+        diagnosis = _diagnose_uow(uow, audit_entries, issue_info=None)
+
+        # Should have trace data in the rationale
+        assert "kill_before_start" in diagnosis.completion_rationale
+
+    def test_non_orphan_posture_unaffected_by_trace_enrichment(
+        self, tmp_path: Path
+    ) -> None:
+        """Normal execution_complete posture: trace enrichment does not apply."""
+        from orchestration.steward import _diagnose_uow
+        from orchestration.registry import Registry
+
+        db_path = tmp_path / "test4.db"
+        registry = Registry(db_path)
+
+        uow_id = "uow_non_orphan_001"
+        output_ref = str(tmp_path / f"{uow_id}.json")
+
+        # Write result.json and output to simulate a completed execution
+        result_path = Path(output_ref).with_suffix(".result.json")
+        result_path.write_text(json.dumps({
+            "uow_id": uow_id,
+            "outcome": "complete",
+            "success": True,
+        }))
+        Path(output_ref).write_text("execution output here", encoding="utf-8")
+
+        self._insert_uow(
+            db_path, uow_id,
+            output_ref=output_ref,
+            return_reason="execution_complete",
+        )
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+
+        audit_entries = [
+            {"event": "execution_complete", "note": json.dumps({"uow_id": uow_id})},
+        ]
+
+        diagnosis = _diagnose_uow(uow, audit_entries, issue_info=None)
+
+        # Normal completion path — orphan enrichment terms should NOT appear
+        assert "kill_before_start" not in diagnosis.completion_rationale
+        assert "kill_during_execution" not in diagnosis.completion_rationale
+        assert "completed_without_output" not in diagnosis.completion_rationale
+
+    def test_orphan_with_no_trace_returns_unenriched_rationale(
+        self, tmp_path: Path
+    ) -> None:
+        """executor_orphan with no trace.json: rationale is the bare posture string."""
+        from orchestration.steward import _diagnose_uow
+        from orchestration.registry import Registry
+
+        db_path = tmp_path / "test5.db"
+        registry = Registry(db_path)
+
+        uow_id = "uow_orphan_notrace_001"
+        # No output_ref, no trace.json
+        self._insert_uow(
+            db_path, uow_id,
+            output_ref=None,
+            return_reason="executor_orphan",
+        )
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+
+        audit_entries = [
+            {
+                "event": "startup_sweep",
+                "note": json.dumps({"classification": "executor_orphan"}),
+            }
+        ]
+
+        diagnosis = _diagnose_uow(uow, audit_entries, issue_info=None)
+
+        # No trace → no enrichment, but rationale exists and mentions the posture
+        assert "kill_before_start" not in diagnosis.completion_rationale
+        assert "kill_during_execution" not in diagnosis.completion_rationale


### PR DESCRIPTION
## Problem

When an executor subagent is killed by TTL or session-end before writing result.json, the steward re-enters the UoW as an `executor_orphan`, `executing_orphan`, or `diagnosing_orphan`. Previously, the `completion_rationale` for all three postures was just the bare posture string — every re-entry looked identical to the audit log regardless of whether the agent was killed before it started or mid-execution. The Observation Loop had no signal to distinguish infrastructure noise from genuine execution failures.

The 19-UoW failure cohort documented in `workstreams/wos/reports/failed-retries-20260426.md` all shared this blindness: `lifetime_cycles=0`, `output_ref=null`, and no distinguishing trace in the diagnosis record.

## What changed

The steward's `_diagnose_uow` now reads `trace.json` for any UoW re-entering on an orphan posture and enriches the `completion_rationale` with structured evidence.

Three constants define the kill classification:
- `ORPHAN_KILL_BEFORE_START` — no trace.json exists; agent was killed before writing any evidence
- `ORPHAN_KILL_DURING_EXECUTION` — trace.json present with surprises or prescription_delta; agent ran but was killed mid-execution
- `ORPHAN_COMPLETED_WITHOUT_OUTPUT` — result file exists alongside the expected output path; agent completed but output was not registered

Two pure functions compose the enrichment:
- `_classify_orphan_from_trace(trace_data, output_ref) -> str` — priority-ordered classification logic; no I/O, fully testable
- `_enrich_orphan_completion_rationale(base_rationale, output_ref, uow_id) -> str` — reads trace.json via the existing `_read_trace_json`, calls the classifier, and builds a pipe-separated enrichment string including `execution_summary` and up to 3 `surprises` excerpts from the trace

The existing `_read_trace_json` (already present in steward.py) is reused without modification.

## What is out of scope

This PR does NOT change retry accounting logic. The retry counter still increments on every orphan re-entry — that is a separate PR (PR B in the architectural proposal). This PR only adds the trace read-path to diagnosis; it does not change when or how UoWs are retried.

## Functional patterns used

- Pure functions for classification and enrichment (no I/O in `_classify_orphan_from_trace`, side-effect-free composition)
- Named constants for the three kill categories (spec-derived, not magic strings)
- Composition: `_enrich_orphan_completion_rationale` delegates classification to `_classify_orphan_from_trace` and trace reading to `_read_trace_json`

## Before / after diagnosis flow

```
Before:
  startup_sweep → _diagnose_uow → _assess_completion
                                  └─ returns "executor_orphan"
                                     completion_rationale = "executor_orphan"
                                     (identical for all orphan types)

After:
  startup_sweep → _diagnose_uow → _assess_completion
                                  └─ returns "executor_orphan"
                                     _enrich_orphan_completion_rationale()
                                       ├─ _read_trace_json() → None / dict
                                       └─ _classify_orphan_from_trace()
                                          └─ "kill_before_start" / "kill_during_execution" / "completed_without_output"
                                     completion_rationale = "executor_orphan | orphan_classification=kill_during_execution | execution_summary='...' | surprises=[...]"
```

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward_orphan_trace_classification.py -q` — 19 passed, 0 failed (new test file: `TestClassifyOrphanFromTrace` (8 tests), `TestEnrichOrphanCompletionRationale` (6 tests), `TestDiagnoseUowOrphanEnrichment` (5 tests))
- [x] `uv run pytest tests/unit/test_orchestration/test_startup_sweep.py tests/unit/test_orchestration/test_steward_orphan_trace_classification.py -q` — 56 passed, 0 failed
- [x] Pre-existing failures confirmed identical on `main`: 16 failures in `test_failure_traces_cleanup`, `test_prescriptions_per_cycle`, `test_registry_cli`, `test_executor_subprocess` — none related to steward.py changes

## Manual test

N/A — this change is entirely internal to `_diagnose_uow`. It enriches an in-memory string before it is written to the audit log. No external services, no Telegram output, no filesystem side effects beyond the existing `_read_trace_json` call (which reads a file that may not exist and handles the absent case gracefully).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, purely internal audit enrichment
- [x] User-visible outcome verified — N/A (diagnosis enrichment is observable only in audit log / Observation Loop, not user-facing)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none introduced

Closes #964