### PR TITLE
startup_sweep: skip kill for executing UoWs with recent heartbeat (#992)

### DIFF
--- a/scheduled-tasks/startup_sweep.py
+++ b/scheduled-tasks/startup_sweep.py
@@ -97,6 +97,16 @@ DISPATCH_WINDOW_SECONDS: int = 120
 # executor.py) if they slip past this window.
 _ACTIVE_SWEEP_THRESHOLD_SECONDS = 300
 
+# Maximum age (seconds) of `last_heartbeat_at` before the startup sweep
+# considers an `executing` UoW's heartbeat stale and proceeds with kill.
+# If `last_heartbeat_at` is non-NULL and more recent than this threshold, the
+# agent is alive and actively working — skip the kill entirely.
+#
+# 2× the heartbeat interval (agents emit every ~60 s) gives a generous margin
+# for jitter and slow tool calls without letting truly dead agents linger.
+# Issue #992: this closes the loop opened by PR #989 (write_wos_heartbeat).
+HEARTBEAT_SKIP_THRESHOLD_SECONDS: int = 120
+
 
 # ---------------------------------------------------------------------------
 # Startup sweep result type
@@ -110,6 +120,7 @@ class StartupSweepResult:
     diagnosing_swept: int
     executing_swept: int
     skipped_dry_run: int
+    skipped_heartbeat_alive: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +194,49 @@ def _classify_executing_orphan_kill_type(
     return "orphan_kill_before_start"
 
 
+def _is_heartbeat_recent(
+    heartbeat_at: str | None,
+    now: datetime,
+    threshold_seconds: int,
+) -> bool:
+    """
+    Return True if `heartbeat_at` is non-NULL and within `threshold_seconds` of `now`.
+
+    Pure function: no side effects, no registry access.
+
+    Used by Population 4 of run_startup_sweep to decide whether to skip killing
+    an `executing` UoW that has exceeded the TTL — a recent heartbeat means the
+    agent is alive and actively working (#992).
+
+    Args:
+        heartbeat_at: ISO timestamp of the most recent heartbeat written by the
+            agent, or None if no heartbeat has ever been written.
+        now: The current UTC datetime (caller-supplied for testability).
+        threshold_seconds: Maximum age (seconds) of `heartbeat_at` to be
+            considered recent. Typically HEARTBEAT_SKIP_THRESHOLD_SECONDS (120 s).
+
+    Returns:
+        True  — heartbeat_at is non-NULL and age < threshold_seconds → skip kill.
+        False — heartbeat_at is NULL, unparseable, or stale → proceed with kill.
+
+    Safe default: False whenever the recency cannot be determined (None input,
+    unparseable timestamp). This is conservative — an ambiguous heartbeat never
+    prevents a kill.
+    """
+    if heartbeat_at is None:
+        return False
+
+    try:
+        hb_dt = datetime.fromisoformat(heartbeat_at.replace("Z", "+00:00"))
+        if hb_dt.tzinfo is None:
+            hb_dt = hb_dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError, AttributeError):
+        return False
+
+    age_seconds = (now - hb_dt).total_seconds()
+    return age_seconds < threshold_seconds
+
+
 def _classify_active_uow(output_ref: str | None) -> tuple[str, dict]:
     """
     Classify an active UoW by examining output_ref.
@@ -245,6 +299,7 @@ def run_startup_sweep(
     orphan_threshold_seconds: int = _EXECUTOR_ORPHAN_THRESHOLD_SECONDS,
     active_sweep_threshold_seconds: int = _ACTIVE_SWEEP_THRESHOLD_SECONDS,
     executing_orphan_threshold_seconds: int = _EXECUTING_ORPHAN_THRESHOLD_SECONDS,
+    heartbeat_skip_threshold_seconds: int = HEARTBEAT_SKIP_THRESHOLD_SECONDS,
     bootup_candidate_gate: bool | None = None,
     github_client: Callable[[int], dict[str, Any]] | None = None,
 ) -> StartupSweepResult:
@@ -279,6 +334,12 @@ def run_startup_sweep(
        written (agent crashed before its first heartbeat write).
        Classified as executing_orphan and transitioned to ready-for-steward.
 
+       Heartbeat recency gate (#992): before killing an executing UoW that has
+       exceeded the TTL, check last_heartbeat_at recency. If heartbeat_at is
+       non-NULL and within heartbeat_skip_threshold_seconds (default: 120 s),
+       the agent is alive — skip the kill and log. Only UoWs with a NULL or
+       stale heartbeat are killed.
+
     Each transition uses the optimistic-lock + audit pattern (Principle 1):
     - Audit entry written in same transaction as status UPDATE.
     - If rows_affected == 0: another process won the race — skip silently.
@@ -295,6 +356,10 @@ def run_startup_sweep(
         is classified as executor_orphan. Default: 3600 s.
     executing_orphan_threshold_seconds: minimum age before an `executing` UoW
         is classified as executing_orphan. Default: 600 s (10 minutes).
+    heartbeat_skip_threshold_seconds: maximum age (seconds) of heartbeat_at
+        before a heartbeat is considered stale. Default: 120 s. UoWs with a
+        heartbeat younger than this are skipped (agent is alive). Pass 0 to
+        disable the gate entirely (original behaviour before #992).
     bootup_candidate_gate: override for BOOTUP_CANDIDATE_GATE module constant.
     github_client: callable(issue_number) → {labels, ...}. Defaults to the
         production gh CLI client from steward.py.
@@ -350,6 +415,7 @@ def run_startup_sweep(
     diagnosing_swept = 0
     executing_swept = 0
     skipped_dry_run = 0
+    skipped_heartbeat_alive = 0
 
     # --- Population 1: active UoWs (Executor crash during execution) ---
     for uow in active_uows:
@@ -606,10 +672,27 @@ def run_startup_sweep(
             # Not old enough — may still be executing normally.
             continue
 
+        # Heartbeat recency gate (#992): if the agent is actively emitting
+        # heartbeats, it is alive — skip the kill regardless of TTL.
+        # _is_heartbeat_recent returns False for NULL or stale heartbeats so
+        # the gate is a no-op for agents that never wrote a heartbeat.
+        heartbeat_at: str | None = getattr(uow, "heartbeat_at", None)
+        if heartbeat_skip_threshold_seconds > 0 and _is_heartbeat_recent(
+            heartbeat_at=heartbeat_at,
+            now=now,
+            threshold_seconds=heartbeat_skip_threshold_seconds,
+        ):
+            log.info(
+                "Startup sweep: skipping executing UoW %s — recent heartbeat "
+                "(heartbeat_at=%s, age=%.0fs, skip_threshold=%ds); agent is alive",
+                uow_id, heartbeat_at, age_seconds, heartbeat_skip_threshold_seconds,
+            )
+            skipped_heartbeat_alive += 1
+            continue
+
         # Classify kill type using heartbeat evidence (issue #963).
         # Safe default: kill_before_start when registry method is unavailable.
         dispatch_ts: str | None = None
-        heartbeat_at: str | None = getattr(uow, "heartbeat_at", None)
         try:
             dispatch_ts = registry.get_executor_dispatch_timestamp(uow_id)
         except (AttributeError, Exception) as _exc:
@@ -654,12 +737,17 @@ def run_startup_sweep(
                 uow_id,
             )
 
-    total = active_swept + executor_orphans_swept + diagnosing_swept + executing_swept + skipped_dry_run
+    total = (
+        active_swept + executor_orphans_swept + diagnosing_swept
+        + executing_swept + skipped_dry_run + skipped_heartbeat_alive
+    )
     if total > 0:
         log.info(
             "Startup sweep complete: %d active swept, %d executor_orphans swept, "
-            "%d diagnosing swept, %d executing_orphans swept, %d skipped (dry-run)",
-            active_swept, executor_orphans_swept, diagnosing_swept, executing_swept, skipped_dry_run,
+            "%d diagnosing swept, %d executing_orphans swept, "
+            "%d skipped (dry-run), %d skipped (heartbeat alive)",
+            active_swept, executor_orphans_swept, diagnosing_swept, executing_swept,
+            skipped_dry_run, skipped_heartbeat_alive,
         )
 
     return StartupSweepResult(
@@ -668,4 +756,5 @@ def run_startup_sweep(
         diagnosing_swept=diagnosing_swept,
         executing_swept=executing_swept,
         skipped_dry_run=skipped_dry_run,
+        skipped_heartbeat_alive=skipped_heartbeat_alive,
     )

--- a/tests/unit/test_orchestration/test_heartbeat_gate.py
+++ b/tests/unit/test_orchestration/test_heartbeat_gate.py
@@ -1,0 +1,621 @@
+"""
+Tests for the heartbeat recency gate in startup_sweep — issue #992.
+
+When startup_sweep finds a UoW in `executing` status that has exceeded the
+TTL, it must now check last_heartbeat_at before killing:
+
+  - Recent heartbeat (< HEARTBEAT_SKIP_THRESHOLD_SECONDS ago) → skip kill,
+    log "agent alive", increment skipped_heartbeat_alive.
+  - Stale heartbeat (≥ HEARTBEAT_SKIP_THRESHOLD_SECONDS ago) → kill,
+    classify correctly (preserving PR #968 classification logic).
+  - NULL heartbeat → kill (same as before PR #989).
+  - UoW under TTL → not killed regardless of heartbeat (regression).
+
+Coverage of _is_heartbeat_recent (pure function):
+  - None → False (safe default)
+  - unparseable timestamp → False (safe default)
+  - heartbeat younger than threshold → True
+  - heartbeat exactly at threshold boundary → False (boundary is exclusive)
+  - heartbeat older than threshold → False
+  - threshold=0 disables gate → False (gate disabled, caller must handle)
+
+Prerequisites this closes the loop on:
+  - PR #968: orphan_kill_before_start / orphan_kill_during_execution classification
+  - PR #989: write_wos_heartbeat MCP tool
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Load startup_sweep module (lives in scheduled-tasks/)
+# ---------------------------------------------------------------------------
+
+_SWEEP_MOD_NAME = "startup_sweep_heartbeat_gate_test_mod"
+_SWEEP_PATH = REPO_ROOT / "scheduled-tasks" / "startup_sweep.py"
+
+
+def _load_startup_sweep():
+    spec = importlib.util.spec_from_file_location(_SWEEP_MOD_NAME, _SWEEP_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_SWEEP_MOD_NAME] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_sweep_mod = _load_startup_sweep()
+run_startup_sweep = _sweep_mod.run_startup_sweep
+_is_heartbeat_recent = _sweep_mod._is_heartbeat_recent
+HEARTBEAT_SKIP_THRESHOLD_SECONDS = _sweep_mod.HEARTBEAT_SKIP_THRESHOLD_SECONDS
+DISPATCH_WINDOW_SECONDS = _sweep_mod.DISPATCH_WINDOW_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Registry import
+# ---------------------------------------------------------------------------
+
+from src.orchestration.registry import Registry
+
+
+# ---------------------------------------------------------------------------
+# Schema — must include heartbeat_at column (added by PR #989 migration)
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS uow_registry (
+    id                  TEXT    PRIMARY KEY,
+    type                TEXT    NOT NULL DEFAULT 'executable',
+    source              TEXT    NOT NULL,
+    source_issue_number INTEGER,
+    sweep_date          TEXT,
+    status              TEXT    NOT NULL DEFAULT 'proposed',
+    posture             TEXT    NOT NULL DEFAULT 'solo',
+    agent               TEXT,
+    children            TEXT    DEFAULT '[]',
+    parent              TEXT,
+    created_at          TEXT    NOT NULL,
+    updated_at          TEXT    NOT NULL,
+    started_at          TEXT,
+    completed_at        TEXT,
+    summary             TEXT    NOT NULL,
+    output_ref          TEXT,
+    hooks_applied       TEXT    DEFAULT '[]',
+    route_reason        TEXT,
+    route_evidence      TEXT    DEFAULT '{}',
+    trigger             TEXT    DEFAULT '{"type": "immediate"}',
+    vision_ref          TEXT    DEFAULT NULL,
+    workflow_artifact   TEXT    NULL,
+    success_criteria    TEXT    NULL,
+    prescribed_skills   TEXT    NULL,
+    steward_cycles      INTEGER NOT NULL DEFAULT 0,
+    timeout_at          TEXT    NULL,
+    estimated_runtime   INTEGER NULL,
+    steward_agenda      TEXT    NULL,
+    steward_log         TEXT    NULL,
+    UNIQUE(source_issue_number, sweep_date)
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          TEXT    NOT NULL,
+    uow_id      TEXT    NOT NULL,
+    event       TEXT    NOT NULL,
+    from_status TEXT,
+    to_status   TEXT,
+    agent       TEXT,
+    note        TEXT
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _open_conn(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _iso_ago(seconds: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
+
+
+def _make_executing_uow(
+    conn: sqlite3.Connection,
+    *,
+    uow_id: str,
+    started_at: str | None = None,
+    heartbeat_at: str | None = None,
+    source_issue_number: int = 42,
+) -> str:
+    now = _now_iso()
+    _started_at = started_at or _iso_ago(1800)  # Default: 30 min ago (past TTL threshold)
+    conn.execute(
+        """
+        INSERT INTO uow_registry (
+            id, type, source, source_issue_number, sweep_date, status, posture,
+            created_at, updated_at, started_at, summary, route_evidence, trigger,
+            heartbeat_at
+        ) VALUES (?, 'executable', ?, ?, '2026-01-01', 'executing', 'solo',
+                  ?, ?, ?, 'Test UoW', '{}', '{"type": "immediate"}', ?)
+        """,
+        (
+            uow_id,
+            f"github:issue/{source_issue_number}",
+            source_issue_number,
+            now,
+            _started_at,
+            _started_at,
+            heartbeat_at,
+        ),
+    )
+    conn.commit()
+    return uow_id
+
+
+def _insert_executor_dispatch_audit(
+    conn: sqlite3.Connection,
+    uow_id: str,
+    timestamp: str,
+) -> None:
+    note = json.dumps({"actor": "executor", "timestamp": timestamp})
+    conn.execute(
+        """
+        INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+        VALUES (?, ?, 'executor_dispatch', 'active', 'executing', 'executor', ?)
+        """,
+        (timestamp, uow_id, note),
+    )
+    conn.commit()
+
+
+def _get_status(db_path: Path, uow_id: str) -> str:
+    conn = _open_conn(db_path)
+    try:
+        row = conn.execute(
+            "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return row["status"] if row else "NOT_FOUND"
+    finally:
+        conn.close()
+
+
+def _get_sweep_audit_entries(db_path: Path, uow_id: str) -> list[dict]:
+    conn = _open_conn(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM audit_log WHERE uow_id = ? AND event = 'startup_sweep' ORDER BY id ASC",
+            (uow_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "registry.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA)
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def registry(tmp_db: Path) -> Registry:
+    return Registry(tmp_db)
+
+
+# ---------------------------------------------------------------------------
+# _is_heartbeat_recent — pure function unit tests
+# ---------------------------------------------------------------------------
+
+class TestIsHeartbeatRecent:
+    """Pure function tests — no registry, no I/O."""
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def test_none_returns_false(self) -> None:
+        """NULL heartbeat_at → safe default → False."""
+        assert _is_heartbeat_recent(None, self._now(), 120) is False
+
+    def test_unparseable_timestamp_returns_false(self) -> None:
+        """Unparseable heartbeat_at → safe default → False."""
+        assert _is_heartbeat_recent("not-a-timestamp", self._now(), 120) is False
+
+    def test_empty_string_returns_false(self) -> None:
+        assert _is_heartbeat_recent("", self._now(), 120) is False
+
+    def test_recent_heartbeat_within_threshold_returns_true(self) -> None:
+        """Heartbeat 30 s ago with threshold=120 s → recent → True."""
+        heartbeat_at = _iso_ago(30)
+        assert _is_heartbeat_recent(heartbeat_at, self._now(), 120) is True
+
+    def test_heartbeat_just_before_threshold_returns_true(self) -> None:
+        """Heartbeat 119 s ago with threshold=120 s → within threshold → True."""
+        heartbeat_at = _iso_ago(119)
+        assert _is_heartbeat_recent(heartbeat_at, self._now(), 120) is True
+
+    def test_heartbeat_at_exact_threshold_boundary_returns_false(self) -> None:
+        """Heartbeat exactly at threshold (age == threshold) → boundary is exclusive → False."""
+        now = self._now()
+        heartbeat_at = (now - timedelta(seconds=120)).isoformat()
+        # age == 120 s, threshold == 120 s → NOT recent (< not <=)
+        assert _is_heartbeat_recent(heartbeat_at, now, 120) is False
+
+    def test_stale_heartbeat_older_than_threshold_returns_false(self) -> None:
+        """Heartbeat 300 s ago with threshold=120 s → stale → False."""
+        heartbeat_at = _iso_ago(300)
+        assert _is_heartbeat_recent(heartbeat_at, self._now(), 120) is False
+
+    def test_threshold_zero_always_returns_false(self) -> None:
+        """threshold=0 disables the gate — always returns False."""
+        heartbeat_at = _iso_ago(1)  # 1 second ago — would be recent with any threshold > 0
+        assert _is_heartbeat_recent(heartbeat_at, self._now(), 0) is False
+
+    def test_heartbeat_skip_threshold_constant_is_positive_integer(self) -> None:
+        """HEARTBEAT_SKIP_THRESHOLD_SECONDS is a named positive integer constant."""
+        assert isinstance(HEARTBEAT_SKIP_THRESHOLD_SECONDS, int)
+        assert HEARTBEAT_SKIP_THRESHOLD_SECONDS > 0
+
+    def test_heartbeat_skip_threshold_constant_is_at_least_60(self) -> None:
+        """Must be at least 2× a typical 30-s heartbeat interval."""
+        assert HEARTBEAT_SKIP_THRESHOLD_SECONDS >= 60
+
+
+# ---------------------------------------------------------------------------
+# Integration: Population 4 heartbeat gate
+# ---------------------------------------------------------------------------
+
+class TestHeartbeatGateInPopulationFour:
+    """
+    Integration tests that run run_startup_sweep against a real Registry.
+
+    These verify the four outcome cells described in issue #992:
+      1. Recent heartbeat → NOT killed
+      2. Stale heartbeat → killed, classified correctly
+      3. NULL heartbeat → killed
+      4. Under TTL → not killed (regression — unchanged behaviour)
+    """
+
+    def _make_uow_over_ttl(
+        self,
+        db_path: Path,
+        *,
+        uow_id: str,
+        heartbeat_at: str | None,
+        dispatch_ago_seconds: float = 1800,
+    ) -> None:
+        """Create an `executing` UoW that has exceeded the default TTL (600 s)."""
+        dispatch_ts = _iso_ago(dispatch_ago_seconds)
+        conn = _open_conn(db_path)
+        _make_executing_uow(
+            conn,
+            uow_id=uow_id,
+            started_at=_iso_ago(dispatch_ago_seconds + 30),
+            heartbeat_at=heartbeat_at,
+        )
+        _insert_executor_dispatch_audit(conn, uow_id, dispatch_ts)
+        conn.close()
+
+    # --- Cell 1: recent heartbeat → skip kill --------------------------------
+
+    def test_recent_heartbeat_within_threshold_is_not_killed(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        UoW has exceeded TTL but emitted a heartbeat 30 s ago.
+        The agent is alive — sweep must NOT kill it.
+        """
+        self._make_uow_over_ttl(
+            tmp_db,
+            uow_id="uow-alive-001",
+            heartbeat_at=_iso_ago(30),  # recent — well within 120 s threshold
+        )
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        assert result.executing_swept == 0
+        assert result.skipped_heartbeat_alive == 1
+        assert _get_status(tmp_db, "uow-alive-001") == "executing"
+        assert len(_get_sweep_audit_entries(tmp_db, "uow-alive-001")) == 0
+
+    def test_recent_heartbeat_increments_skipped_heartbeat_alive_counter(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        Two executing UoWs with recent heartbeats: both skipped, counter = 2.
+        """
+        for i in (1, 2):
+            dispatch_ts = _iso_ago(1800 + i * 60)
+            conn = _open_conn(tmp_db)
+            _make_executing_uow(
+                conn,
+                uow_id=f"uow-alive-multi-{i:03d}",
+                started_at=_iso_ago(1800 + i * 60 + 30),
+                heartbeat_at=_iso_ago(10),
+                source_issue_number=100 + i,  # distinct per UoW to avoid UNIQUE conflict
+            )
+            _insert_executor_dispatch_audit(conn, f"uow-alive-multi-{i:03d}", dispatch_ts)
+            conn.close()
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        assert result.skipped_heartbeat_alive == 2
+        assert result.executing_swept == 0
+
+    # --- Cell 2: stale heartbeat → kill, classify correctly ------------------
+
+    def test_stale_heartbeat_over_threshold_is_killed(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        UoW exceeded TTL and its last heartbeat was 300 s ago (> 120 s threshold).
+        Agent is dead — sweep must kill and classify.
+        """
+        dispatch_ago = 1800
+        # Heartbeat is after dispatch + window, so classification is kill_during_execution
+        heartbeat_at = _iso_ago(dispatch_ago - DISPATCH_WINDOW_SECONDS - 120)
+        self._make_uow_over_ttl(
+            tmp_db,
+            uow_id="uow-stale-001",
+            heartbeat_at=heartbeat_at,
+            dispatch_ago_seconds=dispatch_ago,
+        )
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        assert result.executing_swept == 1
+        assert result.skipped_heartbeat_alive == 0
+        assert _get_status(tmp_db, "uow-stale-001") == "ready-for-steward"
+
+        entries = _get_sweep_audit_entries(tmp_db, "uow-stale-001")
+        assert len(entries) == 1
+        note = json.loads(entries[0]["note"])
+        assert note["kill_classification"] == "orphan_kill_during_execution"
+
+    def test_stale_heartbeat_classified_as_kill_before_start_when_no_dispatch_audit(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        Stale heartbeat (> threshold), no executor_dispatch audit entry →
+        falls back to orphan_kill_before_start (safe default from PR #968).
+        """
+        # Heartbeat 300 s ago (stale), but no dispatch audit
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(
+            conn,
+            uow_id="uow-stale-nodispatch-001",
+            started_at=_iso_ago(1800),
+            heartbeat_at=_iso_ago(300),
+        )
+        conn.close()
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        assert result.executing_swept == 1
+        entries = _get_sweep_audit_entries(tmp_db, "uow-stale-nodispatch-001")
+        assert len(entries) == 1
+        note = json.loads(entries[0]["note"])
+        assert note["kill_classification"] == "orphan_kill_before_start"
+
+    # --- Cell 3: NULL heartbeat → kill (unchanged from before PR #989) ------
+
+    def test_null_heartbeat_is_killed(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        UoW exceeded TTL and has never written a heartbeat (NULL).
+        Behaviour is identical to before PR #989: kill and classify.
+        """
+        self._make_uow_over_ttl(
+            tmp_db,
+            uow_id="uow-null-hb-001",
+            heartbeat_at=None,
+        )
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        assert result.executing_swept == 1
+        assert result.skipped_heartbeat_alive == 0
+        assert _get_status(tmp_db, "uow-null-hb-001") == "ready-for-steward"
+
+    def test_null_heartbeat_classified_as_kill_before_start(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """NULL heartbeat → kill_before_start classification (PR #968 logic preserved)."""
+        self._make_uow_over_ttl(
+            tmp_db,
+            uow_id="uow-null-class-001",
+            heartbeat_at=None,
+        )
+
+        run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        entries = _get_sweep_audit_entries(tmp_db, "uow-null-class-001")
+        assert len(entries) == 1
+        note = json.loads(entries[0]["note"])
+        assert note["kill_classification"] == "orphan_kill_before_start"
+
+    # --- Cell 4: under TTL → not killed (regression) ------------------------
+
+    def test_under_ttl_not_killed_regardless_of_heartbeat(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        A UoW that has NOT exceeded the TTL must never be killed, even if its
+        heartbeat is stale. This is the baseline regression guard.
+        """
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(
+            conn,
+            uow_id="uow-young-001",
+            started_at=_iso_ago(120),   # Only 2 minutes old — under 600 s TTL
+            heartbeat_at=_iso_ago(300), # Stale heartbeat, but TTL hasn't fired
+        )
+        conn.close()
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        assert result.executing_swept == 0
+        assert result.skipped_heartbeat_alive == 0
+        assert _get_status(tmp_db, "uow-young-001") == "executing"
+        assert len(_get_sweep_audit_entries(tmp_db, "uow-young-001")) == 0
+
+    # --- Gate disable: threshold=0 -------------------------------------------
+
+    def test_heartbeat_skip_threshold_zero_disables_gate(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        heartbeat_skip_threshold_seconds=0 disables the gate entirely.
+        A UoW with a very recent heartbeat is killed (gate not in effect).
+        """
+        self._make_uow_over_ttl(
+            tmp_db,
+            uow_id="uow-gate-disabled-001",
+            heartbeat_at=_iso_ago(5),  # Very recent — would be skipped if gate were on
+        )
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=0,  # Gate disabled
+        )
+
+        assert result.executing_swept == 1
+        assert result.skipped_heartbeat_alive == 0
+        assert _get_status(tmp_db, "uow-gate-disabled-001") == "ready-for-steward"
+
+    # --- Mixed population: gate selects correctly ---------------------------
+
+    def test_mixed_population_gate_selects_alive_and_dead(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        Two executing UoWs both over TTL:
+          - "alive": recent heartbeat → skipped
+          - "dead": NULL heartbeat → killed
+
+        The gate must select the correct one in each direction.
+        """
+        # Use distinct source_issue_numbers to avoid UNIQUE(source_issue_number, sweep_date)
+        dispatch_ts = _iso_ago(1800)
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(
+            conn,
+            uow_id="uow-mixed-alive-001",
+            started_at=_iso_ago(1830),
+            heartbeat_at=_iso_ago(30),
+            source_issue_number=201,
+        )
+        _insert_executor_dispatch_audit(conn, "uow-mixed-alive-001", dispatch_ts)
+        _make_executing_uow(
+            conn,
+            uow_id="uow-mixed-dead-001",
+            started_at=_iso_ago(1830),
+            heartbeat_at=None,
+            source_issue_number=202,
+        )
+        _insert_executor_dispatch_audit(conn, "uow-mixed-dead-001", dispatch_ts)
+        conn.close()
+
+        result = run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        assert result.executing_swept == 1
+        assert result.skipped_heartbeat_alive == 1
+
+        assert _get_status(tmp_db, "uow-mixed-alive-001") == "executing"
+        assert _get_status(tmp_db, "uow-mixed-dead-001") == "ready-for-steward"
+
+    # --- PR #968 classification preserved when kill does occur ---------------
+
+    def test_kill_classification_present_in_audit_note_for_stale_heartbeat(
+        self, registry: Registry, tmp_db: Path
+    ) -> None:
+        """
+        When a kill DOES occur (stale heartbeat), the PR #968 kill_classification
+        field must still be present in the audit note.
+        """
+        conn = _open_conn(tmp_db)
+        _make_executing_uow(
+            conn,
+            uow_id="uow-classify-stale-001",
+            started_at=_iso_ago(1800),
+            heartbeat_at=_iso_ago(300),  # Stale
+        )
+        conn.close()
+
+        run_startup_sweep(
+            registry,
+            executing_orphan_threshold_seconds=600,
+            heartbeat_skip_threshold_seconds=120,
+        )
+
+        entries = _get_sweep_audit_entries(tmp_db, "uow-classify-stale-001")
+        assert len(entries) == 1
+        note = json.loads(entries[0]["note"])
+        assert "kill_classification" in note, (
+            "kill_classification from PR #968 must still be present when heartbeat is stale"
+        )

--- a/tests/unit/test_orchestration/test_kill_classification.py
+++ b/tests/unit/test_orchestration/test_kill_classification.py
@@ -605,13 +605,17 @@ class TestStartupSweepKillClassification:
         """
         For UoWs where no executor_dispatch audit entry exists (e.g. older records
         before this migration), the classification defaults to kill_before_start.
+
+        The heartbeat is stale (> HEARTBEAT_SKIP_THRESHOLD_SECONDS) so the
+        heartbeat recency gate (#992) does not protect this UoW — the kill
+        fires and the PR #968 classification logic is exercised.
         """
         conn = _open_conn(tmp_db)
         _make_executing_uow(
             conn,
             uow_id="uow-no-dispatch-audit-001",
             started_at=_iso_ago(1800),
-            heartbeat_at=_iso_ago(60),  # Has a heartbeat but no dispatch audit
+            heartbeat_at=_iso_ago(300),  # Stale heartbeat (> 120 s threshold) — kill fires
         )
         conn.close()
 


### PR DESCRIPTION
## Problem

`startup_sweep` kills any `executing` UoW that exceeds the 600-second TTL. This check is purely time-based and ignores whether the agent is actively emitting heartbeats — producing a ~100% kill rate for long-running legitimate jobs.

**Root cause:** The kill condition is `elapsed > TTL`, with no check on `last_heartbeat_at`. An agent running for 601 seconds but that emitted a heartbeat 10 seconds ago gets killed.

**Prerequisites:**
- PR #968 added `orphan_kill_before_start` / `orphan_kill_during_execution` classification but did not change the kill *condition*.
- PR #989 added `write_wos_heartbeat` so agents can now emit heartbeats.

This PR closes the loop: the sweep must check `last_heartbeat_at` recency before killing.

## What changed

**Before:** `elapsed > TTL` → kill  
**After:** `elapsed > TTL AND (heartbeat_at IS NULL OR heartbeat_age >= 120s)` → kill; else skip

```
elapsed > TTL?
    │ No  → skip (unchanged)
    │ Yes
    ▼
heartbeat recent (< 120s)?
    │ Yes → skip kill, log "agent alive", skipped_heartbeat_alive++
    │ No (NULL or stale)
    ▼
classify kill (PR #968) → transition to ready-for-steward (unchanged)
```

## Changes

**`scheduled-tasks/startup_sweep.py`** (surgical, Population 4 only):
- `HEARTBEAT_SKIP_THRESHOLD_SECONDS = 120` constant alongside the existing TTL constant
- `_is_heartbeat_recent(heartbeat_at, now, threshold)` pure function — safe default `False` for `None` and unparseable inputs; composable and independently testable
- `heartbeat_skip_threshold_seconds` parameter on `run_startup_sweep` (default: constant; pass `0` to disable)
- `skipped_heartbeat_alive` field added to `StartupSweepResult`
- Recency check inserted between TTL gate and kill — no other code paths touched

**`tests/unit/test_orchestration/test_heartbeat_gate.py`** (new):
- 10 pure function tests for `_is_heartbeat_recent` (None, unparseable, boundary, threshold=0)
- 10 integration tests covering all four outcome cells in the decision table

**`tests/unit/test_orchestration/test_kill_classification.py`** (1-line fix):
- `test_backward_compat_no_dispatch_audit_defaults_to_kill_before_start` used `heartbeat_at=_iso_ago(60)` — a recent heartbeat now legitimately protected by the gate. Changed to `_iso_ago(300)` so the kill fires and the PR #968 classification logic is exercised.

## Areas to review closely

1. **The recency check insertion point**: fires after the TTL gate but before kill classification. `heartbeat_at` is bound once and reused in both the gate and the `_classify_executing_orphan_kill_type` call below — verify the binding is not accidentally shadowed.

2. **PR #968 classification preserved**: when the kill does fire (stale/NULL heartbeat), `_classify_executing_orphan_kill_type` is called with the same `heartbeat_at` variable — verify the classification logic is identical to before.

3. **`skipped_heartbeat_alive=0` default on `StartupSweepResult`**: the dataclass has `slots=True` and `frozen=True`. The new field has a default value — confirm existing callers that unpack the result are unaffected.

## Functional patterns

`_is_heartbeat_recent` is a pure predicate (no side effects, no registry access) that composes with the existing `_classify_executing_orphan_kill_type` and `_classify_active_uow` pure functions. The integration point (`run_startup_sweep`) remains the sole place with side effects.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_heartbeat_gate.py -v` — 20 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_startup_sweep.py tests/unit/test_orchestration/test_kill_classification.py -v` — 65 passed, 0 failed (regression clean)
- [x] Combined: 85 passed, 0 failed

## Manual test

N/A — entirely internal to the startup sweep logic. No external service calls, no systemd units, no file I/O beyond what the existing sweep already does. No user-visible Telegram output.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, see above
- [x] User-visible outcome — not applicable, internal logic
- [x] Side-effect audit complete: gate only prevents kills; cannot cause floods or mass sends
- [x] External service calls: none

Closes #992