### PR TITLE
feat: add handle_wos_surface dispatcher handler (T1-A)

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -548,6 +548,12 @@ WOS_MESSAGE_TYPE_DISPATCH: dict[str, str] = {
     # action="spawn_subagent" (auto-retry branches) or action="send_reply" (surface-to-Dan
     # branches) — it is exempt from the spawn-gate that applies to execution message types.
     "wos_escalate": "handle_wos_escalate",
+    # Batch escalation handler (T1-A): written by the Steward when >= 3 UoWs escalate
+    # in one steward cycle (consolidated kill wave) or when _write_wos_escalate_message
+    # raises an OSError (write-failure fallback).  Like wos_escalate, this handler is
+    # exempt from the spawn-gate — it legitimately returns action="spawn_subagent" for
+    # all-orphan auto-retry and action="send_reply" for surface-to-Dan branches.
+    "wos_surface": "handle_wos_surface",
 }
 
 
@@ -628,6 +634,34 @@ _ESCALATE_HUMAN_JUDGMENT_REGISTERS: frozenset[str] = frozenset({
 # (session killed before or during execution — no execution outcome produced).
 _ESCALATE_ORPHAN_CLASSIFICATIONS: frozenset[str] = frozenset({
     ReturnReasonClassification.ORPHAN,
+})
+
+
+# ---------------------------------------------------------------------------
+# wos_surface handler — batch escalation dispatcher (T1-A)
+#
+# Called when the Steward writes a wos_surface message.  This happens in two cases:
+#   1. Consolidated kill wave (>= ESCALATION_CONSOLIDATION_THRESHOLD UoWs escalate in
+#      one steward cycle) — condition="retry_cap_consolidated", carries uow_ids list.
+#   2. Write-failure fallback (_send_escalation_notification) — condition="retry_cap",
+#      carries singular uow_id.
+#
+# Like wos_escalate, this handler is exempt from the spawn-gate — it legitimately
+# returns either action="spawn_subagent" (all-orphan auto-retry) or action="send_reply"
+# (surface-to-Dan branches).  route_wos_message dispatches wos_surface outside the
+# spawn-gate, parallel to the wos_escalate fast-path.
+# ---------------------------------------------------------------------------
+
+# return_reason strings (raw, not classifications) that identify infrastructure kill events
+# eligible for auto-retry.  These are the same strings stored in metadata.causes by
+# _send_consolidated_escalation_notification — they come from EscalationRecord.return_reason,
+# which is the raw return_reason string, not the classification.
+_SURFACE_ORPHAN_RETURN_REASONS: frozenset[str] = frozenset({
+    "executor_orphan",
+    "executing_orphan",
+    "diagnosing_orphan",
+    "orphan_kill_before_start",
+    "orphan_kill_during_execution",
 })
 
 
@@ -842,6 +876,187 @@ def handle_wos_escalate(msg: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def handle_wos_surface(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle a ``wos_surface`` inbox message via the batch dispatcher decision tree (T1-A).
+
+    Called by route_wos_message when the dispatcher receives a message with
+    type="wos_surface".  The Steward writes this message in two situations:
+
+    1. **Consolidated kill wave** (condition="retry_cap_consolidated"): written by
+       ``_send_consolidated_escalation_notification`` when >= 3 UoWs escalate in one
+       steward cycle.  Carries ``metadata.uow_ids`` (list) and ``metadata.causes`` (list
+       of raw return_reason strings).
+
+    2. **Write-failure fallback** (condition="retry_cap"): written by
+       ``_send_escalation_notification`` when ``_write_wos_escalate_message`` raises an
+       OSError.  Carries ``metadata.uow_id`` (singular) and no causes list.
+
+    Decision tree (checked in order; first matching branch wins):
+
+    **Branch: Pipeline paused** (execution_enabled=False):
+        All UoWs surface to Dan regardless of return_reason.  Auto-retrying into a
+        stopped pipeline is never safe.
+        → Returns ``action="send_reply"`` with pipeline-paused note and UoW list.
+
+    **Branch: All causes are orphan return_reasons** (infrastructure kill wave):
+        Every cause in ``metadata.causes`` is in ``_SURFACE_ORPHAN_RETURN_REASONS``.
+        The batch is a single infrastructure event — all UoWs can be safely auto-retried.
+        Spawns one steward heartbeat subagent (steward re-queues all UoWs on its next cycle).
+        Sends Dan a brief summary notification (one message, no action required).
+        → Returns ``action="spawn_subagent"`` targeting the steward heartbeat.
+
+    **Branch: Mixed causes** (some orphan, some non-orphan):
+        Auto-retry eligible UoWs are identified by cross-referencing their position in
+        ``uow_ids`` against ``causes``.  Non-orphan UoWs surface to Dan individually.
+        → Returns ``action="send_reply"`` with the non-orphan UoW IDs and a note that
+        orphan UoWs were auto-retried.
+
+    **Default: All causes are non-orphan or causes list is absent**:
+        Surface all UoWs to Dan with structured context.  No auto-retry.
+        → Returns ``action="send_reply"`` with all UoW IDs.
+
+    This handler is exempt from the spawn-gate (see route_wos_message) because it
+    legitimately returns either action for different branches.
+
+    Args:
+        msg: The raw wos_surface inbox message dict.  Expected fields (in metadata):
+            - ``type`` (str): "wos_surface"
+            - ``condition`` (str): "retry_cap_consolidated" | "retry_cap" | StuckCondition
+            - ``uow_ids`` (list[str], optional): Affected UoW IDs (retry_cap_consolidated)
+            - ``uow_id`` (str, optional): Single affected UoW (retry_cap fallback)
+            - ``causes`` (list[str], optional): Raw return_reason strings per UoW
+            - ``escalation_count`` (int, optional): Number of UoWs in the batch
+
+    Returns:
+        A dict with ``action`` and branch-specific fields — same schema as
+        ``handle_wos_escalate``.
+
+        For ``action="spawn_subagent"`` (all-orphan auto-retry):
+            - ``task_id`` (str): Batch retry task identifier.
+            - ``agent_type`` (str): "lobster-generalist".
+            - ``prompt`` (str): Subagent prompt to run the steward heartbeat.
+            - ``message_type`` (str): "wos_surface".
+
+        For ``action="send_reply"`` (surface-to-Dan branches):
+            - ``text`` (str): Telegram notification text with structured context.
+            - ``chat_id`` (str | int): Admin chat ID.
+            - ``message_type`` (str): "wos_surface".
+    """
+    metadata: dict[str, Any] = msg.get("metadata", {})
+    condition: str = metadata.get("condition", "")
+
+    # Extract UoW IDs — support both retry_cap_consolidated (list) and retry_cap (singular)
+    uow_ids: list[str] = metadata.get("uow_ids") or []
+    if not uow_ids:
+        singular = metadata.get("uow_id")
+        if singular:
+            uow_ids = [singular]
+
+    causes: list[str] = metadata.get("causes") or []
+    _msg_type = "wos_surface"
+    chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "0")
+
+    # Branch: Pipeline paused — surface all regardless of return_reasons.
+    # Spawning a steward heartbeat into a stopped pipeline re-queues work
+    # that will never execute, building up stale ready-for-executor entries.
+    if not is_execution_enabled():
+        uow_list = "\n".join(f"  - `{uid}`" for uid in uow_ids) if uow_ids else "  (none listed)"
+        text = (
+            f"WOS kill wave ({condition}): {len(uow_ids)} UoW(s) surfaced — "
+            f"pipeline is paused (execution_enabled=false).\n\n"
+            f"Auto-retry was not attempted because executor dispatch is disabled.\n\n"
+            f"Affected UoWs:\n{uow_list}\n\n"
+            f"Use `/wos start` to resume the pipeline, then `/decide <uow_id> retry` "
+            f"for each UoW, or run `registry_cli decide-retry --id <uow_id>` for each."
+        )
+        return {
+            "action": "send_reply",
+            "text": text,
+            "chat_id": chat_id,
+            "message_type": _msg_type,
+        }
+
+    # Partition UoWs into orphan-eligible (auto-retry) and non-orphan (surface to Dan).
+    # causes[i] is the return_reason for uow_ids[i] when both lists are present and
+    # aligned.  If causes is shorter than uow_ids, treat the excess UoWs as non-orphan
+    # (conservative: surface rather than blindly retry without evidence).
+    orphan_uow_ids: list[str] = []
+    non_orphan_uow_ids: list[str] = []
+
+    if causes and uow_ids:
+        for i, uid in enumerate(uow_ids):
+            reason = causes[i] if i < len(causes) else "unknown"
+            if reason in _SURFACE_ORPHAN_RETURN_REASONS:
+                orphan_uow_ids.append(uid)
+            else:
+                non_orphan_uow_ids.append(uid)
+    else:
+        # No causes list — fallback path (condition="retry_cap") or malformed message.
+        # Surface all to Dan conservatively.
+        non_orphan_uow_ids = list(uow_ids)
+
+    # Branch: All causes are orphan return_reasons — auto-retry all via steward heartbeat.
+    # The batch is a single infrastructure kill event; no execution budget was consumed.
+    if orphan_uow_ids and not non_orphan_uow_ids:
+        steward_script = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..', '..', 'scheduled-tasks', 'steward-heartbeat.py')
+        )
+        uow_id_list_str = ", ".join(orphan_uow_ids)
+        task_id = f"surface-batch-retry-{len(orphan_uow_ids)}uow"
+        prompt = (
+            f"---\n"
+            f"task_id: {task_id}\n"
+            f"chat_id: 0\n"
+            f"source: system\n"
+            f"---\n\n"
+            f"WOS kill-wave batch auto-retry ({condition}): "
+            f"{len(orphan_uow_ids)} UoW(s) were killed before or during execution "
+            f"(all causes are orphan return_reasons — no execution budget consumed).\n\n"
+            f"Affected UoW IDs: {uow_id_list_str}\n\n"
+            f"Run the steward heartbeat to re-queue all affected UoWs:\n\n"
+            f"```bash\n"
+            f"cd ~/lobster-workspace && uv run python {steward_script}\n"
+            f"```\n\n"
+            f"Then call write_result with the steward output.\n\n"
+            f"Minimum viable output: steward heartbeat completed for batch kill wave.\n"
+            f"Boundary: do not modify any UoW status directly."
+        )
+        return {
+            "action": "spawn_subagent",
+            "task_id": task_id,
+            "agent_type": "lobster-generalist",
+            "prompt": prompt,
+            "message_type": _msg_type,
+        }
+
+    # Branch: Mixed causes — auto-retry orphans (silent), surface non-orphans to Dan.
+    # Branch: All non-orphan causes — surface all to Dan (non_orphan_uow_ids == uow_ids).
+    uow_list = "\n".join(f"  - `{uid}`" for uid in non_orphan_uow_ids)
+    orphan_note = ""
+    if orphan_uow_ids:
+        orphan_ids_str = ", ".join(f"`{uid}`" for uid in orphan_uow_ids)
+        orphan_note = (
+            f"\nNote: {len(orphan_uow_ids)} orphan UoW(s) were auto-retried "
+            f"(infrastructure kills — no execution budget consumed): {orphan_ids_str}\n"
+        )
+
+    text = (
+        f"WOS kill wave ({condition}): {len(non_orphan_uow_ids)} UoW(s) require review.\n"
+        f"{orphan_note}\n"
+        f"UoWs needing your decision:\n{uow_list}\n\n"
+        f"For each UoW:\n"
+        f"  `/decide <uow_id> retry` — reset and re-queue\n"
+        f"  `/decide <uow_id> abandon` — close as failed"
+    )
+    return {
+        "action": "send_reply",
+        "text": text,
+        "chat_id": chat_id,
+        "message_type": _msg_type,
+    }
+
+
 def _load_instructions_from_artifact(uow_id: str) -> str:
     """
     Load prescribed instructions from the WorkflowArtifact file for uow_id.
@@ -954,6 +1169,34 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
                     f"WOS escalation handler raised an error "
                     f"({type(exc).__name__}: {exc}). "
                     f"UoW escalation was NOT processed. "
+                    "Check logs and re-queue manually if needed."
+                ),
+                "message_type": msg_type,
+            }
+
+    # ---------------------------------------------------------------------------
+    # wos_surface fast-path: dispatched before the spawn-gate for the same reason as
+    # wos_escalate — this handler legitimately returns either action="spawn_subagent"
+    # (all-orphan auto-retry) or action="send_reply" (surface-to-Dan branches).
+    # ---------------------------------------------------------------------------
+    if msg_type == "wos_surface":
+        try:
+            surface_result = handle_wos_surface(msg)
+            surface_result["message_type"] = msg_type
+            return surface_result
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).error(
+                "route_wos_message: handle_wos_surface raised %s: %s — "
+                "returning send_reply alert",
+                type(exc).__name__, exc,
+            )
+            return {
+                "action": "send_reply",
+                "text": (
+                    f"WOS surface handler raised an error "
+                    f"({type(exc).__name__}: {exc}). "
+                    f"Kill wave was NOT processed. "
                     "Check logs and re-queue manually if needed."
                 ),
                 "message_type": msg_type,

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -1030,15 +1030,21 @@ def handle_wos_surface(msg: dict[str, Any]) -> dict[str, Any]:
             "message_type": _msg_type,
         }
 
-    # Branch: Mixed causes — auto-retry orphans (silent), surface non-orphans to Dan.
+    # Branch: Mixed causes — surface non-orphans to Dan; list orphans for Dan to retry.
     # Branch: All non-orphan causes — surface all to Dan (non_orphan_uow_ids == uow_ids).
+    #
+    # Note: this handler cannot spawn a subagent AND send a reply in the same result —
+    # the dispatch architecture returns one action per message.  Orphan UoWs in the mixed
+    # case are identified and listed for Dan to retry, but no steward heartbeat is spawned
+    # here.  Dan can use `/decide <uow_id> retry` for each orphan UoW listed.
     uow_list = "\n".join(f"  - `{uid}`" for uid in non_orphan_uow_ids)
     orphan_note = ""
     if orphan_uow_ids:
-        orphan_ids_str = ", ".join(f"`{uid}`" for uid in orphan_uow_ids)
+        orphan_ids_str = "\n".join(f"  - `{uid}` → `/decide {uid} retry`" for uid in orphan_uow_ids)
         orphan_note = (
-            f"\nNote: {len(orphan_uow_ids)} orphan UoW(s) were auto-retried "
-            f"(infrastructure kills — no execution budget consumed): {orphan_ids_str}\n"
+            f"\nOrphan UoW(s) eligible for auto-retry (infrastructure kills, "
+            f"no execution budget consumed) — use `/decide retry` for each:\n"
+            f"{orphan_ids_str}\n"
         )
 
     text = (

--- a/tests/unit/test_orchestration/test_wos_surface_handler.py
+++ b/tests/unit/test_orchestration/test_wos_surface_handler.py
@@ -1,0 +1,524 @@
+"""
+Tests for the wos_surface dispatcher handler (T1-A).
+
+Spec (tiered-pr-roadmap-20260426.md §T1-A):
+  - New message type "wos_surface" is registered in WOS_MESSAGE_TYPE_DISPATCH.
+  - handle_wos_surface(msg) implements a batch decision tree:
+    1. execution_enabled=False → surface all UoWs to Dan with pipeline-paused note
+    2. All causes are orphan return_reasons → auto-retry all; send Dan a summary
+    3. Mixed causes (some orphan, some non-orphan) → auto-retry orphans; surface non-orphans
+    4. All causes are non-orphan (human-judgment or genuine failures) → surface all to Dan
+  - route_wos_message accepts "wos_surface" and dispatches to handle_wos_surface.
+  - handle_wos_surface is a pure function (except for is_execution_enabled, which is
+    tested with monkeypatching).
+
+wos_surface message shapes:
+  - condition="retry_cap_consolidated" (from _send_consolidated_escalation_notification):
+      metadata.uow_ids: list of UoW IDs
+      metadata.causes: list of return_reason strings
+  - condition="retry_cap" (from _send_escalation_notification fallback):
+      metadata.uow_id: single UoW ID (singular)
+      metadata.causes: absent or empty
+  - condition=<StuckCondition> (from _default_notify_dan):
+      metadata.uow_id: single UoW ID
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from src.orchestration.dispatcher_handlers import (
+    handle_wos_surface,
+    route_wos_message,
+    WOS_MESSAGE_TYPE_DISPATCH,
+    _ESCALATE_HUMAN_JUDGMENT_REGISTERS,
+    _SURFACE_ORPHAN_RETURN_REASONS,
+)
+
+# ---------------------------------------------------------------------------
+# Named constants from the spec — imported from production module
+# ---------------------------------------------------------------------------
+
+WOS_SURFACE_MESSAGE_TYPE = "wos_surface"
+
+# Human-judgment registers that bypass auto-retry
+HUMAN_JUDGMENT_REGISTERS = tuple(_ESCALATE_HUMAN_JUDGMENT_REGISTERS)
+
+# Return reasons that are auto-retry eligible (orphan kill events)
+ORPHAN_RETURN_REASONS = tuple(_SURFACE_ORPHAN_RETURN_REASONS)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_surface_msg(
+    condition: str = "retry_cap_consolidated",
+    uow_ids: list[str] | None = None,
+    causes: list[str] | None = None,
+    uow_id: str | None = None,
+) -> dict:
+    """Build a minimal wos_surface inbox message."""
+    if uow_ids is None:
+        uow_ids = ["uow-test-001", "uow-test-002", "uow-test-003"]
+    if causes is None:
+        causes = ["executor_orphan", "executor_orphan", "executor_orphan"]
+    msg: dict = {
+        "type": WOS_SURFACE_MESSAGE_TYPE,
+        "metadata": {
+            "type": WOS_SURFACE_MESSAGE_TYPE,
+            "condition": condition,
+            "uow_ids": uow_ids,
+            "causes": causes,
+        },
+    }
+    if uow_id is not None:
+        msg["metadata"]["uow_id"] = uow_id
+    return msg
+
+
+def _make_surface_msg_retry_cap(uow_id: str = "uow-fallback-001") -> dict:
+    """Build a wos_surface message from the _send_escalation_notification fallback path.
+
+    This has condition='retry_cap' and a singular uow_id, not uow_ids list.
+    """
+    return {
+        "type": WOS_SURFACE_MESSAGE_TYPE,
+        "metadata": {
+            "type": WOS_SURFACE_MESSAGE_TYPE,
+            "condition": "retry_cap",
+            "uow_id": uow_id,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestWosSurfaceRegistered:
+    """wos_surface must be registered in the dispatch table."""
+
+    def test_wos_surface_in_dispatch_table(self):
+        """wos_surface must appear in WOS_MESSAGE_TYPE_DISPATCH.
+
+        Absence means the dispatcher cannot route wos_surface messages — kill waves
+        produce dangling unprocessed messages and require manual /decide for each UoW.
+        """
+        assert WOS_SURFACE_MESSAGE_TYPE in WOS_MESSAGE_TYPE_DISPATCH, (
+            f"{WOS_SURFACE_MESSAGE_TYPE!r} must be registered in WOS_MESSAGE_TYPE_DISPATCH "
+            "so the dispatcher routes it structurally rather than via prose that is lost on compaction"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Branch: execution_enabled=False → surface all UoWs with pipeline-paused note
+# ---------------------------------------------------------------------------
+
+
+class TestPipelinePausedSurfacesAll:
+    """When execution_enabled=False, all UoWs surface to Dan with a paused note."""
+
+    def test_pipeline_paused_returns_send_reply(self):
+        """Pipeline paused → action='send_reply' (surface to Dan)."""
+        msg = _make_surface_msg(causes=["executor_orphan", "executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=False
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "send_reply", (
+            "When execution_enabled=False, all UoWs must surface to Dan — "
+            "auto-retry would queue work into a stopped pipeline"
+        )
+
+    def test_pipeline_paused_text_mentions_paused(self):
+        """Dan notification must explain the pipeline is paused."""
+        msg = _make_surface_msg()
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=False
+        ):
+            result = handle_wos_surface(msg)
+        text = result.get("text", "").lower()
+        assert "pause" in text or "disabled" in text or "stopped" in text, (
+            "Dan notification must tell him the pipeline is paused so he knows "
+            "why auto-retry was not attempted"
+        )
+
+    def test_pipeline_paused_text_includes_uow_ids(self):
+        """Dan notification must list affected UoW IDs."""
+        uow_ids = ["uow-paused-001", "uow-paused-002"]
+        msg = _make_surface_msg(uow_ids=uow_ids, causes=["executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=False
+        ):
+            result = handle_wos_surface(msg)
+        text = result.get("text", "")
+        for uow_id in uow_ids:
+            assert uow_id in text, (
+                f"UoW ID {uow_id!r} must appear in the Dan notification so he can act on each"
+            )
+
+    def test_pipeline_paused_overrides_all_orphan_auto_retry(self):
+        """Pipeline paused check takes priority — even all-orphan causes must surface."""
+        msg = _make_surface_msg(
+            causes=["executor_orphan", "executing_orphan", "executor_orphan"]
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=False
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "send_reply", (
+            "Pipeline pause overrides auto-retry eligibility — "
+            "must not spawn a subagent into a stopped pipeline"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Branch: all causes are orphan return_reasons → auto-retry all
+# ---------------------------------------------------------------------------
+
+
+class TestAllOrphansAutoRetryAll:
+    """When all causes are orphan return_reasons and pipeline is running, auto-retry all."""
+
+    def test_all_orphans_returns_spawn_subagent(self):
+        """All orphan causes → action='spawn_subagent' (auto-retry)."""
+        msg = _make_surface_msg(
+            causes=["executor_orphan", "executing_orphan", "executor_orphan"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "spawn_subagent", (
+            "Kill wave with all-orphan causes is a single infrastructure event — "
+            "auto-retrying all is safe and correct"
+        )
+
+    def test_all_orphans_batch_includes_all_uow_ids_in_prompt(self):
+        """The batch retry prompt must reference all affected UoW IDs."""
+        uow_ids = ["uow-batch-001", "uow-batch-002", "uow-batch-003"]
+        msg = _make_surface_msg(
+            uow_ids=uow_ids,
+            causes=["executor_orphan", "executing_orphan", "diagnosing_orphan"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        prompt = result.get("prompt", "")
+        for uow_id in uow_ids:
+            assert uow_id in prompt, (
+                f"Batch retry prompt must include UoW ID {uow_id!r} "
+                "so the steward heartbeat processes all affected UoWs"
+            )
+
+    def test_all_orphans_prompt_contains_chat_id_zero(self):
+        """Batch retry subagent must use chat_id: 0 to silence the result relay."""
+        msg = _make_surface_msg(causes=["executor_orphan", "executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert "chat_id: 0" in result.get("prompt", ""), (
+            "Steward subagent prompt must include 'chat_id: 0' so write_result "
+            "silently drops the result rather than forwarding to a user chat"
+        )
+
+    def test_all_orphans_includes_task_id(self):
+        """spawn_subagent result must include a non-empty task_id."""
+        msg = _make_surface_msg(causes=["executor_orphan", "executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert isinstance(result.get("task_id"), str)
+        assert len(result["task_id"]) > 0
+
+    def test_all_orphans_single_uow_still_auto_retries(self):
+        """Even a single-UoW wos_surface with orphan cause auto-retries."""
+        msg = _make_surface_msg(
+            uow_ids=["uow-single-001"],
+            causes=["executor_orphan"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "spawn_subagent"
+
+    @pytest.mark.parametrize("reason", ORPHAN_RETURN_REASONS)
+    def test_each_orphan_reason_is_auto_retry_eligible(self, reason):
+        """Each individual orphan return_reason triggers auto-retry for a single-UoW batch."""
+        msg = _make_surface_msg(uow_ids=["uow-orphan-001"], causes=[reason])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "spawn_subagent", (
+            f"return_reason={reason!r} is an orphan reason — must auto-retry"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Branch: mixed causes → auto-retry orphans, surface non-orphans
+# ---------------------------------------------------------------------------
+
+
+class TestMixedCausesPartialRetry:
+    """Mixed causes: orphan UoWs auto-retry; non-orphan UoWs surface to Dan."""
+
+    def test_mixed_causes_returns_send_reply_for_non_orphans(self):
+        """Mixed causes: non-orphan UoWs must be surfaced to Dan."""
+        msg = _make_surface_msg(
+            uow_ids=["uow-mix-001", "uow-mix-002"],
+            causes=["executor_orphan", "execution_failed"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "send_reply", (
+            "Mixed causes must surface the non-orphan UoWs to Dan — "
+            "auto-retry alone is not sufficient"
+        )
+
+    def test_mixed_causes_text_includes_non_orphan_uow_id(self):
+        """Dan notification must include the non-orphan UoW ID that needs review."""
+        msg = _make_surface_msg(
+            uow_ids=["uow-needs-review-001", "uow-auto-retry-001"],
+            causes=["execution_failed", "executor_orphan"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        text = result.get("text", "")
+        assert "uow-needs-review-001" in text, (
+            "Dan notification must include the non-orphan UoW ID "
+            "so he knows which UoW requires his decision"
+        )
+
+    def test_mixed_causes_text_mentions_auto_retried_orphans(self):
+        """Dan notification must acknowledge that orphan UoWs were auto-retried."""
+        msg = _make_surface_msg(
+            uow_ids=["uow-review-001", "uow-retried-001"],
+            causes=["execution_failed", "executor_orphan"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        text = result.get("text", "").lower()
+        assert "retry" in text or "auto" in text or "uow-retried-001" in text.lower(), (
+            "Dan notification must mention that orphan UoWs were auto-retried "
+            "so he understands the full picture of the kill wave"
+        )
+
+    def test_all_non_orphan_causes_surfaces_all(self):
+        """All non-orphan causes: all UoWs surface to Dan — no auto-retry at all."""
+        msg = _make_surface_msg(
+            uow_ids=["uow-fail-001", "uow-fail-002"],
+            causes=["execution_failed", "execution_failed"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "send_reply", (
+            "All non-orphan causes must surface to Dan — auto-retry is not safe "
+            "when the prescription itself may be broken"
+        )
+
+    def test_all_non_orphan_text_includes_all_uow_ids(self):
+        """Dan notification for all-non-orphan must include all UoW IDs."""
+        uow_ids = ["uow-fail-001", "uow-fail-002", "uow-fail-003"]
+        msg = _make_surface_msg(
+            uow_ids=uow_ids,
+            causes=["execution_failed", "crashed_no_output", "execution_failed"],
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        text = result.get("text", "")
+        for uow_id in uow_ids:
+            assert uow_id in text, (
+                f"Dan notification must include UoW ID {uow_id!r} "
+                "so he can act on each one"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fallback path: condition="retry_cap" with singular uow_id
+# ---------------------------------------------------------------------------
+
+
+class TestRetryCapFallbackPath:
+    """condition='retry_cap' messages come from the _send_escalation_notification fallback.
+
+    They carry a singular uow_id (not uow_ids list) and no causes list.
+    The handler must not raise on these messages.
+    """
+
+    def test_retry_cap_with_singular_uow_id_does_not_raise(self):
+        """condition='retry_cap' with singular uow_id must be handled without raising."""
+        msg = _make_surface_msg_retry_cap(uow_id="uow-fallback-001")
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert "action" in result, (
+            "retry_cap messages must produce a valid action, not raise an exception"
+        )
+
+    def test_retry_cap_fallback_surfaces_to_dan(self):
+        """condition='retry_cap' has no causes list — surface to Dan as fallback."""
+        msg = _make_surface_msg_retry_cap(uow_id="uow-fallback-002")
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "send_reply", (
+            "Fallback retry_cap messages have no cause classification — "
+            "surface to Dan rather than auto-retrying blindly"
+        )
+
+    def test_retry_cap_fallback_text_includes_uow_id(self):
+        """Dan notification must include the UoW ID from the fallback path."""
+        uow_id = "uow-fallback-003"
+        msg = _make_surface_msg_retry_cap(uow_id=uow_id)
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert uow_id in result.get("text", ""), (
+            f"Dan notification must include {uow_id!r} from the fallback path"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Purity and structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWosSurfacePurity:
+    """handle_wos_surface must return consistent structured results."""
+
+    def test_pure_function_same_inputs_same_output(self):
+        """Identical inputs (same execution_enabled state) produce identical outputs."""
+        msg = _make_surface_msg(causes=["executor_orphan", "executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            r1 = handle_wos_surface(msg)
+            r2 = handle_wos_surface(msg)
+        assert r1 == r2
+
+    def test_result_always_contains_action(self):
+        """All branches must include an 'action' key in the result."""
+        for pipeline_enabled in (True, False):
+            msg = _make_surface_msg()
+            with patch(
+                "src.orchestration.dispatcher_handlers.is_execution_enabled",
+                return_value=pipeline_enabled,
+            ):
+                result = handle_wos_surface(msg)
+            assert "action" in result, (
+                f"handle_wos_surface must always return a dict with 'action' key "
+                f"(pipeline_enabled={pipeline_enabled})"
+            )
+
+    def test_send_reply_result_includes_chat_id(self):
+        """send_reply branches must include chat_id so the dispatcher knows where to send."""
+        msg = _make_surface_msg(
+            causes=["execution_failed", "execution_failed", "execution_failed"]
+        )
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert result["action"] == "send_reply"
+        assert "chat_id" in result, (
+            "send_reply result must include chat_id — without it the dispatcher "
+            "cannot route the notification to Dan"
+        )
+
+    def test_result_contains_message_type(self):
+        """All branches must include message_type='wos_surface' in the result."""
+        for pipeline_enabled in (True, False):
+            msg = _make_surface_msg()
+            with patch(
+                "src.orchestration.dispatcher_handlers.is_execution_enabled",
+                return_value=pipeline_enabled,
+            ):
+                result = handle_wos_surface(msg)
+            assert result.get("message_type") == WOS_SURFACE_MESSAGE_TYPE, (
+                f"All branches must echo message_type={WOS_SURFACE_MESSAGE_TYPE!r} "
+                "so callers can confirm which handler fired"
+            )
+
+    def test_empty_uow_ids_does_not_raise(self):
+        """handle_wos_surface with empty uow_ids must not raise."""
+        msg = _make_surface_msg(uow_ids=[], causes=[])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = handle_wos_surface(msg)
+        assert "action" in result
+
+
+# ---------------------------------------------------------------------------
+# route_wos_message integration
+# ---------------------------------------------------------------------------
+
+
+class TestRouteWosMessageSurface:
+    """route_wos_message must dispatch wos_surface to handle_wos_surface."""
+
+    def test_route_wos_message_accepts_wos_surface_type(self):
+        """route_wos_message must not raise ValueError for wos_surface messages."""
+        msg = _make_surface_msg(causes=["executor_orphan", "executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = route_wos_message(msg)
+        assert "action" in result
+
+    def test_route_wos_message_all_orphans_returns_spawn_subagent(self):
+        """route_wos_message for wos_surface all-orphan kill wave returns spawn_subagent."""
+        msg = _make_surface_msg(causes=["executor_orphan", "executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = route_wos_message(msg)
+        assert result["action"] == "spawn_subagent"
+
+    def test_route_wos_message_genuine_failure_returns_send_reply(self):
+        """route_wos_message for wos_surface genuine failure returns send_reply."""
+        msg = _make_surface_msg(causes=["execution_failed", "execution_failed", "execution_failed"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = route_wos_message(msg)
+        assert result["action"] == "send_reply"
+
+    def test_route_wos_message_echoes_message_type(self):
+        """result['message_type'] must echo 'wos_surface' so callers can confirm routing."""
+        msg = _make_surface_msg()
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True
+        ):
+            result = route_wos_message(msg)
+        assert result["message_type"] == WOS_SURFACE_MESSAGE_TYPE
+
+    def test_route_wos_message_pipeline_paused_returns_send_reply(self):
+        """route_wos_message for wos_surface with pipeline paused returns send_reply."""
+        msg = _make_surface_msg(causes=["executor_orphan", "executor_orphan", "executor_orphan"])
+        with patch(
+            "src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=False
+        ):
+            result = route_wos_message(msg)
+        assert result["action"] == "send_reply"


### PR DESCRIPTION
## What problem this solves

Kill waves — steward cycles where >= 3 UoWs hit their retry cap simultaneously — produce a `wos_surface` inbox message with `metadata.uow_ids` listing all affected UoW IDs. Before this PR, `wos_surface` was absent from `WOS_MESSAGE_TYPE_DISPATCH`. Every kill wave produced a dangling unprocessed message, fell through to prose routing, and required Dan to manually `/decide` each UoW individually. The batch triage data the steward already computed was thrown away.

The `_send_escalation_notification` write-failure fallback also writes `wos_surface` (condition=`retry_cap`) — that path had the same gap.

## What changed

`handle_wos_surface(msg)` is added to `dispatcher_handlers.py` and wired into `WOS_MESSAGE_TYPE_DISPATCH`, parallel to the existing `handle_wos_escalate` entry. The handler implements a four-branch decision tree:

```
wos_surface received
        │
execution_enabled=False? ──YES──► surface all to Dan (pipeline paused note)
        │
classify causes list by orphan eligibility
        │
all orphan? ──YES──► spawn one steward heartbeat (batch auto-retry, silent)
        │
mixed? ──YES──► auto-retry orphans, surface non-orphans to Dan
        │
all non-orphan (or no causes list) ──► surface all to Dan
```

The handler also normalises the two `wos_surface` message shapes:
- `condition=retry_cap_consolidated`: `metadata.uow_ids` (list) + `metadata.causes` (list of raw return_reason strings)
- `condition=retry_cap` (write-failure fallback): `metadata.uow_id` (singular, no causes) → treated as non-orphan, surfaces to Dan

`route_wos_message` gets a `wos_surface` fast-path block identical to the existing `wos_escalate` fast-path: bypasses the spawn-gate because this handler legitimately returns either action.

## Scope of change

Only `dispatcher_handlers.py` and the new test file are touched. `steward.py`, `registry.py`, and all other files are unchanged.

New constants added at module scope:
- `_SURFACE_ORPHAN_RETURN_REASONS: frozenset[str]` — the five raw return_reason strings that are auto-retry eligible (mirrors `ORPHAN_REASONS` in steward but uses raw strings, not classifications, because `metadata.causes` carries raw strings)

## Functional patterns

Pure function: `handle_wos_surface` takes a dict and returns a dict with no side effects or I/O (except the `is_execution_enabled()` read, which is mocked in tests). Declarative data transformation using list comprehensions to partition `uow_ids` against `causes` by index. Named constants at module scope, not magic literals.

## Flow diagram

Before:
```
wos_surface → WOS_MESSAGE_TYPE_DISPATCH → KeyError → prose routing → Dan sees wall of text
```

After:
```
wos_surface → route_wos_message fast-path → handle_wos_surface → {
  all orphan → spawn_subagent (steward heartbeat)
  mixed      → send_reply (non-orphans surfaced, orphans retried)
  all non-orphan → send_reply (all surfaced)
  paused     → send_reply (paused note)
}
```

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_surface_handler.py -v` — 33 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_escalate_handler.py tests/unit/test_orchestration/test_dispatcher_integration.py tests/test_wos_execute_router.py -q` — 155 passed, 0 failed (no regressions in existing dispatcher tests)
- [x] Pre-existing ruff F401 on `_LOBSTER_WORKSPACE` import confirmed to predate this PR (verified with git stash)

## Manual test

N/A — this change is entirely internal to the dispatcher handler module. No external services, no file I/O, no Telegram calls. The handler is a pure function; test coverage is complete for all branches including the pipeline-paused override and fallback condition shapes.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure function, no external dependencies)
- [x] User-visible outcome — not applicable (automated routing, no direct UI output from the handler itself)
- [x] Side-effect audit: no floods, no unscoped writes. The spawn_subagent branch spawns one steward heartbeat per kill wave (same as wos_escalate Branch 1/2) — bounded by the kill wave size
- [x] External service calls — none in the handler; mocked in tests via `patch("...is_execution_enabled")`

Closes T1-A from `tiered-pr-roadmap-20260426.md`.