### PR TITLE
fix(audit): surface lifetime_cycles in completed_uow_durations

### DIFF
--- a/src/orchestration/audit_queries.py
+++ b/src/orchestration/audit_queries.py
@@ -400,7 +400,7 @@ def completed_uow_durations(
     Returns
     -------
     list of dicts with keys:
-        uow_id, created_at, completed_at, steward_cycles,
+        uow_id, created_at, completed_at, steward_cycles, lifetime_cycles,
         wall_clock_hours, register, type
     """
     path = registry_path if registry_path is not None else _default_registry_path()
@@ -411,7 +411,7 @@ def completed_uow_durations(
     try:
         rows = conn.execute(
             """
-            SELECT id, created_at, completed_at, steward_cycles, register, type
+            SELECT id, created_at, completed_at, steward_cycles, lifetime_cycles, register, type
             FROM uow_registry
             WHERE status = 'done'
               AND completed_at IS NOT NULL
@@ -448,6 +448,7 @@ def completed_uow_durations(
             "created_at": created,
             "completed_at": completed,
             "steward_cycles": row["steward_cycles"],
+            "lifetime_cycles": row["lifetime_cycles"],
             "wall_clock_hours": wall_clock_hours,
             "register": row["register"] or "operational",
             "type": row["type"] or "executable",

--- a/tests/unit/test_orchestration/test_audit_queries.py
+++ b/tests/unit/test_orchestration/test_audit_queries.py
@@ -413,6 +413,7 @@ class TestCompletedUowDurations:
         created_at: str,
         completed_at: str,
         steward_cycles: int = 1,
+        lifetime_cycles: int = 0,
         register: str = "operational",
     ) -> None:
         conn = sqlite3.connect(str(db_path))
@@ -420,11 +421,11 @@ class TestCompletedUowDurations:
             """
             INSERT INTO uow_registry
                 (id, source, status, summary, created_at, updated_at,
-                 steward_cycles, steward_log, success_criteria, completed_at, register)
-            VALUES (?, ?, 'done', ?, ?, ?, ?, '', '', ?, ?)
+                 steward_cycles, lifetime_cycles, steward_log, success_criteria, completed_at, register)
+            VALUES (?, ?, 'done', ?, ?, ?, ?, ?, '', '', ?, ?)
             """,
             (uow_id, "github:issue/1", "test", created_at, created_at,
-             steward_cycles, completed_at, register),
+             steward_cycles, lifetime_cycles, completed_at, register),
         )
         conn.commit()
         conn.close()
@@ -472,6 +473,20 @@ class TestCompletedUowDurations:
         )
         result = completed_uow_durations("2026-01-01", registry_path=db_path)
         assert result[0]["register"] == "reflective"
+
+    def test_lifetime_cycles_field_included(self, db_path):
+        from src.orchestration.audit_queries import completed_uow_durations
+
+        self._insert_done_uow(
+            db_path, "uow-lc",
+            created_at="2026-01-01T00:00:00+00:00",
+            completed_at="2026-01-01T03:00:00+00:00",
+            steward_cycles=2,
+            lifetime_cycles=7,
+        )
+        result = completed_uow_durations("2026-01-01", registry_path=db_path)
+        assert len(result) == 1
+        assert result[0]["lifetime_cycles"] == 7
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `lifetime_cycles` to the SQL `SELECT` in `completed_uow_durations()` so the field is fetched from the registry
- Add `"lifetime_cycles": row["lifetime_cycles"]` to the returned dict so consumers see the true lifetime effort (not just the per-round `steward_cycles`)
- Update docstring `Returns` section to document the new key
- Update `_insert_done_uow` test fixture to accept and insert `lifetime_cycles`
- Add `test_lifetime_cycles_field_included` asserting a seeded value of 7 is correctly returned

Fixes uow_20260428_b4773d

## Test plan

- [x] `uv run pytest tests/unit/test_orchestration/test_audit_queries.py -v` — all 36 tests pass
- [x] `uv run pytest tests/unit/test_orchestration/ -v -k "cycle"` — 92 pass, 8 pre-existing failures unrelated to this change

WOS-UoW: uow_20260428_b4773d

🤖 Generated with [Claude Code](https://claude.com/claude-code)