### PR TITLE
fix: add -- sentinel before prompt in claude -p subprocess invocations

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -1036,9 +1036,12 @@ def _dispatch_via_claude_p(instructions: str, uow_id: str) -> str:
 
     command = [
         _CLAUDE_BIN,
-        "-p", prompt,
+        "-p",
         "--dangerously-skip-permissions",
         "--max-turns", "40",
+        "--",  # end-of-options sentinel: prevents prompts starting with '---' from being
+               # parsed as CLI flags by the claude argument parser
+        prompt,
     ]
 
     # Use error capture to detect and log subprocess failures with context.
@@ -1170,9 +1173,12 @@ def _dispatch_via_stub(register_name: str, instructions: str, uow_id: str) -> st
 
     command = [
         _CLAUDE_BIN,
-        "-p", instructions,
+        "-p",
         "--dangerously-skip-permissions",
         "--max-turns", "40",
+        "--",  # end-of-options sentinel: prevents prompts starting with '---' from being
+               # parsed as CLI flags by the claude argument parser
+        instructions,
     ]
 
     # Pass an explicit env so CLAUDE_CODE_OAUTH_TOKEN is present even when

--- a/tests/unit/test_orchestration/test_executor_subprocess.py
+++ b/tests/unit/test_orchestration/test_executor_subprocess.py
@@ -440,3 +440,81 @@ class TestAuthTokenPassthrough:
 
         assert len(captured_envs) == 1
         assert captured_envs[0].get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-from-credentials-json"
+
+
+class TestEndOfOptionsSeparator:
+    """
+    _dispatch_via_claude_p and _dispatch_via_stub must place '--' before the prompt
+    in the subprocess command list so that prompts starting with '---' (e.g. YAML
+    front matter blocks) are not parsed as unknown CLI flags by the claude binary.
+
+    Background: '-p' / '--print' is a boolean flag — not a value-taking option.
+    The prompt is a positional argument. When a prompt starts with '---', the
+    claude CLI's argument parser sees an unknown option unless '--' precedes it.
+    """
+
+    def test_dispatch_via_claude_p_places_double_dash_before_yaml_front_matter_prompt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        A prompt starting with '---' must not be passed as a CLI flag.
+        '--' must appear in the command list immediately before the prompt.
+        """
+        import orchestration.executor as executor_mod
+
+        captured_commands: list[list] = []
+
+        def mock_run_capture(*args, **kwargs):
+            captured_commands.append(kwargs.get("command") or list(args[0] if args else []))
+            proc = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            return proc, None
+
+        monkeypatch.setattr(executor_mod, "run_subprocess_with_error_capture", mock_run_capture)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test-separator")
+
+        yaml_prompt = "---\ntask_id: wos-uow_test\nchat_id: 0\nsource: system\n---\nDo the thing."
+        _dispatch_via_claude_p(yaml_prompt, "uow-test-sep-001")
+
+        assert len(captured_commands) == 1
+        cmd = captured_commands[0]
+        assert "--" in cmd, "'--' sentinel must be present in the command list"
+        sep_idx = cmd.index("--")
+        assert cmd[sep_idx + 1] == yaml_prompt, (
+            "Prompt must immediately follow '--' in the command list"
+        )
+        # The prompt must not appear before '--' where it could be parsed as a flag
+        assert yaml_prompt not in cmd[:sep_idx], (
+            "Prompt must not appear before the '--' sentinel"
+        )
+
+    def test_dispatch_via_stub_places_double_dash_before_yaml_front_matter_prompt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Same guarantee for _dispatch_via_stub (used by non-general register dispatchers).
+        """
+        import orchestration.executor as executor_mod
+
+        captured_commands: list[list] = []
+
+        def mock_run_capture(*args, **kwargs):
+            captured_commands.append(kwargs.get("command") or list(args[0] if args else []))
+            proc = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            return proc, None
+
+        monkeypatch.setattr(executor_mod, "run_subprocess_with_error_capture", mock_run_capture)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test-separator-stub")
+
+        yaml_prompt = "---\ntask_id: wos-uow_test\nchat_id: 0\nsource: system\n---\nDo the thing."
+        _dispatch_via_stub("frontier-writer", yaml_prompt, "uow-test-sep-002")
+
+        assert len(captured_commands) == 1
+        cmd = captured_commands[0]
+        assert "--" in cmd, "'--' sentinel must be present in the command list"
+        sep_idx = cmd.index("--")
+        assert cmd[sep_idx + 1] == yaml_prompt, (
+            "Prompt must immediately follow '--' in the command list"
+        )
+        assert yaml_prompt not in cmd[:sep_idx], (
+            "Prompt must not appear before the '--' sentinel"
+        )


### PR DESCRIPTION
## Summary

WOS UoW dispatch was failing for every unit of work because the `claude` CLI was interpreting the YAML front matter at the start of each prompt as an unknown CLI flag.

The `claude -p` flag is a **boolean** (print mode) — it takes no value. The prompt is a **positional argument**. When `_dispatch_via_claude_p` built its command list as `[..., "-p", prompt, ...]`, and the prompt began with `---` (a WOS YAML front matter block), the CLI parser saw an argument like `---\ntask_id: wos-uow_...` and rejected it as an unknown option, returning exit status 1.

## Fix

Insert `"--"` (POSIX end-of-options separator) before the prompt in both call sites in `_dispatch_via_claude_p` and `_dispatch_via_stub`:

**Before:**
```python
command = [_CLAUDE_BIN, "-p", prompt, "--dangerously-skip-permissions", "--max-turns", "40"]
```

**After:**
```python
command = [_CLAUDE_BIN, "-p", "--dangerously-skip-permissions", "--max-turns", "40", "--", prompt]
```

The `--` sentinel tells the argument parser that everything after it is positional, regardless of what the content looks like. This is the canonical POSIX approach for prompts that may start with `-` or `---`.

## Functional patterns used

Pure function: `_dispatch_via_claude_p` remains a side-effect-isolated function with no mutation of shared state. The fix only alters the command list construction — a pure list transformation.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_executor_subprocess.py -v` — 17 passed, 1 warning (2 new tests in `TestEndOfOptionsSeparator` pass; 1 pre-existing failure in `TestHappyPath::test_instructions_are_passed_to_dispatcher` confirmed present on `main` before this change)

## Manual test

Manually verified the fix by running:
```bash
claude -p --dangerously-skip-permissions --max-turns 1 -- "---
task_id: test
---
say hello"
```
Output: `Hello! How can I help you today?` — confirming the `--` sentinel allows YAML front matter prompts to be parsed as positional arguments.

The broken invocation (`claude -p "---\ntask_id:..."`) produces `error: unknown option '---\ntask_id:...'` — confirming the root cause.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see ## Manual test
- [x] User-visible outcome: WOS UoW dispatch no longer fails with `CalledProcessError` for prompts starting with `---`
- [x] Side-effect audit complete: this change only affects how subprocess command lists are constructed — no volume, no shared state writes, no unintended side effects
- [x] External service calls: subprocess invocation is mocked in tests; manual verification used a bounded single-call test

Closes #985