### PR TITLE
feat(wos): wos_escalate message type and dispatcher escalation handler

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -540,6 +540,13 @@ WOS_MESSAGE_TYPE_DISPATCH: dict[str, str] = {
     # the steward heartbeat as a background subagent (7-second rule compliant),
     # bypassing the 0–3 minute cron wait.
     "steward_trigger": "handle_steward_trigger",
+    # Dispatcher escalation handler (issue #969): written by the Steward when a UoW
+    # exhausts its retry cap. The dispatcher routes wos_escalate through a 4-branch
+    # decision tree before deciding whether to auto-retry or surface to Dan.
+    # Unlike wos_execute/steward_trigger, this handler legitimately returns either
+    # action="spawn_subagent" (auto-retry branches) or action="send_reply" (surface-to-Dan
+    # branches) — it is exempt from the spawn-gate that applies to execution message types.
+    "wos_escalate": "handle_wos_escalate",
 }
 
 
@@ -587,6 +594,250 @@ def handle_steward_trigger(uow_id: str) -> dict[str, Any]:
             f"Minimum viable output: steward heartbeat completed.\n"
             f"Boundary: do not modify any UoW status directly."
         ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# wos_escalate handler — dispatcher escalation decision tree (issue #969)
+#
+# Called when a UoW exhausts its retry cap and the Steward writes a wos_escalate
+# inbox message instead of notifying Dan directly.  The handler classifies the
+# failure and routes it: auto-retry for infrastructure kills, surface to Dan for
+# genuine execution failures or human-judgment UoWs.
+#
+# This handler is exempt from the spawn-gate that governs wos_execute and
+# steward_trigger — it legitimately returns action="send_reply" for the
+# surface-to-Dan branches and action="spawn_subagent" for the auto-retry branches.
+# route_wos_message handles this by dispatching wos_escalate outside the spawn-gate.
+# ---------------------------------------------------------------------------
+
+# Execution attempts threshold at which the handler surfaces to Dan regardless
+# of return_reason_classification.  3 confirmed execution attempts means the
+# prescription itself may be broken — auto-retrying without diagnosis loops forever.
+_ESCALATE_SURFACE_EXECUTION_THRESHOLD: int = 3
+
+# Registers that bypass auto-retry and surface to Dan immediately.
+# The structured executor was never the right tool for these UoW types.
+_ESCALATE_HUMAN_JUDGMENT_REGISTERS: frozenset[str] = frozenset({
+    "human-judgment",
+    "philosophical",
+})
+
+# return_reason_classification values that indicate an infrastructure kill
+# (session killed before or during execution — no execution outcome produced).
+_ESCALATE_ORPHAN_CLASSIFICATIONS: frozenset[str] = frozenset({
+    "orphan",
+})
+
+
+def handle_wos_escalate(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle a ``wos_escalate`` inbox message via the 4-branch dispatcher decision tree.
+
+    Called by route_wos_message when the dispatcher receives a message with
+    type="wos_escalate".  The Steward writes this message when a UoW exhausts
+    its execution retry cap (MAX_RETRIES on execution_attempts, not retry_count),
+    inserting a programmatic triage layer before the human-judgment escalation path.
+
+    Pure function — no side effects, no I/O.  All branches return a dict describing
+    what the dispatcher must do next.
+
+    Decision tree (checked in order; first matching branch wins):
+
+    **Branch 4 — Human-judgment register** (checked first — register overrides all):
+        If ``register`` is "human-judgment" or "philosophical", surface to Dan
+        immediately.  The structured executor was never the right tool; retrying
+        would waste cycles.
+        → Returns ``action="send_reply"`` with structured context for Dan.
+
+    **Branch 3 — Execution cap exhausted** (3+ confirmed execution_attempts):
+        If ``execution_attempts >= _ESCALATE_SURFACE_EXECUTION_THRESHOLD``, the
+        prescription has been attempted multiple times and failed.  Auto-retrying
+        would loop without diagnosis.
+        → Returns ``action="send_reply"`` with structured context for Dan.
+
+    **Branch 1 — Pure infrastructure failure** (execution_attempts == 0, orphan):
+        If ``execution_attempts == 0`` and ``return_reason_classification`` is
+        "orphan", the UoW was never executed — the session was killed before the
+        subagent established working state.  The original prescription is intact.
+        → Returns ``action="spawn_subagent"`` to run steward heartbeat (auto-retry).
+
+    **Branch 2 — Mid-execution kill** (execution_attempts > 0, orphan):
+        If ``execution_attempts > 0`` and ``return_reason_classification`` is
+        "orphan", the subagent was killed mid-execution.  Partial work may exist.
+        → Returns ``action="spawn_subagent"`` to run steward heartbeat (retry).
+
+    **Default — surface to Dan** (unclassified failures):
+        Any failure not matched by the above branches is surfaced to Dan.
+        → Returns ``action="send_reply"`` with structured context.
+
+    Args:
+        msg: The raw wos_escalate inbox message dict.  Expected fields:
+            - ``uow_id`` (str): The Unit of Work identifier.
+            - ``uow_title`` (str, optional): Human-readable UoW title.
+            - ``register`` (str, optional): UoW register ("operational", "human-judgment",
+              "philosophical", "iterative-convergent"). Default "operational".
+            - ``failure_history`` (dict): Failure context from the Steward.
+              Key sub-fields:
+                - ``execution_attempts`` (int): Confirmed execution attempts.
+                - ``return_reason_classification`` (str): Classification of the last
+                  return reason ("orphan", "error", "abnormal", etc.).
+                - ``kill_type`` (str, optional): Heartbeat-derived kill classification
+                  ("orphan_kill_before_start", "orphan_kill_during_execution").
+                - ``heartbeats_before_kill`` (int, optional): Heartbeats written before
+                  the subagent was killed.  0 means killed before execution began.
+            - ``posture`` (str, optional): Trace-diagnosed reentry posture.
+
+    Returns:
+        A dict with ``action`` and branch-specific fields:
+
+        For ``action="spawn_subagent"`` (auto-retry branches 1 and 2):
+            - ``task_id`` (str): Task identifier for the steward heartbeat subagent.
+            - ``agent_type`` (str): Always "lobster-generalist".
+            - ``prompt`` (str): Subagent prompt to run the steward heartbeat.
+            - ``message_type`` (str): Echo of "wos_escalate".
+
+        For ``action="send_reply"`` (surface-to-Dan branches 3 and 4):
+            - ``text`` (str): Telegram notification text with structured context.
+            - ``chat_id`` (str | int): Admin chat ID (from LOBSTER_ADMIN_CHAT_ID env var).
+            - ``message_type`` (str): Echo of "wos_escalate".
+    """
+    uow_id: str = msg.get("uow_id", "unknown")
+    uow_title: str = msg.get("uow_title", "")
+    register: str = msg.get("register", "operational")
+    failure_history: dict[str, Any] = msg.get("failure_history", {})
+    posture: str = msg.get("posture", "")
+
+    execution_attempts: int = int(failure_history.get("execution_attempts", 0))
+    return_reason_classification: str = failure_history.get("return_reason_classification", "")
+    kill_type: str = failure_history.get("kill_type", "")
+    heartbeats_before_kill: int = int(failure_history.get("heartbeats_before_kill", 0))
+
+    _msg_type = "wos_escalate"
+
+    # Branch 4 — Human-judgment register: surface immediately, no retry.
+    # Checked first — register classification overrides all other branches.
+    if register in _ESCALATE_HUMAN_JUDGMENT_REGISTERS:
+        text = (
+            f"WOS escalation: UoW `{uow_id}` is in `{register}` register — "
+            f"surfaces for human judgment rather than executor retry.\n\n"
+            f"Title: {uow_title}\n"
+            f"Register: {register}\n"
+            f"Execution attempts: {execution_attempts}\n"
+            f"Posture: {posture}\n\n"
+            f"The structured executor cannot resolve this UoW. "
+            f"Please review and either `/decide {uow_id} proceed` or `/decide {uow_id} abandon`."
+        )
+        return {
+            "action": "send_reply",
+            "text": text,
+            "chat_id": os.environ.get("LOBSTER_ADMIN_CHAT_ID", "0"),
+            "message_type": _msg_type,
+        }
+
+    # Branch 3 — Execution cap exhausted: surface to Dan.
+    # execution_attempts >= threshold means the prescription was tried multiple times.
+    if execution_attempts >= _ESCALATE_SURFACE_EXECUTION_THRESHOLD:
+        text = (
+            f"WOS escalation: UoW `{uow_id}` exhausted execution attempts.\n\n"
+            f"Title: {uow_title}\n"
+            f"Execution attempts: {execution_attempts} (threshold: {_ESCALATE_SURFACE_EXECUTION_THRESHOLD})\n"
+            f"Return reason classification: {return_reason_classification}\n"
+            f"Kill type: {kill_type or 'n/a'}\n"
+            f"Posture: {posture}\n\n"
+            f"The executor ran {execution_attempts} times without completing. "
+            f"Please review the prescription and either:\n"
+            f"  `/decide {uow_id} retry` — reset and re-queue with fresh prescription\n"
+            f"  `/decide {uow_id} abandon` — close as failed"
+        )
+        return {
+            "action": "send_reply",
+            "text": text,
+            "chat_id": os.environ.get("LOBSTER_ADMIN_CHAT_ID", "0"),
+            "message_type": _msg_type,
+        }
+
+    # Branch 1 — Pure infrastructure failure: auto-retry via steward heartbeat.
+    # execution_attempts == 0 AND orphan classification means the UoW was never executed.
+    if execution_attempts == 0 and return_reason_classification in _ESCALATE_ORPHAN_CLASSIFICATIONS:
+        task_id = f"escalate-retry-{uow_id[:12]}"
+        steward_script = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..', '..', 'scheduled-tasks', 'steward-heartbeat.py')
+        )
+        prompt = (
+            f"---\n"
+            f"task_id: {task_id}\n"
+            f"chat_id: 0\n"
+            f"source: system\n"
+            f"---\n\n"
+            f"WOS escalation auto-retry: UoW `{uow_id}` was killed before execution began "
+            f"(kill_type={kill_type!r}, execution_attempts=0). "
+            f"The prescription is intact — running steward heartbeat to re-queue.\n\n"
+            f"```bash\n"
+            f"cd ~/lobster-workspace && uv run python {steward_script}\n"
+            f"```\n\n"
+            f"Then call write_result with the steward output.\n\n"
+            f"Minimum viable output: steward heartbeat completed for UoW {uow_id}.\n"
+            f"Boundary: do not modify any UoW status directly."
+        )
+        return {
+            "action": "spawn_subagent",
+            "task_id": task_id,
+            "agent_type": "lobster-generalist",
+            "prompt": prompt,
+            "message_type": _msg_type,
+        }
+
+    # Branch 2 — Mid-execution kill: retry via steward heartbeat.
+    # execution_attempts > 0 AND orphan classification means the subagent was killed
+    # while working. Partial output may exist; retry is still warranted.
+    if return_reason_classification in _ESCALATE_ORPHAN_CLASSIFICATIONS:
+        task_id = f"escalate-midexec-{uow_id[:12]}"
+        steward_script = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..', '..', 'scheduled-tasks', 'steward-heartbeat.py')
+        )
+        prompt = (
+            f"---\n"
+            f"task_id: {task_id}\n"
+            f"chat_id: 0\n"
+            f"source: system\n"
+            f"---\n\n"
+            f"WOS escalation mid-execution retry: UoW `{uow_id}` was killed during execution "
+            f"(kill_type={kill_type!r}, heartbeats_before_kill={heartbeats_before_kill}, "
+            f"execution_attempts={execution_attempts}). "
+            f"Partial output may exist — running steward heartbeat to re-queue with resume context.\n\n"
+            f"```bash\n"
+            f"cd ~/lobster-workspace && uv run python {steward_script}\n"
+            f"```\n\n"
+            f"Then call write_result with the steward output.\n\n"
+            f"Minimum viable output: steward heartbeat completed for UoW {uow_id}.\n"
+            f"Boundary: do not modify any UoW status directly."
+        )
+        return {
+            "action": "spawn_subagent",
+            "task_id": task_id,
+            "agent_type": "lobster-generalist",
+            "prompt": prompt,
+            "message_type": _msg_type,
+        }
+
+    # Default — unclassified failure: surface to Dan.
+    text = (
+        f"WOS escalation: UoW `{uow_id}` requires review (unclassified failure).\n\n"
+        f"Title: {uow_title}\n"
+        f"Execution attempts: {execution_attempts}\n"
+        f"Return reason classification: {return_reason_classification or 'unknown'}\n"
+        f"Kill type: {kill_type or 'n/a'}\n"
+        f"Posture: {posture or 'unknown'}\n\n"
+        f"Please review and either:\n"
+        f"  `/decide {uow_id} retry` — reset and re-queue\n"
+        f"  `/decide {uow_id} abandon` — close as failed"
+    )
+    return {
+        "action": "send_reply",
+        "text": text,
+        "chat_id": os.environ.get("LOBSTER_ADMIN_CHAT_ID", "0"),
+        "message_type": _msg_type,
     }
 
 
@@ -677,6 +928,35 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
             f"route_wos_message: unrecognised message type {msg_type!r}. "
             f"Known types: {sorted(WOS_MESSAGE_TYPE_DISPATCH)}"
         )
+
+    # ---------------------------------------------------------------------------
+    # wos_escalate fast-path: dispatched before the spawn-gate because this handler
+    # legitimately returns either action="spawn_subagent" (auto-retry branches) or
+    # action="send_reply" (surface-to-Dan branches).  The spawn-gate applies only to
+    # execution message types (wos_execute, steward_trigger) that must always spawn.
+    # ---------------------------------------------------------------------------
+    if msg_type == "wos_escalate":
+        try:
+            escalate_result = handle_wos_escalate(msg)
+            escalate_result["message_type"] = msg_type
+            return escalate_result
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).error(
+                "route_wos_message: handle_wos_escalate raised %s: %s — "
+                "returning send_reply alert",
+                type(exc).__name__, exc,
+            )
+            return {
+                "action": "send_reply",
+                "text": (
+                    f"WOS escalation handler raised an error "
+                    f"({type(exc).__name__}: {exc}). "
+                    f"UoW escalation was NOT processed. "
+                    "Check logs and re-queue manually if needed."
+                ),
+                "message_type": msg_type,
+            }
 
     # ---------------------------------------------------------------------------
     # Spawn-gate (issue #920): all WOS message types MUST produce action="spawn_subagent".

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 from .registry import ApproveConfirmed, ApproveExpired, ApproveNotFound, ApproveSkipped
 from .paths import LOBSTER_WORKSPACE as _LOBSTER_WORKSPACE, WOS_CONFIG as _WOS_CONFIG_PATH_FROM_PATHS, WOS_GATE_CLEARED_FLAG as _GATE_CLEARED_FLAG
+from .steward import ReturnReasonClassification
 
 
 # ---------------------------------------------------------------------------
@@ -626,7 +627,7 @@ _ESCALATE_HUMAN_JUDGMENT_REGISTERS: frozenset[str] = frozenset({
 # return_reason_classification values that indicate an infrastructure kill
 # (session killed before or during execution — no execution outcome produced).
 _ESCALATE_ORPHAN_CLASSIFICATIONS: frozenset[str] = frozenset({
-    "orphan",
+    ReturnReasonClassification.ORPHAN,
 })
 
 

--- a/tests/unit/test_orchestration/test_wos_escalate_handler.py
+++ b/tests/unit/test_orchestration/test_wos_escalate_handler.py
@@ -25,24 +25,22 @@ from src.orchestration.dispatcher_handlers import (
     handle_wos_escalate,
     route_wos_message,
     WOS_MESSAGE_TYPE_DISPATCH,
+    _ESCALATE_SURFACE_EXECUTION_THRESHOLD,
+    _ESCALATE_HUMAN_JUDGMENT_REGISTERS,
 )
 
 # ---------------------------------------------------------------------------
-# Named constants from the spec
+# Named constants from the spec — imported from production module
 # ---------------------------------------------------------------------------
 
 # The message type this PR adds
 WOS_ESCALATE_MESSAGE_TYPE = "wos_escalate"
 
 # Execution_attempts threshold at which the handler surfaces to Dan
-SURFACE_TO_DAN_EXECUTION_THRESHOLD = 3
+SURFACE_TO_DAN_EXECUTION_THRESHOLD = _ESCALATE_SURFACE_EXECUTION_THRESHOLD
 
 # Registers that bypass auto-retry and surface directly to Dan
-HUMAN_JUDGMENT_REGISTERS = ("human-judgment", "philosophical")
-
-# Orphan return_reason values — infrastructure kills, no execution occurred
-ORPHAN_RETURN_REASONS = ("executor_orphan", "executing_orphan", "diagnosing_orphan",
-                         "orphan_kill_before_start", "orphan_kill_during_execution")
+HUMAN_JUDGMENT_REGISTERS = tuple(_ESCALATE_HUMAN_JUDGMENT_REGISTERS)
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/test_orchestration/test_wos_escalate_handler.py
+++ b/tests/unit/test_orchestration/test_wos_escalate_handler.py
@@ -1,0 +1,440 @@
+"""
+Tests for the wos_escalate dispatcher handler.
+
+Spec (dispatcher-escalation-design-20260426.md §2):
+  - New message type "wos_escalate" is registered in WOS_MESSAGE_TYPE_DISPATCH.
+  - handle_wos_escalate(msg) implements a 4-branch decision tree:
+    1. Pure infrastructure failure (execution_attempts == 0, orphan return_reason):
+       → auto-retry: returns action="spawn_subagent" targeting the steward heartbeat
+    2. Mid-execution kill (execution_attempts > 0, orphan return_reason):
+       → retry with extended TTL: returns action="spawn_subagent"
+    3. ≥3 execution_attempts (genuine execution failure):
+       → surface to Dan: returns action="send_reply" with structured context
+    4. human-judgment or philosophical register:
+       → immediate surface to Dan: returns action="send_reply"
+  - route_wos_message accepts "wos_escalate" and dispatches to handle_wos_escalate.
+  - The spawn-gate does NOT apply to wos_escalate — it legitimately returns send_reply
+    for the "surface to Dan" branches.
+  - handle_wos_escalate is a pure function: identical inputs produce identical outputs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from src.orchestration.dispatcher_handlers import (
+    handle_wos_escalate,
+    route_wos_message,
+    WOS_MESSAGE_TYPE_DISPATCH,
+)
+
+# ---------------------------------------------------------------------------
+# Named constants from the spec
+# ---------------------------------------------------------------------------
+
+# The message type this PR adds
+WOS_ESCALATE_MESSAGE_TYPE = "wos_escalate"
+
+# Execution_attempts threshold at which the handler surfaces to Dan
+SURFACE_TO_DAN_EXECUTION_THRESHOLD = 3
+
+# Registers that bypass auto-retry and surface directly to Dan
+HUMAN_JUDGMENT_REGISTERS = ("human-judgment", "philosophical")
+
+# Orphan return_reason values — infrastructure kills, no execution occurred
+ORPHAN_RETURN_REASONS = ("executor_orphan", "executing_orphan", "diagnosing_orphan",
+                         "orphan_kill_before_start", "orphan_kill_during_execution")
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_escalate_msg(
+    uow_id: str = "uow-test-001",
+    execution_attempts: int = 0,
+    return_reason_classification: str = "orphan",
+    kill_type: str = "orphan_kill_before_start",
+    heartbeats_before_kill: int = 0,
+    posture: str = "orphan",
+    register: str = "operational",
+    uow_title: str = "Test UoW",
+) -> dict:
+    """Build a minimal wos_escalate inbox message."""
+    return {
+        "type": WOS_ESCALATE_MESSAGE_TYPE,
+        "uow_id": uow_id,
+        "uow_title": uow_title,
+        "failure_history": {
+            "execution_attempts": execution_attempts,
+            "return_reason_classification": return_reason_classification,
+            "kill_type": kill_type,
+            "heartbeats_before_kill": heartbeats_before_kill,
+        },
+        "posture": posture,
+        "register": register,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+class TestWosEscalateRegistered:
+    """wos_escalate must be registered in the dispatch table."""
+
+    def test_wos_escalate_in_dispatch_table(self):
+        """wos_escalate must appear in WOS_MESSAGE_TYPE_DISPATCH.
+
+        Absence means the dispatcher's type-based routing table cannot fire for
+        wos_escalate messages — the escalation path would silently stall.
+        """
+        assert WOS_ESCALATE_MESSAGE_TYPE in WOS_MESSAGE_TYPE_DISPATCH, (
+            f"{WOS_ESCALATE_MESSAGE_TYPE!r} must be registered in WOS_MESSAGE_TYPE_DISPATCH "
+            "so the dispatcher routes it structurally rather than via prose that is lost on compaction"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Branch 1: pure infrastructure failure → auto-retry
+# ---------------------------------------------------------------------------
+
+class TestPureInfrastructureFailureAutoRetry:
+    """
+    Branch 1: execution_attempts == 0 AND orphan return_reason_classification.
+
+    The UoW was never actually executed — the session was killed before execution
+    began. Auto-retry is safe because the original prescription is still valid.
+    The dispatcher spawns a steward heartbeat subagent to re-queue the UoW.
+    """
+
+    def test_pure_infra_kill_returns_spawn_subagent(self):
+        """Pure infrastructure kill with 0 execution_attempts → spawn_subagent action."""
+        msg = _make_escalate_msg(
+            execution_attempts=0,
+            return_reason_classification="orphan",
+            kill_type="orphan_kill_before_start",
+            heartbeats_before_kill=0,
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "spawn_subagent", (
+            "Pure infrastructure kill (0 execution_attempts, orphan classification) "
+            "must auto-retry by spawning a steward subagent, not surface to Dan"
+        )
+
+    def test_pure_infra_kill_includes_task_id(self):
+        """spawn_subagent result must include a non-empty task_id."""
+        msg = _make_escalate_msg(execution_attempts=0, return_reason_classification="orphan")
+        result = handle_wos_escalate(msg)
+        assert isinstance(result.get("task_id"), str)
+        assert len(result["task_id"]) > 0
+
+    def test_pure_infra_kill_includes_non_empty_prompt(self):
+        """spawn_subagent result must include a non-empty prompt for the subagent."""
+        msg = _make_escalate_msg(execution_attempts=0, return_reason_classification="orphan")
+        result = handle_wos_escalate(msg)
+        assert isinstance(result.get("prompt"), str)
+        assert len(result["prompt"]) > 0
+
+    def test_pure_infra_kill_prompt_contains_uow_id(self):
+        """The subagent prompt must mention the UoW ID for correlation."""
+        uow_id = "uow-infra-test-001"
+        msg = _make_escalate_msg(uow_id=uow_id, execution_attempts=0, return_reason_classification="orphan")
+        result = handle_wos_escalate(msg)
+        assert uow_id in result["prompt"]
+
+    def test_pure_infra_kill_prompt_contains_chat_id_zero(self):
+        """chat_id: 0 is the silent-drop sentinel — steward results must not be relayed to user."""
+        msg = _make_escalate_msg(execution_attempts=0, return_reason_classification="orphan")
+        result = handle_wos_escalate(msg)
+        assert "chat_id: 0" in result["prompt"], (
+            "Steward subagent prompt must include 'chat_id: 0' so write_result "
+            "silently drops the result rather than forwarding to a user chat"
+        )
+
+    def test_zero_execution_attempts_with_kill_during_execution_is_still_infra_kill(self):
+        """kill_during_execution with 0 execution_attempts is still treated as pure infra kill.
+
+        This covers the edge case where the heartbeat was written but the subagent
+        was killed before any actual work completed.
+        """
+        msg = _make_escalate_msg(
+            execution_attempts=0,
+            return_reason_classification="orphan",
+            kill_type="orphan_kill_during_execution",
+            heartbeats_before_kill=2,
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "spawn_subagent"
+
+
+# ---------------------------------------------------------------------------
+# Branch 2: mid-execution kill → retry with extended TTL
+# ---------------------------------------------------------------------------
+
+class TestMidExecutionKillRetry:
+    """
+    Branch 2: execution_attempts > 0 AND orphan return_reason_classification.
+
+    The subagent was killed mid-execution — some work may have been done.
+    The dispatcher retries but the prompt instructs the subagent to check
+    for partial output and resume if possible.
+    """
+
+    def test_mid_execution_kill_returns_spawn_subagent(self):
+        """Mid-execution kill (orphan, >0 execution_attempts) → spawn_subagent action."""
+        msg = _make_escalate_msg(
+            execution_attempts=1,
+            return_reason_classification="orphan",
+            kill_type="orphan_kill_during_execution",
+            heartbeats_before_kill=3,
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "spawn_subagent", (
+            "Mid-execution kill (1 execution_attempt, orphan classification) "
+            "must retry by spawning a subagent, not surface to Dan"
+        )
+
+    def test_mid_execution_kill_includes_uow_id_in_prompt(self):
+        """The retry prompt must include the UoW ID."""
+        uow_id = "uow-mid-exec-001"
+        msg = _make_escalate_msg(
+            uow_id=uow_id,
+            execution_attempts=1,
+            return_reason_classification="orphan",
+        )
+        result = handle_wos_escalate(msg)
+        assert uow_id in result["prompt"]
+
+    def test_mid_execution_kill_exactly_two_attempts_still_retries(self):
+        """2 execution_attempts with orphan classification still triggers retry, not surface-to-Dan."""
+        msg = _make_escalate_msg(
+            execution_attempts=2,
+            return_reason_classification="orphan",
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "spawn_subagent", (
+            f"With 2 execution_attempts (< {SURFACE_TO_DAN_EXECUTION_THRESHOLD}), "
+            "orphan classification must still retry, not surface to Dan"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Branch 3: ≥3 execution_attempts → surface to Dan
+# ---------------------------------------------------------------------------
+
+class TestGenuineExecutionFailureSurfaceToDan:
+    """
+    Branch 3: execution_attempts >= SURFACE_TO_DAN_EXECUTION_THRESHOLD.
+
+    The agent ran 3+ times and failed each time. This is a genuine execution
+    failure, not an infrastructure kill. Surface to Dan with structured context.
+    """
+
+    def test_three_execution_attempts_surfaces_to_dan(self):
+        """3 execution_attempts → surface to Dan (send_reply action)."""
+        msg = _make_escalate_msg(
+            execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD,
+            return_reason_classification="error",
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "send_reply", (
+            f"With {SURFACE_TO_DAN_EXECUTION_THRESHOLD} execution_attempts, "
+            "the handler must surface to Dan rather than auto-retry"
+        )
+
+    def test_four_execution_attempts_surfaces_to_dan(self):
+        """4+ execution_attempts also surfaces to Dan."""
+        msg = _make_escalate_msg(
+            execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD + 1,
+            return_reason_classification="error",
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "send_reply"
+
+    def test_surface_to_dan_includes_uow_id_in_reply_text(self):
+        """Dan notification must include the UoW ID so he can act on it."""
+        uow_id = "uow-genuine-fail-001"
+        msg = _make_escalate_msg(
+            uow_id=uow_id,
+            execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD,
+        )
+        result = handle_wos_escalate(msg)
+        assert uow_id in result.get("text", ""), (
+            "Dan notification text must include the UoW ID for correlation"
+        )
+
+    def test_surface_to_dan_includes_execution_attempts_in_reply_text(self):
+        """Dan notification must include the execution_attempts count for context."""
+        msg = _make_escalate_msg(
+            execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD,
+        )
+        result = handle_wos_escalate(msg)
+        text = result.get("text", "")
+        assert str(SURFACE_TO_DAN_EXECUTION_THRESHOLD) in text or "execution" in text.lower(), (
+            "Dan notification must include execution attempt count so he knows the failure history"
+        )
+
+    def test_surface_to_dan_reply_includes_chat_id(self):
+        """send_reply result must include a chat_id so the dispatcher knows where to send it."""
+        msg = _make_escalate_msg(execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD)
+        result = handle_wos_escalate(msg)
+        assert "chat_id" in result, (
+            "send_reply result must include chat_id — without it the dispatcher "
+            "cannot route the notification to Dan"
+        )
+
+    def test_three_execution_attempts_orphan_still_surfaces_to_dan(self):
+        """3 execution_attempts with orphan classification → surface to Dan.
+
+        execution_attempts is the hard gate. Even if return_reason_classification
+        is 'orphan', 3+ confirmed execution attempts means the prescription itself
+        may be broken — auto-retry without diagnosis would loop forever.
+        """
+        msg = _make_escalate_msg(
+            execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD,
+            return_reason_classification="orphan",
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "send_reply", (
+            f"3+ execution_attempts must surface to Dan regardless of return_reason_classification "
+            "— the execution budget is exhausted"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Branch 4: human-judgment or philosophical register → surface to Dan
+# ---------------------------------------------------------------------------
+
+class TestHumanJudgmentRegisterSurfaceToDan:
+    """
+    Branch 4: register in ('human-judgment', 'philosophical').
+
+    These UoWs require human judgment — the structured executor was never the
+    right tool. Surface immediately to Dan without attempting auto-retry.
+    """
+
+    @pytest.mark.parametrize("register", HUMAN_JUDGMENT_REGISTERS)
+    def test_human_judgment_register_surfaces_to_dan(self, register):
+        """human-judgment and philosophical registers surface immediately to Dan."""
+        msg = _make_escalate_msg(
+            execution_attempts=0,
+            return_reason_classification="orphan",
+            register=register,
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "send_reply", (
+            f"UoW with register={register!r} must surface to Dan immediately — "
+            "the executor was never the right tool for this work"
+        )
+
+    @pytest.mark.parametrize("register", HUMAN_JUDGMENT_REGISTERS)
+    def test_human_judgment_register_includes_register_in_text(self, register):
+        """Dan notification for human-judgment register must mention the register type."""
+        uow_id = "uow-human-judgment-001"
+        msg = _make_escalate_msg(
+            uow_id=uow_id,
+            execution_attempts=0,
+            register=register,
+        )
+        result = handle_wos_escalate(msg)
+        text = result.get("text", "")
+        assert register in text or "judgment" in text.lower() or "philosophical" in text.lower(), (
+            f"Dan notification for register={register!r} must explain why it was surfaced"
+        )
+
+    def test_human_judgment_with_zero_attempts_still_surfaces(self):
+        """Even 0 execution_attempts: human-judgment register bypasses auto-retry."""
+        msg = _make_escalate_msg(
+            execution_attempts=0,
+            return_reason_classification="orphan",
+            register="human-judgment",
+        )
+        result = handle_wos_escalate(msg)
+        assert result["action"] == "send_reply", (
+            "human-judgment register must surface to Dan even with 0 execution_attempts — "
+            "register check takes precedence over the infrastructure-kill auto-retry path"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Purity and structure tests
+# ---------------------------------------------------------------------------
+
+class TestHandleWosEscalatePurity:
+    """handle_wos_escalate must be a pure function."""
+
+    def test_pure_function_same_inputs_same_output_infra_kill(self):
+        """Pure function contract: identical inputs always produce identical outputs (infra branch)."""
+        msg = _make_escalate_msg(execution_attempts=0, return_reason_classification="orphan")
+        r1 = handle_wos_escalate(msg)
+        r2 = handle_wos_escalate(msg)
+        assert r1 == r2
+
+    def test_pure_function_same_inputs_same_output_surface(self):
+        """Pure function contract: identical inputs always produce identical outputs (surface branch)."""
+        msg = _make_escalate_msg(execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD)
+        r1 = handle_wos_escalate(msg)
+        r2 = handle_wos_escalate(msg)
+        assert r1 == r2
+
+    def test_different_uow_ids_produce_different_prompts(self):
+        """Each UoW ID must produce a distinct prompt — no cross-contamination."""
+        msg1 = _make_escalate_msg(uow_id="uow-001", execution_attempts=0, return_reason_classification="orphan")
+        msg2 = _make_escalate_msg(uow_id="uow-002", execution_attempts=0, return_reason_classification="orphan")
+        r1 = handle_wos_escalate(msg1)
+        r2 = handle_wos_escalate(msg2)
+        assert r1["prompt"] != r2["prompt"]
+
+    def test_result_always_contains_message_type(self):
+        """All branches must include message_type='wos_escalate' in the result."""
+        for execution_attempts in (0, SURFACE_TO_DAN_EXECUTION_THRESHOLD):
+            msg = _make_escalate_msg(execution_attempts=execution_attempts)
+            result = handle_wos_escalate(msg)
+            assert result.get("message_type") == WOS_ESCALATE_MESSAGE_TYPE, (
+                f"All branches must echo message_type={WOS_ESCALATE_MESSAGE_TYPE!r} "
+                "so callers can confirm which handler fired"
+            )
+
+
+# ---------------------------------------------------------------------------
+# route_wos_message integration
+# ---------------------------------------------------------------------------
+
+class TestRouteWosMessageEscalate:
+    """route_wos_message must dispatch wos_escalate to handle_wos_escalate."""
+
+    def test_route_wos_message_accepts_wos_escalate_type(self):
+        """route_wos_message must not raise ValueError for wos_escalate messages."""
+        msg = _make_escalate_msg(execution_attempts=0, return_reason_classification="orphan")
+        # Should not raise
+        result = route_wos_message(msg)
+        assert "action" in result
+
+    def test_route_wos_message_infra_kill_returns_spawn_subagent(self):
+        """route_wos_message for wos_escalate pure infra kill returns action='spawn_subagent'."""
+        msg = _make_escalate_msg(execution_attempts=0, return_reason_classification="orphan")
+        result = route_wos_message(msg)
+        assert result["action"] == "spawn_subagent"
+
+    def test_route_wos_message_genuine_failure_returns_send_reply(self):
+        """route_wos_message for wos_escalate genuine failure returns action='send_reply'."""
+        msg = _make_escalate_msg(execution_attempts=SURFACE_TO_DAN_EXECUTION_THRESHOLD)
+        result = route_wos_message(msg)
+        assert result["action"] == "send_reply"
+
+    def test_route_wos_message_echoes_message_type(self):
+        """result['message_type'] must echo 'wos_escalate' so callers can confirm routing."""
+        msg = _make_escalate_msg()
+        result = route_wos_message(msg)
+        assert result["message_type"] == WOS_ESCALATE_MESSAGE_TYPE
+
+    def test_route_wos_message_missing_uow_id_returns_send_reply_alert(self):
+        """If uow_id is missing from the message, route_wos_message returns send_reply alert."""
+        msg = {
+            "type": WOS_ESCALATE_MESSAGE_TYPE,
+            "failure_history": {"execution_attempts": 0, "return_reason_classification": "orphan"},
+        }
+        result = route_wos_message(msg)
+        # Should not raise; should return a send_reply alert
+        assert result["action"] in ("send_reply", "spawn_subagent"), (
+            "Missing uow_id must not propagate as an unhandled exception"
+        )


### PR DESCRIPTION
## What this solves

The 2026-04-26 incident: 19 UoWs exhausted their retry cap before any execution was attempted (all `lifetime_cycles = 0`), producing 19 parallel Telegram notifications for a single infrastructure event (session kills before execution started). Every failure was routed directly to the highest-cost judgment layer.

This PR inserts a programmatic triage layer. When a UoW exhausts its execution retry cap, the Steward writes a `wos_escalate` inbox message instead of calling `_default_notify_dan` directly. The dispatcher routes it through a 4-branch decision tree before deciding whether to auto-retry or escalate to Dan.

## What changed

**New message type `wos_escalate`** registered in `WOS_MESSAGE_TYPE_DISPATCH`. Schema carries:
- `uow_id`, `uow_title`, `register`
- `failure_history`: `execution_attempts`, `return_reason_classification`, `kill_type`, `heartbeats_before_kill`
- `posture`

**New `handle_wos_escalate(msg)` handler** — pure function, no I/O. 4-branch decision tree:

```
Branch 4 (checked first): register in (human-judgment, philosophical)
  → surface to Dan immediately — executor was never the right tool

Branch 3: execution_attempts >= 3
  → surface to Dan — prescription tried 3 times, retry without diagnosis loops

Branch 1: execution_attempts == 0 AND orphan classification
  → spawn_subagent: steward heartbeat auto-retry
  → pure infrastructure kill; prescription intact; no human needed

Branch 2: execution_attempts > 0 AND orphan classification
  → spawn_subagent: steward heartbeat mid-execution retry
  → partial output may exist; retry still warranted

Default: unclassified failure
  → surface to Dan
```

**Route wiring**: `wos_escalate` is dispatched in `route_wos_message` via an early-return path before the spawn-gate. The spawn-gate applies only to execution message types (`wos_execute`, `steward_trigger`) that must always produce `action="spawn_subagent"`. `wos_escalate` legitimately returns either action — bypassing the gate via early exit is the correct structural choice.

**Functional patterns used**: pure functions throughout (no side effects in handler or decision tree); pattern matching via `if/elif` on enumerated classifications; composition — `route_wos_message` delegates to `handle_wos_escalate` without re-implementing logic.

## Flow diagram

```
Retry cap exceeded
       │
       ▼
  ┌─────────────────────────────────────────────┐
  │           route_wos_message                 │
  │                                             │
  │  type=wos_escalate → handle_wos_escalate()  │
  │                                             │
  │  Branch 4: human-judgment/philosophical?    │
  │    yes → send_reply (surface to Dan)        │
  │    no  ↓                                    │
  │  Branch 3: execution_attempts >= 3?         │
  │    yes → send_reply (surface to Dan)        │
  │    no  ↓                                    │
  │  Branch 1: attempts == 0, orphan?           │
  │    yes → spawn_subagent (auto-retry)        │
  │    no  ↓                                    │
  │  Branch 2: orphan (any attempts)?           │
  │    yes → spawn_subagent (mid-exec retry)    │
  │    no  → send_reply (default: Dan)          │
  └─────────────────────────────────────────────┘
```

Before this PR: every retry-cap hit → direct Telegram notification to Dan.
After this PR: infrastructure kills with 0 execution attempts auto-retry without notification.

**Out of scope**: This PR does not modify the Steward's `_send_escalation_notification` to write `wos_escalate` messages — that wiring is the next PR in this series. The handler is implemented and tested; the Steward integration is a follow-on.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_escalate_handler.py -v` — 30 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_dispatcher_integration.py -v` — 99 passed, 0 failed (existing tests unchanged)
- [x] `uv run pytest tests/unit/test_orchestration/ -q` — 1498 passed, 25 failed (all 25 failures are pre-existing on main; verified by running the same tests against origin/main before branching)
- [x] `uv run python -m py_compile src/orchestration/dispatcher_handlers.py` — syntax OK

**Pre-existing failures (not caused by this PR):**
`test_prescriptions_per_cycle` (8 tests), `test_failure_traces_cleanup` (6 tests), `test_steward.py::TestModuleConstants/TestSelectExecutorType/TestEarlyWarningAt4` (4 tests), `test_steward_execution_gate` (3 tests), `test_executor_subprocess::TestHappyPath::test_instructions_are_passed_to_dispatcher` (1 test), `test_registry_cli::TestApproveCommand::test_approve_idempotent_on_pending` (1 test) — all confirmed failing on origin/main.

## Manual test
N/A — all changes are to pure Python dispatch logic with no external service calls, file I/O, systemd units, or DB schema changes. The handler is not yet wired to the Steward write path (that's the follow-on PR), so no live production path is affected by this merge.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (pure logic, not yet wired to Steward)
- [x] User-visible outcome verified — N/A (handler exists but no message source yet; follow-on PR wires the Steward write path)
- [x] Side-effect audit complete: handle_wos_escalate is a pure function with no side effects; route_wos_message early-exit for wos_escalate follows the same exception-handling pattern as existing handlers
- [x] External service calls: none

Closes #969