### PR TITLE
fix(docs): mark dispatch-boundary 'retry' outcome as reserved

### DIFF
--- a/docs/wos-dispatch-failure-modes.md
+++ b/docs/wos-dispatch-failure-modes.md
@@ -86,10 +86,10 @@ All dispatch attempts are logged to `~/lobster-workspace/logs/dispatch-boundary.
 |-------|------|-------------|
 | `ts` | ISO 8601 | Timestamp of the dispatch attempt |
 | `uow_id` | string | The UoW being dispatched |
-| `dispatch_attempt` | int | Attempt number (1 for first, 2+ for retries) |
-| `outcome` | enum | `success`, `retry`, or `failure` |
+| `dispatch_attempt` | int | Attempt number (currently always 1 — no retry loop is implemented) |
+| `outcome` | enum | `success` or `failure` (`retry` is reserved but not implemented) |
 | `msg_id` | string? | Inbox message ID (on success) |
-| `failure_reason` | string? | Reason for failure or retry (on non-success) |
+| `failure_reason` | string? | Reason for failure (on non-success) |
 
 ### Query Examples
 

--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -1328,8 +1328,8 @@ _INBOX_DIR_TEMPLATE = "~/messages/inbox"
 _DISPATCH_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
 
 #: Dispatch boundary log — structured JSONL records for observability.
-#: Records all dispatch attempts, retries, and failures at the executor→inbox
-#: boundary. Location: ~/lobster-workspace/logs/dispatch-boundary.jsonl
+#: Records dispatch attempts and failures at the executor→inbox boundary.
+#: Location: ~/lobster-workspace/logs/dispatch-boundary.jsonl
 _DISPATCH_BOUNDARY_LOG_TEMPLATE = "~/lobster-workspace/logs/dispatch-boundary.jsonl"
 
 
@@ -1351,8 +1351,10 @@ def _log_dispatch_boundary(
 
     Args:
         uow_id: The UoW being dispatched.
-        dispatch_attempt: Attempt number (1 for first attempt, 2+ for retries).
-        outcome: One of "success", "retry", "failure".
+        dispatch_attempt: Attempt number (currently always 1 — no retry loop
+            is implemented at the dispatch boundary).
+        outcome: One of "success" or "failure". ("retry" is reserved in the
+            schema but no code path produces it.)
         msg_id: The inbox message ID (on success).
         failure_reason: Reason for failure or retry (on non-success).
     """
@@ -1439,9 +1441,9 @@ def _dispatch_via_inbox(instructions: str, uow_id: str, agent_type: str = "funct
 
     The message_id is returned as the executor_id for audit correlation.
 
-    Observability: All dispatch attempts, retries, and failures are logged to
+    Observability: All dispatch attempts and failures are logged to
     ~/lobster-workspace/logs/dispatch-boundary.jsonl with structured records:
-    {uow_id, dispatch_attempt, timestamp, outcome: success|retry|failure, failure_reason?}
+    {uow_id, dispatch_attempt, timestamp, outcome: success|failure, failure_reason?}
 
     Raises OSError if the inbox directory cannot be created or the message
     file cannot be written.


### PR DESCRIPTION
## Summary

The `dispatch-boundary.jsonl` schema documents three `outcome` values (`success`, `retry`, `failure`) but no code path ever produces `outcome: 'retry'`. Every call to `_log_dispatch_boundary()` passes either `"success"` or `"failure"`. Similarly, `dispatch_attempt` is always hardcoded to `1` — the "2+ for retries" description is aspirational, not actual. This creates false expectations for downstream consumers and readers who assume retry logic exists at the dispatch boundary.

This PR annotates the schema and docstrings to reflect actual behavior:
- `outcome` enum: `retry` is marked as reserved but not implemented
- `dispatch_attempt`: documented as currently always 1
- Removed references to "retries" in module-level comments and function docstrings

No behavioral changes. No code logic modified. The `_log_dispatch_boundary()` function signature is unchanged — `retry` remains a valid string value so that implementing it later requires no schema migration.

## Option chosen

**Option A (mark reserved)** — no code path produces `retry`, the "Fallback Dispatch" section in `docs/wos-dispatch-failure-modes.md` explicitly says "Not Implemented", and no open design document calls for a retry loop at the dispatch boundary. Recovery is handled at a higher level (steward heartbeat observation + TTL recovery).

## Files changed

- `docs/wos-dispatch-failure-modes.md` — schema table annotations
- `src/orchestration/executor.py` — docstrings only (no logic changes)

## Tests run

- [x] `uv run pytest tests/unit/test_executor*.py -x -q` — 16 passed, 1 pre-existing failure (`TestOptimisticLock::test_rejects_if_not_in_ready_for_executor`, confirmed failing on `main`)
- [x] `uv run pytest tests/ --ignore=tests/unit/test_attunement.py -k "executor or dispatch" -x -q` — 55 passed, 1 pre-existing failure (`test_dispatch_job_sh.py`)

## Manual test

N/A — this change is purely documentation/comments. No runtime behavior, no external services, no state changes.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, doc-only change
- [x] User-visible outcome verified OR not applicable — not applicable (no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: N/A

WOS-UoW: uow_20260428_c36be3