### PR TITLE
Add GitHub API rate limit pre-dispatch check to WOS executor heartbeat

### DIFF
--- a/oracle/verdicts/decision-github-rate-limit-gate.md
+++ b/oracle/verdicts/decision-github-rate-limit-gate.md
@@ -1,0 +1,32 @@
+# Design Decision: GitHub API Rate Limit Pre-Dispatch Gate
+
+**Date:** 2026-04-27
+**Status:** ACCEPTED
+**Vision anchor:** principle-1 (structural prevention is preferred over reactive recovery), vision.yaml core.inviolable_constraints.constraint-3 (Encoded Orientation requires prior logged decision of same class and a traceable vision.yaml anchor)
+**Linked issue:** dcetlin/Lobster#984
+
+## Decision
+
+Authorize the `GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD = 100` gate in `executor-heartbeat.py`:
+
+- **Pre-dispatch rate limit check:** Once per dispatch cycle (after the context pressure throttle, before `run_executor_cycle`), the heartbeat calls `check_github_rate_limit()` via `gh api rate_limit`. If `remaining < 100`, the cycle is skipped and main() returns 0.
+- **Threshold value:** `GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD = 100` is the authorized default. This is a named module constant, not a magic number.
+- **Fail-open on tool failure:** If the gh CLI is unavailable, returns a non-zero exit code, or emits unparseable JSON, the gate is bypassed and dispatch proceeds normally. Tooling failure is not a reason to suppress user work.
+
+## Rationale
+
+The observed failure mode (issue #984): when the GitHub API rate limit is exhausted, dispatched subagents burn their full TTL waiting for gh CLI calls that never succeed. The user's work is consumed — quota spent, TTL burned — with no successful outcome. This is reactive degradation: the system dispatches work it cannot complete.
+
+The rate limit gate converts this from reactive failure to structural prevention (principle-1). By checking remaining quota before dispatch, the system avoids spawning subagents that will fail immediately. One skipped cycle at low quota is less costly than one or more subagents burning full TTLs.
+
+This is an Encoded Orientation decision: the system autonomously suppresses dispatch cycles without Dan's explicit input per invocation. It is authorized here with a traceable vision.yaml anchor (principle-1) and a logged prior decision (this document), satisfying constraint-3.
+
+The structural class is the same as `decision-needs-human-review-escalation.md` (steward escalation after MAX_RETRIES) and `decision-system-retrospective-automation.md` (automated issue filing): an autonomous behavioral gate backed by a logged decision and a vision.yaml anchor.
+
+## Constraints
+
+- The check is per-cycle, not per-UoW — one gh CLI call per dispatch loop iteration
+- The threshold (100) is a named constant; changing it requires a code change (intentionally not runtime-configurable, to keep behavioral complexity bounded)
+- Fail-open on all error paths — a broken gh CLI does not suppress dispatch
+- The gate does not affect TTL recovery, which runs independently of the rate limit check
+- The 10-second subprocess timeout adds negligible latency at a 3-minute cycle cadence

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -38,7 +38,9 @@ import argparse
 import json
 import logging
 import os
+import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -144,6 +146,95 @@ def _warn_if_legacy_registry_exists() -> None:
 # ---------------------------------------------------------------------------
 
 RECOVERY_STALE_MINUTES: int = 5
+
+# ---------------------------------------------------------------------------
+# GitHub API rate limit pre-dispatch check
+#
+# Subagents dispatched by the executor call `gh issue view` as step 1.
+# When the GitHub API rate limit is exhausted, that call fails immediately —
+# but the subagent still burns its full 10-minute TTL before getting orphan-
+# killed. Checking the rate limit once per dispatch cycle avoids wasting slots
+# and prevents unnecessary executor_orphan audit entries.
+#
+# Fail-open: if the gh CLI is unavailable or its output is unparseable, the
+# check returns ok=True so dispatch is not blocked by a tooling failure.
+# ---------------------------------------------------------------------------
+
+#: Minimum remaining GitHub API requests required before the executor will
+#: dispatch a UoW in this cycle. Subagents use a small number of API calls
+#: (issue view, PR create, label apply), so 100 provides a comfortable buffer
+#: that prevents wasted TTL slots without blocking dispatch prematurely.
+GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD: int = 100
+
+
+@dataclass(frozen=True)
+class RateLimitStatus:
+    """Result of a GitHub API rate limit check.
+
+    ok: True when dispatch may proceed (remaining >= threshold or check failed).
+    remaining: Requests remaining as reported by GitHub, or None on error.
+    reset_at: ISO 8601 UTC timestamp of the next rate limit reset, or None.
+    """
+    ok: bool
+    remaining: int | None
+    reset_at: str | None
+
+
+def check_github_rate_limit(
+    threshold: int = GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD,
+) -> RateLimitStatus:
+    """Query the GitHub API rate limit and return a dispatch-gate result.
+
+    Calls `gh api rate_limit` and parses the remaining and reset fields.
+    Returns ok=True (dispatch allowed) when:
+    - remaining >= threshold, OR
+    - the gh CLI fails or returns unparseable output (fail-open)
+
+    Returns ok=False (dispatch should be skipped) when:
+    - remaining < threshold AND the call succeeded.
+
+    Pure in behaviour: no side effects beyond the subprocess call. The
+    caller owns all logging and the skip decision.
+
+    Args:
+        threshold: Minimum remaining requests to allow dispatch.
+                   Defaults to GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD.
+
+    Returns:
+        RateLimitStatus with ok, remaining, and reset_at fields.
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "api", "rate_limit", "--jq", ".rate | {remaining, reset}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        # gh not on PATH, subprocess error, or timeout — fail open.
+        return RateLimitStatus(ok=True, remaining=None, reset_at=None)
+
+    if proc.returncode != 0:
+        # gh CLI failed (auth error, network, etc.) — fail open.
+        return RateLimitStatus(ok=True, remaining=None, reset_at=None)
+
+    try:
+        data = json.loads(proc.stdout.strip())
+        remaining = int(data["remaining"])
+        reset_epoch = data.get("reset")
+        reset_at: str | None = None
+        if reset_epoch is not None:
+            from datetime import datetime, timezone
+            reset_at = datetime.fromtimestamp(int(reset_epoch), tz=timezone.utc).isoformat()
+    except Exception:
+        # Unparseable output — fail open.
+        return RateLimitStatus(ok=True, remaining=None, reset_at=None)
+
+    return RateLimitStatus(
+        ok=remaining >= threshold,
+        remaining=remaining,
+        reset_at=reset_at,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -547,6 +638,30 @@ def main() -> int:
         )
         log.info("Executor heartbeat complete")
         return 0
+
+    # GitHub API rate limit check — called once per dispatch cycle.
+    # Subagents call `gh issue view` as step 1; if the rate limit is exhausted
+    # the subagent fails immediately but still burns its full 10-minute TTL.
+    # Skipping dispatch when the quota is low avoids wasted slots and prevents
+    # unnecessary executor_orphan audit entries.
+    if not dry_run:
+        rate_status = check_github_rate_limit()
+        if not rate_status.ok:
+            reset_msg = f", next reset at {rate_status.reset_at}" if rate_status.reset_at else ""
+            log.info(
+                "Skipping dispatch: GitHub API rate limit low "
+                "(remaining=%d%s). Dispatching will resume after reset.",
+                rate_status.remaining,
+                reset_msg,
+            )
+            log.info("Executor heartbeat complete")
+            return 0
+        if rate_status.remaining is not None:
+            log.debug(
+                "GitHub API rate limit ok: %d remaining (threshold=%d)",
+                rate_status.remaining,
+                GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD,
+            )
 
     try:
         result = run_executor_cycle(registry, dry_run=dry_run)

--- a/tests/unit/test_orchestration/test_github_rate_limit_check.py
+++ b/tests/unit/test_orchestration/test_github_rate_limit_check.py
@@ -3,7 +3,7 @@ Tests for the GitHub API rate limit pre-dispatch check in executor-heartbeat.py.
 
 The rate limit check fires once per dispatch cycle (in main(), after the context
 pressure throttle and before run_executor_cycle). It is a pure-ish function
-(check_github_rate_limit) that shells out to `gh api rate_limit --jq .rate.remaining`
+(check_github_rate_limit) that shells out to `gh api rate_limit --jq '.rate | {remaining, reset}'`
 and returns a named result so the caller can log and skip without knowing the details.
 
 Coverage:
@@ -155,21 +155,6 @@ def _make_mock_registry(tmp_path):
     db_path = tmp_path / "test_registry.db"
     return Registry(db_path)
 
-
-def _run_main_with_clean_argv(hb_module, patches: dict):
-    """Run hb_module.main() with sys.argv cleared so argparse doesn't see pytest args."""
-    context_managers = [patch.object(hb_module, name, **kwargs) if isinstance(kwargs, dict) else patch.object(hb_module, name, kwargs) for name, kwargs in patches.items()]
-    # Build the patches as a flat list of context managers
-    with patch("sys.argv", ["executor-heartbeat.py"]):
-        all_patches = [
-            patch.object(hb_module, name, new=val)
-            for name, val in patches.items()
-        ]
-        # stack them all
-        from contextlib import ExitStack
-        with ExitStack() as stack:
-            mocks = {name: stack.enter_context(p) for name, p in zip(patches.keys(), all_patches)}
-            return hb_module.main(), mocks
 
 
 def test_dispatch_skipped_when_rate_limit_low(tmp_path):

--- a/tests/unit/test_orchestration/test_github_rate_limit_check.py
+++ b/tests/unit/test_orchestration/test_github_rate_limit_check.py
@@ -1,0 +1,281 @@
+"""
+Tests for the GitHub API rate limit pre-dispatch check in executor-heartbeat.py.
+
+The rate limit check fires once per dispatch cycle (in main(), after the context
+pressure throttle and before run_executor_cycle). It is a pure-ish function
+(check_github_rate_limit) that shells out to `gh api rate_limit --jq .rate.remaining`
+and returns a named result so the caller can log and skip without knowing the details.
+
+Coverage:
+- GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD constant is a positive integer
+- check_github_rate_limit: returns ok=True when remaining >= threshold
+- check_github_rate_limit: returns ok=False when remaining < threshold
+- check_github_rate_limit: returns ok=True when remaining == threshold (boundary)
+- check_github_rate_limit: returns ok=True with remaining=None when gh CLI fails
+  (fail-open: do not block dispatch on tool failure)
+- check_github_rate_limit: remaining and reset_at are surfaced in the result
+- main(): dispatch is skipped when rate limit check returns ok=False
+- main(): dispatch proceeds when rate limit check returns ok=True
+- main(): rate limit check is called once per cycle (not per UoW)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+import json
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Load executor-heartbeat.py via importlib (hyphenated filename, no __init__)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_HEARTBEAT_PATH = _REPO_ROOT / "scheduled-tasks" / "executor-heartbeat.py"
+
+
+def _load_heartbeat():
+    """Load executor-heartbeat module from file path (hyphen in name)."""
+    spec = importlib.util.spec_from_file_location("executor_heartbeat", _HEARTBEAT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["executor_heartbeat"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_hb = _load_heartbeat()
+check_github_rate_limit = _hb.check_github_rate_limit
+GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD = _hb.GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Constant sanity check
+# ---------------------------------------------------------------------------
+
+def test_threshold_is_positive_integer():
+    assert isinstance(GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD, int)
+    assert GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD > 0
+
+
+# ---------------------------------------------------------------------------
+# check_github_rate_limit unit tests (subprocess mocked)
+# ---------------------------------------------------------------------------
+
+def _mock_subprocess_result(stdout: str, returncode: int = 0):
+    """Return a mock CompletedProcess-like object."""
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+def _rate_json(remaining: int, reset: int = 1745748000) -> str:
+    """Return the JSON string that gh api rate_limit --jq '.rate | {remaining, reset}' emits."""
+    return json.dumps({"remaining": remaining, "reset": reset})
+
+
+def test_rate_limit_ok_when_remaining_above_threshold():
+    """ok=True when remaining > threshold."""
+    with patch("subprocess.run", return_value=_mock_subprocess_result(_rate_json(500))) as mock_run:
+        result = check_github_rate_limit()
+    assert result.ok is True
+    assert result.remaining == 500
+    mock_run.assert_called_once()
+
+
+def test_rate_limit_not_ok_when_remaining_below_threshold():
+    """ok=False when remaining < threshold."""
+    with patch("subprocess.run", return_value=_mock_subprocess_result(_rate_json(50))):
+        result = check_github_rate_limit()
+    assert result.ok is False
+    assert result.remaining == 50
+
+
+def test_rate_limit_ok_at_exact_threshold():
+    """ok=True when remaining == threshold (boundary: threshold is the minimum allowed)."""
+    threshold = GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD
+    with patch("subprocess.run", return_value=_mock_subprocess_result(_rate_json(threshold))):
+        result = check_github_rate_limit()
+    assert result.ok is True
+    assert result.remaining == threshold
+
+
+def test_rate_limit_ok_when_gh_cli_fails():
+    """Fail-open: ok=True when gh CLI returns non-zero exit code.
+
+    A broken gh CLI must not block dispatch — the subagent will hit the
+    rate limit and fail on its own terms, but blocking dispatch on a CLI
+    failure would be worse than letting it proceed.
+    """
+    with patch("subprocess.run", return_value=_mock_subprocess_result("", returncode=1)):
+        result = check_github_rate_limit()
+    assert result.ok is True
+    assert result.remaining is None
+
+
+def test_rate_limit_ok_when_gh_cli_raises():
+    """Fail-open: ok=True when subprocess.run raises (e.g. gh not on PATH)."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
+        result = check_github_rate_limit()
+    assert result.ok is True
+    assert result.remaining is None
+
+
+def test_rate_limit_ok_when_output_unparseable():
+    """Fail-open: ok=True when gh output is not valid JSON."""
+    with patch("subprocess.run", return_value=_mock_subprocess_result("not-json\n")):
+        result = check_github_rate_limit()
+    assert result.ok is True
+    assert result.remaining is None
+
+
+def test_rate_limit_result_surfaces_reset_at():
+    """reset_at is a non-None ISO string when gh output includes a reset epoch."""
+    with patch("subprocess.run", return_value=_mock_subprocess_result(_rate_json(500, reset=1745748000))):
+        result = check_github_rate_limit()
+    assert result.reset_at is not None
+    # Should be a parseable ISO timestamp
+    from datetime import datetime
+    datetime.fromisoformat(result.reset_at)  # raises if not valid
+
+
+# ---------------------------------------------------------------------------
+# Integration with main() — dispatch skipped when rate limit is low
+# ---------------------------------------------------------------------------
+
+def _make_mock_registry(tmp_path):
+    """Create a minimal mock registry that satisfies main()'s usage."""
+    from orchestration.registry import Registry
+    db_path = tmp_path / "test_registry.db"
+    return Registry(db_path)
+
+
+def _run_main_with_clean_argv(hb_module, patches: dict):
+    """Run hb_module.main() with sys.argv cleared so argparse doesn't see pytest args."""
+    context_managers = [patch.object(hb_module, name, **kwargs) if isinstance(kwargs, dict) else patch.object(hb_module, name, kwargs) for name, kwargs in patches.items()]
+    # Build the patches as a flat list of context managers
+    with patch("sys.argv", ["executor-heartbeat.py"]):
+        all_patches = [
+            patch.object(hb_module, name, new=val)
+            for name, val in patches.items()
+        ]
+        # stack them all
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            mocks = {name: stack.enter_context(p) for name, p in zip(patches.keys(), all_patches)}
+            return hb_module.main(), mocks
+
+
+def test_dispatch_skipped_when_rate_limit_low(tmp_path):
+    """run_executor_cycle is NOT called when check_github_rate_limit returns ok=False."""
+    db_path = tmp_path / "registry.db"
+    db_path.touch()
+
+    _hb_fresh = _load_heartbeat()
+
+    low_limit_result = MagicMock()
+    low_limit_result.ok = False
+    low_limit_result.remaining = 42
+    low_limit_result.reset_at = "2026-04-27T10:00:00Z"
+
+    mock_cycle = MagicMock()
+
+    with (
+        patch("sys.argv", ["executor-heartbeat.py"]),
+        patch.object(_hb_fresh, "_is_job_enabled", return_value=True),
+        patch.object(_hb_fresh, "check_github_rate_limit", return_value=low_limit_result),
+        patch.object(_hb_fresh, "run_executor_cycle", mock_cycle),
+        patch.object(_hb_fresh, "run_ttl_recovery"),
+        patch.object(_hb_fresh, "REGISTRY_DB", db_path),
+        patch("src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True),
+        patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=False),
+        patch("src.agents.session_store.get_active_sessions", return_value=[]),
+        patch("src.orchestration.heartbeat_sidecar.write_heartbeats_for_active_uows",
+              return_value=MagicMock(checked=0, written=0, skipped=0, errors=0)),
+    ):
+        exit_code = _hb_fresh.main()
+
+    mock_cycle.assert_not_called()
+    assert exit_code == 0
+
+
+def test_dispatch_proceeds_when_rate_limit_ok(tmp_path):
+    """run_executor_cycle IS called when check_github_rate_limit returns ok=True."""
+    db_path = tmp_path / "registry.db"
+    db_path.touch()
+
+    _hb_fresh = _load_heartbeat()
+
+    ok_limit_result = MagicMock()
+    ok_limit_result.ok = True
+    ok_limit_result.remaining = 500
+    ok_limit_result.reset_at = None
+
+    cycle_result = {
+        "evaluated": 1, "ready": 1, "stale": 1,
+        "dispatched": 1, "skipped": 0, "errors": 0,
+    }
+    mock_cycle = MagicMock(return_value=cycle_result)
+
+    with (
+        patch("sys.argv", ["executor-heartbeat.py"]),
+        patch.object(_hb_fresh, "_is_job_enabled", return_value=True),
+        patch.object(_hb_fresh, "check_github_rate_limit", return_value=ok_limit_result),
+        patch.object(_hb_fresh, "run_executor_cycle", mock_cycle),
+        patch.object(_hb_fresh, "run_ttl_recovery"),
+        patch.object(_hb_fresh, "REGISTRY_DB", db_path),
+        patch("src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True),
+        patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=False),
+        patch("src.agents.session_store.get_active_sessions", return_value=[]),
+        patch("src.orchestration.heartbeat_sidecar.write_heartbeats_for_active_uows",
+              return_value=MagicMock(checked=0, written=0, skipped=0, errors=0)),
+    ):
+        exit_code = _hb_fresh.main()
+
+    mock_cycle.assert_called_once()
+    assert exit_code == 0
+
+
+def test_rate_limit_check_called_once_per_cycle(tmp_path):
+    """check_github_rate_limit is called exactly once per dispatch cycle, not per UoW."""
+    db_path = tmp_path / "registry.db"
+    db_path.touch()
+
+    _hb_fresh = _load_heartbeat()
+
+    ok_limit_result = MagicMock()
+    ok_limit_result.ok = True
+    ok_limit_result.remaining = 500
+    ok_limit_result.reset_at = None
+
+    cycle_result = {
+        "evaluated": 3, "ready": 3, "stale": 3,
+        "dispatched": 3, "skipped": 0, "errors": 0,
+    }
+
+    mock_check = MagicMock(return_value=ok_limit_result)
+
+    with (
+        patch("sys.argv", ["executor-heartbeat.py"]),
+        patch.object(_hb_fresh, "_is_job_enabled", return_value=True),
+        patch.object(_hb_fresh, "check_github_rate_limit", mock_check),
+        patch.object(_hb_fresh, "run_executor_cycle", return_value=cycle_result),
+        patch.object(_hb_fresh, "run_ttl_recovery"),
+        patch.object(_hb_fresh, "REGISTRY_DB", db_path),
+        patch("src.orchestration.dispatcher_handlers.is_execution_enabled", return_value=True),
+        patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=False),
+        patch("src.agents.session_store.get_active_sessions", return_value=[]),
+        patch("src.orchestration.heartbeat_sidecar.write_heartbeats_for_active_uows",
+              return_value=MagicMock(checked=0, written=0, skipped=0, errors=0)),
+    ):
+        _hb_fresh.main()
+
+    # Regardless of how many UoWs run_executor_cycle dispatched (3),
+    # the rate limit check is called exactly once.
+    assert mock_check.call_count == 1


### PR DESCRIPTION
## Summary

When the GitHub API rate limit is exhausted, dispatched subagents fail immediately on `gh issue view` (step 1 of the functional-engineer protocol) — but they still burn their full 10-minute TTL heartbeating the registry before being orphan-killed. This produces wasted dispatch slots and false-positive `executor_orphan` audit entries that require Steward re-diagnosis.

This PR adds a single rate limit check at the top of the executor dispatch cycle. Before iterating eligible UoWs, the heartbeat queries `gh api rate_limit` and skips the entire dispatch cycle if remaining requests are below `GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD` (100). The check is **fail-open**: if `gh` is unavailable or returns unparseable output, `ok=True` and dispatch proceeds normally — a CLI failure is never a reason to block work.

## What changed

- `scheduled-tasks/executor-heartbeat.py`: Added `RateLimitStatus` dataclass, `check_github_rate_limit()` pure function, constant `GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD = 100`, and the check call in `main()` after the context pressure throttle and before `run_executor_cycle()`.
- `tests/unit/test_orchestration/test_github_rate_limit_check.py`: 11 new tests covering threshold boundary, fail-open paths (non-zero exit, FileNotFoundError, unparseable output), reset_at surfacing, and integration with `main()` (dispatch skipped when low, proceeds when ok, called exactly once per cycle not per UoW).

## Functional patterns used

- Pure function (`check_github_rate_limit`) with no side effects beyond the subprocess call — the caller owns all logging and the skip decision.
- Frozen dataclass (`RateLimitStatus`) for the result — immutable, typed, pattern-matchable.
- Named constant (`GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD`) referenced in both tests and implementation.

## Before / after dispatch flow

```
Before:
  [executor-heartbeat main()]
    → context pressure check
    → run_executor_cycle()   ← dispatches even when API quota exhausted
        → executor.execute_uow() × N
            → subagent spawned
                → gh issue view  ← fails immediately, burns 10-min TTL

After:
  [executor-heartbeat main()]
    → context pressure check
    → check_github_rate_limit()
        ok=False → log skip + return 0  (no slots wasted)
        ok=True  → continue
    → run_executor_cycle()
        → executor.execute_uow() × N
```

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_github_rate_limit_check.py -v` — 11 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_executor_heartbeat.py tests/unit/test_orchestration/test_github_rate_limit_check.py -v` — 33 passed, 0 failed (22 pre-existing + 11 new)
- [x] `uv run pytest tests/unit/test_executor.py -v` — 67 passed, 3 failed (3 failures are pre-existing on `main`, unrelated to this change — `TestOptimisticLock` tests that expect `RuntimeError` not to propagate)

## Manual test

N/A. This change is a pure pre-dispatch check: it calls `subprocess.run(["gh", "api", "rate_limit", ...])` and reads a count. The call is mocked in all tests. No external service is called in automated tests. The change does not affect systemd, cron entries, file I/O state, or DB schema.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external service calls at runtime of tests)
- [x] User-visible outcome verified — N/A (this is an internal dispatch gate with no Telegram output)
- [x] Side-effect audit complete: check is read-only (one `gh api` call per cycle), no writes, no floods
- [x] External service calls: mocked in all tests; at runtime calls GitHub read-only API once per 3-min cycle

WOS-UoW: N/A (engineer-initiated task)
Closes #984