### PR TITLE
fix(wos): repair intake dedup to prevent duplicate UoW rows

### DIFF
--- a/src/orchestration/garden_caretaker.py
+++ b/src/orchestration/garden_caretaker.py
@@ -560,16 +560,42 @@ class GardenCaretaker:
     def _reactivate_uow(self, uow: UoW) -> int:
         """Reactivate an archived/terminal UoW back to proposed. Returns 1 if done.
 
-        Idempotency guard: if scan() already created a new proposed UoW for the
-        same issue on a different sweep_date while this UoW was terminal, skip
-        reactivation to prevent a duplicate proposed row.  This closes the race
-        where archived → scan creates new row → tend reactivates old row.
+        Uses Registry.reactivate_if_no_active() which combines the dedup check
+        and the status update in a single BEGIN IMMEDIATE transaction, eliminating
+        the TOCTOU race where a concurrent intake could insert a new proposed row
+        between the check and the write.
         """
         issue_number = self._extract_issue_number(uow.source or "")
-        if issue_number is not None and self.registry.has_active_uow_for_issue(issue_number):
+        if issue_number is None:
+            # Cannot extract issue number — fall back to direct reactivation.
+            # This path is rare (only UoWs with malformed source_ref).
+            try:
+                self.registry.set_status_direct(uow.id, UoWStatus.PROPOSED)
+                self.registry.append_audit_log(uow.id, {
+                    "event": "reactivated_by_caretaker",
+                    "actor": "garden_caretaker",
+                    "classification": "source_reopened",
+                    "from_status": str(uow.status),
+                    "to_status": "proposed",
+                    "source_ref": uow.source,
+                    "timestamp": _now_iso(),
+                })
+                logger.info("tend: reactivated UoW %s → proposed (source reopened, no issue_number)", uow.id)
+                return 1
+            except Exception as exc:
+                logger.warning("tend: failed to reactivate UoW %s: %s", uow.id, exc)
+                return 0
+
+        try:
+            reactivated = self.registry.reactivate_if_no_active(uow.id, issue_number)
+        except Exception as exc:
+            logger.warning("tend: failed to reactivate UoW %s: %s", uow.id, exc)
+            return 0
+
+        if not reactivated:
             logger.info(
                 "tend: skipping reactivation of UoW %s — a non-terminal UoW already exists "
-                "for issue #%d (dedup guard)",
+                "for issue #%d (atomic dedup guard)",
                 uow.id, issue_number,
             )
             self.registry.append_audit_log(uow.id, {
@@ -582,24 +608,17 @@ class GardenCaretaker:
             })
             return 0
 
-        # Use set_status_direct — the UoW is in a terminal state and we need
-        # to bypass the conditional transition guard.
-        try:
-            self.registry.set_status_direct(uow.id, UoWStatus.PROPOSED)
-            self.registry.append_audit_log(uow.id, {
-                "event": "reactivated_by_caretaker",
-                "actor": "garden_caretaker",
-                "classification": "source_reopened",
-                "from_status": str(uow.status),
-                "to_status": "proposed",
-                "source_ref": uow.source,
-                "timestamp": _now_iso(),
-            })
-            logger.info("tend: reactivated UoW %s → proposed (source reopened)", uow.id)
-            return 1
-        except Exception as exc:
-            logger.warning("tend: failed to reactivate UoW %s: %s", uow.id, exc)
-            return 0
+        self.registry.append_audit_log(uow.id, {
+            "event": "reactivated_by_caretaker",
+            "actor": "garden_caretaker",
+            "classification": "source_reopened",
+            "from_status": str(uow.status),
+            "to_status": "proposed",
+            "source_ref": uow.source,
+            "timestamp": _now_iso(),
+        })
+        logger.info("tend: reactivated UoW %s → proposed (source reopened)", uow.id)
+        return 1
 
     @staticmethod
     def _extract_issue_number(source_ref: str) -> int | None:

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -594,19 +594,20 @@ class Registry:
             conn.execute("BEGIN IMMEDIATE")
 
             # Cross-sweep-date pre-check: any non-terminal record for this issue?
-            # 'cancelled' is a terminal status (UoWStatus.CANCELLED) that allows
-            # re-proposal after a cancellation.
-            # 'closed' is a legacy DB status predating the UoWStatus enum; treat it
-            # as terminal so that legacy rows do not permanently block re-proposal.
+            # Uses _TERMINAL_STATUSES_FOR_ISSUE_CHECK — single source of truth
+            # shared with has_active_uow_for_issue() — so both dedup paths
+            # stay in sync when terminal statuses are added or removed.
+            _terminal = self._TERMINAL_STATUSES_FOR_ISSUE_CHECK
+            _placeholders = ", ".join("?" * len(_terminal))
             existing = conn.execute(
-                """
+                f"""
                 SELECT id, status FROM uow_registry
                 WHERE source_issue_number = ?
-                  AND status NOT IN ('done', 'failed', 'expired', 'cancelled', 'closed')
+                  AND status NOT IN ({_placeholders})
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
-                (issue_number,),
+                (issue_number, *_terminal),
             ).fetchone()
 
             if existing:
@@ -1023,6 +1024,65 @@ class Registry:
                 (issue_number, *self._TERMINAL_STATUSES_FOR_ISSUE_CHECK),
             ).fetchone()
             return row is not None
+        finally:
+            conn.close()
+
+    def reactivate_if_no_active(self, uow_id: str, issue_number: int) -> bool:
+        """Atomically reactivate a terminal UoW to proposed IFF no non-terminal row exists.
+
+        Combines the has_active_uow_for_issue check and the status update in a
+        single BEGIN IMMEDIATE transaction to eliminate the TOCTOU race between
+        the check and the write.
+
+        Returns True if the UoW was reactivated, False if skipped (because a
+        non-terminal row already exists for this issue).
+        """
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+
+            _terminal = self._TERMINAL_STATUSES_FOR_ISSUE_CHECK
+            _placeholders = ", ".join("?" * len(_terminal))
+            conflict = conn.execute(
+                f"""
+                SELECT id FROM uow_registry
+                WHERE source_issue_number = ?
+                  AND status NOT IN ({_placeholders})
+                LIMIT 1
+                """,
+                (issue_number, *_terminal),
+            ).fetchone()
+
+            if conflict:
+                conn.commit()
+                return False
+
+            row = conn.execute(
+                "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+            ).fetchone()
+            if row is None:
+                conn.commit()
+                return False
+
+            old_status = row["status"]
+            now = _now_iso()
+            self._write_audit(
+                conn,
+                uow_id=uow_id,
+                event="status_change",
+                from_status=old_status,
+                to_status=UoWStatus.PROPOSED,
+                note="reactivation (atomic dedup guard)",
+            )
+            conn.execute(
+                "UPDATE uow_registry SET status = ?, updated_at = ? WHERE id = ?",
+                (UoWStatus.PROPOSED, now, uow_id),
+            )
+            conn.commit()
+            return True
+        except Exception:
+            conn.rollback()
+            raise
         finally:
             conn.close()
 

--- a/tests/test_garden_caretaker.py
+++ b/tests/test_garden_caretaker.py
@@ -701,3 +701,59 @@ class TestReactivationDedup:
     ) -> None:
         """Registry.has_active_uow_for_issue must return False for an issue with no UoWs."""
         assert registry.has_active_uow_for_issue(99999) is False
+
+
+class TestAtomicReactivation:
+    """Tests for Registry.reactivate_if_no_active — the atomic check+write
+    that prevents TOCTOU races in the reactivation path."""
+
+    def test_reactivate_if_no_active_succeeds_when_no_conflict(
+        self, registry: Registry
+    ) -> None:
+        """Reactivation succeeds when no non-terminal UoW exists for the issue."""
+        upsert = registry.upsert(issue_number=90, title="Expired", success_criteria="Done.")
+        registry.set_status_direct(upsert.id, "expired")
+
+        result = registry.reactivate_if_no_active(upsert.id, issue_number=90)
+        assert result is True
+
+        proposed = registry.query(status="proposed")
+        assert len(proposed) == 1
+        assert proposed[0].id == upsert.id
+
+    def test_reactivate_if_no_active_skipped_when_active_exists(
+        self, registry: Registry
+    ) -> None:
+        """Reactivation is skipped when a non-terminal UoW already exists.
+
+        This is the core dedup scenario: scan() created a new proposed row,
+        then tend() tries to reactivate the old expired row atomically.
+        """
+        ISSUE_NUMBER = 91
+
+        # Old UoW archived to expired.
+        old = registry.upsert(issue_number=ISSUE_NUMBER, title="Old", success_criteria="Done.")
+        registry.set_status_direct(old.id, "expired")
+
+        # New UoW created by scan() on a different sweep_date.
+        new = registry.upsert(
+            issue_number=ISSUE_NUMBER, title="New", success_criteria="Done.",
+            sweep_date="2099-01-01",
+        )
+        assert isinstance(new, UpsertInserted)
+
+        # Atomic reactivation must be skipped — new proposed row exists.
+        result = registry.reactivate_if_no_active(old.id, issue_number=ISSUE_NUMBER)
+        assert result is False
+
+        # Only one proposed UoW — the new one.
+        proposed = registry.query(status="proposed")
+        assert len(proposed) == 1
+        assert proposed[0].id == new.id
+
+    def test_reactivate_if_no_active_returns_false_for_missing_uow(
+        self, registry: Registry
+    ) -> None:
+        """Returns False when the UoW ID does not exist in the registry."""
+        result = registry.reactivate_if_no_active("nonexistent_uow_id", issue_number=999)
+        assert result is False

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -277,6 +277,91 @@ class TestUpsert:
         conn2.close()
         assert row["status"] == "pending"
 
+    def test_repropose_active_issue_returns_upsert_skipped(self, registry, db_path):
+        """Re-proposing an issue with an existing non-terminal UoW must return UpsertSkipped.
+
+        Regression test for the intake dedup bug: if a UoW already exists for
+        an issue in any non-terminal status (proposed, ready-for-steward, active,
+        etc.), a subsequent upsert for the same issue must be idempotent — no
+        duplicate row created.
+        """
+        from src.orchestration.registry import UpsertInserted, UpsertSkipped
+
+        ISSUE_NUMBER = 42
+        DAY_1 = "2026-04-01"
+        DAY_2 = "2026-04-02"
+
+        # Insert initial UoW in proposed status.
+        first = registry.upsert(
+            issue_number=ISSUE_NUMBER, title="Issue 42", sweep_date=DAY_1,
+            success_criteria="Completion criteria.",
+        )
+        assert isinstance(first, UpsertInserted)
+
+        # Transition to a non-terminal in-flight status.
+        registry.set_status_direct(first.id, "ready-for-steward")
+
+        # Second upsert on a different sweep_date must be skipped.
+        second = registry.upsert(
+            issue_number=ISSUE_NUMBER, title="Issue 42", sweep_date=DAY_2,
+            success_criteria="Completion criteria.",
+        )
+        assert isinstance(second, UpsertSkipped), (
+            f"Expected UpsertSkipped but got {type(second).__name__}"
+        )
+
+        # Exactly one row for issue 42 in the registry.
+        conn = _open_db(db_path)
+        rows = conn.execute(
+            "SELECT id FROM uow_registry WHERE source_issue_number = ?",
+            (ISSUE_NUMBER,),
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1, f"Expected exactly 1 row for issue {ISSUE_NUMBER}, got {len(rows)}"
+
+    def test_repropose_terminal_issue_creates_new_uow(self, registry, db_path):
+        """Re-proposing an issue whose only UoW is terminal must create a new UoW.
+
+        Verifies that terminal statuses (done, closed) correctly allow
+        re-proposal — the dedup gate must not block legitimate re-intake.
+        """
+        from src.orchestration.registry import UpsertInserted
+
+        ISSUE_NUMBER = 43
+        DAY_1 = "2026-04-01"
+        DAY_2 = "2026-04-02"
+        DAY_3 = "2026-04-03"
+
+        # Insert and mark done.
+        first = registry.upsert(
+            issue_number=ISSUE_NUMBER, title="Issue 43", sweep_date=DAY_1,
+            success_criteria="Completion criteria.",
+        )
+        registry.set_status_direct(first.id, "done")
+
+        second = registry.upsert(
+            issue_number=ISSUE_NUMBER, title="Issue 43 reopened", sweep_date=DAY_2,
+            success_criteria="Completion criteria.",
+        )
+        assert isinstance(second, UpsertInserted), (
+            f"Expected UpsertInserted after done, got {type(second).__name__}"
+        )
+
+        # Also verify 'closed' (legacy terminal status) allows re-proposal.
+        registry.set_status_direct(second.id, "done")
+        conn = _open_db(db_path)
+        conn.execute("UPDATE uow_registry SET status='closed' WHERE id=?", (second.id,))
+        conn.commit()
+        conn.close()
+
+        third = registry.upsert(
+            issue_number=ISSUE_NUMBER, title="Issue 43 re-reopened", sweep_date=DAY_3,
+            success_criteria="Completion criteria.",
+        )
+        assert isinstance(third, UpsertInserted), (
+            f"Expected UpsertInserted after closed, got {type(third).__name__}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Issue #488: success_criteria enforcement and issue_url population


### PR DESCRIPTION
## Summary

The WOS intake pipeline allowed duplicate UoW rows for the same active issue through two related gaps in the dedup mechanism:

**Gap 1 — Hardcoded status list in `_upsert_typed`:** The cross-sweep-date dedup query used hardcoded terminal status strings (`'done', 'failed', 'expired', 'cancelled', 'closed'`) instead of the `_TERMINAL_STATUSES_FOR_ISSUE_CHECK` frozenset that `has_active_uow_for_issue()` uses. While both lists currently match, any future addition to the frozenset would silently diverge from the upsert check — a maintenance hazard that invites regression.

**Gap 2 — TOCTOU race in `_reactivate_uow`:** The reactivation path in GardenCaretaker performed a non-atomic check-then-act: `has_active_uow_for_issue()` (read on connection A, closed) followed by `set_status_direct()` (write on connection B). A concurrent intake process (cultivator or another caretaker) could insert a new proposed row between the check and the write, producing two proposed UoWs for the same issue.

## Fix

- **`_upsert_typed`**: The dedup query now uses `_TERMINAL_STATUSES_FOR_ISSUE_CHECK` via parameterized placeholders — single source of truth for terminal statuses across both dedup paths.

- **`Registry.reactivate_if_no_active(uow_id, issue_number)`**: New method that combines the active-UoW check and the status update in a single `BEGIN IMMEDIATE` transaction. The check and write execute on the same connection under the same lock, eliminating the TOCTOU window.

- **`GardenCaretaker._reactivate_uow`**: Replaced the two-step `has_active_uow_for_issue` + `set_status_direct` pattern with a single call to `reactivate_if_no_active`.

## What is NOT changed

- No changes to executor dispatch, steward logic, or the migration cleanup script (`migrate_dedup_proposed_uows.py`)
- No existing UoW rows modified in the live registry
- No method signatures changed — `reactivate_if_no_active` is additive
- `has_active_uow_for_issue` retained for read-only callers; the new method is for write paths

## Functional patterns

- Pure constant (`_TERMINAL_STATUSES_FOR_ISSUE_CHECK` frozenset) as single source of truth — eliminates duplication between dedup paths
- Atomic transaction boundary wrapping the check+write — side effects isolated to a single commit point

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_garden_caretaker.py tests/unit/test_orchestration/test_migrate_dedup_proposed_uows.py -v` — 149 passed, 0 failed
- [x] `uv run pytest tests/test_garden_caretaker.py -v` — all new tests pass; 6 pre-existing failures (on main) unrelated to this change (TestTendNoChange, TestTendArchiveOnClose, TestTendSurfaceOnClose, TestSourceTracking)

## Manual test

N/A — this change is entirely internal to the registry write path. No systemd, cron, external services, file I/O, or DB schema changes. The fix is exercised by unit tests that use real SQLite databases in tmp_path.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, pure internal logic
- [x] User-visible outcome verified OR not applicable — not applicable: no user-facing output
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change

WOS-UoW: uow_20260427_7ba98f