### PR TITLE
fix: mark outcome='retry' as reserved in dispatch-boundary schema

### DIFF
--- a/docs/wos-dispatch-failure-modes.md
+++ b/docs/wos-dispatch-failure-modes.md
@@ -86,10 +86,10 @@ All dispatch attempts are logged to `~/lobster-workspace/logs/dispatch-boundary.
 |-------|------|-------------|
 | `ts` | ISO 8601 | Timestamp of the dispatch attempt |
 | `uow_id` | string | The UoW being dispatched |
-| `dispatch_attempt` | int | Attempt number (1 for first, 2+ for retries) |
-| `outcome` | enum | `success`, `retry`, or `failure` |
+| `dispatch_attempt` | int | Attempt number (always 1 — retry logic not implemented at this layer; re-queue is handled by the Observation Loop TTL recovery) |
+| `outcome` | enum | `success` or `failure` (`retry` is reserved — not implemented; no code path produces it) |
 | `msg_id` | string? | Inbox message ID (on success) |
-| `failure_reason` | string? | Reason for failure or retry (on non-success) |
+| `failure_reason` | string? | Reason for failure (on non-success) |
 
 ### Query Examples
 

--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -1352,9 +1352,13 @@ def _log_dispatch_boundary(
     Args:
         uow_id: The UoW being dispatched.
         dispatch_attempt: Attempt number (1 for first attempt, 2+ for retries).
-        outcome: One of "success", "retry", "failure".
+            Currently always 1 — retry logic is not implemented at this layer;
+            TTL recovery in the Observation Loop handles re-queue on stall.
+        outcome: One of "success" or "failure".
+            "retry" is reserved — not implemented. No code path currently
+            produces this value; dispatch_attempt is always 1.
         msg_id: The inbox message ID (on success).
-        failure_reason: Reason for failure or retry (on non-success).
+        failure_reason: Reason for failure (on non-success).
     """
     record = {
         "ts": _now_iso(),


### PR DESCRIPTION
## Summary

- `_log_dispatch_boundary` in `executor.py` documented `outcome` as `"success" | "retry" | "failure"` but no code path ever produces `"retry"` and `dispatch_attempt` is always `1`
- `docs/wos-dispatch-failure-modes.md` schema table described `retry` as a live enum value and `dispatch_attempt` as `2+ for retries`
- Both locations are updated to mark `retry` as **reserved — not implemented**; re-queue on stall is handled by the Observation Loop TTL recovery, not by a dispatch-layer retry loop

## Resolution

Option A (mark reserved). No retry loop was implemented or called for by any open design document. This is a documentation-code gap identified in oracle/learnings.md via PR #708 oracle advisory S3P2-E.

## Test plan

- [ ] `grep -n "retry" src/orchestration/executor.py` — confirms docstring reads "reserved — not implemented"
- [ ] `grep -n "retry" docs/wos-dispatch-failure-modes.md` — confirms schema table annotates `retry` as reserved
- [ ] No runtime code changed; annotation-only fix

WOS-UoW: uow_20260428_c36be3

🤖 Generated with [Claude Code](https://claude.com/claude-code)