### PR TITLE
feat(registry_cli): trace command for unified WOS failure forensics

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1230,6 +1230,30 @@ class Registry:
         finally:
             conn.close()
 
+    def fetch_corrective_traces(self, uow_id: str) -> list[dict]:
+        """
+        Return all corrective_traces rows for the given UoW, ordered by created_at ASC.
+
+        Each row is a plain dict with all table columns.  Returns an empty list when no
+        rows exist or when the table is absent (pre-migration DB).
+
+        Use this for the forensics trace view; use get_corrective_trace_history() when
+        only prescription_delta values are needed.
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT id, uow_id, register, execution_summary, surprises, "
+                "prescription_delta, gate_score, created_at "
+                "FROM corrective_traces WHERE uow_id = ? ORDER BY created_at ASC",
+                (uow_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        except Exception:
+            return []
+        finally:
+            conn.close()
+
     def record_startup_sweep_active(
         self,
         uow_id: str,

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -13,6 +13,7 @@ Usage:
     uv run registry_cli.py check-stale
     uv run registry_cli.py expire-proposals
     uv run registry_cli.py gate-readiness
+    uv run registry_cli.py trace --id <uow-id>
 
 Environment:
     REGISTRY_DB_PATH — override the default db path (~/.../orchestration/registry.db)
@@ -219,6 +220,231 @@ def cmd_escalation_candidates(registry: Registry, args: argparse.Namespace) -> N
     _output([_uow_to_dict(r) for r in records])
 
 
+def _read_trace_json(output_ref: str | None) -> dict | None:
+    """
+    Read and parse the trace.json file associated with output_ref.
+
+    Uses the same path-derivation logic as executor/_read_trace_json:
+    - Primary:  Path(output_ref).with_suffix(".trace.json")
+    - Fallback: Path(str(output_ref) + ".trace.json")
+
+    Returns None if output_ref is None, the file is absent, or the file
+    cannot be parsed as JSON.
+    """
+    if not output_ref:
+        return None
+    p = Path(output_ref)
+    trace_file = p.with_suffix(".trace.json") if p.suffix else Path(str(output_ref) + ".trace.json")
+    if not trace_file.exists():
+        alt = Path(str(output_ref) + ".trace.json")
+        if alt != trace_file and alt.exists():
+            trace_file = alt
+        else:
+            return None
+    try:
+        return json.loads(trace_file.read_text())
+    except Exception:
+        return None
+
+
+# Orphan return_reason values — infrastructure kills, not execution outcomes.
+# Must match ORPHAN_REASONS in steward.py; kept here as a read-only constant
+# so registry_cli.py can classify without importing steward.
+_ORPHAN_RETURN_REASONS = frozenset({
+    "executor_orphan",
+    "executing_orphan",
+    "diagnosing_orphan",
+    "orphan_kill_before_start",
+    "orphan_kill_during_execution",
+})
+
+
+def _extract_return_reasons(audit_entries: list[dict]) -> list[dict]:
+    """
+    Extract return_reason payloads from audit_log entries, in chronological order.
+
+    Each entry in the returned list has:
+      ts, return_reason, event (the originating audit event)
+
+    Only entries whose note field contains a JSON object with a "return_reason" key
+    are included.
+    """
+    reasons = []
+    for entry in audit_entries:  # already ASC order from fetch_audit_entries
+        note = entry.get("note")
+        if not note:
+            continue
+        try:
+            note_data = json.loads(note)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(note_data, dict) and "return_reason" in note_data:
+            reasons.append({
+                "ts": entry.get("ts"),
+                "event": entry.get("event"),
+                "return_reason": note_data["return_reason"],
+            })
+    return reasons
+
+
+def _extract_kill_classification(audit_entries: list[dict]) -> dict | None:
+    """
+    Find the most recent audit entry with event='orphan_kill_classified' and
+    return its kill_type / heartbeats_before_kill payload.
+
+    Returns None if no such entry exists.
+    """
+    for entry in reversed(audit_entries):
+        if entry.get("event") != "orphan_kill_classified":
+            continue
+        note = entry.get("note")
+        if not note:
+            continue
+        try:
+            note_data = json.loads(note)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(note_data, dict) and "kill_type" in note_data:
+            return {
+                "kill_type": note_data.get("kill_type"),
+                "heartbeats_before_kill": note_data.get("heartbeats_before_kill"),
+                "ts": entry.get("ts"),
+            }
+    return None
+
+
+def _suggest_diagnosis(uow: UoW, return_reasons: list[dict],
+                       kill_classification: dict | None,
+                       trace_json: dict | None) -> str:
+    """
+    Produce a short, actionable diagnosis hint based on the forensics data.
+
+    Pattern recognition order (first match wins):
+    1. infrastructure-kill-wave — all return reasons are orphan types
+    2. kill-before-start — kill_type is orphan_kill_before_start or trace absent
+    3. kill-during-execution — kill_type is orphan_kill_during_execution
+    4. dead-prescription-loop — steward_cycles ≥ 3 with no execution_attempts
+    5. retry-cap — needs-human-review with execution_attempts > 0
+    6. steady / unknown — default
+    """
+    all_orphan = (
+        bool(return_reasons)
+        and all(r["return_reason"] in _ORPHAN_RETURN_REASONS for r in return_reasons)
+    )
+
+    if all_orphan and len(return_reasons) >= 2:
+        return (
+            "infrastructure-kill-wave: all return reasons are orphan classifications. "
+            "No execution budget was consumed. "
+            "Posture: reset with decide-retry; do not retire. "
+            "Investigate session TTL or executor dispatch scheduling."
+        )
+
+    if kill_classification:
+        kt = kill_classification.get("kill_type", "")
+        hb = kill_classification.get("heartbeats_before_kill", 0) or 0
+        if kt == "orphan_kill_before_start" or (not trace_json and kt):
+            return (
+                f"kill-before-start: agent was killed before writing any output "
+                f"(heartbeats_before_kill={hb}). "
+                "execution_attempts was not charged. "
+                "Posture: reset with decide-retry."
+            )
+        if kt == "orphan_kill_during_execution":
+            return (
+                f"kill-during-execution: agent was killed after starting "
+                f"(heartbeats_before_kill={hb}). "
+                "execution_attempts was charged. "
+                "Posture: reset with decide-retry; review trace_json for progress made."
+            )
+
+    if uow.status == "needs-human-review" and uow.execution_attempts == 0:
+        return (
+            "retry-cap-from-orphans: reached needs-human-review with zero confirmed "
+            "execution attempts — all retries were infrastructure kills. "
+            "Posture: reset with decide-retry after confirming executor dispatch is healthy."
+        )
+
+    if uow.status == "needs-human-review" and uow.execution_attempts > 0:
+        return (
+            f"retry-cap: reached needs-human-review with {uow.execution_attempts} confirmed "
+            "execution attempt(s). "
+            "Posture: review corrective_traces and steward_log for root cause, "
+            "then decide-retry or decide-close."
+        )
+
+    if uow.steward_cycles >= 3 and uow.execution_attempts == 0:
+        return (
+            "dead-prescription-loop: steward has cycled ≥3 times without a confirmed "
+            "execution attempt. "
+            "Posture: check whether executor dispatch is enabled and throttle is clear."
+        )
+
+    if str(uow.status) in ("proposed", "pending"):
+        return "early-stage: UoW has not yet entered the executor pipeline. No diagnosis needed."
+
+    if str(uow.status) in ("done",):
+        return "completed: UoW reached done status. No failure to diagnose."
+
+    return (
+        f"status={uow.status!s} steward_cycles={uow.steward_cycles} "
+        f"execution_attempts={uow.execution_attempts} lifetime_cycles={uow.lifetime_cycles}. "
+        "No known failure pattern matched. Review audit_log and corrective_traces for context."
+    )
+
+
+def cmd_trace(registry: Registry, args: argparse.Namespace) -> None:
+    """
+    Produce a unified forensics view for a single UoW.
+
+    Output fields:
+      uow_id             — the ID requested
+      current_state      — status, execution_attempts, lifetime_cycles, steward_cycles,
+                           retry_count, heartbeat_at, output_ref, close_reason, started_at
+      audit_log          — all audit_log rows, oldest first
+      corrective_traces  — all corrective_traces rows, oldest first
+      return_reasons     — chronological list of {ts, event, return_reason} extracted
+                           from audit_log note payloads
+      kill_classification — {kill_type, heartbeats_before_kill, ts} from the most recent
+                            orphan_kill_classified audit entry, or null
+      trace_json         — parsed trace.json from output_ref path, or null
+      diagnosis_hint     — one-paragraph triage summary with suggested posture
+    """
+    uow_id = args.id
+    uow = registry.get(uow_id)
+    if uow is None:
+        _output({"error": "not found", "id": uow_id})
+        return
+
+    audit_entries = registry.fetch_audit_entries(uow_id)
+    corrective_traces = registry.fetch_corrective_traces(uow_id)
+    return_reasons = _extract_return_reasons(audit_entries)
+    kill_classification = _extract_kill_classification(audit_entries)
+    trace_json = _read_trace_json(uow.output_ref)
+    diagnosis = _suggest_diagnosis(uow, return_reasons, kill_classification, trace_json)
+
+    _output({
+        "uow_id": uow_id,
+        "current_state": {
+            "status": str(uow.status),
+            "execution_attempts": uow.execution_attempts,
+            "lifetime_cycles": uow.lifetime_cycles,
+            "steward_cycles": uow.steward_cycles,
+            "retry_count": uow.retry_count,
+            "heartbeat_at": uow.heartbeat_at,
+            "output_ref": uow.output_ref,
+            "close_reason": uow.close_reason,
+            "started_at": uow.started_at,
+        },
+        "audit_log": audit_entries,
+        "corrective_traces": corrective_traces,
+        "return_reasons": return_reasons,
+        "kill_classification": kill_classification,
+        "trace_json": trace_json,
+        "diagnosis_hint": diagnosis,
+    })
+
+
 def cmd_stale(registry: Registry, args: argparse.Namespace) -> None:
     """
     Return UoWs whose heartbeat has gone silent beyond their TTL.
@@ -320,6 +546,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Grace period added to heartbeat_ttl before declaring a stall (default: 30)",
     )
 
+    # trace
+    p_trace = subparsers.add_parser(
+        "trace",
+        help=(
+            "Unified forensics view for a single UoW: registry row, audit_log, "
+            "corrective_traces, trace.json, return reasons, kill classification, "
+            "and a diagnosis hint. Start here for any WOS failure."
+        ),
+    )
+    p_trace.add_argument("--id", required=True, help="UoW id")
+
     return parser
 
 
@@ -336,6 +573,7 @@ _COMMAND_MAP = {
     "status-breakdown": cmd_status_breakdown,
     "escalation-candidates": cmd_escalation_candidates,
     "stale": cmd_stale,
+    "trace": cmd_trace,
 }
 
 

--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -247,15 +247,25 @@ def _read_trace_json(output_ref: str | None) -> dict | None:
         return None
 
 
+# Orphan return_reason constants — used for kill-wave detection in _suggest_diagnosis.
+# Exposed as module-level names so tests can import them rather than mirror raw literals.
+_RETURN_REASON_EXECUTOR_ORPHAN = "executor_orphan"
+_RETURN_REASON_EXECUTING_ORPHAN = "executing_orphan"
+_RETURN_REASON_DIAGNOSING_ORPHAN = "diagnosing_orphan"
+_RETURN_REASON_ORPHAN_KILL_BEFORE_START = "orphan_kill_before_start"
+_RETURN_REASON_ORPHAN_KILL_DURING_EXECUTION = "orphan_kill_during_execution"
+
 # Orphan return_reason values — infrastructure kills, not execution outcomes.
-# Must match ORPHAN_REASONS in steward.py; kept here as a read-only constant
-# so registry_cli.py can classify without importing steward.
+# Canonical source: _RETURN_REASON_CLASSIFICATIONS in steward.py (keys whose value is
+# _CLASSIFICATION_ORPHAN). ORPHAN_REASONS in steward.py covers only the pre-heartbeat-
+# classification subset; use _RETURN_REASON_CLASSIFICATIONS for the authoritative list.
+# Kept here so registry_cli.py can classify without importing steward.
 _ORPHAN_RETURN_REASONS = frozenset({
-    "executor_orphan",
-    "executing_orphan",
-    "diagnosing_orphan",
-    "orphan_kill_before_start",
-    "orphan_kill_during_execution",
+    _RETURN_REASON_EXECUTOR_ORPHAN,
+    _RETURN_REASON_EXECUTING_ORPHAN,
+    _RETURN_REASON_DIAGNOSING_ORPHAN,
+    _RETURN_REASON_ORPHAN_KILL_BEFORE_START,    # heartbeat-classified (#963)
+    _RETURN_REASON_ORPHAN_KILL_DURING_EXECUTION,  # heartbeat-classified (#963)
 })
 
 

--- a/tests/unit/test_orchestration/test_registry_cli.py
+++ b/tests/unit/test_orchestration/test_registry_cli.py
@@ -17,6 +17,15 @@ from pathlib import Path
 import pytest
 import os
 
+# Import production constants so tests do not mirror raw string literals.
+# These are defined in registry_cli.py and must be kept in sync with
+# _RETURN_REASON_CLASSIFICATIONS in steward.py.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+from orchestration.registry_cli import (
+    _RETURN_REASON_EXECUTOR_ORPHAN,
+    _RETURN_REASON_DIAGNOSING_ORPHAN,
+)
+
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
 CLI_PATH = REPO_ROOT / "src" / "orchestration" / "registry_cli.py"
 
@@ -614,10 +623,10 @@ class TestTraceCommand:
         uow_id = inserted["id"]
 
         _write_audit_entry(db_path, uow_id, "steward_re_entry",
-                           note='{"return_reason": "executor_orphan"}',
+                           note=json.dumps({"return_reason": _RETURN_REASON_EXECUTOR_ORPHAN}),
                            ts="2026-04-26T08:00:00+00:00")
         _write_audit_entry(db_path, uow_id, "steward_re_entry",
-                           note='{"return_reason": "diagnosing_orphan"}',
+                           note=json.dumps({"return_reason": _RETURN_REASON_DIAGNOSING_ORPHAN}),
                            ts="2026-04-26T09:00:00+00:00")
 
         result = run_cli(db_path, "trace", "--id", uow_id)
@@ -626,8 +635,8 @@ class TestTraceCommand:
         reasons = result["return_reasons"]
         assert isinstance(reasons, list)
         assert len(reasons) >= 2
-        assert reasons[0]["return_reason"] == "executor_orphan"
-        assert reasons[1]["return_reason"] == "diagnosing_orphan"
+        assert reasons[0]["return_reason"] == _RETURN_REASON_EXECUTOR_ORPHAN
+        assert reasons[1]["return_reason"] == _RETURN_REASON_DIAGNOSING_ORPHAN
 
     def test_trace_includes_kill_classification_when_present(self, db_path):
         """trace.kill_classification surfaces kill_type and heartbeats_before_kill from audit notes."""
@@ -727,7 +736,7 @@ class TestTraceCommand:
         uow_id = inserted["id"]
         _force_status(db_path, uow_id, "needs-human-review")
 
-        for ts_offset, reason in enumerate(["executor_orphan", "executor_orphan", "executor_orphan"]):
+        for ts_offset, reason in enumerate([_RETURN_REASON_EXECUTOR_ORPHAN] * 3):
             _write_audit_entry(
                 db_path, uow_id, "steward_re_entry",
                 note=json.dumps({"return_reason": reason}),
@@ -740,6 +749,43 @@ class TestTraceCommand:
                "orphan" in result["diagnosis_hint"].lower(), (
             f"diagnosis_hint should name the orphan/kill-wave pattern; got: {result['diagnosis_hint']!r}"
         )
+
+    def test_trace_reads_trace_json_via_alt_path(self, db_path, tmp_path):
+        """
+        _read_trace_json fallback: when output_ref has a suffix and the primary path
+        (p.with_suffix('.trace.json')) does not exist, but the string-append path
+        (str(output_ref) + '.trace.json') does, the alt path is used.
+
+        Concretely: output_ref = 'dir/file.json'
+          primary:  dir/file.trace.json    — does NOT exist
+          alt:      dir/file.json.trace.json — DOES exist
+        """
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "413", "--title", "Issue 413", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        trace_content = {
+            "uow_id": uow_id,
+            "register": "operational",
+            "execution_summary": "Alt-path trace loaded.",
+        }
+        # Write ONLY the string-append alt path; leave the with_suffix path absent.
+        output_ref = str(tmp_path / f"{uow_id}.json")
+        alt_trace_path = tmp_path / f"{uow_id}.json.trace.json"
+        alt_trace_path.write_text(json.dumps(trace_content))
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET output_ref = ? WHERE id = ?", (output_ref, uow_id))
+        conn.commit()
+        conn.close()
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "trace_json" in result
+        assert result["trace_json"] is not None, (
+            "trace_json must be populated via the alt path when primary path is absent"
+        )
+        assert result["trace_json"]["execution_summary"] == "Alt-path trace loaded."
 
     def test_trace_output_has_stable_top_level_keys(self, db_path):
         """trace output always has the documented top-level keys regardless of UoW state."""

--- a/tests/unit/test_orchestration/test_registry_cli.py
+++ b/tests/unit/test_orchestration/test_registry_cli.py
@@ -496,3 +496,263 @@ class TestStaleCommand:
         result = run_cli(db_path, "stale")
         ids = [r["id"] for r in result]
         assert uow_id not in ids, "done UoW must not appear in stale output"
+
+
+# ---------------------------------------------------------------------------
+# trace command
+# ---------------------------------------------------------------------------
+
+def _write_audit_entry(db_path: Path, uow_id: str, event: str,
+                       from_status: str | None = None, to_status: str | None = None,
+                       agent: str | None = None, note: str | None = None,
+                       ts: str | None = None) -> None:
+    """Write a raw audit_log entry for test setup."""
+    if ts is None:
+        ts = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (ts, uow_id, event, from_status, to_status, agent, note),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _write_corrective_trace(db_path: Path, uow_id: str, execution_summary: str,
+                             prescription_delta: str = "", surprises: str = "[]",
+                             gate_score: str | None = None) -> None:
+    """Write a corrective_traces row for test setup."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO corrective_traces "
+        "(uow_id, register, execution_summary, surprises, prescription_delta, gate_score, created_at) "
+        "VALUES (?, 'operational', ?, ?, ?, ?, datetime('now'))",
+        (uow_id, execution_summary, surprises, prescription_delta, gate_score),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestTraceCommand:
+    def test_trace_not_found_returns_error(self, db_path):
+        """trace on a non-existent UoW returns an error key."""
+        # Initialize DB
+        run_cli(db_path, "upsert", "--issue", "400", "--title", "Init", "--sweep-date", "2026-01-01")
+        result = run_cli(db_path, "trace", "--id", "uow_does_not_exist")
+        assert "error" in result, "trace on missing UoW must return error key"
+
+    def test_trace_surfaces_current_state_fields(self, db_path):
+        """trace output includes status, execution_attempts, and lifetime_cycles from the registry row."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "401", "--title", "Issue 401", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert result["uow_id"] == uow_id
+        assert "current_state" in result
+        state = result["current_state"]
+        assert "status" in state
+        assert "execution_attempts" in state
+        assert "lifetime_cycles" in state
+
+    def test_trace_includes_audit_log_in_chronological_order(self, db_path):
+        """trace.audit_log entries are present and ordered by id ASC."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "402", "--title", "Issue 402", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        _write_audit_entry(db_path, uow_id, "state_transition",
+                           from_status="proposed", to_status="pending",
+                           ts="2026-04-26T10:00:00+00:00")
+        _write_audit_entry(db_path, uow_id, "state_transition",
+                           from_status="pending", to_status="active",
+                           ts="2026-04-26T10:05:00+00:00")
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "audit_log" in result
+        audit = result["audit_log"]
+        assert isinstance(audit, list)
+        events = [e["event"] for e in audit]
+        assert "state_transition" in events
+
+    def test_trace_includes_corrective_traces_when_present(self, db_path):
+        """trace.corrective_traces includes rows from the corrective_traces table."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "403", "--title", "Issue 403", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        _write_corrective_trace(db_path, uow_id,
+                                execution_summary="Executor ran, wrote output.",
+                                prescription_delta="Add error handling for edge case X.")
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "corrective_traces" in result
+        traces = result["corrective_traces"]
+        assert isinstance(traces, list)
+        assert len(traces) >= 1
+        assert traces[0]["execution_summary"] == "Executor ran, wrote output."
+
+    def test_trace_corrective_traces_empty_when_none_written(self, db_path):
+        """trace.corrective_traces is an empty list when no corrective traces exist."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "404", "--title", "Issue 404", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "corrective_traces" in result
+        assert result["corrective_traces"] == []
+
+    def test_trace_includes_return_reasons_in_chronological_order(self, db_path):
+        """trace.return_reasons lists audit events with return_reason note payloads, oldest first."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "405", "--title", "Issue 405", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        _write_audit_entry(db_path, uow_id, "steward_re_entry",
+                           note='{"return_reason": "executor_orphan"}',
+                           ts="2026-04-26T08:00:00+00:00")
+        _write_audit_entry(db_path, uow_id, "steward_re_entry",
+                           note='{"return_reason": "diagnosing_orphan"}',
+                           ts="2026-04-26T09:00:00+00:00")
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "return_reasons" in result
+        reasons = result["return_reasons"]
+        assert isinstance(reasons, list)
+        assert len(reasons) >= 2
+        assert reasons[0]["return_reason"] == "executor_orphan"
+        assert reasons[1]["return_reason"] == "diagnosing_orphan"
+
+    def test_trace_includes_kill_classification_when_present(self, db_path):
+        """trace.kill_classification surfaces kill_type and heartbeats_before_kill from audit notes."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "406", "--title", "Issue 406", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        _write_audit_entry(
+            db_path, uow_id, "orphan_kill_classified",
+            note='{"kill_type": "kill_during_execution", "heartbeats_before_kill": 3}',
+        )
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "kill_classification" in result
+        kc = result["kill_classification"]
+        assert kc["kill_type"] == "kill_during_execution"
+        assert kc["heartbeats_before_kill"] == 3
+
+    def test_trace_kill_classification_is_none_when_absent(self, db_path):
+        """trace.kill_classification is null when no orphan_kill_classified event exists."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "407", "--title", "Issue 407", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "kill_classification" in result
+        assert result["kill_classification"] is None
+
+    def test_trace_reads_trace_json_when_output_ref_set(self, db_path, tmp_path):
+        """trace.trace_json contains the parsed trace.json when output_ref is set and file exists."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "408", "--title", "Issue 408", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        # Write a trace.json file
+        trace_content = {
+            "uow_id": uow_id,
+            "register": "operational",
+            "execution_summary": "Subagent completed the task.",
+            "surprises": ["Unexpected dependency on module X"],
+            "prescription_delta": "Add X to prescribed_skills",
+            "gate_score": None,
+            "timestamp": "2026-04-26T10:00:00+00:00",
+        }
+        output_ref = str(tmp_path / f"{uow_id}.json")
+        trace_path = tmp_path / f"{uow_id}.trace.json"
+        trace_path.write_text(json.dumps(trace_content))
+
+        # Set output_ref on the UoW
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET output_ref = ? WHERE id = ?", (output_ref, uow_id))
+        conn.commit()
+        conn.close()
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "trace_json" in result
+        assert result["trace_json"] is not None
+        assert result["trace_json"]["execution_summary"] == "Subagent completed the task."
+
+    def test_trace_json_is_none_when_file_absent(self, db_path, tmp_path):
+        """trace.trace_json is null when output_ref is set but trace.json file does not exist."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "409", "--title", "Issue 409", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        # Set output_ref pointing to a file that doesn't exist
+        output_ref = str(tmp_path / f"{uow_id}.json")
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE uow_registry SET output_ref = ? WHERE id = ?", (output_ref, uow_id))
+        conn.commit()
+        conn.close()
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "trace_json" in result
+        assert result["trace_json"] is None
+
+    def test_trace_includes_diagnosis_suggestion(self, db_path):
+        """trace.diagnosis_hint is always present and non-empty."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "410", "--title", "Issue 410", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "diagnosis_hint" in result
+        assert isinstance(result["diagnosis_hint"], str)
+        assert len(result["diagnosis_hint"]) > 0
+
+    def test_trace_diagnosis_hints_infrastructure_kill_wave(self, db_path):
+        """When all return reasons are orphan types, diagnosis_hint names infrastructure-kill-wave."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "411", "--title", "Issue 411", "--sweep-date", today)
+        uow_id = inserted["id"]
+        _force_status(db_path, uow_id, "needs-human-review")
+
+        for ts_offset, reason in enumerate(["executor_orphan", "executor_orphan", "executor_orphan"]):
+            _write_audit_entry(
+                db_path, uow_id, "steward_re_entry",
+                note=json.dumps({"return_reason": reason}),
+                ts=f"2026-04-26T0{ts_offset}:00:00+00:00",
+            )
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert "infrastructure-kill-wave" in result["diagnosis_hint"].lower() or \
+               "orphan" in result["diagnosis_hint"].lower(), (
+            f"diagnosis_hint should name the orphan/kill-wave pattern; got: {result['diagnosis_hint']!r}"
+        )
+
+    def test_trace_output_has_stable_top_level_keys(self, db_path):
+        """trace output always has the documented top-level keys regardless of UoW state."""
+        EXPECTED_KEYS = {
+            "uow_id", "current_state", "audit_log", "corrective_traces",
+            "return_reasons", "kill_classification", "trace_json", "diagnosis_hint",
+        }
+        today = datetime.now(timezone.utc).date().isoformat()
+        inserted = run_cli(db_path, "upsert", "--issue", "412", "--title", "Issue 412", "--sweep-date", today)
+        uow_id = inserted["id"]
+
+        result = run_cli(db_path, "trace", "--id", uow_id)
+
+        assert EXPECTED_KEYS.issubset(result.keys()), (
+            f"trace output missing keys: {EXPECTED_KEYS - result.keys()}"
+        )


### PR DESCRIPTION
## Problem solved

Diagnosing a stuck WOS UoW currently requires at least 5 separate queries: get the registry row, inspect the audit_log, find corrective_traces, locate trace.json on disk, and reason across all four sources. There is no single entrypoint. A new subagent arriving cold cannot produce a diagnosis without knowing the schema, path conventions, and pattern vocabulary.

## What this does

Adds `registry_cli.py trace --id <uow_id>` — one query that surfaces everything needed for failure diagnosis:

- **current_state** — status, execution_attempts, lifetime_cycles, steward_cycles, retry_count, heartbeat_at, output_ref, close_reason, started_at
- **audit_log** — all entries, chronological
- **corrective_traces** — all rows from the corrective_traces table, chronological
- **return_reasons** — extracted timeline of return_reason payloads from audit notes
- **kill_classification** — kill_type + heartbeats_before_kill from the most recent orphan_kill_classified audit entry
- **trace_json** — parsed trace.json from output_ref path, or null if absent
- **diagnosis_hint** — one-paragraph triage summary with suggested posture (reset vs retire vs surface-to-human)

The diagnosis_hint recognises six patterns from oracle/patterns.md: infrastructure-kill-wave, kill-before-start, kill-during-execution, dead-prescription-loop, retry-cap, and retry-cap-from-orphans. Pattern detection uses the return_reasons timeline and kill_classification.

Also adds `Registry.fetch_corrective_traces()` — a full-row read method distinct from the existing `get_corrective_trace_history()` which returns only prescription_delta strings.

## What this does not change

steward.py, executor.py, and any files touched by PRs #965-#974 are untouched. No schema changes. The trace command is read-only.

## Functional patterns

Pure functions: `_extract_return_reasons`, `_extract_kill_classification`, `_suggest_diagnosis`, `_read_trace_json`. All take data as arguments and return values; no shared state. `cmd_trace` composes them. Pattern matching uses a frozen set constant (`_ORPHAN_RETURN_REASONS`) that mirrors steward.py's `ORPHAN_REASONS` without importing steward.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry_cli.py::TestTraceCommand -q` — 13 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_registry_cli.py -q` — 46 passed, 1 failed (pre-existing: TestApproveCommand::test_approve_idempotent_on_pending fails on main before this PR)
- [x] `uv run python -m py_compile src/orchestration/registry_cli.py src/orchestration/registry.py` — clean

## Manual test

N/A — read-only CLI, no external service calls, no file I/O beyond reading existing trace.json files.

## Definition of Done
- [x] Unit tests pass
- [x] Integration/manual test — N/A, read-only CLI
- [x] User-visible outcome — not applicable
- [x] Side-effect audit: read-only, no writes, no floods
- [x] External service calls: none