### PR TITLE
feat(gates): integrate elegant economy as structural dispatch gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The format for a HYPOTHESIS entry is:
               ┌─────────────┼─────────────┐
               │               │               │
          Telegram Bot    Slack Bot      (Future: Signal, SMS)
-         (active)        (optional)     (see docs/FUTURE.md)
+         (active)        (optional)     (see docs/setup/FUTURE.md)
 ```
 
 ## Available Tools (MCP)

--- a/docs/wos/current/wos-v3-spec.md
+++ b/docs/wos/current/wos-v3-spec.md
@@ -4,6 +4,10 @@
 > This is the single source of truth for WOS v3 architecture and implementation.
 > wos-v3-proposal.md and wos-v3-steward-executor-spec.md are archived at docs/wos/archived/.
 
+> **Production vs. Spec:** This document describes the full V3 architecture as designed. Not all sections reflect current production behavior.
+> **Currently in production (as of 2026-05):** UoW lifecycle (proposed → pending → executing → done/failed), Steward diagnosis and prescription (`run_steward_cycle`, `_process_uow`), Executor dispatch (`functional-engineer` type), corrective trace one-cycle gate (`trace_gate_waited` / `trace_gate_contract_violation`, PR #607), LLM-only prescription path, and basic stuck-condition detection (`hard_cap`, `crash_repeated`).
+> **Planned / not yet in production:** Register-aware diagnosis (`_register_completion_policy`, `_assess_completion` policy branch), register-mismatch gate (`_check_register_executor_compatibility`), frontier-writer executor type and dispatch, expanded Dan interrupt conditions (`philosophical_register`, `no_gate_improvement` stuck conditions), corrective trace injection in the prescribe branch (beyond the one-cycle gate), and Observation Loop drift detection.
+
 ---
 
 ## 1. Vision and Design Premises

--- a/oracle/verdicts/decision-result-elegance-audit.md
+++ b/oracle/verdicts/decision-result-elegance-audit.md
@@ -1,0 +1,35 @@
+# Design Decision: Result Elegance Audit as Dispatcher Behavioral Default
+
+**Date:** 2026-05-01
+**Status:** ACCEPTED
+**Vision anchor:** `core.inviolable_constraints.constraint-4` — minimize metabolic cost of cybernetic engagement; the system should reduce friction and screen time, not maximize output volume or feature density
+**Secondary anchor:** `core.operating_principles.principle-1` — structural prevention is preferred over reactive recovery
+**Linked commit:** ef131141 (feat(gates): integrate elegant economy as structural dispatch gate)
+**WOS-UoW:** uow_20260427_c174a3
+
+## Decision
+
+Authorize the Result Elegance Audit block inserted into the dispatcher main loop before the `# RELAY` step in `.claude/sys.dispatcher.bootup.md`:
+
+- **What it does:** Before relaying a subagent result to the user, the dispatcher evaluates whether each section of the response is load-bearing (would the response fail without it?), whether there is noise trimmable without losing meaning, and whether output volume matches task complexity.
+- **Trim gate:** If output-to-task ratio is high, trim non-load-bearing sections before sending.
+- **Calibration signal (not a hard gate):** If trimming would lose meaning, relay as-is but log: `write_observation(category="elegance_signal", text="task=<slug> ratio=high sections=<count> trimmed=<count>")`.
+- **Not blocking:** The audit never suppresses delivery — it either reduces volume before relay or logs a calibration signal without changing the output.
+
+## Rationale
+
+This is an Encoded Orientation decision: the dispatcher applies a behavioral heuristic (output volume calibration) without Dan's explicit per-message input. Per `core.inviolable_constraints.constraint-3`, Encoded Orientation decisions require a prior logged decision of the same class and a traceable vision.yaml anchor.
+
+**Primary vision anchor:** `core.inviolable_constraints.constraint-4` states: "Minimize metabolic cost of cybernetic engagement. The system should reduce friction and screen time, not maximize output volume or feature density." Output volume calibration before relay is a direct structural implementation of constraint-4: it reduces screen time by trimming non-load-bearing content before delivery rather than requiring Dan to manually filter signal from noise.
+
+**Secondary anchor:** `core.operating_principles.principle-1` (proactive resilience over reactive recovery). A relay filter that fires before delivery is structural prevention — it prevents volume accumulation rather than correcting for it after the user receives it.
+
+**Structural class:** Same as `decision-github-rate-limit-gate.md` (autonomous behavioral gate backed by a logged decision and a vision.yaml anchor) and `decision-system-retrospective-automation.md` (autonomous action backed by constraint-3 and principle-1). The elegance audit is calibration (soft signal + optional trim), not suppression (hard gate). This makes it lower-stakes than either prior decision — it never prevents delivery.
+
+## Constraints
+
+- The audit is not a hard gate — it never blocks or delays delivery
+- Trim decisions apply to non-load-bearing sections: repeated context, scaffolding prose, header boilerplate
+- The `elegance_signal` observation is informational only — it does not trigger automated remediation
+- The block applies only to subagent results before relay, not to direct dispatcher responses
+- Tasks explicitly requesting full output (audit reports, transcripts, complete diffs) are not subject to trim


### PR DESCRIPTION
## Summary

This PR bundles several workstreams. All changes listed explicitly below.

### Primary: Elegant Economy Gate (uow_20260427_c174a3)
- **CLAUDE.md**: Dispatch template gate enforcement upgraded from Advisory → Structural. Missing `Minimum viable output` or `Boundary` field is now an explicit dispatch blocker; a dispatch without both fields is a gate miss requiring `write_observation`.
- **sys.dispatcher.bootup.md**: Matching gate table entry updated to Structural. Result Elegance Audit block inserted inline before the `# RELAY` step — calibrates output volume via `write_observation(category="elegance_signal")` without blocking delivery.
- **Workspace task files** (not in repo): `morning-briefing.md` and `system-retrospective.md` updated with `Minimum viable output` and `Economy constraint` headers.

### Bundled: Document review protocol
- **oracle/document-review-protocol.md** (commit e0614bb5): New oracle protocol for non-code artifact verdicts (retros, design docs, synthesis work). Defines verdict format and storage convention (`oracle/verdicts/document-<slug>.md`).

### Bundled: lifetime_cycles surfacing in audit
- **src/** (commit fe96cf7c): Surface `lifetime_cycles` field in `completed_uow_durations` audit output.

### Bundled: retry-reserved enum cleanup
- **docs/wos-sprint3-part2-design.md** (commit 9aa71d83): Annotate `outcome='retry'` as reserved in the sprint design doc.

### Bundled: WOS docs restructure and wos-v3-spec unification
- **docs/wos/** (commits 4461cc40–5c2417ec): Create epistemic-status directory skeleton, move WOS files into typed subdirectories, mark wos-v2-design and wos-v3-proposal as superseded, unify wos-v3-proposal and wos-v3-steward-executor-spec into docs/wos/current/wos-v3-spec.md.

### Oracle gap fixes (round 1)
- **CLAUDE.md**: Fix stale path `docs/FUTURE.md` → `docs/setup/FUTURE.md`
- **docs/wos/current/wos-v3-spec.md**: Add production-vs-spec blockquote distinguishing what is live vs. planned
- **oracle/verdicts/decision-result-elegance-audit.md**: Decision record for Result Elegance Audit, citing vision.yaml `constraint-4` as authorizing anchor

## Test plan

- [ ] Confirm `CLAUDE.md` Dispatch template row Enforcement column says "Structural" and references dispatch blocker language
- [ ] Confirm `.claude/sys.dispatcher.bootup.md` gate table entry updated to Structural
- [ ] Confirm Result Elegance Audit block appears before `# RELAY` in dispatcher bootup
- [ ] Confirm `grep -r "Minimum viable output" /home/lobster/lobster/.claude/` returns expected entries
- [ ] Confirm task files in `~/lobster-workspace/scheduled-jobs/tasks/` carry the headers
- [ ] Confirm `CLAUDE.md` references `docs/setup/FUTURE.md` (not `docs/FUTURE.md`)
- [ ] Confirm wos-v3-spec.md has production-vs-spec blockquote after AUTHORITATIVE status
- [ ] Confirm `oracle/verdicts/decision-result-elegance-audit.md` exists and cites constraint-4

WOS-UoW: uow_20260427_c174a3

🤖 Generated with [Claude Code](https://claude.com/claude-code)