### PR TITLE
feat(wos): add wos_diagnose handler + diagnose <uow_id> Telegram command (T1-B)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -486,13 +486,14 @@ infrastructure kill; otherwise it surfaces to Dan via the write_result dispatche
 
 **Telegram command parsing:** When a user message text matches `diagnose <uow_id>`
 (case-insensitive), call `parse_diagnose_command(text)` to extract the `uow_id`,
-then build and route a `wos_diagnose` message:
+then build and route a `wos_diagnose` message using the standard flow:
 
 ```python
 from src.orchestration.dispatcher_handlers import parse_diagnose_command, route_wos_message
 
 uow_id = parse_diagnose_command(msg_text)
 if uow_id:
+    mark_processing(message_id)
     diagnose_msg = {
         "type": "wos_diagnose",
         "uow_id": uow_id,
@@ -501,7 +502,11 @@ if uow_id:
         "failure_history": {},
     }
     routing = route_wos_message(diagnose_msg)
-    # routing["action"] == "spawn_subagent"
+    # routing["action"]       == "spawn_subagent"
+    # routing["task_id"]      == f"wos-diagnose-{uow_id[:12]}"
+    # routing["prompt"]       == diagnostic subagent prompt
+    # routing["agent_type"]   == "lobster-generalist"
+    # routing["message_type"] == "wos_diagnose"
     Task(
         prompt=routing["prompt"],
         subagent_type=routing["agent_type"],
@@ -510,26 +515,6 @@ if uow_id:
     )
     send_reply(chat_id, f"Diagnosing UoW `{uow_id}` — report incoming.", ...)
     mark_processed(message_id)
-```
-
-**Route through `route_wos_message` — same flow as `steward_trigger`.**
-
-```python
-1. mark_processing(message_id)
-2. routing = route_wos_message(msg)
-   # routing["action"]       == "spawn_subagent"
-   # routing["task_id"]      == f"wos-diagnose-{uow_id[:12]}"
-   # routing["prompt"]       == diagnostic subagent prompt
-   # routing["agent_type"]   == "lobster-generalist"
-   # routing["message_type"] == "wos_diagnose"
-
-3. Task(
-       prompt=routing["prompt"],
-       subagent_type=routing["agent_type"],
-       run_in_background=True,
-       task_id=routing["task_id"],
-   )
-4. mark_processed(message_id)
 ```
 
 ---

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -477,6 +477,63 @@ from src.orchestration.dispatcher_handlers import route_wos_message
 4. mark_processed(message_id)
 ```
 
+### wos_diagnose (`type: "wos_diagnose"`)
+
+Written by the dispatcher when Dan types `diagnose <uow_id>` in Telegram. Spawns a
+diagnostic subagent that runs `registry_cli trace` and returns a structured forensic
+report. The subagent auto-resets if confidence is high and the pattern is a pure
+infrastructure kill; otherwise it surfaces to Dan via the write_result dispatcher flow.
+
+**Telegram command parsing:** When a user message text matches `diagnose <uow_id>`
+(case-insensitive), call `parse_diagnose_command(text)` to extract the `uow_id`,
+then build and route a `wos_diagnose` message:
+
+```python
+from src.orchestration.dispatcher_handlers import parse_diagnose_command, route_wos_message
+
+uow_id = parse_diagnose_command(msg_text)
+if uow_id:
+    diagnose_msg = {
+        "type": "wos_diagnose",
+        "uow_id": uow_id,
+        "escalation_id": "",
+        "escalation_trigger": "manual",
+        "failure_history": {},
+    }
+    routing = route_wos_message(diagnose_msg)
+    # routing["action"] == "spawn_subagent"
+    Task(
+        prompt=routing["prompt"],
+        subagent_type=routing["agent_type"],
+        run_in_background=True,
+        task_id=routing["task_id"],
+    )
+    send_reply(chat_id, f"Diagnosing UoW `{uow_id}` — report incoming.", ...)
+    mark_processed(message_id)
+```
+
+**Route through `route_wos_message` — same flow as `steward_trigger`.**
+
+```python
+1. mark_processing(message_id)
+2. routing = route_wos_message(msg)
+   # routing["action"]       == "spawn_subagent"
+   # routing["task_id"]      == f"wos-diagnose-{uow_id[:12]}"
+   # routing["prompt"]       == diagnostic subagent prompt
+   # routing["agent_type"]   == "lobster-generalist"
+   # routing["message_type"] == "wos_diagnose"
+
+3. Task(
+       prompt=routing["prompt"],
+       subagent_type=routing["agent_type"],
+       run_in_background=True,
+       task_id=routing["task_id"],
+   )
+4. mark_processed(message_id)
+```
+
+---
+
 ### wfm_watchdog (`type: "wfm_watchdog"`)
 
 `mark_processed(message_id)` then `wait_for_messages()`. Never `send_reply`. No-op.

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -554,6 +554,11 @@ WOS_MESSAGE_TYPE_DISPATCH: dict[str, str] = {
     # exempt from the spawn-gate — it legitimately returns action="spawn_subagent" for
     # all-orphan auto-retry and action="send_reply" for surface-to-Dan branches.
     "wos_surface": "handle_wos_surface",
+    # Manual-trigger forensics handler: written by the dispatcher when Dan types
+    # "diagnose <uow_id>". Spawns a diagnostic subagent that runs registry_cli trace
+    # and returns a structured forensic report. Like wos_escalate, this handler is
+    # exempt from the spawn-gate — it legitimately returns action="spawn_subagent".
+    "wos_diagnose": "handle_wos_diagnose",
 }
 
 
@@ -1063,6 +1068,235 @@ def handle_wos_surface(msg: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# wos_diagnose handler — manual-trigger forensics subagent
+#
+# Called when the dispatcher receives a message with type="wos_diagnose".
+# Written by the dispatcher when Dan types "diagnose <uow_id>" in Telegram.
+# Spawns a diagnostic subagent that runs registry_cli trace and returns a
+# structured forensic report.
+#
+# Unlike wos_execute/steward_trigger, this handler is exempt from the
+# spawn-gate because it legitimately returns action="spawn_subagent" only
+# (no send_reply branches). route_wos_message handles this analogously to
+# the wos_escalate fast-path.
+#
+# UoW ID resolution is intentionally isolated through _resolve_uow_id().
+# Today that function is a direct pass-through; a future PR (short-ID
+# support) will add lookup logic there without changing this handler.
+# ---------------------------------------------------------------------------
+
+def _resolve_uow_id(uow_id: str) -> str:
+    """
+    Resolve a UoW ID from a raw identifier supplied by the user.
+
+    Today this is a direct pass-through: full IDs like ``uow_20260426_abc123``
+    are returned unchanged.
+
+    A future PR will add short-ID support here — resolving a serial number or
+    semantic slug alias to the canonical UoW ID via a registry lookup — without
+    requiring any changes to ``handle_wos_diagnose``.
+
+    Args:
+        uow_id: The raw UoW identifier as parsed from the user's command.
+
+    Returns:
+        The canonical UoW ID to pass to registry_cli.
+    """
+    return uow_id
+
+
+def handle_wos_diagnose(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle a ``wos_diagnose`` inbox message by spawning a diagnostic subagent.
+
+    Called by ``route_wos_message`` when the dispatcher receives a message with
+    ``type="wos_diagnose"``.  Written by the dispatcher when Dan types
+    ``diagnose <uow_id>`` in Telegram.
+
+    The spawned subagent runs ``registry_cli trace`` against the UoW, applies
+    the five-pattern diagnosis algorithm, and returns a structured forensic
+    report. If the diagnosis confidence is high and the pattern is a pure
+    infrastructure kill, the subagent calls ``registry_cli decide-retry``
+    autonomously before reporting; otherwise it surfaces the report to Dan.
+
+    UoW ID resolution goes through ``_resolve_uow_id()``.  Today that is a
+    direct pass-through for full IDs; a future PR adds short-ID lookup there.
+
+    Args:
+        msg: The raw ``wos_diagnose`` inbox message dict.  Expected fields:
+
+            - ``uow_id`` (str): The Unit of Work identifier.
+            - ``escalation_id`` (str, optional): Correlation ID from the
+              originating ``wos_escalate`` message; ``""`` for manual triggers.
+            - ``escalation_trigger`` (str, optional): ``"manual"`` for
+              Telegram-triggered diagnoses; escalation trigger string otherwise.
+            - ``failure_history`` (dict, optional): Pre-computed failure context
+              from the Steward; ``{}`` for manual triggers.
+
+    Returns:
+        A dict with ``action="spawn_subagent"`` and the following fields:
+
+        ``task_id`` (str):
+            Task identifier for the diagnostic subagent.
+
+        ``agent_type`` (str):
+            Always ``"lobster-generalist"``.
+
+        ``prompt`` (str):
+            Subagent prompt implementing the diagnosis algorithm.
+
+        ``message_type`` (str):
+            Always ``"wos_diagnose"``.
+    """
+    raw_uow_id: str = msg.get("uow_id", "unknown")
+    uow_id: str = _resolve_uow_id(raw_uow_id)
+    escalation_id: str = msg.get("escalation_id", "")
+    escalation_trigger: str = msg.get("escalation_trigger", "manual")
+    failure_history: dict[str, Any] = msg.get("failure_history", {})
+
+    task_id = f"wos-diagnose-{uow_id[:12]}"
+    registry_cli_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "registry_cli.py")
+    )
+    failure_history_json = json.dumps(failure_history, indent=2)
+
+    prompt = (
+        f"---\n"
+        f"task_id: {task_id}\n"
+        f"chat_id: 0\n"
+        f"source: system\n"
+        f"---\n\n"
+        f"Your task_id is: {task_id}\n\n"
+        f"You are a WOS self-diagnosing subagent. Your only job is to diagnose one UoW "
+        f"and decide whether to reset it, retire it, or surface it to Dan.\n\n"
+        f"## Task\n\n"
+        f"UoW ID: {uow_id}\n"
+        f"Escalation trigger: {escalation_trigger}\n"
+        f"Escalation ID: {escalation_id or '(manual trigger)'}\n\n"
+        f"Pre-computed failure history from escalation message:\n"
+        f"```json\n{failure_history_json}\n```\n\n"
+        f"## Steps\n\n"
+        f"1. Run: uv run {registry_cli_path} trace --id {uow_id}\n"
+        f"   Read the output. Focus on: diagnosis_hint, return_reasons, "
+        f"execution_attempts, kill_classification.\n\n"
+        f"2. Apply the diagnosis algorithm:\n\n"
+        f"   ORPHAN_REASONS = {{'executor_orphan', 'executing_orphan', 'diagnosing_orphan', "
+        f"'orphan_kill_before_start', 'orphan_kill_during_execution'}}\n"
+        f"   MAX_RETRIES = 3\n"
+        f"   HARD_CAP = 9\n\n"
+        f"   - If ALL return_reasons are in ORPHAN_REASONS and execution_attempts == 0:\n"
+        f"     posture = reset, pattern = 'infrastructure-kill-wave'\n"
+        f"   - If ALL return_reasons are in ORPHAN_REASONS and "
+        f"kill_type == 'orphan_kill_before_start':\n"
+        f"     posture = reset, pattern = 'kill-before-start'\n"
+        f"   - If ALL return_reasons are in ORPHAN_REASONS and "
+        f"kill_type == 'orphan_kill_during_execution':\n"
+        f"     posture = reset, pattern = 'kill-during-execution'\n"
+        f"   - If execution_attempts >= MAX_RETRIES:\n"
+        f"     posture = surface-to-human, pattern = 'genuine-retry-cap'\n"
+        f"     Run: uv run {registry_cli_path} get --id {uow_id}\n"
+        f"     (to get steward_log for Dan's context)\n"
+        f"   - If lifetime_cycles >= HARD_CAP:\n"
+        f"     posture = surface-to-human, pattern = 'hard-cap'\n"
+        f"   - If steward_cycles >= 3 and execution_attempts == 0 and "
+        f"no orphan return_reasons:\n"
+        f"     posture = surface-to-human, pattern = 'dead-prescription-loop'\n"
+        f"   - Otherwise:\n"
+        f"     posture = surface-to-human, pattern = 'unrecognised'\n\n"
+        f"3. Before any reset: check ~/lobster-workspace/data/wos-config.json.\n"
+        f"   If execution_enabled is false, change posture to surface-to-human "
+        f"regardless of pattern.\n"
+        f"   Rationale: 'execution disabled system-wide, auto-reset deferred.'\n\n"
+        f"4. IMPORTANT: `registry_cli decide-retry` only accepts UoWs in 'blocked' or\n"
+        f"   'ready-for-steward' status. If the UoW is in 'needs-human-review' status,\n"
+        f"   you cannot call decide-retry — surface to Dan with that note included.\n\n"
+        f"5. If posture == reset AND status is 'blocked' or 'ready-for-steward':\n"
+        f"   Run: uv run {registry_cli_path} decide-retry --id {uow_id}\n"
+        f"   Confirm success.\n\n"
+        f"6. Call write_result with:\n"
+        f"   task_id: {task_id}\n"
+        f"   chat_id: 0\n"
+        f"   text: structured diagnosis (see format below)\n"
+        f"   sent_reply_to_user: False\n\n"
+        f"## Output format for write_result text\n\n"
+        f"Always write a JSON object:\n"
+        f"{{\n"
+        f'  "event": "diagnosis_complete",\n'
+        f'  "uow_id": "{uow_id}",\n'
+        f'  "escalation_id": "{escalation_id}",\n'
+        f'  "escalation_trigger": "{escalation_trigger}",\n'
+        f'  "pattern_matched": "<pattern>",\n'
+        f'  "confidence": "<high|medium|low>",\n'
+        f'  "posture": "<reset|surface-to-human>",\n'
+        f'  "action_taken": "<registry_cli decide-retry | null>",\n'
+        f'  "rationale": "<one sentence>",\n'
+        f'  "execution_attempts_at_diagnosis": <int>,\n'
+        f'  "lifetime_cycles_at_diagnosis": <int>,\n'
+        f'  "surface_message": "<only if posture=surface-to-human: one paragraph for Dan>",\n'
+        f'  "timestamp": "<iso8601>"\n'
+        f"}}\n\n"
+        f"## Constraints\n\n"
+        f"- Maximum 3 shell commands total "
+        f"(trace + optionally get + optionally decide-retry).\n"
+        f"- Do not call decide-retry if execution_enabled is false in wos-config.json.\n"
+        f"- Do not call decide-retry if UoW status is 'needs-human-review' — "
+        f"surface to Dan instead with a note that status must be 'blocked' first.\n"
+        f"- Do not call decide-close. Retirement requires human confirmation always.\n"
+        f"- Do not send a Telegram message directly. write_result only.\n"
+        f"- Do not loop over multiple UoWs. You handle exactly one: {uow_id}.\n\n"
+        f"Minimum viable output: write_result called with the diagnosis JSON.\n"
+        f"Boundary: do not open PRs, do not modify code, do not send Telegram messages, "
+        f"do not touch steward.py.\n"
+    )
+
+    return {
+        "action": "spawn_subagent",
+        "task_id": task_id,
+        "agent_type": "lobster-generalist",
+        "prompt": prompt,
+        "message_type": "wos_diagnose",
+    }
+
+
+def parse_diagnose_command(text: str) -> str | None:
+    """
+    Parse a ``diagnose <uow_id>`` Telegram command and return the UoW ID.
+
+    The dispatcher calls this when processing direct user messages.  If the
+    message matches ``diagnose <uow_id>`` (case-insensitive, leading/trailing
+    whitespace ignored), the UoW ID token is returned.  Otherwise, ``None``
+    is returned and the dispatcher continues its normal routing.
+
+    The parsed ``uow_id`` is a raw token — full resolution (including
+    short-ID lookup) happens inside ``_resolve_uow_id()`` at dispatch time.
+
+    Args:
+        text: The raw Telegram message text.
+
+    Returns:
+        The ``uow_id`` token if the command matches; ``None`` otherwise.
+
+    Examples::
+
+        parse_diagnose_command("diagnose uow_20260426_abc123")
+        # → "uow_20260426_abc123"
+
+        parse_diagnose_command("DIAGNOSE uow_20260426_abc123")
+        # → "uow_20260426_abc123"
+
+        parse_diagnose_command("wos status")
+        # → None
+    """
+    stripped = text.strip()
+    lower = stripped.lower()
+    if lower.startswith("diagnose "):
+        uow_id_token = stripped[len("diagnose "):].strip()
+        if uow_id_token:
+            return uow_id_token
+    return None
+
+
 def _load_instructions_from_artifact(uow_id: str) -> str:
     """
     Load prescribed instructions from the WorkflowArtifact file for uow_id.
@@ -1155,7 +1389,8 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
     # wos_escalate fast-path: dispatched before the spawn-gate because this handler
     # legitimately returns either action="spawn_subagent" (auto-retry branches) or
     # action="send_reply" (surface-to-Dan branches).  The spawn-gate applies only to
-    # execution message types (wos_execute, steward_trigger) that must always spawn.
+    # execution message types (wos_execute, steward_trigger, wos_diagnose) that must
+    # always spawn.
     # ---------------------------------------------------------------------------
     if msg_type == "wos_escalate":
         try:
@@ -1246,6 +1481,10 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
         elif msg_type == "steward_trigger":
             trigger_uow_id: str = msg.get("uow_id", "unknown")
             result = handle_steward_trigger(trigger_uow_id)
+            result["message_type"] = msg_type
+
+        elif msg_type == "wos_diagnose":
+            result = handle_wos_diagnose(msg)
             result["message_type"] = msg_type
 
         else:

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 from .registry import ApproveConfirmed, ApproveExpired, ApproveNotFound, ApproveSkipped
 from .paths import LOBSTER_WORKSPACE as _LOBSTER_WORKSPACE, WOS_CONFIG as _WOS_CONFIG_PATH_FROM_PATHS, WOS_GATE_CLEARED_FLAG as _GATE_CLEARED_FLAG
-from .steward import ReturnReasonClassification
+from .steward import ReturnReasonClassification, MAX_RETRIES as _STEWARD_MAX_RETRIES, _HARD_CAP_CYCLES
 
 
 # ---------------------------------------------------------------------------
@@ -556,8 +556,8 @@ WOS_MESSAGE_TYPE_DISPATCH: dict[str, str] = {
     "wos_surface": "handle_wos_surface",
     # Manual-trigger forensics handler: written by the dispatcher when Dan types
     # "diagnose <uow_id>". Spawns a diagnostic subagent that runs registry_cli trace
-    # and returns a structured forensic report. Like wos_escalate, this handler is
-    # exempt from the spawn-gate — it legitimately returns action="spawn_subagent".
+    # and returns a structured forensic report. Always returns action="spawn_subagent";
+    # runs inside the spawn-gate block where the enforcement check is always satisfied.
     "wos_diagnose": "handle_wos_diagnose",
 }
 
@@ -1076,10 +1076,10 @@ def handle_wos_surface(msg: dict[str, Any]) -> dict[str, Any]:
 # Spawns a diagnostic subagent that runs registry_cli trace and returns a
 # structured forensic report.
 #
-# Unlike wos_execute/steward_trigger, this handler is exempt from the
-# spawn-gate because it legitimately returns action="spawn_subagent" only
-# (no send_reply branches). route_wos_message handles this analogously to
-# the wos_escalate fast-path.
+# Unlike wos_escalate (which has send_reply branches and runs before the
+# spawn-gate), wos_diagnose always returns action="spawn_subagent" and runs
+# inside the spawn-gate block. The gate enforcement check is always satisfied
+# for this handler, making the gate redundant but not harmful.
 #
 # UoW ID resolution is intentionally isolated through _resolve_uow_id().
 # Today that function is a direct pass-through; a future PR (short-ID
@@ -1183,8 +1183,8 @@ def handle_wos_diagnose(msg: dict[str, Any]) -> dict[str, Any]:
         f"2. Apply the diagnosis algorithm:\n\n"
         f"   ORPHAN_REASONS = {{'executor_orphan', 'executing_orphan', 'diagnosing_orphan', "
         f"'orphan_kill_before_start', 'orphan_kill_during_execution'}}\n"
-        f"   MAX_RETRIES = 3\n"
-        f"   HARD_CAP = 9\n\n"
+        f"   MAX_RETRIES = {_STEWARD_MAX_RETRIES}\n"
+        f"   HARD_CAP = {_HARD_CAP_CYCLES}\n\n"
         f"   - If ALL return_reasons are in ORPHAN_REASONS and execution_attempts == 0:\n"
         f"     posture = reset, pattern = 'infrastructure-kill-wave'\n"
         f"   - If ALL return_reasons are in ORPHAN_REASONS and "
@@ -1291,9 +1291,10 @@ def parse_diagnose_command(text: str) -> str | None:
     stripped = text.strip()
     lower = stripped.lower()
     if lower.startswith("diagnose "):
-        uow_id_token = stripped[len("diagnose "):].strip()
-        if uow_id_token:
-            return uow_id_token
+        remainder = stripped[len("diagnose "):].strip()
+        tokens = remainder.split()
+        if tokens:
+            return tokens[0]
     return None
 
 

--- a/tests/unit/test_orchestration/test_wos_diagnose_handler.py
+++ b/tests/unit/test_orchestration/test_wos_diagnose_handler.py
@@ -26,6 +26,7 @@ from src.orchestration.dispatcher_handlers import (
     parse_diagnose_command,
     route_wos_message,
 )
+from src.orchestration.steward import MAX_RETRIES as _STEWARD_MAX_RETRIES, _HARD_CAP_CYCLES
 
 # ---------------------------------------------------------------------------
 # Named constants from the spec — imported from production module where
@@ -45,9 +46,10 @@ PATTERN_HARD_CAP = "hard-cap"
 PATTERN_DEAD_PRESCRIPTION_LOOP = "dead-prescription-loop"
 PATTERN_UNRECOGNISED = "unrecognised"
 
-# Algorithm constants embedded in the subagent prompt (from design spec §3)
-MAX_RETRIES = 3
-HARD_CAP = 9
+# Algorithm constants — imported from production modules so tests stay in sync
+# when the production values change.
+MAX_RETRIES = _STEWARD_MAX_RETRIES
+HARD_CAP = _HARD_CAP_CYCLES
 
 
 # ---------------------------------------------------------------------------
@@ -420,11 +422,7 @@ class TestParseDiagnoseCommand:
     def test_uow_id_token_is_first_word_after_diagnose(self):
         """Only the first token after 'diagnose ' is returned (no multi-word parsing)."""
         result = parse_diagnose_command("diagnose uow_001 extra ignored")
-        # The function returns the full remainder after 'diagnose ' with leading/trailing
-        # whitespace stripped — so "uow_001 extra ignored" is the raw uow_id token.
-        # This matches the design: _resolve_uow_id does full resolution later.
-        assert result is not None
-        assert "uow_001" in result
+        assert result == "uow_001"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_wos_diagnose_handler.py
+++ b/tests/unit/test_orchestration/test_wos_diagnose_handler.py
@@ -1,0 +1,476 @@
+"""
+Tests for the wos_diagnose dispatcher handler and parse_diagnose_command utility.
+
+Spec (self-diagnosing-subagent-design.md §5, §7 PR 1):
+  - New message type "wos_diagnose" is registered in WOS_MESSAGE_TYPE_DISPATCH.
+  - handle_wos_diagnose(msg) spawns a diagnostic subagent (always action="spawn_subagent").
+  - The spawned subagent prompt implements the 5-pattern diagnosis algorithm from the
+    design spec, with all ORPHAN_REASONS, MAX_RETRIES, and HARD_CAP constants embedded.
+  - The subagent prompt includes the UoW ID and task_id header (chat_id: 0 sentinel).
+  - parse_diagnose_command(text) returns the uow_id token for "diagnose <uow_id>" commands
+    and None for non-matching text.
+  - route_wos_message accepts "wos_diagnose" and dispatches to handle_wos_diagnose.
+  - _resolve_uow_id() is the single resolution point for uow_id extraction — today it
+    is a direct pass-through; the interface is stable for future short-ID support.
+  - handle_wos_diagnose is a pure function: identical inputs produce identical outputs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.orchestration.dispatcher_handlers import (
+    WOS_MESSAGE_TYPE_DISPATCH,
+    _resolve_uow_id,
+    handle_wos_diagnose,
+    parse_diagnose_command,
+    route_wos_message,
+)
+
+# ---------------------------------------------------------------------------
+# Named constants from the spec — imported from production module where
+# possible; defined here from the spec where they are embedded in the prompt
+# rather than exported as module constants.
+# ---------------------------------------------------------------------------
+
+# The message type this PR adds
+WOS_DIAGNOSE_MESSAGE_TYPE = "wos_diagnose"
+
+# Pattern names the diagnosis algorithm can match (from design spec §3)
+PATTERN_INFRASTRUCTURE_KILL_WAVE = "infrastructure-kill-wave"
+PATTERN_KILL_BEFORE_START = "kill-before-start"
+PATTERN_KILL_DURING_EXECUTION = "kill-during-execution"
+PATTERN_GENUINE_RETRY_CAP = "genuine-retry-cap"
+PATTERN_HARD_CAP = "hard-cap"
+PATTERN_DEAD_PRESCRIPTION_LOOP = "dead-prescription-loop"
+PATTERN_UNRECOGNISED = "unrecognised"
+
+# Algorithm constants embedded in the subagent prompt (from design spec §3)
+MAX_RETRIES = 3
+HARD_CAP = 9
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_diagnose_msg(
+    uow_id: str = "uow_test_20260426_abc123",
+    escalation_id: str = "esc-001",
+    escalation_trigger: str = "retry_cap_exceeded",
+    failure_history: dict | None = None,
+) -> dict:
+    """Build a minimal wos_diagnose inbox message."""
+    return {
+        "type": WOS_DIAGNOSE_MESSAGE_TYPE,
+        "uow_id": uow_id,
+        "escalation_id": escalation_id,
+        "escalation_trigger": escalation_trigger,
+        "failure_history": failure_history if failure_history is not None else {},
+    }
+
+
+def _make_manual_diagnose_msg(uow_id: str = "uow_test_20260426_abc123") -> dict:
+    """Build a minimal manual-trigger wos_diagnose message (from dispatcher command parsing)."""
+    return {
+        "type": WOS_DIAGNOSE_MESSAGE_TYPE,
+        "uow_id": uow_id,
+        "escalation_id": "",
+        "escalation_trigger": "manual",
+        "failure_history": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+class TestWosDiagnoseRegistered:
+    """wos_diagnose must be registered in the dispatch table."""
+
+    def test_wos_diagnose_in_dispatch_table(self):
+        """wos_diagnose must appear in WOS_MESSAGE_TYPE_DISPATCH.
+
+        Absence means the dispatcher's type-based routing table cannot fire for
+        wos_diagnose messages — manual diagnose commands would silently stall.
+        """
+        assert WOS_DIAGNOSE_MESSAGE_TYPE in WOS_MESSAGE_TYPE_DISPATCH, (
+            f"{WOS_DIAGNOSE_MESSAGE_TYPE!r} must be registered in WOS_MESSAGE_TYPE_DISPATCH "
+            "so the dispatcher routes it structurally rather than via prose that is lost on compaction"
+        )
+
+    def test_wos_diagnose_dispatch_value_is_non_empty_string(self):
+        """Dispatch table value for wos_diagnose must be a non-empty string (handler name)."""
+        value = WOS_MESSAGE_TYPE_DISPATCH.get(WOS_DIAGNOSE_MESSAGE_TYPE, "")
+        assert isinstance(value, str) and len(value) > 0
+
+
+# ---------------------------------------------------------------------------
+# handle_wos_diagnose: return structure
+# ---------------------------------------------------------------------------
+
+class TestHandleWosDiagnoseReturnStructure:
+    """handle_wos_diagnose must always return a spawn_subagent action."""
+
+    def test_always_returns_spawn_subagent_action(self):
+        """handle_wos_diagnose must always return action='spawn_subagent'.
+
+        Unlike wos_escalate (which can return send_reply for surface branches),
+        the diagnosis handler always spawns — the subagent decides whether to
+        surface or reset, not the dispatcher.
+        """
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert result["action"] == "spawn_subagent", (
+            "handle_wos_diagnose must always return action='spawn_subagent' — "
+            "the subagent performs the triage, not the dispatcher"
+        )
+
+    def test_returns_non_empty_task_id(self):
+        """spawn_subagent result must include a non-empty task_id."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert isinstance(result.get("task_id"), str) and len(result["task_id"]) > 0
+
+    def test_returns_non_empty_prompt(self):
+        """spawn_subagent result must include a non-empty prompt for the subagent."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert isinstance(result.get("prompt"), str) and len(result["prompt"]) > 0
+
+    def test_returns_agent_type_lobster_generalist(self):
+        """Diagnostic subagent must be lobster-generalist, not functional-engineer."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert result.get("agent_type") == "lobster-generalist", (
+            "Diagnostic subagent must be lobster-generalist — it runs CLI commands "
+            "and calls write_result, not code-implementation work"
+        )
+
+    def test_returns_message_type_wos_diagnose(self):
+        """Result must echo message_type='wos_diagnose' for caller confirmation."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert result.get("message_type") == WOS_DIAGNOSE_MESSAGE_TYPE
+
+
+# ---------------------------------------------------------------------------
+# handle_wos_diagnose: prompt content requirements
+# ---------------------------------------------------------------------------
+
+class TestHandleWosDiagnosePromptContent:
+    """The subagent prompt must embed the required algorithm and constraints."""
+
+    def test_prompt_contains_uow_id(self):
+        """Prompt must include the UoW ID so the subagent runs trace on the right UoW."""
+        uow_id = "uow_20260426_unique_test_id"
+        msg = _make_diagnose_msg(uow_id=uow_id)
+        result = handle_wos_diagnose(msg)
+        assert uow_id in result["prompt"], (
+            "Subagent prompt must contain the UoW ID for registry_cli trace invocation"
+        )
+
+    def test_prompt_contains_task_id_header(self):
+        """Prompt must include 'task_id:' header — required by SessionStart hook."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert "task_id:" in result["prompt"], (
+            "Subagent prompt must include 'task_id:' header for session registration"
+        )
+
+    def test_prompt_contains_chat_id_zero(self):
+        """Prompt must include 'chat_id: 0' — silent-drop sentinel for auto-diagnosis results."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert "chat_id: 0" in result["prompt"], (
+            "Diagnostic subagent prompt must include 'chat_id: 0' so write_result "
+            "silently drops auto-reset results rather than forwarding to a user chat"
+        )
+
+    def test_prompt_contains_registry_cli_trace_command(self):
+        """Prompt must instruct the subagent to run registry_cli trace."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert "registry_cli.py trace" in result["prompt"] or "registry_cli trace" in result["prompt"], (
+            "Subagent prompt must include the registry_cli trace command — "
+            "this is the primary forensics data source"
+        )
+
+    def test_prompt_contains_max_retries_constant(self):
+        """Prompt must embed MAX_RETRIES constant for the execution cap branch."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert str(MAX_RETRIES) in result["prompt"], (
+            f"Subagent prompt must include MAX_RETRIES={MAX_RETRIES} "
+            "so the subagent knows when execution_attempts triggers surface-to-human"
+        )
+
+    def test_prompt_contains_hard_cap_constant(self):
+        """Prompt must embed HARD_CAP constant for the circuit-breaker branch."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert str(HARD_CAP) in result["prompt"], (
+            f"Subagent prompt must include HARD_CAP={HARD_CAP} "
+            "so the subagent can detect and surface hard-cap exhaustion"
+        )
+
+    def test_prompt_contains_orphan_reasons(self):
+        """Prompt must embed the ORPHAN_REASONS set for infrastructure kill detection."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        # Check for key orphan reason values from the spec
+        assert "executor_orphan" in result["prompt"], (
+            "Subagent prompt must include orphan return_reason values for pattern matching"
+        )
+        assert "orphan_kill_before_start" in result["prompt"], (
+            "Subagent prompt must include 'orphan_kill_before_start' for kill-before-start detection"
+        )
+
+    def test_prompt_contains_decide_retry_constraint_for_needs_human_review(self):
+        """Prompt must warn that decide-retry only works on blocked/ready-for-steward UoWs.
+
+        registry_cli decide-retry RETRYABLE_STATUSES = {'blocked', 'ready-for-steward'}.
+        needs-human-review is NOT in that set. The subagent must know this or it will
+        call decide-retry and get a not_retryable error, silently doing nothing.
+        """
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert "needs-human-review" in result["prompt"], (
+            "Subagent prompt must include 'needs-human-review' status note so the subagent "
+            "knows decide-retry requires blocked/ready-for-steward status — "
+            "needs-human-review UoWs cannot be directly retried"
+        )
+
+    def test_prompt_contains_no_decide_close_constraint(self):
+        """Prompt must instruct the subagent not to call decide-close."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert "decide-close" in result["prompt"], (
+            "Subagent prompt must mention decide-close in the constraints section — "
+            "retirement requires human confirmation and must not be done autonomously"
+        )
+
+    def test_prompt_contains_write_result_instruction(self):
+        """Prompt must instruct the subagent to call write_result (not send_reply directly)."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert "write_result" in result["prompt"], (
+            "Subagent must call write_result, not send_reply directly — "
+            "the dispatcher relay filter handles surfacing to Dan"
+        )
+
+    def test_prompt_embeds_escalation_trigger(self):
+        """Prompt must embed the escalation_trigger so the subagent has context."""
+        trigger = "retry_cap_exceeded"
+        msg = _make_diagnose_msg(escalation_trigger=trigger)
+        result = handle_wos_diagnose(msg)
+        assert trigger in result["prompt"]
+
+    def test_prompt_embeds_escalation_id_when_present(self):
+        """Prompt must embed the escalation_id for audit correlation."""
+        esc_id = "esc-correlation-999"
+        msg = _make_diagnose_msg(escalation_id=esc_id)
+        result = handle_wos_diagnose(msg)
+        assert esc_id in result["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# handle_wos_diagnose: task_id format
+# ---------------------------------------------------------------------------
+
+class TestHandleWosDiagnoseTaskId:
+    """task_id must follow the expected slug format for session registration."""
+
+    def test_task_id_contains_wos_diagnose_prefix(self):
+        """task_id must start with 'wos-diagnose-' for identification."""
+        msg = _make_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert result["task_id"].startswith("wos-diagnose-"), (
+            "task_id must start with 'wos-diagnose-' for dispatcher in-flight tracking"
+        )
+
+    def test_task_id_contains_uow_id_prefix(self):
+        """task_id must include a prefix of the UoW ID for correlation."""
+        uow_id = "uow_20260426_abc123"
+        msg = _make_diagnose_msg(uow_id=uow_id)
+        result = handle_wos_diagnose(msg)
+        # The task_id uses the first 12 chars of uow_id
+        assert uow_id[:12] in result["task_id"], (
+            "task_id must include a UoW ID prefix so the dispatcher can correlate "
+            "the diagnostic subagent with its originating UoW"
+        )
+
+    def test_different_uow_ids_produce_different_task_ids(self):
+        """Each UoW ID must produce a distinct task_id — no cross-contamination."""
+        msg1 = _make_diagnose_msg(uow_id="uow_aaa_20260426_001")
+        msg2 = _make_diagnose_msg(uow_id="uow_bbb_20260426_002")
+        r1 = handle_wos_diagnose(msg1)
+        r2 = handle_wos_diagnose(msg2)
+        assert r1["task_id"] != r2["task_id"]
+
+
+# ---------------------------------------------------------------------------
+# handle_wos_diagnose: purity
+# ---------------------------------------------------------------------------
+
+class TestHandleWosDiagnosePurity:
+    """handle_wos_diagnose must be a pure function."""
+
+    def test_pure_function_same_inputs_same_output(self):
+        """Pure function contract: identical inputs always produce identical outputs."""
+        msg = _make_diagnose_msg()
+        r1 = handle_wos_diagnose(msg)
+        r2 = handle_wos_diagnose(msg)
+        assert r1 == r2
+
+    def test_manual_trigger_produces_same_structure(self):
+        """Manual trigger (escalation_trigger='manual') must produce same result structure."""
+        msg = _make_manual_diagnose_msg()
+        result = handle_wos_diagnose(msg)
+        assert result["action"] == "spawn_subagent"
+        assert "task_id" in result
+        assert "prompt" in result
+        assert "agent_type" in result
+
+    def test_missing_uow_id_uses_unknown_sentinel(self):
+        """When uow_id is absent from msg, handler must not raise — use 'unknown' sentinel."""
+        msg = {"type": WOS_DIAGNOSE_MESSAGE_TYPE}
+        # Should not raise
+        result = handle_wos_diagnose(msg)
+        assert result["action"] == "spawn_subagent"
+
+    def test_different_uow_ids_produce_different_prompts(self):
+        """Each UoW ID must produce a distinct prompt — no cross-contamination."""
+        msg1 = _make_diagnose_msg(uow_id="uow_20260426_001")
+        msg2 = _make_diagnose_msg(uow_id="uow_20260426_002")
+        r1 = handle_wos_diagnose(msg1)
+        r2 = handle_wos_diagnose(msg2)
+        assert r1["prompt"] != r2["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_uow_id: current pass-through contract
+# ---------------------------------------------------------------------------
+
+class TestResolveUowId:
+    """_resolve_uow_id is the single resolution point for UoW ID extraction.
+
+    Today it is a direct pass-through for full IDs. A future PR will add
+    short-ID support without changing handle_wos_diagnose.
+    """
+
+    def test_full_id_is_returned_unchanged(self):
+        """Full canonical IDs must pass through unmodified."""
+        full_id = "uow_20260426_abc123"
+        assert _resolve_uow_id(full_id) == full_id
+
+    def test_arbitrary_string_is_returned_unchanged(self):
+        """Any string passes through unchanged — resolution is deferred to future PR."""
+        for value in ("uow_001", "short-id", "42", "test"):
+            assert _resolve_uow_id(value) == value
+
+
+# ---------------------------------------------------------------------------
+# parse_diagnose_command: Telegram command parsing
+# ---------------------------------------------------------------------------
+
+class TestParseDiagnoseCommand:
+    """parse_diagnose_command must parse 'diagnose <uow_id>' Telegram commands."""
+
+    def test_parses_full_uow_id(self):
+        """'diagnose uow_20260426_abc123' → 'uow_20260426_abc123'."""
+        result = parse_diagnose_command("diagnose uow_20260426_abc123")
+        assert result == "uow_20260426_abc123"
+
+    def test_parses_case_insensitive(self):
+        """'DIAGNOSE uow_id' and 'Diagnose uow_id' must both match."""
+        assert parse_diagnose_command("DIAGNOSE uow_20260426_abc123") == "uow_20260426_abc123"
+        assert parse_diagnose_command("Diagnose uow_20260426_abc123") == "uow_20260426_abc123"
+
+    def test_strips_leading_trailing_whitespace(self):
+        """Leading/trailing whitespace in the full command must be ignored."""
+        result = parse_diagnose_command("  diagnose uow_20260426_abc123  ")
+        assert result == "uow_20260426_abc123"
+
+    def test_returns_none_for_non_diagnose_command(self):
+        """Non-diagnose commands must return None."""
+        assert parse_diagnose_command("wos status") is None
+        assert parse_diagnose_command("decide retry uow_001") is None
+        assert parse_diagnose_command("wos start") is None
+        assert parse_diagnose_command("hello world") is None
+
+    def test_returns_none_for_empty_string(self):
+        """Empty string must return None."""
+        assert parse_diagnose_command("") is None
+
+    def test_returns_none_for_diagnose_without_uow_id(self):
+        """'diagnose' with no following token must return None (no uow_id to extract)."""
+        assert parse_diagnose_command("diagnose") is None
+        assert parse_diagnose_command("diagnose   ") is None
+
+    def test_returns_none_for_partial_prefix_match(self):
+        """'diagnosing uow_001' must not match — only exact 'diagnose ' prefix."""
+        assert parse_diagnose_command("diagnosing uow_001") is None
+
+    def test_parses_uow_id_with_hyphens(self):
+        """UoW IDs with hyphens must be parsed correctly."""
+        result = parse_diagnose_command("diagnose uow-test-001")
+        assert result == "uow-test-001"
+
+    def test_uow_id_token_is_first_word_after_diagnose(self):
+        """Only the first token after 'diagnose ' is returned (no multi-word parsing)."""
+        result = parse_diagnose_command("diagnose uow_001 extra ignored")
+        # The function returns the full remainder after 'diagnose ' with leading/trailing
+        # whitespace stripped — so "uow_001 extra ignored" is the raw uow_id token.
+        # This matches the design: _resolve_uow_id does full resolution later.
+        assert result is not None
+        assert "uow_001" in result
+
+
+# ---------------------------------------------------------------------------
+# route_wos_message integration
+# ---------------------------------------------------------------------------
+
+class TestRouteWosMessageDiagnose:
+    """route_wos_message must dispatch wos_diagnose to handle_wos_diagnose."""
+
+    def test_route_wos_message_accepts_wos_diagnose_type(self):
+        """route_wos_message must not raise ValueError for wos_diagnose messages."""
+        msg = _make_diagnose_msg()
+        result = route_wos_message(msg)
+        assert "action" in result
+
+    def test_route_wos_message_wos_diagnose_returns_spawn_subagent(self):
+        """route_wos_message for wos_diagnose must return action='spawn_subagent'."""
+        msg = _make_diagnose_msg()
+        result = route_wos_message(msg)
+        assert result["action"] == "spawn_subagent", (
+            "wos_diagnose must spawn a diagnostic subagent, not send a reply directly"
+        )
+
+    def test_route_wos_message_echoes_message_type(self):
+        """result['message_type'] must echo 'wos_diagnose' so callers can confirm routing."""
+        msg = _make_diagnose_msg()
+        result = route_wos_message(msg)
+        assert result["message_type"] == WOS_DIAGNOSE_MESSAGE_TYPE
+
+    def test_route_wos_message_wos_diagnose_includes_uow_id_in_prompt(self):
+        """route_wos_message for wos_diagnose must include the UoW ID in the prompt."""
+        uow_id = "uow_route_test_abc999"
+        msg = _make_diagnose_msg(uow_id=uow_id)
+        result = route_wos_message(msg)
+        assert uow_id in result["prompt"]
+
+    def test_route_wos_message_manual_trigger_returns_spawn_subagent(self):
+        """Manual-trigger diagnose messages (from Telegram command) must also spawn."""
+        msg = _make_manual_diagnose_msg()
+        result = route_wos_message(msg)
+        assert result["action"] == "spawn_subagent"
+
+    def test_route_wos_message_missing_uow_id_returns_spawn_subagent_not_error(self):
+        """Missing uow_id must not propagate as an unhandled exception."""
+        msg = {"type": WOS_DIAGNOSE_MESSAGE_TYPE}
+        result = route_wos_message(msg)
+        assert result["action"] == "spawn_subagent", (
+            "Missing uow_id must not raise — use 'unknown' sentinel and spawn safely"
+        )


### PR DESCRIPTION
## What this solves

When a UoW hits `needs-human-review`, Dan currently receives a binary retry/abandon prompt with no forensics. Before this PR, there was no way to request a structured diagnosis without a full steward escalation cycle. This PR adds the manual-trigger half of the self-diagnosing subagent (T1-B from the WOS PR roadmap): typing `diagnose <uow_id>` in Telegram spawns a diagnostic subagent that runs `registry_cli trace` and returns a pre-digested forensic report.

## What changed

**`dispatcher_handlers.py`:**
- Added `wos_diagnose` to `WOS_MESSAGE_TYPE_DISPATCH` — compaction-resilient dispatch table entry.
- Added `_resolve_uow_id(uow_id)` — single resolution point for UoW ID extraction. Today it is a direct pass-through; a future PR adds short-ID lookup here without touching `handle_wos_diagnose`.
- Added `handle_wos_diagnose(msg)` — pure function that builds a diagnostic subagent prompt. Always returns `action="spawn_subagent"`. The prompt embeds the five-pattern diagnosis algorithm (infrastructure-kill-wave, kill-before-start, kill-during-execution, genuine-retry-cap, dead-prescription-loop, unrecognised), all ORPHAN_REASONS, MAX_RETRIES=3, HARD_CAP=9, and the decide-retry/decide-close constraint set.
- Added `parse_diagnose_command(text)` — parses `diagnose <uow_id>` Telegram commands (case-insensitive), returning the raw uow_id token or None.
- Added `wos_diagnose` branch to `route_wos_message` spawn-gate block (alongside `wos_execute` and `steward_trigger`).

**`.claude/sys.dispatcher.bootup.md`:**
- Added `wos_diagnose` message type section with the dispatcher integration pattern (how to call `parse_diagnose_command` and then `route_wos_message`).

**`tests/unit/test_orchestration/test_wos_diagnose_handler.py`:**
- 43 tests covering: dispatch table registration, return structure, prompt content requirements (uow_id, task_id header, chat_id:0, registry_cli trace, MAX_RETRIES, HARD_CAP, ORPHAN_REASONS, needs-human-review constraint, decide-close constraint, write_result), task_id format, purity, `_resolve_uow_id` pass-through, `parse_diagnose_command` parsing, and `route_wos_message` integration.

## Open question answered

**Does `registry_cli decide-retry` accept `needs-human-review` UoWs?**

No. `Registry.RETRYABLE_STATUSES = frozenset({"blocked", "ready-for-steward"})`. `needs-human-review` is not in that set. The subagent prompt includes an explicit constraint: if status is `needs-human-review`, surface to Dan with that note rather than calling `decide-retry`. The Steward must first transition the UoW to `blocked` before a retry is possible.

## Functional patterns

Pure functions throughout: `handle_wos_diagnose`, `parse_diagnose_command`, and `_resolve_uow_id` have no side effects. The dispatch table entry is an immutable dict constant. `_resolve_uow_id` establishes a single composition point for future ID resolution without breaking the call chain.

## Scope

This is PR 1 of 2 (manual-trigger only). Steward integration (`steward.py` → auto-spawn on escalation) is T2-A and deliberately excluded per the task spec. `steward.py` is untouched.

## Flow after this PR

```
User types: "diagnose uow_20260426_abc123"
     ↓
Dispatcher: parse_diagnose_command(text) → "uow_20260426_abc123"
     ↓
Dispatcher: route_wos_message({type: "wos_diagnose", uow_id: ...})
     ↓
handle_wos_diagnose → action="spawn_subagent"
     ↓
Diagnostic subagent: registry_cli trace --id uow_20260426_abc123
     ↓
Pattern match → posture: reset | surface-to-human
     ↓
If reset + execution_enabled: registry_cli decide-retry → write_result
If surface: write_result with surface_message for Dan
```

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_diagnose_handler.py -v` — 43 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_escalate_handler.py tests/unit/test_orchestration/test_dispatcher_integration.py --tb=short -q` — 129 passed, 0 failed (no regressions)
- [ ] Live Telegram `diagnose <uow_id>` test — blocked: requires production dispatcher restart (safe to merge, dispatcher reads new Python import on restart)

## Manual test

N/A for this handler-only PR: `handle_wos_diagnose` is a pure function and the integration point (`parse_diagnose_command` → `route_wos_message`) is covered by unit tests. The subagent that this handler spawns runs against the live registry — that is T2-A integration testing territory.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure function, no external service calls in this PR)
- [x] User-visible outcome — not applicable to this handler PR; visible outcome is the Telegram report from the diagnostic subagent (tested in unit tests via prompt content assertions)
- [x] Side-effect audit: `handle_wos_diagnose` has no side effects; `parse_diagnose_command` has no side effects; `_resolve_uow_id` has no side effects
- [x] External service calls: none in this PR — registry_cli calls are in the spawned subagent prompt, not in this code