### PR TITLE
fix(test): import constants from wos_queue_monitor instead of re-declaring locally

### DIFF
--- a/tests/unit/test_wos_queue_monitor.py
+++ b/tests/unit/test_wos_queue_monitor.py
@@ -40,12 +40,12 @@ qm = _load_module()
 
 
 # ---------------------------------------------------------------------------
-# Constants — must match the spec, not derived from implementation
+# Constants — imported from the production module to avoid divergence
 # ---------------------------------------------------------------------------
 
-STARVATION_CONSECUTIVE_READINGS = 12    # 6 hours at 30-min cadence
-TOXICITY_DEPTH_THRESHOLD = 10
-TOXICITY_CONSECUTIVE_READINGS = 3
+STARVATION_CONSECUTIVE_READINGS = qm.STARVATION_CONSECUTIVE_READINGS
+TOXICITY_DEPTH_THRESHOLD = qm.TOXICITY_DEPTH_THRESHOLD
+TOXICITY_CONSECUTIVE_READINGS = qm.TOXICITY_CONSECUTIVE_READINGS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes local re-declarations of `STARVATION_CONSECUTIVE_READINGS`, `TOXICITY_DEPTH_THRESHOLD`, and `TOXICITY_CONSECUTIVE_READINGS` in `test_wos_queue_monitor.py`
- Replaces them with assignments from the loaded production module (`qm.*`), so tests always reflect the actual production values
- No test logic, assertions, or test structure changed — only the constant declarations

## Test plan

- [x] All 31 tests in `test_wos_queue_monitor.py` pass (`uv run pytest tests/unit/test_wos_queue_monitor.py -v`)

Addresses oracle advisory from S3-D review of PR #700 (same pattern as PR #696).

WOS-UoW: uow_20260428_90d08e