### PR TITLE
feat: outcome_telemetry — extend write_result with token_usage and wall_clock_seconds

### DIFF
--- a/scheduled-tasks/wos-metabolic-digest.py
+++ b/scheduled-tasks/wos-metabolic-digest.py
@@ -263,6 +263,35 @@ def compute_avg_duration(uows: list[dict]) -> str:
     return f"{avg} min"
 
 
+def aggregate_token_usage(uows: list[dict]) -> int | None:
+    """
+    Sum token_usage across UoWs that reported it.
+
+    Returns the total token count, or None if no UoW reported usage.
+    UoWs with NULL token_usage (pre-migration or unreported) are excluded from
+    the sum but do not invalidate it — partial data is better than no data.
+    """
+    values = [u["token_usage"] for u in uows if u.get("token_usage") is not None]
+    return sum(values) if values else None
+
+
+def compute_wall_clock_stats(uows: list[dict]) -> dict:
+    """
+    Compute wall_clock_seconds statistics across UoWs.
+
+    Returns a dict with keys: count (UoWs with data), total_seconds, avg_seconds.
+    All values are None when no UoWs reported wall_clock_seconds.
+    """
+    values = [u["wall_clock_seconds"] for u in uows if u.get("wall_clock_seconds") is not None]
+    if not values:
+        return {"count": 0, "total_seconds": None, "avg_seconds": None}
+    return {
+        "count": len(values),
+        "total_seconds": sum(values),
+        "avg_seconds": round(sum(values) / len(values)),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Registry query — reads completed UoWs in the lookback window
 # ---------------------------------------------------------------------------
@@ -304,11 +333,22 @@ def query_completed_uows(db_path: Path, lookback_hours: int) -> list[dict]:
             uow_ids = [r["uow_id"] for r in transition_rows]
             id_placeholders = ",".join("?" * len(uow_ids))
 
-            # Fetch full UoW records for each matched ID
+            # Fetch full UoW records for each matched ID.
+            # token_usage: per-UoW cost telemetry (issue #990); NULL for pre-migration rows.
+            # wall_clock_seconds: derived from completed_at - started_at delta at query time.
             rows = conn.execute(
                 f"""
                 SELECT id, status, summary, register, close_reason, output_ref,
-                       started_at, closed_at, updated_at, created_at, steward_cycles
+                       started_at, closed_at, updated_at, created_at, steward_cycles,
+                       token_usage,
+                       CASE
+                         WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
+                         THEN CAST(
+                           (julianday(completed_at) - julianday(started_at)) * 86400.0
+                           AS INTEGER
+                         )
+                         ELSE NULL
+                       END AS wall_clock_seconds
                 FROM uow_registry
                 WHERE id IN ({id_placeholders})
                   AND status IN ({terminal_placeholders})
@@ -388,7 +428,9 @@ def format_digest(
 
     # Register breakdown — count by register across all classified UoWs
     register_counts: dict[str, int] = {}
+    all_uows: list[dict] = []
     for label, uows in groups.items():
+        all_uows.extend(uows)
         for uow in uows:
             reg = uow.get("register") or "operational"
             register_counts[reg] = register_counts.get(reg, 0) + 1
@@ -400,6 +442,10 @@ def format_digest(
     # Average durations per category
     pearl_avg = compute_avg_duration(groups[OUTCOME_PEARL])
     heat_avg = compute_avg_duration(groups[OUTCOME_HEAT])
+
+    # Telemetry: aggregate token_usage and wall_clock_seconds (issue #990)
+    total_tokens = aggregate_token_usage(all_uows)
+    wall_clock = compute_wall_clock_stats(all_uows)
 
     # Stalled display
     stalled_line = ""
@@ -417,6 +463,12 @@ def format_digest(
     if total > 0:
         lines.append(f"Register breakdown: {register_parts}")
         lines.append(f"Avg duration: {pearl_avg} (pearl), {heat_avg} (heat)")
+        # Token and wall-clock telemetry — only show when data is available
+        if total_tokens is not None:
+            lines.append(f"Tokens: {total_tokens:,} total")
+        if wall_clock["avg_seconds"] is not None:
+            avg_min = round(wall_clock["avg_seconds"] / 60, 1)
+            lines.append(f"Wall-clock avg: {avg_min} min ({wall_clock['count']} UoWs with data)")
     else:
         lines.append("No UoWs completed in this window.")
 
@@ -494,6 +546,10 @@ def run_digest(db_path: Path, lookback_hours: int, dry_run: bool = False) -> dic
 
     _write_inbox_digest(digest_text, dry_run=dry_run)
 
+    all_uows = [uow for uows in groups.values() for uow in uows]
+    total_tokens = aggregate_token_usage(all_uows)
+    wall_stats = compute_wall_clock_stats(all_uows)
+
     return {
         "timestamp": now_iso,
         "lookback_hours": lookback_hours,
@@ -505,6 +561,10 @@ def run_digest(db_path: Path, lookback_hours: int, dry_run: bool = False) -> dic
         "stalled_count": len(stalled),
         "dry_run": dry_run,
         "digest_text": digest_text,
+        # Telemetry (issue #990) — None when no UoWs reported data
+        "total_tokens": total_tokens,
+        "wall_clock_uow_count": wall_stats["count"],
+        "wall_clock_avg_seconds": wall_stats["avg_seconds"],
     }
 
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2670,6 +2670,16 @@ async def list_tools() -> list[Tool]:
                         ),
                         "enum": ["heat", "shit", "seed", "pearl"],
                     },
+                    "token_usage": {
+                        "type": "integer",
+                        "description": (
+                            "Optional total token count consumed by this subagent (input + output tokens combined). "
+                            "Report what the Claude API returned in response metadata across all tool calls and turns. "
+                            "Accumulate usage.input_tokens + usage.output_tokens across turns and report the total here. "
+                            "Used for per-UoW cost telemetry in the WOS registry. "
+                            "Omit if token counts were not available or not tracked."
+                        ),
+                    },
                 },
                 "required": ["task_id", "chat_id", "text"],
             },
@@ -7699,7 +7709,12 @@ async def handle_write_task_output(args: dict) -> list[TextContent]:
 # WOS registry completion helper (issue #669)
 # =============================================================================
 
-def _maybe_complete_wos_uow(task_id: str, status: str, result_text: str | None = None) -> None:
+def _maybe_complete_wos_uow(
+    task_id: str,
+    status: str,
+    result_text: str | None = None,
+    token_usage: int | None = None,
+) -> None:
     """
     Transition a WOS UoW from 'executing' to 'ready-for-steward' when its subagent
     calls write_result with status='success'.
@@ -7712,6 +7727,9 @@ def _maybe_complete_wos_uow(task_id: str, status: str, result_text: str | None =
     can distinguish pearl (PR opened), heat (nothing to do), and seed (default)
     outcomes when building the GitHub close-out comment.
 
+    token_usage is forwarded to record per-UoW cost telemetry in the registry
+    (issue #990). NULL when the subagent did not report usage.
+
     Errors are logged but never raised — write_result delivery must not be blocked
     by registry update failures.
     """
@@ -7723,7 +7741,7 @@ def _maybe_complete_wos_uow(task_id: str, status: str, result_text: str | None =
         if _src not in _sys.path:
             _sys.path.insert(0, _src)
         from orchestration.wos_completion import maybe_complete_wos_uow
-        maybe_complete_wos_uow(task_id, status, result_text=result_text)
+        maybe_complete_wos_uow(task_id, status, result_text=result_text, token_usage=token_usage)
     except Exception as exc:
         log.warning("_maybe_complete_wos_uow: unexpected error — %s: %s", type(exc).__name__, exc)
 
@@ -7752,6 +7770,14 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     outcome_category = (
         outcome_category_raw
         if outcome_category_raw in VALID_OUTCOME_CATEGORIES
+        else None
+    )
+    # token_usage: optional integer reported by the subagent (input + output tokens).
+    # Validated as a positive integer; ignored if absent, None, or non-integer.
+    _token_usage_raw = args.get("token_usage")
+    token_usage: int | None = (
+        int(_token_usage_raw)
+        if _token_usage_raw is not None and isinstance(_token_usage_raw, (int, float)) and int(_token_usage_raw) > 0
         else None
     )
     # Accept new name (sent_reply_to_user) with backward-compat alias (forward).
@@ -7890,7 +7916,8 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     # task_id convention: "wos-{uow_id}" (set by route_wos_message in dispatcher_handlers.py)
     # result_text is forwarded so the output classifier can build an accurate close-out
     # comment (pearl for PR opened, heat for nothing to do, seed as default).
-    _maybe_complete_wos_uow(task_id, status, result_text=text or None)
+    # token_usage is forwarded for per-UoW cost telemetry (issue #990).
+    _maybe_complete_wos_uow(task_id, status, result_text=text or None, token_usage=token_usage)
 
     # Notify wire server so SSE clients update within 40ms
     asyncio.create_task(_notify_wire_server())

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -400,7 +400,11 @@ def handle_wos_execute(uow_id: str, instructions: str, output_ref: str) -> str:
         f"  2. Write JSON to {output_ref}.tmp, then rename to {output_ref}\n\n"
         f"After writing the result file:\n"
         f'  write_result(task_id="wos-{uow_id}", chat_id=0, source="system",\n'
-        f'               text="WOS UoW {uow_id}: outcome=<outcome>")\n\n'
+        f'               text="WOS UoW {uow_id}: outcome=<outcome>",\n'
+        f'               token_usage=<total_input_plus_output_tokens>)\n\n'
+        f"token_usage: accumulate usage.input_tokens + usage.output_tokens from every Claude API\n"
+        f"response across all turns and report the total. This enables per-UoW cost telemetry.\n"
+        f"Omit token_usage if you did not track it.\n\n"
         f"Minimum viable output: {output_ref} with uow_id, outcome, and success fields.\n"
         f"Boundary: do not modify executor.py, registry.py, or any WOS source files.\n"
     )

--- a/src/orchestration/migrations/0015_add_token_usage.sql
+++ b/src/orchestration/migrations/0015_add_token_usage.sql
@@ -1,0 +1,18 @@
+-- Migration 0015: add token_usage field for per-UoW cost telemetry (issue #990).
+--
+-- Problem:
+--   WOS UoWs have outcome_category (heat/shit/seed/pearl) since PR #759, but lack
+--   per-UoW token metering. Without this we cannot track cost per UoW, identify
+--   expensive outliers, or build cost-awareness into orchestration decisions.
+--
+-- Fix:
+--   Add token_usage INTEGER NULL to uow_registry.
+--   Written by the write_result handler when a subagent reports token consumption.
+--   wall_clock_seconds is a derived field (completed_at - started_at delta),
+--   not stored — computed from existing timestamps at query time.
+--
+-- Backward compatibility:
+--   Existing UoWs get token_usage=NULL (not available before this migration).
+--   write_result accepts token_usage as optional; omitting it leaves the field NULL.
+
+ALTER TABLE uow_registry ADD COLUMN token_usage INTEGER NULL;

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1652,7 +1652,12 @@ class Registry:
         finally:
             conn.close()
 
-    def complete_uow(self, uow_id: str, output_ref: str) -> None:
+    def complete_uow(
+        self,
+        uow_id: str,
+        output_ref: str,
+        token_usage: int | None = None,
+    ) -> None:
         """
         Transition a UoW to 'ready-for-steward' with an execution_complete audit entry.
 
@@ -1665,6 +1670,10 @@ class Registry:
 
         The from_status is derived from the current DB state so the audit entry
         is accurate regardless of which dispatch path was used.
+
+        token_usage: optional integer (input + output tokens) reported by the subagent
+        via write_result. Written to the registry when provided; NULL otherwise.
+        wall_clock_seconds is derived at query time from completed_at - started_at.
 
         Single transaction: audit INSERT before status UPDATE
         (audit-before-transition invariant).
@@ -1680,16 +1689,27 @@ class Registry:
                 "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
             ).fetchone()
             current_status = row["status"] if row else "active"
+            audit_note = json.dumps({
+                "actor": "executor",
+                "output_ref": output_ref,
+                "timestamp": now,
+                **({"token_usage": token_usage} if token_usage is not None else {}),
+            })
             conn.execute(
                 """
                 INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
                 VALUES (?, ?, 'execution_complete', ?, 'ready-for-steward', 'executor', ?)
                 """,
-                (now, uow_id, current_status, json.dumps({"actor": "executor", "output_ref": output_ref, "timestamp": now})),
+                (now, uow_id, current_status, audit_note),
             )
             conn.execute(
-                "UPDATE uow_registry SET status = 'ready-for-steward', updated_at = ? WHERE id = ?",
-                (now, uow_id),
+                """
+                UPDATE uow_registry
+                SET status = 'ready-for-steward', updated_at = ?, completed_at = ?,
+                    token_usage = COALESCE(?, token_usage)
+                WHERE id = ?
+                """,
+                (now, now, token_usage, uow_id),
             )
             conn.commit()
         except Exception:

--- a/src/orchestration/schema.sql
+++ b/src/orchestration/schema.sql
@@ -97,6 +97,13 @@ CREATE TABLE IF NOT EXISTS uow_registry (
     --   Steward-private (excluded from executor_uow_view).
     execution_attempts  INTEGER NOT NULL DEFAULT 0,
 
+    -- token_usage: total tokens consumed by the executing subagent (input + output).
+    --   Reported by the subagent via write_result at completion time.
+    --   NULL for UoWs completed before this migration or when the subagent did not report usage.
+    --   Executor-accessible (included in executor_uow_view).
+    --   wall_clock_seconds is a derived field: computed from completed_at - started_at at query time.
+    token_usage         INTEGER NULL,
+
     UNIQUE(source_issue_number, sweep_date)
 );
 -- vision_ref: JSON {layer, field, statement, anchored_at}
@@ -129,7 +136,7 @@ SELECT
     source_issue_number, summary,
     workflow_artifact, success_criteria, prescribed_skills,
     steward_cycles, timeout_at, estimated_runtime,
-    issue_url
+    issue_url, token_usage
 FROM uow_registry
 WHERE status = 'ready-for-executor';
 -- steward_agenda: Steward-private, excluded from executor_uow_view.

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -760,6 +760,7 @@ def maybe_complete_wos_uow(
     task_id: str,
     status: str,
     result_text: str | None = None,
+    token_usage: int | None = None,
     gh_bin: str = "gh",
 ) -> None:
     """
@@ -794,6 +795,10 @@ def maybe_complete_wos_uow(
         status:  The status from the write_result call ("success" or "error").
         result_text: Optional text from the write_result call; used in the
                      close-out comment summary and output classification.
+        token_usage: Optional total token count (input + output) reported by
+                     the subagent via write_result. Written to the registry
+                     when provided; NULL otherwise. Used for per-UoW cost
+                     telemetry (issue #990).
         gh_bin:  Path to the gh CLI binary (injectable for tests; default "gh").
     """
     if not task_id.startswith(WOS_TASK_ID_PREFIX):
@@ -839,7 +844,7 @@ def maybe_complete_wos_uow(
             return
 
         output_ref = uow.output_ref or ""
-        registry.complete_uow(uow_id, output_ref)
+        registry.complete_uow(uow_id, output_ref, token_usage=token_usage)
         log.info(
             "maybe_complete_wos_uow: UoW %r transitioned executing → ready-for-steward "
             "(execution_complete written on write_result confirmation)",

--- a/tests/unit/test_orchestration/test_outcome_telemetry.py
+++ b/tests/unit/test_orchestration/test_outcome_telemetry.py
@@ -1,0 +1,604 @@
+"""
+Tests for outcome_telemetry (issue #990).
+
+Covers:
+- token_usage column written to uow_registry when complete_uow is called with a value
+- token_usage remains NULL when complete_uow is called without a value
+- COALESCE semantics: existing non-NULL token_usage is not overwritten by NULL
+- wall_clock_seconds computed at query time from completed_at - started_at
+- maybe_complete_wos_uow forwards token_usage to complete_uow
+- metabolic digest: aggregate_token_usage returns sum for UoWs with data, None when absent
+- metabolic digest: compute_wall_clock_stats returns correct avg and count
+- metabolic digest: format_digest includes token and wall-clock lines when data present
+
+Named constants mirror the spec so test failures are self-documenting.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — make src importable
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from orchestration.wos_completion import (
+    WOS_TASK_ID_PREFIX,
+    WRITE_RESULT_SUCCESS_STATUS,
+    maybe_complete_wos_uow,
+)
+from orchestration.registry import Registry, UoWStatus, UpsertInserted
+
+# ---------------------------------------------------------------------------
+# Load metabolic digest module (script, not a package)
+# ---------------------------------------------------------------------------
+
+_DIGEST_SCRIPT_PATH = _REPO_ROOT / "scheduled-tasks" / "wos-metabolic-digest.py"
+
+
+def _load_digest_module():
+    spec = importlib.util.spec_from_file_location("wos_metabolic_digest", _DIGEST_SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Named constants matching the spec
+# ---------------------------------------------------------------------------
+
+# Threshold below which token_usage is rejected as invalid (non-positive)
+TOKEN_USAGE_MIN_VALID = 1
+
+# Representative valid token counts from the spec context
+SMALL_TOKEN_COUNT = 1_234
+LARGE_TOKEN_COUNT = 98_765
+COMBINED_TOKEN_COUNT = SMALL_TOKEN_COUNT + LARGE_TOKEN_COUNT  # 100_000 - 1
+
+# Wall-clock thresholds used in the digest display
+WALL_CLOCK_60S = 60
+WALL_CLOCK_120S = 120
+WALL_CLOCK_AVG_MIN = round((WALL_CLOCK_60S + WALL_CLOCK_120S) / 2 / 60, 1)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _seed_executing_uow(registry: Registry, tmp_path: Path) -> tuple[str, str]:
+    """
+    Seed a UoW and advance it to 'executing'. Returns (uow_id, output_ref).
+    """
+    result = registry.upsert(
+        issue_number=9902,
+        title="Telemetry test UoW",
+        success_criteria="token_usage and wall_clock_seconds are recorded",
+    )
+    assert isinstance(result, UpsertInserted)
+    uow_id = result.id
+
+    registry.approve(uow_id)
+
+    output_ref = str(tmp_path / f"{uow_id}.json")
+    registry.set_status_direct(uow_id, "active")
+
+    # Write output_ref directly — bypasses Executor internals for test isolation
+    conn = sqlite3.connect(str(registry.db_path))
+    conn.execute(
+        "UPDATE uow_registry SET output_ref = ? WHERE id = ?",
+        (output_ref, uow_id),
+    )
+    conn.commit()
+    conn.close()
+
+    registry.transition_to_executing(uow_id, "mock-executor-001")
+    return uow_id, output_ref
+
+
+def _fetch_uow_row(db_path: Path, uow_id: str) -> dict:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM uow_registry WHERE id = ?", (uow_id,)
+    ).fetchone()
+    conn.close()
+    assert row is not None, f"UoW {uow_id!r} not found in registry"
+    return dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Registry: complete_uow with token_usage
+# ---------------------------------------------------------------------------
+
+class TestCompleteUowTokenUsage:
+    """Token usage is written to the registry when complete_uow provides it."""
+
+    def test_token_usage_stored_when_provided(self, tmp_path: Path) -> None:
+        """
+        complete_uow(token_usage=N) writes N to the token_usage column.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        registry.complete_uow(uow_id, output_ref, token_usage=SMALL_TOKEN_COUNT)
+
+        row = _fetch_uow_row(db_path, uow_id)
+        assert row["token_usage"] == SMALL_TOKEN_COUNT, (
+            f"Expected token_usage={SMALL_TOKEN_COUNT}, got {row['token_usage']}"
+        )
+
+    def test_token_usage_null_when_not_provided(self, tmp_path: Path) -> None:
+        """
+        complete_uow() without token_usage leaves the column NULL.
+
+        NULL is the correct state for UoWs whose subagent did not report usage —
+        it distinguishes 'not reported' from '0 tokens'.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        registry.complete_uow(uow_id, output_ref)
+
+        row = _fetch_uow_row(db_path, uow_id)
+        assert row["token_usage"] is None, (
+            f"Expected token_usage=NULL when not provided, got {row['token_usage']}"
+        )
+
+    def test_existing_token_usage_not_overwritten_by_null(self, tmp_path: Path) -> None:
+        """
+        COALESCE semantics: a pre-existing non-NULL token_usage is not overwritten
+        when complete_uow is called without token_usage.
+
+        This covers the edge case where token_usage was written by a prior call
+        (e.g. partial update) and a subsequent complete_uow with no usage data
+        should not erase the existing value.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        # Pre-set token_usage directly
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE uow_registry SET token_usage = ? WHERE id = ?",
+            (LARGE_TOKEN_COUNT, uow_id),
+        )
+        conn.commit()
+        conn.close()
+
+        # complete_uow without token_usage — COALESCE should preserve existing value
+        registry.complete_uow(uow_id, output_ref, token_usage=None)
+
+        row = _fetch_uow_row(db_path, uow_id)
+        assert row["token_usage"] == LARGE_TOKEN_COUNT, (
+            f"COALESCE failed: expected {LARGE_TOKEN_COUNT}, got {row['token_usage']}"
+        )
+
+    def test_token_usage_in_audit_note(self, tmp_path: Path) -> None:
+        """
+        When token_usage is provided, it appears in the execution_complete audit note.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        registry.complete_uow(uow_id, output_ref, token_usage=SMALL_TOKEN_COUNT)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        audit_row = conn.execute(
+            "SELECT note FROM audit_log WHERE uow_id = ? AND event = 'execution_complete'",
+            (uow_id,),
+        ).fetchone()
+        conn.close()
+
+        assert audit_row is not None, "execution_complete audit entry must exist"
+        note = json.loads(audit_row["note"])
+        assert note.get("token_usage") == SMALL_TOKEN_COUNT, (
+            f"Expected token_usage in audit note, got: {note}"
+        )
+
+    def test_token_usage_absent_from_audit_note_when_not_provided(self, tmp_path: Path) -> None:
+        """
+        When token_usage is not provided, the key is absent from the audit note
+        (not present as null — absence is the signal 'not reported').
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        registry.complete_uow(uow_id, output_ref)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        audit_row = conn.execute(
+            "SELECT note FROM audit_log WHERE uow_id = ? AND event = 'execution_complete'",
+            (uow_id,),
+        ).fetchone()
+        conn.close()
+
+        assert audit_row is not None
+        note = json.loads(audit_row["note"])
+        assert "token_usage" not in note, (
+            f"token_usage key should be absent when not provided, got: {note}"
+        )
+
+    def test_completed_at_written_on_complete_uow(self, tmp_path: Path) -> None:
+        """
+        complete_uow sets completed_at, which enables wall_clock_seconds computation.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        registry.complete_uow(uow_id, output_ref)
+
+        row = _fetch_uow_row(db_path, uow_id)
+        assert row["completed_at"] is not None, (
+            "completed_at must be set by complete_uow to enable wall_clock_seconds"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry: wall_clock_seconds computed from timestamps
+# ---------------------------------------------------------------------------
+
+class TestWallClockSeconds:
+    """wall_clock_seconds is computed at query time from started_at/completed_at."""
+
+    def test_wall_clock_computed_from_timestamps(self, tmp_path: Path) -> None:
+        """
+        A UoW with both started_at and completed_at yields a non-NULL
+        wall_clock_seconds when queried via the julianday expression.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        # Set started_at explicitly so we can compute expected delta
+        started = datetime.now(timezone.utc) - timedelta(seconds=WALL_CLOCK_60S)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE uow_registry SET started_at = ? WHERE id = ?",
+            (started.isoformat(), uow_id),
+        )
+        conn.commit()
+        conn.close()
+
+        registry.complete_uow(uow_id, output_ref)
+
+        # Query using the same expression as the metabolic digest
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT CASE
+                WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
+                THEN CAST(
+                    (julianday(completed_at) - julianday(started_at)) * 86400.0
+                    AS INTEGER
+                )
+                ELSE NULL
+            END AS wall_clock_seconds
+            FROM uow_registry WHERE id = ?
+            """,
+            (uow_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row["wall_clock_seconds"] is not None, (
+            "wall_clock_seconds should be non-NULL when both timestamps present"
+        )
+        # Allow ±2s tolerance for test execution time
+        assert abs(row["wall_clock_seconds"] - WALL_CLOCK_60S) <= 2, (
+            f"Expected wall_clock ~{WALL_CLOCK_60S}s, got {row['wall_clock_seconds']}s"
+        )
+
+    def test_wall_clock_null_when_started_at_missing(self, tmp_path: Path) -> None:
+        """
+        A UoW without started_at yields NULL wall_clock_seconds.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, output_ref = _seed_executing_uow(registry, tmp_path)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE uow_registry SET started_at = NULL WHERE id = ?",
+            (uow_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        registry.complete_uow(uow_id, output_ref)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT CASE
+                WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
+                THEN CAST(
+                    (julianday(completed_at) - julianday(started_at)) * 86400.0
+                    AS INTEGER
+                )
+                ELSE NULL
+            END AS wall_clock_seconds
+            FROM uow_registry WHERE id = ?
+            """,
+            (uow_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row["wall_clock_seconds"] is None, (
+            "wall_clock_seconds must be NULL when started_at is missing"
+        )
+
+
+# ---------------------------------------------------------------------------
+# wos_completion: maybe_complete_wos_uow forwards token_usage
+# ---------------------------------------------------------------------------
+
+class TestMaybeCompleteWosUowTokenUsage:
+    """maybe_complete_wos_uow propagates token_usage to complete_uow."""
+
+    def test_token_usage_forwarded_to_registry(self, tmp_path: Path) -> None:
+        """
+        maybe_complete_wos_uow(token_usage=N) results in token_usage=N in the registry.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, _ = _seed_executing_uow(registry, tmp_path)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        with (
+            patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}),
+            patch("orchestration.wos_completion._write_steward_trigger"),
+            patch("orchestration.wos_completion._backpropagate_result_to_output_file"),
+            patch("orchestration.wos_completion._enrich_result_file"),
+            patch("orchestration.wos_completion._post_closeout_comment_if_github"),
+        ):
+            maybe_complete_wos_uow(
+                task_id,
+                WRITE_RESULT_SUCCESS_STATUS,
+                result_text="WOS test complete",
+                token_usage=SMALL_TOKEN_COUNT,
+            )
+
+        row = _fetch_uow_row(db_path, uow_id)
+        assert row["token_usage"] == SMALL_TOKEN_COUNT, (
+            f"Expected token_usage={SMALL_TOKEN_COUNT} after maybe_complete, got {row['token_usage']}"
+        )
+
+    def test_token_usage_null_when_not_passed(self, tmp_path: Path) -> None:
+        """
+        maybe_complete_wos_uow without token_usage leaves the registry column NULL.
+        """
+        db_path = tmp_path / "registry.db"
+        registry = Registry(db_path)
+        uow_id, _ = _seed_executing_uow(registry, tmp_path)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        with (
+            patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}),
+            patch("orchestration.wos_completion._write_steward_trigger"),
+            patch("orchestration.wos_completion._backpropagate_result_to_output_file"),
+            patch("orchestration.wos_completion._enrich_result_file"),
+            patch("orchestration.wos_completion._post_closeout_comment_if_github"),
+        ):
+            maybe_complete_wos_uow(
+                task_id,
+                WRITE_RESULT_SUCCESS_STATUS,
+                result_text="WOS test complete",
+            )
+
+        row = _fetch_uow_row(db_path, uow_id)
+        assert row["token_usage"] is None, (
+            f"Expected token_usage=NULL when not provided, got {row['token_usage']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Metabolic digest: aggregate_token_usage
+# ---------------------------------------------------------------------------
+
+class TestAggregateTokenUsage:
+    """aggregate_token_usage correctly sums token counts across UoW dicts."""
+
+    def setup_method(self):
+        self.mod = _load_digest_module()
+
+    def test_returns_sum_of_reporting_uows(self) -> None:
+        """
+        UoWs that reported token_usage are summed; the result equals COMBINED_TOKEN_COUNT.
+        """
+        uows = [
+            {"token_usage": SMALL_TOKEN_COUNT, "id": "a"},
+            {"token_usage": LARGE_TOKEN_COUNT, "id": "b"},
+        ]
+        result = self.mod.aggregate_token_usage(uows)
+        assert result == COMBINED_TOKEN_COUNT, (
+            f"Expected {COMBINED_TOKEN_COUNT}, got {result}"
+        )
+
+    def test_returns_none_when_all_null(self) -> None:
+        """
+        None is returned when all UoWs have NULL token_usage (no data available).
+        """
+        uows = [{"token_usage": None, "id": "a"}, {"id": "b"}]
+        result = self.mod.aggregate_token_usage(uows)
+        assert result is None, "Expected None when no UoWs reported token_usage"
+
+    def test_partial_data_returns_partial_sum(self) -> None:
+        """
+        Only UoWs with non-NULL token_usage contribute to the sum.
+        Partial data is better than no data — the sum excludes NULLs.
+        """
+        uows = [
+            {"token_usage": SMALL_TOKEN_COUNT, "id": "a"},
+            {"token_usage": None, "id": "b"},
+        ]
+        result = self.mod.aggregate_token_usage(uows)
+        assert result == SMALL_TOKEN_COUNT, (
+            f"Partial sum should equal {SMALL_TOKEN_COUNT}, got {result}"
+        )
+
+    def test_empty_list_returns_none(self) -> None:
+        """An empty UoW list yields None (no data)."""
+        result = self.mod.aggregate_token_usage([])
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Metabolic digest: compute_wall_clock_stats
+# ---------------------------------------------------------------------------
+
+class TestComputeWallClockStats:
+    """compute_wall_clock_stats returns correct count, total, and avg."""
+
+    def setup_method(self):
+        self.mod = _load_digest_module()
+
+    def test_stats_from_two_uows(self) -> None:
+        """
+        Two UoWs with wall_clock_seconds yield the correct avg and count.
+        """
+        uows = [
+            {"wall_clock_seconds": WALL_CLOCK_60S, "id": "a"},
+            {"wall_clock_seconds": WALL_CLOCK_120S, "id": "b"},
+        ]
+        stats = self.mod.compute_wall_clock_stats(uows)
+        assert stats["count"] == 2
+        assert stats["total_seconds"] == WALL_CLOCK_60S + WALL_CLOCK_120S
+        expected_avg = round((WALL_CLOCK_60S + WALL_CLOCK_120S) / 2)
+        assert stats["avg_seconds"] == expected_avg
+
+    def test_null_wall_clock_excluded(self) -> None:
+        """UoWs with NULL wall_clock_seconds are excluded from stats."""
+        uows = [
+            {"wall_clock_seconds": WALL_CLOCK_60S, "id": "a"},
+            {"wall_clock_seconds": None, "id": "b"},
+        ]
+        stats = self.mod.compute_wall_clock_stats(uows)
+        assert stats["count"] == 1
+        assert stats["avg_seconds"] == WALL_CLOCK_60S
+
+    def test_all_null_returns_none_avg(self) -> None:
+        """All-NULL input yields zero count and None avg."""
+        uows = [{"wall_clock_seconds": None, "id": "a"}]
+        stats = self.mod.compute_wall_clock_stats(uows)
+        assert stats["count"] == 0
+        assert stats["avg_seconds"] is None
+        assert stats["total_seconds"] is None
+
+    def test_empty_list_returns_zero_count(self) -> None:
+        """Empty input yields zero count and None values."""
+        stats = self.mod.compute_wall_clock_stats([])
+        assert stats["count"] == 0
+        assert stats["avg_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# Metabolic digest: format_digest includes telemetry
+# ---------------------------------------------------------------------------
+
+class TestFormatDigestTelemetry:
+    """format_digest includes token and wall-clock lines when data is present."""
+
+    def setup_method(self):
+        self.mod = _load_digest_module()
+
+    def _make_groups(self, token_usage=None, wall_clock_seconds=None) -> dict:
+        """Construct a groups dict with one pearl UoW carrying the given telemetry."""
+        uow = {
+            "id": "test-uow-1",
+            "status": "done",
+            "summary": "test",
+            "register": "operational",
+            "close_reason": "pr opened",
+            "output_ref": "",
+            "started_at": None,
+            "closed_at": None,
+            "updated_at": None,
+            "created_at": None,
+            "steward_cycles": 0,
+            "token_usage": token_usage,
+            "wall_clock_seconds": wall_clock_seconds,
+        }
+        return {
+            "pearl": [uow],
+            "heat": [],
+            "seed": [],
+            "shit": [],
+        }
+
+    def test_token_line_present_when_data_available(self) -> None:
+        """
+        format_digest includes a 'Tokens:' line when token_usage is available.
+        """
+        groups = self._make_groups(token_usage=SMALL_TOKEN_COUNT)
+        result = self.mod.format_digest(groups, [], 24, "2026-04-27T00:00:00Z")
+        assert "Tokens:" in result, f"Expected 'Tokens:' line in digest:\n{result}"
+        assert f"{SMALL_TOKEN_COUNT:,}" in result
+
+    def test_token_line_absent_when_no_data(self) -> None:
+        """
+        format_digest omits the 'Tokens:' line when no UoW reported token_usage.
+        """
+        groups = self._make_groups(token_usage=None)
+        result = self.mod.format_digest(groups, [], 24, "2026-04-27T00:00:00Z")
+        assert "Tokens:" not in result, f"'Tokens:' line should be absent:\n{result}"
+
+    def test_wall_clock_line_present_when_data_available(self) -> None:
+        """
+        format_digest includes a 'Wall-clock avg:' line when wall_clock_seconds is available.
+        """
+        groups = self._make_groups(wall_clock_seconds=WALL_CLOCK_60S)
+        result = self.mod.format_digest(groups, [], 24, "2026-04-27T00:00:00Z")
+        assert "Wall-clock avg:" in result, f"Expected 'Wall-clock avg:' line:\n{result}"
+
+    def test_wall_clock_line_absent_when_no_data(self) -> None:
+        """
+        format_digest omits wall-clock line when no UoW has wall_clock_seconds.
+        """
+        groups = self._make_groups(wall_clock_seconds=None)
+        result = self.mod.format_digest(groups, [], 24, "2026-04-27T00:00:00Z")
+        assert "Wall-clock avg:" not in result, f"'Wall-clock avg:' should be absent:\n{result}"
+
+    def test_both_lines_present_when_full_data(self) -> None:
+        """
+        format_digest includes both telemetry lines when both values are available.
+        """
+        groups = self._make_groups(
+            token_usage=SMALL_TOKEN_COUNT,
+            wall_clock_seconds=WALL_CLOCK_60S,
+        )
+        result = self.mod.format_digest(groups, [], 24, "2026-04-27T00:00:00Z")
+        assert "Tokens:" in result
+        assert "Wall-clock avg:" in result
+
+    def test_no_uow_window_omits_telemetry(self) -> None:
+        """
+        format_digest with zero UoWs omits telemetry lines (no data to show).
+        """
+        groups = {"pearl": [], "heat": [], "seed": [], "shit": []}
+        result = self.mod.format_digest(groups, [], 24, "2026-04-27T00:00:00Z")
+        assert "Tokens:" not in result
+        assert "Wall-clock avg:" not in result
+        assert "No UoWs completed" in result

--- a/tests/unit/test_wos_metabolic_digest.py
+++ b/tests/unit/test_wos_metabolic_digest.py
@@ -124,12 +124,14 @@ def db_path(tmp_path: Path) -> Path:
             close_reason TEXT,
             output_ref TEXT,
             started_at TEXT,
+            completed_at TEXT,
             closed_at TEXT,
             updated_at TEXT,
             created_at TEXT NOT NULL,
             heartbeat_at TEXT,
             heartbeat_ttl INTEGER DEFAULT 300,
-            steward_cycles INTEGER DEFAULT 0
+            steward_cycles INTEGER DEFAULT 0,
+            token_usage INTEGER NULL
         )
     """)
     conn.execute("""


### PR DESCRIPTION
Closes #990

## Why this exists

WOS UoWs have `outcome_category` (heat/shit/seed/pearl) since PR #759 but no per-UoW cost signal. Without token metering we cannot track cost per UoW, identify expensive outliers, or build cost-awareness into orchestration decisions. wall_clock is nearly free since `started_at` already exists — only `completed_at` was missing.

## What changed

**write_result API extension (backwards-compatible)**
`write_result` now accepts an optional `token_usage` integer. Callers that omit it are unaffected — the parameter defaults to NULL. Subagents accumulate `usage.input_tokens + usage.output_tokens` across API turns and report the total.

**Registry schema: `token_usage` column + migration**
`uow_registry` gains `token_usage INTEGER NULL` (migration 0015). Written by `complete_uow` when a subagent reports it. `COALESCE(?, token_usage)` prevents NULL from overwriting an existing value. `completed_at` is now explicitly set by `complete_uow`, enabling the wall-clock derived field.

**wall_clock_seconds: derived, not stored**
Computed at query time via `julianday(completed_at) - julianday(started_at) * 86400`. No new column — `started_at` and `completed_at` already existed; this is just arithmetic on existing timestamps.

**Token+wall-clock propagation chain**
`handle_write_result` → `_maybe_complete_wos_uow` → `maybe_complete_wos_uow` → `registry.complete_uow`. Each link passes `token_usage=token_usage`. No existing call sites change.

**Subagent prompt update**
`handle_wos_execute` prompt in `dispatcher_handlers.py` now instructs subagents to accumulate and report `token_usage` at `write_result` time. Omitting it is still valid — the field is optional.

**Metabolic digest**
`wos-metabolic-digest.py` query now fetches `token_usage` and computes `wall_clock_seconds` inline. `format_digest` conditionally adds two lines: `Tokens: N total` and `Wall-clock avg: N min (K UoWs with data)`. Both lines are absent when no UoWs reported the respective data (partial data degrades gracefully).

## Before/After: data flow

Before:
```
write_result(task_id, text) → _maybe_complete_wos_uow → complete_uow(uow_id, output_ref)
                                                         └─ status, updated_at only
```

After:
```
write_result(task_id, text, token_usage=N) → _maybe_complete_wos_uow(token_usage=N)
  → maybe_complete_wos_uow(token_usage=N) → complete_uow(uow_id, output_ref, token_usage=N)
                                             └─ status, updated_at, completed_at, token_usage
```

## Out of scope

- Duration tier (short/medium/long self-declaration) — deferred, not in this PR
- Token aggregation across multiple retries — each `complete_uow` call captures the final execution's usage; retry history is in the audit log
- Cost-per-dollar conversion — raw token counts only; conversion belongs in reporting, not telemetry collection

## Functional patterns

Pure functions for the new aggregation helpers (`aggregate_token_usage`, `compute_wall_clock_stats`), dict spread for conditional audit note enrichment, SQL `COALESCE` for safe nullable writes.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_outcome_telemetry.py -v` — 24 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py tests/unit/test_wos_metabolic_digest.py tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_migrations.py tests/unit/test_orchestration/test_outcome_telemetry.py -v` — 248 passed, 0 failed

## Manual test

N/A — this change is entirely internal (registry schema + MCP tool parameter + digest formatting). No external service calls, no user-visible Telegram output from this PR alone. The metabolic digest change adds conditional lines to an existing message when data is present; that will only appear after subagents begin reporting `token_usage`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal change, no external surface until subagents report usage)
- [x] User-visible outcome verified — N/A (digest change is additive and conditional; produces no output until data flows)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this PR