### PR TITLE
fix(wos): enforce idempotent intake — skip re-proposal for active UoWs

### DIFF
--- a/oracle/decisions.md
+++ b/oracle/decisions.md
@@ -158,3 +158,60 @@ guarantee a dispatch slot for null-juice UoWs within a bounded time window
 when juiced UoWs are continuously present. A follow-on task should evaluate
 whether a fairness slot (e.g., every N cycles, promote the oldest null-juice
 ready-for-steward UoW to the front) is warranted as load increases.
+
+---
+
+## ADR-004: 'closed' Treated as Terminal in SQL Exclusion Contexts — Encoded Orientation
+
+**Date:** 2026-04-27
+**Status:** Accepted
+**PR:** #1003 (fix/issue-dedup-reactivate)
+
+### Context
+
+The UoWStatus enum covers all current status values. However, the production
+registry contains rows with `status='closed'` — a legacy value set externally
+before enum enforcement was introduced. As of the time this ADR was written,
+768 rows carried `status='closed'`.
+
+`UoWStatus.is_terminal()` intentionally excludes 'closed' because it is not
+a valid enum value — `UoWStatus('closed')` raises `ValueError`. Rows in
+`'closed'` state cannot be represented as `UoWStatus` instances.
+
+### Problem
+
+In `_upsert_typed` and `has_active_uow_for_issue`, the SQL exclusion list
+(the set of statuses that count as "already done, re-proposal is allowed")
+did not include 'closed'. This caused legacy rows with `status='closed'` to
+be treated as non-terminal — i.e., as if an active UoW already existed for
+that issue — permanently blocking re-proposal for any issue whose only
+registry row was in the 'closed' state.
+
+### Decision
+
+'closed' is treated as terminal in all SQL exclusion contexts. Specifically:
+
+- `_upsert_typed` adds 'closed' to its NOT IN exclusion list alongside the
+  enum terminal statuses (done, failed, expired, cancelled).
+- `has_active_uow_for_issue` uses `_TERMINAL_STATUSES_FOR_ISSUE_CHECK` — a
+  frozenset containing the same five values — as the authoritative source for
+  its SQL NOT IN clause.
+
+`UoWStatus.is_terminal()` is NOT updated. It covers only enum-representable
+statuses. The docstring for `is_terminal()` explicitly names this boundary.
+
+### Rationale
+
+Semantically, 'closed' means the same thing as 'done': the work is finished
+and re-proposal should be allowed. The only reason it was not enumerated is
+that the enum did not exist when those rows were written. Treating 'closed'
+as non-terminal was unintentional — an artifact of the enum boundary, not a
+deliberate design choice.
+
+### Constraint
+
+New code must not write `status='closed'` directly. All new terminal writes
+must use `UoWStatus.DONE` (or another enum value as appropriate). The 'closed'
+treatment as terminal is for legacy-row compatibility only. The production
+migration to reclassify existing 'closed' rows as 'done' is out of scope for
+this PR and tracked as a follow-on.

--- a/src/orchestration/garden_caretaker.py
+++ b/src/orchestration/garden_caretaker.py
@@ -558,7 +558,30 @@ class GardenCaretaker:
         return 0
 
     def _reactivate_uow(self, uow: UoW) -> int:
-        """Reactivate an archived/terminal UoW back to proposed. Returns 1 if done."""
+        """Reactivate an archived/terminal UoW back to proposed. Returns 1 if done.
+
+        Idempotency guard: if scan() already created a new proposed UoW for the
+        same issue on a different sweep_date while this UoW was terminal, skip
+        reactivation to prevent a duplicate proposed row.  This closes the race
+        where archived → scan creates new row → tend reactivates old row.
+        """
+        issue_number = self._extract_issue_number(uow.source or "")
+        if issue_number is not None and self.registry.has_active_uow_for_issue(issue_number):
+            logger.info(
+                "tend: skipping reactivation of UoW %s — a non-terminal UoW already exists "
+                "for issue #%d (dedup guard)",
+                uow.id, issue_number,
+            )
+            self.registry.append_audit_log(uow.id, {
+                "event": "reactivation_skipped",
+                "actor": "garden_caretaker",
+                "classification": "duplicate_guard",
+                "reason": f"non-terminal UoW already exists for issue #{issue_number}",
+                "uow_id": uow.id,
+                "timestamp": _now_iso(),
+            })
+            return 0
+
         # Use set_status_direct — the UoW is in a terminal state and we need
         # to bypass the conditional transition guard.
         try:

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -587,11 +587,13 @@ class Registry:
             # Cross-sweep-date pre-check: any non-terminal record for this issue?
             # 'cancelled' is a terminal status (UoWStatus.CANCELLED) that allows
             # re-proposal after a cancellation.
+            # 'closed' is a legacy DB status predating the UoWStatus enum; treat it
+            # as terminal so that legacy rows do not permanently block re-proposal.
             existing = conn.execute(
                 """
                 SELECT id, status FROM uow_registry
                 WHERE source_issue_number = ?
-                  AND status NOT IN ('done', 'failed', 'expired', 'cancelled')
+                  AND status NOT IN ('done', 'failed', 'expired', 'cancelled', 'closed')
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
@@ -981,6 +983,38 @@ class Registry:
         parameter — used by the Registrar sweep to fetch only `pending` UoWs.
         """
         return self.list(status=status)
+
+    # Terminal statuses for has_active_uow_for_issue — mirrors the exclusion list
+    # in _upsert_typed. 'closed' is a legacy DB status treated as terminal here.
+    _TERMINAL_STATUSES_FOR_ISSUE_CHECK = frozenset({
+        "done", "failed", "expired", "cancelled", "closed",
+    })
+
+    def has_active_uow_for_issue(self, issue_number: int) -> bool:
+        """Return True if a non-terminal UoW already exists for the given issue number.
+
+        Used by GardenCaretaker._reactivate_uow to guard against creating a
+        duplicate when scan() has already created a new proposed UoW for the
+        same issue on a different sweep_date while the old UoW was temporarily
+        in a terminal state.
+
+        Mirrors the exclusion logic in _upsert_typed exactly so the two
+        idempotency checks stay in sync.
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                """
+                SELECT id FROM uow_registry
+                WHERE source_issue_number = ?
+                  AND status NOT IN ('done', 'failed', 'expired', 'cancelled', 'closed')
+                LIMIT 1
+                """,
+                (issue_number,),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
 
     def transition(
         self,

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -70,7 +70,16 @@ class UoWStatus(StrEnum):
     NEEDS_HUMAN_REVIEW = "needs-human-review"
 
     def is_terminal(self) -> bool:
-        """True for statuses that allow re-proposal (done, failed, expired, cancelled)."""
+        """True for statuses that allow re-proposal (done, failed, expired, cancelled).
+
+        Note: 'closed' is NOT included here. 'closed' is a legacy DB status that
+        predates the UoWStatus enum — it was set externally on rows that existed
+        before enum enforcement was introduced. Semantically it means "done", but
+        it cannot be expressed as a UoWStatus value (UoWStatus('closed') raises
+        ValueError). SQL queries that need to exclude terminal rows therefore handle
+        'closed' separately via _TERMINAL_STATUSES_FOR_ISSUE_CHECK; this method
+        covers only the enum-representable statuses.
+        """
         return self in {UoWStatus.DONE, UoWStatus.FAILED, UoWStatus.EXPIRED, UoWStatus.CANCELLED}
 
     def is_in_flight(self) -> bool:
@@ -1003,14 +1012,15 @@ class Registry:
         """
         conn = self._connect()
         try:
+            placeholders = ", ".join("?" * len(self._TERMINAL_STATUSES_FOR_ISSUE_CHECK))
             row = conn.execute(
-                """
+                f"""
                 SELECT id FROM uow_registry
                 WHERE source_issue_number = ?
-                  AND status NOT IN ('done', 'failed', 'expired', 'cancelled', 'closed')
+                  AND status NOT IN ({placeholders})
                 LIMIT 1
                 """,
-                (issue_number,),
+                (issue_number, *self._TERMINAL_STATUSES_FOR_ISSUE_CHECK),
             ).fetchone()
             return row is not None
         finally:

--- a/tests/test_garden_caretaker.py
+++ b/tests/test_garden_caretaker.py
@@ -605,3 +605,99 @@ class TestRun:
         assert result["seeded"] == 1
         assert result["no_change"] == 1
         assert result["archived"] == 0
+
+
+# ===========================================================================
+# Dedup guard: reactivation must not create a duplicate when scan() already
+# proposed a new UoW for the same issue on a different sweep_date.
+# ===========================================================================
+
+class TestReactivationDedup:
+    def test_reactivation_skipped_when_new_proposed_uow_exists(
+        self, registry: Registry
+    ) -> None:
+        """tend() must not reactivate an expired UoW when a newer proposed UoW already
+        exists for the same issue number.
+
+        Regression scenario (issue #833 reopen path):
+        1. Old UoW (sweep_date D) is archived to expired.
+        2. scan() creates a new proposed UoW (sweep_date D+1) because the old one is terminal.
+        3. tend() finds the old expired UoW and sees source is open → would reactivate.
+        4. Without the guard this produces two proposed UoWs for the same issue.
+        With the guard, step 4 must be a no-op — reactivation count stays at 0.
+        """
+        # Step 1: Create old UoW and archive it to expired.
+        old = registry.upsert(issue_number=77, title="Old UoW", success_criteria="Old done.")
+        registry.set_status_direct(old.id, "expired")
+
+        # Step 2: Simulate scan() creating a new proposed UoW for the same issue
+        # on a different sweep_date (future date forces a new row past the UNIQUE constraint).
+        new = registry.upsert(
+            issue_number=77,
+            title="New UoW same issue",
+            success_criteria="New done.",
+            sweep_date="2099-01-01",
+        )
+        assert isinstance(new, UpsertInserted), "New UoW must be inserted"
+        assert len(registry.query(status="proposed")) == 1
+
+        # Step 3 + 4: tend() processes old expired UoW, source is open.
+        snap = _snap(issue_number=77, state="open")
+        source = StubIssueSource(issue_map={"github:issue/77": snap})
+        caretaker = GardenCaretaker(source=source, registry=registry)
+
+        result = caretaker.tend()
+
+        # Reactivation must be skipped — dedup guard fires.
+        assert result["reactivated"] == 0, (
+            "tend() must not reactivate when a non-terminal UoW already exists for the issue"
+        )
+        # The new proposed UoW must be the only proposed UoW.
+        proposed = registry.query(status="proposed")
+        assert len(proposed) == 1
+        assert proposed[0].id == new.id, "Only the new proposed UoW must remain"
+        # Old UoW must remain expired (not promoted).
+        expired = registry.query(status="expired")
+        assert len(expired) == 1
+        assert expired[0].id == old.id
+
+    def test_reactivation_proceeds_when_no_other_active_uow_exists(
+        self, registry: Registry
+    ) -> None:
+        """tend() must still reactivate an expired UoW when no other non-terminal UoW
+        exists for the same issue — normal reactivation path must not be broken.
+        """
+        upsert = registry.upsert(issue_number=78, title="Was expired", success_criteria="Done.")
+        registry.set_status_direct(upsert.id, "expired")
+
+        snap = _snap(issue_number=78, state="open")
+        source = StubIssueSource(issue_map={"github:issue/78": snap})
+        caretaker = GardenCaretaker(source=source, registry=registry)
+
+        result = caretaker.tend()
+
+        assert result["reactivated"] == 1
+        proposed = registry.query(status="proposed")
+        assert len(proposed) == 1
+        assert proposed[0].id == upsert.id
+
+    def test_has_active_uow_for_issue_returns_true_when_proposed_exists(
+        self, registry: Registry
+    ) -> None:
+        """Registry.has_active_uow_for_issue must return True when a proposed UoW exists."""
+        registry.upsert(issue_number=79, title="Proposed", success_criteria="Done.")
+        assert registry.has_active_uow_for_issue(79) is True
+
+    def test_has_active_uow_for_issue_returns_false_when_only_terminal_exists(
+        self, registry: Registry
+    ) -> None:
+        """Registry.has_active_uow_for_issue must return False when only terminal UoWs exist."""
+        upsert = registry.upsert(issue_number=80, title="Terminal", success_criteria="Done.")
+        registry.set_status_direct(upsert.id, "expired")
+        assert registry.has_active_uow_for_issue(80) is False
+
+    def test_has_active_uow_for_issue_returns_false_for_unknown_issue(
+        self, registry: Registry
+    ) -> None:
+        """Registry.has_active_uow_for_issue must return False for an issue with no UoWs."""
+        assert registry.has_active_uow_for_issue(99999) is False


### PR DESCRIPTION
## What this fixes

The WOS intake had a dedup gap in the `tend()` reactivation path that produced 667 duplicate UoW entries across 317 issues in production.

**Root cause — the race between scan() and tend():**

1. A UoW (sweep\_date D) gets archived to `expired` by `tend()` because the source appears closed/deleted.
2. On sweep\_date D+1, `scan()` sees no non-terminal UoW for the issue (the old one is `expired`) and correctly creates a new `proposed` row.
3. In the same or a subsequent `tend()` call, the old `expired` UoW is found in `_fetch_active_uows()` and the source is now "open" — so `_reactivate_uow()` fires and sets it back to `proposed`.
4. Result: two `proposed` UoWs for the same issue — the old row and the new row.

The `_upsert_typed` pre-check correctly prevents re-proposals while a UoW is non-terminal, but `_reactivate_uow` had no equivalent guard. It called `set_status_direct` unconditionally without asking "does another active UoW already exist for this issue?"

**Secondary fix:** The `_upsert_typed` pre-check excluded `('done', 'failed', 'expired', 'cancelled')` but not `'closed'`. `'closed'` is a legacy DB status predating the `UoWStatus` enum (set externally before enum enforcement). Legacy rows with `status='closed'` were treated as non-terminal, permanently blocking re-proposal for those issues.

## What changed

**`Registry.has_active_uow_for_issue(issue_number: int) -> bool`** — new helper that returns True if any non-terminal UoW exists for the given issue number. Mirrors the exclusion list in `_upsert_typed` exactly.

**`GardenCaretaker._reactivate_uow()`** — now calls `has_active_uow_for_issue()` before setting status to `proposed`. If a conflict exists, writes a `reactivation_skipped` audit entry and returns 0 (no-op). Normal reactivation when no conflict exists is unchanged.

**`_upsert_typed` pre-check** — adds `'closed'` to the terminal-status exclusion list so legacy rows do not permanently block re-proposal.

## Flow before / after

```
Before:                               After:
scan() day D+1                        scan() day D+1
  old UoW = expired                     old UoW = expired
  → INSERT new proposed row             → INSERT new proposed row

tend() day D+1                        tend() day D+1
  old UoW still in _fetch_active       old UoW still in _fetch_active
  source = open → reactivate           source = open → check has_active_uow_for_issue(N)
  → set_status_direct(old, PROPOSED)   → True → skip reactivation, write audit
                                                  entry reactivation_skipped
RESULT: 2 proposed UoWs (BUG)         RESULT: 1 proposed UoW (correct)
```

## Out of scope

- Executor and steward paths are not touched.
- Migration numbering: no DB schema change; no migration file added.
- Pre-existing 6 test failures in `tests/test_garden_caretaker.py` (surface-on-close and pending tests) are unrelated to this change and existed before.

## Tests run

- [x] `uv run pytest tests/test_garden_caretaker.py -v` — 25 passed, 6 pre-existing failures (unchanged)
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_garden_caretaker.py tests/unit/test_orchestration/test_migrate_dedup_proposed_uows.py -v` — 147 passed, 0 failed
- [x] 5 new tests added in `TestReactivationDedup` covering: duplicate scenario is a no-op, normal reactivation path still works, and `has_active_uow_for_issue` for true/false/unknown-issue cases.
- [x] `uv run python -m py_compile src/orchestration/garden_caretaker.py src/orchestration/registry.py` — clean

## Manual test

N/A — this change is entirely internal registry logic. No external service calls, no Telegram output, no file I/O affecting runtime state. The scenario is captured in `TestReactivationDedup.test_reactivation_skipped_when_new_proposed_uow_exists`.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] User-visible outcome: not applicable — this is an internal consistency fix
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume. The fix adds a SELECT before reactivation, never writes unless no conflict exists.
- [x] External service calls: none