### PR TITLE
feat(wos): heartbeat-based kill classification for executing orphans (#963)

### DIFF
--- a/scheduled-tasks/startup_sweep.py
+++ b/scheduled-tasks/startup_sweep.py
@@ -68,6 +68,21 @@ _EXECUTOR_ORPHAN_THRESHOLD_SECONDS = 3600  # 1 hour: ready-for-executor age thre
 # of the 24h TTL recovery ceiling.
 _EXECUTING_ORPHAN_THRESHOLD_SECONDS = 600  # 10 minutes
 
+# Grace window (seconds) after executor_dispatch before we expect the subagent
+# to have written its first heartbeat.  Absorbs agent startup jitter (model
+# load, context injection, first tool call).
+#
+# If heartbeat_at is more than DISPATCH_WINDOW_SECONDS after the
+# executor_dispatch timestamp, the agent demonstrably started working before
+# being killed → orphan_kill_during_execution.  Otherwise the kill happened
+# before the agent established any foothold → orphan_kill_before_start.
+#
+# 120 s is generous: model load + session startup typically takes <30 s.
+# A 2-minute window ensures we do not false-positive classify a freshly-started
+# agent as kill_during_execution if it happened to run a tool before writing its
+# first heartbeat within the window.
+DISPATCH_WINDOW_SECONDS: int = 120
+
 # Fallback minimum age (seconds) for an `active` UoW before the startup sweep
 # will classify it as a crash candidate.  This constant is used when the UoW
 # does not have an `estimated_runtime` value (S3P2-C).
@@ -100,6 +115,73 @@ class StartupSweepResult:
 # ---------------------------------------------------------------------------
 # Phase 1: Startup sweep — crash recovery (#307)
 # ---------------------------------------------------------------------------
+
+def _classify_executing_orphan_kill_type(
+    dispatch_ts: str | None,
+    heartbeat_at: str | None,
+) -> str:
+    """
+    Classify the kill type of an `executing` orphan UoW using the heartbeat signal.
+
+    Pure function: no side effects, no registry access.
+
+    Args:
+        dispatch_ts: ISO timestamp of the most recent executor_dispatch audit entry.
+            None if no executor_dispatch entry exists (e.g. older records before
+            the inbox-dispatch path was added).
+        heartbeat_at: ISO timestamp of the most recent heartbeat_at value on the
+            UoW, or None if heartbeat_at was never written.
+
+    Returns:
+        'orphan_kill_before_start': No evidence of agent working after dispatch.
+            Either heartbeat_at is None, or it does not exceed
+            dispatch_ts + DISPATCH_WINDOW_SECONDS.
+            Re-entry strategy: treat as clean first execution (no partial state).
+
+        'orphan_kill_during_execution': Agent wrote a heartbeat after the
+            dispatch window, confirming it had started processing before being
+            killed.
+            Re-entry strategy: note partial execution evidence for diagnosis.
+
+    Safe default: returns 'orphan_kill_before_start' whenever the classification
+    cannot be determined (None inputs, unparseable timestamps, missing dispatch
+    audit). This is conservative — treating an ambiguous kill as kill-before-start
+    avoids over-claiming partial execution evidence that may not exist.
+    """
+    # No dispatch timestamp → cannot determine if heartbeat was post-dispatch.
+    # Safe default: kill_before_start.
+    if dispatch_ts is None:
+        return "orphan_kill_before_start"
+
+    # No heartbeat → agent never wrote one → kill-before-start.
+    if heartbeat_at is None:
+        return "orphan_kill_before_start"
+
+    # Parse both timestamps for comparison.
+    try:
+        dispatch_dt = datetime.fromisoformat(dispatch_ts.replace("Z", "+00:00"))
+        if dispatch_dt.tzinfo is None:
+            dispatch_dt = dispatch_dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError, AttributeError):
+        return "orphan_kill_before_start"
+
+    try:
+        heartbeat_dt = datetime.fromisoformat(heartbeat_at.replace("Z", "+00:00"))
+        if heartbeat_dt.tzinfo is None:
+            heartbeat_dt = heartbeat_dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError, AttributeError):
+        return "orphan_kill_before_start"
+
+    # heartbeat_at must be strictly after dispatch_ts + DISPATCH_WINDOW_SECONDS.
+    # This absorbs startup jitter: even if the agent wrote a heartbeat quickly,
+    # we require it to be beyond the window to count as "working" evidence.
+    from datetime import timedelta
+    threshold_dt = dispatch_dt + timedelta(seconds=DISPATCH_WINDOW_SECONDS)
+    if heartbeat_dt > threshold_dt:
+        return "orphan_kill_during_execution"
+
+    return "orphan_kill_before_start"
+
 
 def _classify_active_uow(output_ref: str | None) -> tuple[str, dict]:
     """
@@ -479,6 +561,13 @@ def run_startup_sweep(
     # path (get_stale_heartbeat_uows) catches most of these when heartbeat_at is
     # non-NULL. This population covers the gap: agents that crashed before their
     # first heartbeat write (heartbeat_at = NULL) and never called write_result.
+    #
+    # Kill classification (issue #963): each executing orphan is classified by
+    # comparing the executor_dispatch audit timestamp against heartbeat_at.
+    # - orphan_kill_before_start: no heartbeat evidence after dispatch window
+    # - orphan_kill_during_execution: heartbeat written after dispatch window
+    # The classification is stored in the startup_sweep audit note for downstream
+    # use by the Steward's re-entry classifier.
     for uow in executing_uows:
         uow_id = uow.id
 
@@ -517,11 +606,28 @@ def run_startup_sweep(
             # Not old enough — may still be executing normally.
             continue
 
+        # Classify kill type using heartbeat evidence (issue #963).
+        # Safe default: kill_before_start when registry method is unavailable.
+        dispatch_ts: str | None = None
+        heartbeat_at: str | None = getattr(uow, "heartbeat_at", None)
+        try:
+            dispatch_ts = registry.get_executor_dispatch_timestamp(uow_id)
+        except (AttributeError, Exception) as _exc:
+            log.debug(
+                "Startup sweep: could not get dispatch timestamp for UoW %s — %s "
+                "(defaulting to orphan_kill_before_start)",
+                uow_id, _exc,
+            )
+        kill_classification = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at=heartbeat_at,
+        )
+
         if dry_run:
             log.info(
                 "Startup sweep (DRY RUN): executing UoW %s (age=%.0fs) "
-                "would be classified as executing_orphan and transitioned to ready-for-steward",
-                uow_id, age_seconds,
+                "would be classified as %s and transitioned to ready-for-steward",
+                uow_id, age_seconds, kill_classification,
             )
             skipped_dry_run += 1
             continue
@@ -531,14 +637,15 @@ def run_startup_sweep(
             started_at=started_at,
             age_seconds=age_seconds,
             threshold_seconds=executing_orphan_threshold_seconds,
+            kill_classification=kill_classification,
         )
 
         if rows == 1:
             executing_swept += 1
             log.info(
-                "Startup sweep: executing_orphan UoW %s → ready-for-steward "
+                "Startup sweep: %s UoW %s → ready-for-steward "
                 "(age=%.0fs, threshold=%ds — subagent never called write_result)",
-                uow_id, age_seconds, executing_orphan_threshold_seconds,
+                kill_classification, uow_id, age_seconds, executing_orphan_threshold_seconds,
             )
         else:
             log.debug(

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1391,6 +1391,59 @@ class Registry:
         finally:
             conn.close()
 
+    def get_executor_dispatch_timestamp(self, uow_id: str) -> str | None:
+        """
+        Return the timestamp of the most recent executor_dispatch audit entry
+        for this UoW, or None if no such entry exists.
+
+        Called by startup_sweep at classification time to determine whether
+        any heartbeat writes occurred AFTER the subagent was dispatched. This
+        enables distinguishing kill-before-start from kill-during-execution:
+
+        - If heartbeat_at is None or <= dispatch_ts + DISPATCH_WINDOW_SECONDS:
+          the agent was killed before establishing any working state.
+        - If heartbeat_at > dispatch_ts + DISPATCH_WINDOW_SECONDS:
+          the agent was actively working when killed.
+
+        The timestamp is extracted from the `note` JSON field of the
+        executor_dispatch audit entry (key: "timestamp"). Falls back to the
+        `ts` column if the note is absent or unparseable.
+
+        Returns None on any query error (safe default: treat as no dispatch,
+        classify as orphan_kill_before_start).
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT ts, note FROM audit_log
+                WHERE uow_id = ?
+                  AND event = 'executor_dispatch'
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (uow_id,),
+            ).fetchall()
+            if not rows:
+                return None
+            row = rows[0]
+            # Prefer the timestamp from the note JSON (written at dispatch time).
+            note_str = row["note"] if hasattr(row, "__getitem__") else None
+            if note_str:
+                try:
+                    data = json.loads(note_str)
+                    ts = data.get("timestamp")
+                    if ts:
+                        return str(ts)
+                except (json.JSONDecodeError, TypeError, AttributeError):
+                    pass
+            # Fallback: use the audit_log ts column
+            return str(row["ts"]) if row["ts"] else None
+        except Exception:
+            return None
+        finally:
+            conn.close()
+
     def record_startup_sweep_diagnosing(
         self,
         uow_id: str,
@@ -1454,6 +1507,7 @@ class Registry:
         started_at: str | None,
         age_seconds: float,
         threshold_seconds: int,
+        kill_classification: str = "orphan_kill_before_start",
     ) -> int:
         """
         Atomically write a startup_sweep audit entry and transition an
@@ -1475,12 +1529,21 @@ class Registry:
             started_at: ISO timestamp when the UoW was claimed (for audit note).
             age_seconds: How long the UoW has been in executing status.
             threshold_seconds: The threshold that was exceeded (for audit note).
+            kill_classification: Heartbeat-derived kill type. One of:
+                'orphan_kill_before_start': no heartbeat evidence after dispatch
+                    — agent killed before establishing working state.
+                'orphan_kill_during_execution': heartbeat written after dispatch
+                    — agent was actively working when killed.
+                Defaults to 'orphan_kill_before_start' (safe default when
+                heartbeat evidence is absent or the registry method is not
+                available).
         """
         now = _now_iso()
         note_json = json.dumps({
             "event": "startup_sweep",
             "actor": "steward",
-            "classification": "executing_orphan",
+            "classification": kill_classification,
+            "kill_classification": kill_classification,
             "output_ref": None,
             "uow_id": uow_id,
             "timestamp": now,

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -755,6 +755,8 @@ _RETURN_REASON_CLASSIFICATIONS: dict[str, str] = {
     "executor_orphan": _CLASSIFICATION_ORPHAN,
     "diagnosing_orphan": _CLASSIFICATION_ORPHAN,
     "executing_orphan": _CLASSIFICATION_ORPHAN,  # subagent dispatched but write_result never received (#858)
+    "orphan_kill_before_start": _CLASSIFICATION_ORPHAN,    # heartbeat-classified: killed before work began (#963)
+    "orphan_kill_during_execution": _CLASSIFICATION_ORPHAN,  # heartbeat-classified: killed mid-execution (#963)
 }
 
 
@@ -937,14 +939,20 @@ def _determine_reentry_posture(
     - 'executor_orphan': executor never ran
     - 'first_execution': no prior execution cycle (steward_cycles == 0)
     """
-    if not audit_entries:
-        return "first_execution"
-
+    # Explicit return_reason values that map 1:1 to a posture always win,
+    # even when there are no audit entries (e.g. fresh state after migration).
     if return_reason == "executor_orphan":
         return "executor_orphan"
 
     if return_reason == "executing_orphan":
         return "executing_orphan"
+
+    # Heartbeat-classified kill types (issue #963): pass through directly.
+    if return_reason in ("orphan_kill_before_start", "orphan_kill_during_execution"):
+        return return_reason
+
+    if not audit_entries:
+        return "first_execution"
 
     classification = _RETURN_REASON_CLASSIFICATIONS.get(return_reason or "", None)
 
@@ -957,34 +965,41 @@ def _determine_reentry_posture(
             return "crashed_no_output"
         return "execution_failed"
     elif classification == _CLASSIFICATION_ORPHAN:
-        return "executor_orphan"
+        # For orphan classifications without a specific return_reason match above,
+        # fall through to audit inspection to get the most precise posture.
+        pass
     else:
-        # Fall back to audit event inspection
-        for entry in reversed(audit_entries):
-            event = entry.get("event", "")
-            if event == "execution_complete":
-                return "execution_complete"
-            elif event == "stall_detected":
-                return "stall_detected"
-            elif event == "startup_sweep":
-                note = entry.get("note", "")
-                try:
-                    data = json.loads(note) if note else {}
-                except (json.JSONDecodeError, TypeError):
-                    data = {}
-                clf = data.get("classification", "")
-                if clf == "possibly_complete":
-                    return "startup_sweep_possibly_complete"
-                elif clf in ("crashed_no_output", "crashed_zero_bytes", "crashed_output_ref_missing"):
-                    return clf
-                elif clf == "executor_orphan":
-                    return "executor_orphan"
-                elif clf == "diagnosing_orphan":
-                    return "diagnosing_orphan"
-                elif clf == "executing_orphan":
-                    return "executing_orphan"
-            elif event == "execution_failed":
-                return "execution_failed"
+        pass
+
+    # Fall back to audit event inspection
+    for entry in reversed(audit_entries):
+        event = entry.get("event", "")
+        if event == "execution_complete":
+            return "execution_complete"
+        elif event == "stall_detected":
+            return "stall_detected"
+        elif event == "startup_sweep":
+            note = entry.get("note", "")
+            try:
+                data = json.loads(note) if note else {}
+            except (json.JSONDecodeError, TypeError):
+                data = {}
+            clf = data.get("classification", "")
+            if clf == "possibly_complete":
+                return "startup_sweep_possibly_complete"
+            elif clf in ("crashed_no_output", "crashed_zero_bytes", "crashed_output_ref_missing"):
+                return clf
+            elif clf == "executor_orphan":
+                return "executor_orphan"
+            elif clf == "diagnosing_orphan":
+                return "diagnosing_orphan"
+            elif clf == "executing_orphan":
+                return "executing_orphan"
+            elif clf in ("orphan_kill_before_start", "orphan_kill_during_execution"):
+                # Heartbeat-classified kill types (#963): preserve the precise value.
+                return clf
+        elif event == "execution_failed":
+            return "execution_failed"
 
     return "first_execution"
 
@@ -1169,6 +1184,10 @@ def _posture_rationale(diagnosis: Diagnosis, cycles: int, trace_posture: str | N
                 return "Executor never claimed UoW — re-prescribing."
             if posture == "executing_orphan":
                 return "Subagent dispatched but write_result never received — re-prescribing."
+            if posture == "orphan_kill_before_start":
+                return "Subagent killed before starting work — re-prescribing."
+            if posture == "orphan_kill_during_execution":
+                return "Subagent killed mid-execution (heartbeat evidence) — re-prescribing."
             return "Unexpected state encountered — investigating."
         elif trace_posture == "closing_with_discovery":
             return "Completion criteria satisfied — closing with findings documented."
@@ -1189,6 +1208,10 @@ def _posture_rationale(diagnosis: Diagnosis, cycles: int, trace_posture: str | N
             return "Steward crashed mid-diagnosis — re-diagnosing from current state."
         case "executing_orphan":
             return "UoW stuck in executing — subagent dispatched but write_result never received (#858)."
+        case "orphan_kill_before_start":
+            return "UoW stuck in executing — subagent killed before writing any heartbeat (no work started) (#963)."
+        case "orphan_kill_during_execution":
+            return "UoW stuck in executing — subagent was actively working (heartbeats present) when killed (#963)."
         case "steward_cycle_cap":
             return f"Steward cycle cap reached ({cycles} cycles) — surfacing to Dan."
         case _:
@@ -1238,6 +1261,10 @@ def _posture_prediction(diagnosis: Diagnosis) -> str | None:
             return "Re-prescription will be issued — executor never claimed UoW."
         case "executing_orphan":
             return "Re-prescription will be issued — subagent dispatched but write_result never received."
+        case "orphan_kill_before_start":
+            return "Re-prescription will be issued — subagent killed before starting work."
+        case "orphan_kill_during_execution":
+            return "Re-prescription will be issued — subagent killed mid-execution (heartbeat evidence present)."
         case _:
             return "Next prescription will be determined from diagnosis output."
 
@@ -2460,6 +2487,8 @@ def _build_deterministic_prescription_instructions(
         "executor_orphan": "Executor never ran on this UoW. Execute fresh.",
         "diagnosing_orphan": "Steward crashed mid-diagnosis. Re-diagnosing from current state.",
         "executing_orphan": "Subagent was dispatched but never called write_result (crashed or lost context). Re-execute fresh.",
+        "orphan_kill_before_start": "Subagent was dispatched but killed before writing any heartbeat — no work was started. Re-execute fresh.",
+        "orphan_kill_during_execution": "Subagent was dispatched, wrote heartbeats (was actively working), then was killed before write_result. Re-execute fresh.",
     }
 
     posture_msg = posture_context.get(reentry_posture, "Continue from previous attempt.")
@@ -3751,13 +3780,25 @@ def _process_uow(
     # retried — the retry loop cannot fix a subagent that systematically skips
     # the result contract. Mark failed immediately so the Steward does not
     # re-dispatch into an infinite loop.
-    if reentry_posture == "executing_orphan":
-        orphan_reason = "executing_orphan: subagent exited without calling write_result"
+    #
+    # Heartbeat-classified kill types (#963) surface with distinct condition
+    # values so that the notification and audit trail distinguish:
+    # - orphan_kill_before_start: agent killed before any work (infrastructure event)
+    # - orphan_kill_during_execution: agent killed mid-execution (partial work)
+    # Retry accounting is not changed here (separate PR per task boundary).
+    if reentry_posture in (
+        "executing_orphan",
+        "orphan_kill_before_start",
+        "orphan_kill_during_execution",
+    ):
+        surface_condition = reentry_posture  # preserve precise kill classification
+        orphan_reason = f"{reentry_posture}: subagent exited without calling write_result"
         orphan_log_entry = {
             "event": "executing_orphan_failed",
             "uow_id": uow_id,
             "steward_cycles": cycles,
             "reason": orphan_reason,
+            "kill_classification": reentry_posture,
             "timestamp": _now_iso(),
         }
         current_log_str = _append_steward_log_entry(registry, uow_id, current_log_str, orphan_log_entry)
@@ -3769,6 +3810,7 @@ def _process_uow(
                 "uow_id": uow_id,
                 "steward_cycles": cycles,
                 "reason": orphan_reason,
+                "kill_classification": reentry_posture,
                 "timestamp": _now_iso(),
             })
             registry.fail_uow(uow_id, orphan_reason)
@@ -3780,7 +3822,7 @@ def _process_uow(
             next_action="failed",
             artifact_dir=artifact_dir,
         )
-        return Surfaced(uow_id=uow_id, condition="executing_orphan")
+        return Surfaced(uow_id=uow_id, condition=surface_condition)
 
     # 4c: Prescribe another Executor pass
     # executor-contract.md Steward Interpretation Table: `partial` and `failed`

--- a/tests/unit/test_orchestration/test_kill_classification.py
+++ b/tests/unit/test_orchestration/test_kill_classification.py
@@ -1,0 +1,711 @@
+"""
+Tests for heartbeat-based kill classification of executing orphans.
+
+Issue #963: When startup_sweep finds a UoW stuck in `executing`, use the
+heartbeat signal to distinguish two kill scenarios:
+  - orphan_kill_before_start: agent was killed before writing any heartbeat
+    after dispatch (no evidence of work having begun)
+  - orphan_kill_during_execution: agent wrote heartbeats after dispatch
+    (was actively working before being killed)
+
+Coverage:
+- DISPATCH_WINDOW_SECONDS constant: positive integer
+- classify_executing_orphan_kill_type:
+    no heartbeat (NULL) → orphan_kill_before_start
+    heartbeat exists but at or before dispatch time → orphan_kill_before_start
+    heartbeat exists after dispatch + DISPATCH_WINDOW_SECONDS → orphan_kill_during_execution
+    heartbeat is non-parseable → orphan_kill_before_start (safe default)
+    dispatch timestamp is None (no executor_dispatch audit) → orphan_kill_before_start
+- registry.get_executor_dispatch_timestamp:
+    returns None when no audit_log entries exist
+    returns None when no executor_dispatch entry exists
+    returns ISO timestamp from executor_dispatch entry
+    returns most recent executor_dispatch timestamp when multiple exist
+- startup_sweep Population 4 (executing UoWs):
+    no heartbeat written after dispatch → kill_classification = orphan_kill_before_start
+    heartbeat written after dispatch → kill_classification = orphan_kill_during_execution
+    kill_classification field present in audit note JSON
+- steward._determine_reentry_posture:
+    startup_sweep note with classification=orphan_kill_before_start → returns orphan_kill_before_start
+    startup_sweep note with classification=orphan_kill_during_execution → returns orphan_kill_during_execution
+    backward compat: startup_sweep note with classification=executing_orphan still returns executing_orphan
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Named constants under test
+# ---------------------------------------------------------------------------
+
+DISPATCH_WINDOW_SECONDS: int  # loaded from startup_sweep module below
+
+
+# ---------------------------------------------------------------------------
+# Load startup_sweep module (lives in scheduled-tasks/)
+# ---------------------------------------------------------------------------
+
+_SWEEP_MOD_NAME = "startup_sweep_kill_test_mod"  # isolated sys.modules key
+_SWEEP_PATH = REPO_ROOT / "scheduled-tasks" / "startup_sweep.py"
+
+
+def _load_startup_sweep():
+    spec = importlib.util.spec_from_file_location(_SWEEP_MOD_NAME, _SWEEP_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_SWEEP_MOD_NAME] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_sweep_mod = _load_startup_sweep()
+run_startup_sweep = _sweep_mod.run_startup_sweep
+_classify_executing_orphan_kill_type = _sweep_mod._classify_executing_orphan_kill_type
+DISPATCH_WINDOW_SECONDS = _sweep_mod.DISPATCH_WINDOW_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Registry import (full schema via Registry)
+# ---------------------------------------------------------------------------
+
+from src.orchestration.registry import Registry
+
+
+# ---------------------------------------------------------------------------
+# Schema helper — matches the test_startup_sweep.py pattern but includes
+# heartbeat_at, heartbeat_ttl, and the full schema needed for these tests.
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS uow_registry (
+    id                  TEXT    PRIMARY KEY,
+    type                TEXT    NOT NULL DEFAULT 'executable',
+    source              TEXT    NOT NULL,
+    source_issue_number INTEGER,
+    sweep_date          TEXT,
+    status              TEXT    NOT NULL DEFAULT 'proposed',
+    posture             TEXT    NOT NULL DEFAULT 'solo',
+    agent               TEXT,
+    children            TEXT    DEFAULT '[]',
+    parent              TEXT,
+    created_at          TEXT    NOT NULL,
+    updated_at          TEXT    NOT NULL,
+    started_at          TEXT,
+    completed_at        TEXT,
+    summary             TEXT    NOT NULL,
+    output_ref          TEXT,
+    hooks_applied       TEXT    DEFAULT '[]',
+    route_reason        TEXT,
+    route_evidence      TEXT    DEFAULT '{}',
+    trigger             TEXT    DEFAULT '{"type": "immediate"}',
+    vision_ref          TEXT    DEFAULT NULL,
+    workflow_artifact   TEXT    NULL,
+    success_criteria    TEXT    NULL,
+    prescribed_skills   TEXT    NULL,
+    steward_cycles      INTEGER NOT NULL DEFAULT 0,
+    timeout_at          TEXT    NULL,
+    estimated_runtime   INTEGER NULL,
+    steward_agenda      TEXT    NULL,
+    steward_log         TEXT    NULL,
+    UNIQUE(source_issue_number, sweep_date)
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          TEXT    NOT NULL,
+    uow_id      TEXT    NOT NULL,
+    event       TEXT    NOT NULL,
+    from_status TEXT,
+    to_status   TEXT,
+    agent       TEXT,
+    note        TEXT
+);
+"""
+
+
+def _open_conn(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _iso_ago(seconds: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
+
+
+def _iso_future(seconds: float) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+def _make_executing_uow(
+    conn: sqlite3.Connection,
+    *,
+    uow_id: str,
+    started_at: str | None = None,
+    heartbeat_at: str | None = None,
+    source_issue_number: int = 42,
+) -> str:
+    """Insert an `executing` UoW into the registry for tests."""
+    now = _now_iso()
+    _started_at = started_at or _iso_ago(1800)  # Default: 30 min ago (past threshold)
+    conn.execute(
+        """
+        INSERT INTO uow_registry (
+            id, type, source, source_issue_number, sweep_date, status, posture,
+            created_at, updated_at, started_at, summary, route_evidence, trigger,
+            heartbeat_at
+        ) VALUES (?, 'executable', ?, ?, '2026-01-01', 'executing', 'solo',
+                  ?, ?, ?, 'Test UoW', '{}', '{"type": "immediate"}', ?)
+        """,
+        (
+            uow_id,
+            f"github:issue/{source_issue_number}",
+            source_issue_number,
+            now,
+            _started_at,
+            _started_at,
+            heartbeat_at,
+        ),
+    )
+    conn.commit()
+    return uow_id
+
+
+def _insert_executor_dispatch_audit(
+    conn: sqlite3.Connection,
+    uow_id: str,
+    timestamp: str,
+) -> None:
+    """Insert an executor_dispatch audit entry simulating inbox dispatch."""
+    note = json.dumps({
+        "actor": "executor",
+        "executor_id": f"agent-{uow_id[:8]}",
+        "timestamp": timestamp,
+    })
+    conn.execute(
+        """
+        INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+        VALUES (?, ?, 'executor_dispatch', 'active', 'executing', 'executor', ?)
+        """,
+        (timestamp, uow_id, note),
+    )
+    conn.commit()
+
+
+def _get_audit_entries(db_path: Path, uow_id: str) -> list[dict]:
+    conn = _open_conn(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id ASC",
+            (uow_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def _get_status(db_path: Path, uow_id: str) -> str:
+    conn = _open_conn(db_path)
+    try:
+        row = conn.execute(
+            "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return row["status"] if row else "NOT_FOUND"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "registry.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA)
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def registry(tmp_db: Path) -> Registry:
+    return Registry(tmp_db)
+
+
+# ---------------------------------------------------------------------------
+# DISPATCH_WINDOW_SECONDS constant sanity check
+# ---------------------------------------------------------------------------
+
+class TestDispatchWindowConstant:
+    def test_is_positive_integer(self) -> None:
+        assert isinstance(DISPATCH_WINDOW_SECONDS, int)
+        assert DISPATCH_WINDOW_SECONDS > 0
+
+    def test_is_at_least_60_seconds(self) -> None:
+        """Must be long enough to absorb agent startup jitter."""
+        assert DISPATCH_WINDOW_SECONDS >= 60
+
+
+# ---------------------------------------------------------------------------
+# _classify_executing_orphan_kill_type — pure function unit tests
+# ---------------------------------------------------------------------------
+
+class TestClassifyExecutingOrphanKillType:
+    """
+    Pure function tests for kill classification.
+
+    classify_executing_orphan_kill_type(dispatch_ts, heartbeat_at) -> str
+
+    Returns:
+    - 'orphan_kill_before_start': no evidence of heartbeat after dispatch
+    - 'orphan_kill_during_execution': heartbeat exists after dispatch window
+    """
+
+    def test_no_heartbeat_null_is_kill_before_start(self) -> None:
+        """NULL heartbeat_at → agent never wrote a heartbeat → kill-before-start."""
+        dispatch_ts = _iso_ago(1800)
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at=None,
+        )
+        assert result == "orphan_kill_before_start"
+
+    def test_no_dispatch_timestamp_is_kill_before_start(self) -> None:
+        """No executor_dispatch audit entry → cannot confirm work started → kill-before-start."""
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=None,
+            heartbeat_at=_iso_ago(1200),
+        )
+        assert result == "orphan_kill_before_start"
+
+    def test_both_none_is_kill_before_start(self) -> None:
+        """Both None → kill-before-start (safe default)."""
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=None,
+            heartbeat_at=None,
+        )
+        assert result == "orphan_kill_before_start"
+
+    def test_heartbeat_before_dispatch_is_kill_before_start(self) -> None:
+        """
+        Heartbeat written BEFORE dispatch (stale initial value from set_heartbeat_ttl).
+        This is the key case: set_heartbeat_ttl writes the initial heartbeat_at at
+        claim time (before dispatch). If heartbeat_at <= dispatch_ts + window, the
+        subagent never updated it.
+        """
+        dispatch_ts = _iso_ago(1800)
+        # Heartbeat written 10 seconds BEFORE dispatch (initial set_heartbeat_ttl)
+        heartbeat_before_dispatch = _iso_ago(1810)
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at=heartbeat_before_dispatch,
+        )
+        assert result == "orphan_kill_before_start"
+
+    def test_heartbeat_at_exact_dispatch_time_is_kill_before_start(self) -> None:
+        """Heartbeat at exactly dispatch time → within window → kill-before-start."""
+        dispatch_ts = _iso_ago(1800)
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at=dispatch_ts,  # Same timestamp
+        )
+        assert result == "orphan_kill_before_start"
+
+    def test_heartbeat_within_dispatch_window_is_kill_before_start(self) -> None:
+        """
+        Heartbeat written just after dispatch but within the window is still
+        kill-before-start — the window absorbs agent startup jitter.
+        """
+        dispatch_ts = _iso_ago(1800)
+        # Heartbeat written 30 seconds after dispatch (within window)
+        heartbeat_just_after = _iso_ago(1800 - 30)
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at=heartbeat_just_after,
+        )
+        assert result == "orphan_kill_before_start"
+
+    def test_heartbeat_after_dispatch_window_is_kill_during_execution(self) -> None:
+        """
+        Heartbeat written after dispatch + DISPATCH_WINDOW_SECONDS →
+        agent was actively working before being killed.
+        """
+        dispatch_ts = _iso_ago(1800)
+        # Heartbeat written DISPATCH_WINDOW_SECONDS + 60 after dispatch (clearly working)
+        heartbeat_after_window = _iso_ago(1800 - DISPATCH_WINDOW_SECONDS - 60)
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at=heartbeat_after_window,
+        )
+        assert result == "orphan_kill_during_execution"
+
+    def test_recent_heartbeat_is_kill_during_execution(self) -> None:
+        """A very recent heartbeat (agent was actively working) → kill-during-execution."""
+        dispatch_ts = _iso_ago(600)
+        heartbeat_recent = _iso_ago(30)  # 30 seconds ago — agent was running
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at=heartbeat_recent,
+        )
+        assert result == "orphan_kill_during_execution"
+
+    def test_unparseable_heartbeat_is_kill_before_start(self) -> None:
+        """Unparseable heartbeat_at → cannot confirm work started → kill-before-start (safe default)."""
+        dispatch_ts = _iso_ago(1800)
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts=dispatch_ts,
+            heartbeat_at="not-a-timestamp",
+        )
+        assert result == "orphan_kill_before_start"
+
+    def test_unparseable_dispatch_ts_is_kill_before_start(self) -> None:
+        """Unparseable dispatch_ts → cannot compare → kill-before-start (safe default)."""
+        result = _classify_executing_orphan_kill_type(
+            dispatch_ts="not-a-timestamp",
+            heartbeat_at=_iso_ago(600),
+        )
+        assert result == "orphan_kill_before_start"
+
+
+# ---------------------------------------------------------------------------
+# registry.get_executor_dispatch_timestamp
+# ---------------------------------------------------------------------------
+
+class TestGetExecutorDispatchTimestamp:
+    def test_returns_none_when_no_audit_entries(self, registry: Registry, tmp_db: Path) -> None:
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(conn, uow_id="uow-no-audit-001")
+        conn.close()
+
+        result = registry.get_executor_dispatch_timestamp("uow-no-audit-001")
+        assert result is None
+
+    def test_returns_none_when_no_executor_dispatch_event(self, registry: Registry, tmp_db: Path) -> None:
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(conn, uow_id="uow-no-dispatch-001")
+        # Write an unrelated audit entry (not executor_dispatch)
+        conn.execute(
+            "INSERT INTO audit_log (ts, uow_id, event, agent) VALUES (?, ?, 'startup_sweep', 'steward')",
+            (_iso_ago(600), "uow-no-dispatch-001"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = registry.get_executor_dispatch_timestamp("uow-no-dispatch-001")
+        assert result is None
+
+    def test_returns_timestamp_from_executor_dispatch_entry(self, registry: Registry, tmp_db: Path) -> None:
+        dispatch_ts = _iso_ago(1800)
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(conn, uow_id="uow-dispatch-001")
+        _insert_executor_dispatch_audit(conn, "uow-dispatch-001", dispatch_ts)
+        conn.close()
+
+        result = registry.get_executor_dispatch_timestamp("uow-dispatch-001")
+        assert result is not None
+        # Should match the dispatch timestamp (may have minor precision diff)
+        result_dt = datetime.fromisoformat(result)
+        expected_dt = datetime.fromisoformat(dispatch_ts)
+        assert abs((result_dt - expected_dt).total_seconds()) < 1.0
+
+    def test_returns_most_recent_executor_dispatch_when_multiple(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """Multiple executor_dispatch entries → return the most recent one."""
+        older_dispatch = _iso_ago(3600)
+        newer_dispatch = _iso_ago(1800)
+
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(conn, uow_id="uow-multi-dispatch-001")
+        _insert_executor_dispatch_audit(conn, "uow-multi-dispatch-001", older_dispatch)
+        _insert_executor_dispatch_audit(conn, "uow-multi-dispatch-001", newer_dispatch)
+        conn.close()
+
+        result = registry.get_executor_dispatch_timestamp("uow-multi-dispatch-001")
+        assert result is not None
+        result_dt = datetime.fromisoformat(result)
+        newer_dt = datetime.fromisoformat(newer_dispatch)
+        older_dt = datetime.fromisoformat(older_dispatch)
+        # Result should be closer to newer_dispatch than to older_dispatch
+        assert abs((result_dt - newer_dt).total_seconds()) < abs((result_dt - older_dt).total_seconds())
+
+    def test_returns_none_for_unknown_uow(self, registry: Registry) -> None:
+        result = registry.get_executor_dispatch_timestamp("uow-does-not-exist")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# startup_sweep Population 4 — kill_classification in audit note
+# ---------------------------------------------------------------------------
+
+class TestStartupSweepKillClassification:
+    """
+    Integration tests for Population 4 of startup_sweep.
+
+    When startup_sweep processes an `executing` UoW, the audit note must include
+    a `kill_classification` field indicating whether the agent was killed before
+    starting work or mid-execution.
+    """
+
+    def _make_uow_with_dispatch(
+        self,
+        db_path: Path,
+        *,
+        uow_id: str,
+        dispatch_ago_seconds: float,
+        heartbeat_at: str | None = None,
+    ) -> None:
+        """Create an executing UoW with an executor_dispatch audit entry."""
+        dispatch_ts = _iso_ago(dispatch_ago_seconds)
+        conn = _open_conn(db_path)
+        _make_executing_uow(
+            conn,
+            uow_id=uow_id,
+            started_at=_iso_ago(dispatch_ago_seconds + 30),
+            heartbeat_at=heartbeat_at,
+        )
+        _insert_executor_dispatch_audit(conn, uow_id, dispatch_ts)
+        conn.close()
+
+    def test_executing_orphan_with_no_heartbeat_classified_as_kill_before_start(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        An executing UoW with NULL heartbeat_at gets kill_classification=orphan_kill_before_start.
+        """
+        self._make_uow_with_dispatch(
+            tmp_db,
+            uow_id="uow-kill-before-001",
+            dispatch_ago_seconds=1800,
+            heartbeat_at=None,
+        )
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+        )
+
+        assert result.executing_swept == 1
+        entries = _get_audit_entries(tmp_db, "uow-kill-before-001")
+        sweep_entries = [e for e in entries if e["event"] == "startup_sweep"]
+        assert len(sweep_entries) == 1
+
+        note = json.loads(sweep_entries[0]["note"])
+        assert note["kill_classification"] == "orphan_kill_before_start"
+        assert note["classification"] == "orphan_kill_before_start"
+
+    def test_executing_orphan_with_heartbeat_after_dispatch_classified_as_kill_during_execution(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        An executing UoW with heartbeat_at after dispatch + DISPATCH_WINDOW_SECONDS
+        gets kill_classification=orphan_kill_during_execution.
+        """
+        dispatch_ago = 1800
+        # Heartbeat written well after dispatch + window (agent was working)
+        heartbeat_at = _iso_ago(dispatch_ago - DISPATCH_WINDOW_SECONDS - 120)
+        self._make_uow_with_dispatch(
+            tmp_db,
+            uow_id="uow-kill-during-001",
+            dispatch_ago_seconds=dispatch_ago,
+            heartbeat_at=heartbeat_at,
+        )
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+        )
+
+        assert result.executing_swept == 1
+        entries = _get_audit_entries(tmp_db, "uow-kill-during-001")
+        sweep_entries = [e for e in entries if e["event"] == "startup_sweep"]
+        assert len(sweep_entries) == 1
+
+        note = json.loads(sweep_entries[0]["note"])
+        assert note["kill_classification"] == "orphan_kill_during_execution"
+        assert note["classification"] == "orphan_kill_during_execution"
+
+    def test_kill_classification_field_always_present_in_executing_orphan_note(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        The kill_classification field must be present in the audit note for all
+        executing orphan transitions (even when it defaults to kill_before_start).
+        """
+        # No heartbeat, no dispatch audit → defaults to kill_before_start
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(
+            conn,
+            uow_id="uow-kill-field-001",
+            started_at=_iso_ago(1800),
+            heartbeat_at=None,
+        )
+        conn.close()
+
+        run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+        )
+
+        entries = _get_audit_entries(tmp_db, "uow-kill-field-001")
+        sweep_entries = [e for e in entries if e["event"] == "startup_sweep"]
+        assert len(sweep_entries) == 1
+
+        note = json.loads(sweep_entries[0]["note"])
+        assert "kill_classification" in note, (
+            "kill_classification must always be present in executing_orphan audit note"
+        )
+
+    def test_executing_orphan_transition_still_occurs_regardless_of_kill_type(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        Both kill types result in status transition to ready-for-steward.
+        The classification is metadata; it doesn't affect the transition itself.
+        """
+        self._make_uow_with_dispatch(
+            tmp_db,
+            uow_id="uow-transition-001",
+            dispatch_ago_seconds=1800,
+            heartbeat_at=None,
+        )
+
+        run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+        )
+
+        assert _get_status(tmp_db, "uow-transition-001") == "ready-for-steward"
+
+    def test_backward_compat_no_dispatch_audit_defaults_to_kill_before_start(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        For UoWs where no executor_dispatch audit entry exists (e.g. older records
+        before this migration), the classification defaults to kill_before_start.
+        """
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(
+            conn,
+            uow_id="uow-no-dispatch-audit-001",
+            started_at=_iso_ago(1800),
+            heartbeat_at=_iso_ago(60),  # Has a heartbeat but no dispatch audit
+        )
+        conn.close()
+
+        run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+        )
+
+        entries = _get_audit_entries(tmp_db, "uow-no-dispatch-audit-001")
+        sweep_entries = [e for e in entries if e["event"] == "startup_sweep"]
+        assert len(sweep_entries) == 1
+        note = json.loads(sweep_entries[0]["note"])
+        assert note["kill_classification"] == "orphan_kill_before_start"
+
+
+# ---------------------------------------------------------------------------
+# steward._determine_reentry_posture — new classification values
+# ---------------------------------------------------------------------------
+
+class TestReentryPostureForNewClassifications:
+    """
+    _determine_reentry_posture reads the startup_sweep audit note and returns
+    the classification as the reentry posture.
+
+    New values:
+    - orphan_kill_before_start: kill before work began
+    - orphan_kill_during_execution: kill mid-execution
+
+    Backward compat: executing_orphan still works (for existing records).
+    """
+
+    def _make_audit_entries_with_sweep(self, classification: str) -> list[dict]:
+        """Build a minimal audit_entries list with a startup_sweep entry."""
+        note = json.dumps({
+            "event": "startup_sweep",
+            "actor": "steward",
+            "classification": classification,
+            "output_ref": None,
+            "uow_id": "test-uow",
+            "timestamp": _now_iso(),
+            "prior_status": "executing",
+        })
+        return [
+            {
+                "event": "startup_sweep",
+                "note": note,
+                "from_status": "executing",
+                "to_status": "ready-for-steward",
+            }
+        ]
+
+    def test_orphan_kill_before_start_returns_correct_posture(self) -> None:
+        from src.orchestration.steward import _determine_reentry_posture
+        entries = self._make_audit_entries_with_sweep("orphan_kill_before_start")
+        posture = _determine_reentry_posture(entries, return_reason=None)
+        assert posture == "orphan_kill_before_start"
+
+    def test_orphan_kill_during_execution_returns_correct_posture(self) -> None:
+        from src.orchestration.steward import _determine_reentry_posture
+        entries = self._make_audit_entries_with_sweep("orphan_kill_during_execution")
+        posture = _determine_reentry_posture(entries, return_reason=None)
+        assert posture == "orphan_kill_during_execution"
+
+    def test_executing_orphan_still_works_for_backward_compat(self) -> None:
+        """Pre-existing records with classification=executing_orphan continue to work."""
+        from src.orchestration.steward import _determine_reentry_posture
+        entries = self._make_audit_entries_with_sweep("executing_orphan")
+        posture = _determine_reentry_posture(entries, return_reason=None)
+        assert posture == "executing_orphan"
+
+    def test_return_reason_orphan_kill_before_start_maps_to_correct_posture(self) -> None:
+        """When return_reason is directly set to the new value, it maps correctly."""
+        from src.orchestration.steward import _determine_reentry_posture
+        # Empty audit entries — posture comes from return_reason
+        posture = _determine_reentry_posture(
+            audit_entries=[],
+            return_reason="orphan_kill_before_start",
+        )
+        assert posture == "orphan_kill_before_start"
+
+    def test_return_reason_orphan_kill_during_execution_maps_to_correct_posture(self) -> None:
+        """When return_reason is directly set to the new value, it maps correctly."""
+        from src.orchestration.steward import _determine_reentry_posture
+        posture = _determine_reentry_posture(
+            audit_entries=[],
+            return_reason="orphan_kill_during_execution",
+        )
+        assert posture == "orphan_kill_during_execution"
+
+    def test_new_classifications_are_in_orphan_classification_table(self) -> None:
+        """Both new values must be in _RETURN_REASON_CLASSIFICATIONS as orphan type."""
+        from src.orchestration.steward import _RETURN_REASON_CLASSIFICATIONS
+        assert "orphan_kill_before_start" in _RETURN_REASON_CLASSIFICATIONS
+        assert "orphan_kill_during_execution" in _RETURN_REASON_CLASSIFICATIONS
+        # Both should map to the orphan classification bucket
+        assert _RETURN_REASON_CLASSIFICATIONS["orphan_kill_before_start"] == "orphan"
+        assert _RETURN_REASON_CLASSIFICATIONS["orphan_kill_during_execution"] == "orphan"


### PR DESCRIPTION
## What this solves

When `startup_sweep` recovers a UoW stuck in `executing`, all cases were previously treated identically as `executing_orphan`. This made it impossible to distinguish between:

1. An agent that was killed immediately after dispatch (infrastructure kill, no work attempted)
2. An agent that was actively working — wrote heartbeats, made progress — and was killed mid-execution

Those two scenarios have different operational implications: a kill-before-start is a pure infrastructure event, while a kill-during-execution may mean partial work was done. Surfacing them as distinct conditions enables callers (and future retry logic) to react appropriately.

## What changed

**`scheduled-tasks/startup_sweep.py`**
- Added `DISPATCH_WINDOW_SECONDS = 120` constant — the grace window after dispatch during which a heartbeat that has not advanced past `dispatch_time + window` is treated as "no work started"
- Added pure function `_classify_executing_orphan_kill_type(dispatch_ts, heartbeat_at) -> str` — compares the most recent `executor_dispatch` audit timestamp against the UoW's `heartbeat_at`; defaults to `orphan_kill_before_start` on any error or missing data
- Population 4 (executing-orphan recovery loop) now calls `registry.get_executor_dispatch_timestamp()` and the classifier, then passes `kill_classification` into `record_startup_sweep_executing()`

**`src/orchestration/registry.py`**
- Added `get_executor_dispatch_timestamp(uow_id) -> str | None` — reads the most recent `executor_dispatch` audit entry and returns the timestamp, preferring the `timestamp` field in the JSON note over the row's `ts` column
- Updated `record_startup_sweep_executing()` signature to accept `kill_classification: str = "orphan_kill_before_start"` (backward-compatible default); the kill classification is written to both `classification` and `kill_classification` keys in the audit note JSON

**`src/orchestration/steward.py`**
- Added both new values to `_RETURN_REASON_CLASSIFICATIONS` as `_CLASSIFICATION_ORPHAN`
- Fixed ordering bug in `_determine_reentry_posture`: moved the `return_reason`-based early returns (for `executor_orphan`, `executing_orphan`, and now `orphan_kill_before_start`/`orphan_kill_during_execution`) to occur **before** the `not audit_entries → first_execution` guard. Previously, a UoW with `return_reason=orphan_kill_before_start` but empty audit entries would incorrectly return `first_execution`.
- Added audit loop cases to extract precise classification from `startup_sweep` note JSON
- `_process_uow()` executing-orphan short-circuit now includes both new postures and surfaces the precise value as `stuck_condition`
- `_narrative_context_string()` and `_posture_prediction()` include labeled messages for both new postures
- Prescription context dict includes descriptions for both new postures

## Before / After

```
Before:
  startup_sweep detects executing orphan
    → audit note: classification = "executing_orphan"
    → steward sees: executing_orphan (always)

After:
  startup_sweep detects executing orphan
    ↓
    get_executor_dispatch_timestamp() → dispatch_ts
    ↓
    compare heartbeat_at vs dispatch_ts + DISPATCH_WINDOW_SECONDS
    ↓
    heartbeat not advanced → "orphan_kill_before_start"
    heartbeat advanced     → "orphan_kill_during_execution"
    no dispatch audit      → "orphan_kill_before_start" (safe default)
    ↓
    audit note: kill_classification = <precise value>
    steward sees: <precise stuck_condition>
```

Backward compatibility: existing records with `classification: "executing_orphan"` continue to be handled by the pre-existing code path unchanged.

## Functional patterns used

Pure functions (`_classify_executing_orphan_kill_type`, `get_executor_dispatch_timestamp`), safe defaults on all error paths, explicit named constant (`DISPATCH_WINDOW_SECONDS`) for the spec-derived threshold value.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_kill_classification.py -v` — 28 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_startup_sweep.py -q` — 37 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py -q` — 74 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_heartbeat_locking.py test_heartbeat_sidecar.py test_executor_heartbeat.py -q` — 53 passed, 0 failed

## Manual test

N/A — this change is entirely internal to the WOS orchestration system. No external service calls, no Telegram output, no systemd/cron changes. The classification logic is exercised by the unit tests above which use a real SQLite database.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (see above)
- [x] User-visible outcome verified — N/A (internal orchestration state; downstream effects tested via unit tests)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change

Closes #963