### PR TITLE
fix: mark outcome='retry' as reserved in dispatch-boundary schema

### DIFF
--- a/docs/wos-dispatch-failure-modes.md
+++ b/docs/wos-dispatch-failure-modes.md
@@ -86,10 +86,10 @@ All dispatch attempts are logged to `~/lobster-workspace/logs/dispatch-boundary.
 |-------|------|-------------|
 | `ts` | ISO 8601 | Timestamp of the dispatch attempt |
 | `uow_id` | string | The UoW being dispatched |
-| `dispatch_attempt` | int | Attempt number (1 for first, 2+ for retries) |
-| `outcome` | enum | `success`, `retry`, or `failure` |
+| `dispatch_attempt` | int | Attempt number (always 1 — retry logic is not implemented) |
+| `outcome` | enum | `success` or `failure`; `retry` is reserved — not implemented |
 | `msg_id` | string? | Inbox message ID (on success) |
-| `failure_reason` | string? | Reason for failure or retry (on non-success) |
+| `failure_reason` | string? | Reason for failure (on non-success) |
 
 ### Query Examples
 

--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -1351,10 +1351,10 @@ def _log_dispatch_boundary(
 
     Args:
         uow_id: The UoW being dispatched.
-        dispatch_attempt: Attempt number (1 for first attempt, 2+ for retries).
-        outcome: One of "success", "retry", "failure".
+        dispatch_attempt: Attempt number (always 1 — retry logic is not implemented).
+        outcome: One of "success", "failure". "retry" is reserved — not implemented.
         msg_id: The inbox message ID (on success).
-        failure_reason: Reason for failure or retry (on non-success).
+        failure_reason: Reason for failure (on non-success).
     """
     record = {
         "ts": _now_iso(),
@@ -1441,7 +1441,7 @@ def _dispatch_via_inbox(instructions: str, uow_id: str, agent_type: str = "funct
 
     Observability: All dispatch attempts, retries, and failures are logged to
     ~/lobster-workspace/logs/dispatch-boundary.jsonl with structured records:
-    {uow_id, dispatch_attempt, timestamp, outcome: success|retry|failure, failure_reason?}
+    {uow_id, dispatch_attempt, timestamp, outcome: success|failure, failure_reason?}
 
     Raises OSError if the inbox directory cannot be created or the message
     file cannot be written.


### PR DESCRIPTION
## Summary

- `outcome: 'retry'` was listed as a valid enum value in `_log_dispatch_boundary` docstring and `docs/wos-dispatch-failure-modes.md` schema table, but no code path ever produces it
- `dispatch_attempt` was described as "2+ for retries" but is always hardcoded as `1`
- This PR applies Option A from issue #709: annotate `retry` as reserved, update `dispatch_attempt` description

## Changes

- `src/orchestration/executor.py`: update `_log_dispatch_boundary` docstring — mark `retry` as reserved, update `dispatch_attempt` description
- `docs/wos-dispatch-failure-modes.md`: update schema table — mark `retry` reserved in outcome enum, update `dispatch_attempt` description

## Test plan

- [ ] Grep for `retry` in schema/doc files confirms annotation is present and consistent
- [ ] No runtime code paths changed — all call sites still use `"success"` or `"failure"` only

Closes #709

WOS-UoW: uow_20260428_c36be3