### PR TITLE
fix: mark outcome='retry' as reserved in dispatch-boundary schema

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -1346,11 +1346,12 @@ def _log_dispatch_boundary(
 
     Args:
         uow_id: The UoW being dispatched.
-        dispatch_attempt: Attempt number (1 for first attempt, 2+ for retries).
-        outcome: One of "success", "failure". (`retry` is reserved for a future
-            retry loop and is not currently emitted.)
+        dispatch_attempt: Attempt number (always 1 — retry is not implemented;
+            values >1 are reserved for a future retry loop).
+        outcome: One of "success" or "failure". "retry" is reserved — not
+            implemented; no code path produces this value.
         msg_id: The inbox message ID (on success).
-        failure_reason: Reason for failure or retry (on non-success).
+        failure_reason: Reason for failure (on non-success).
     """
     record = {
         "ts": _now_iso(),
@@ -1435,10 +1436,10 @@ def _dispatch_via_inbox(instructions: str, uow_id: str, agent_type: str = "funct
 
     The message_id is returned as the executor_id for audit correlation.
 
-    Observability: All dispatch attempts, retries, and failures are logged to
+    Observability: All dispatch attempts and failures are logged to
     ~/lobster-workspace/logs/dispatch-boundary.jsonl with structured records:
     {uow_id, dispatch_attempt, timestamp, outcome: success|failure, failure_reason?}
-    (`retry` is reserved for a future retry loop; `dispatch_attempt` is always 1.)
+    Note: outcome='retry' and dispatch_attempt>1 are reserved — not implemented.
 
     Raises OSError if the inbox directory cannot be created or the message
     file cannot be written.


### PR DESCRIPTION
## Summary

- `outcome='retry'` and `dispatch_attempt>1` appear in schema definitions and docstrings, but no code path in `_dispatch_via_inbox` ever produces these values — consumers filtering on `retry` always get zero results (oracle advisory S3P2-E from PR #708)
- This is Option A (mark reserved): annotate the dead enum values in schema docs and docstrings; do not implement a retry loop

## Changes

- `docs/wos-dispatch-failure-modes.md`: schema table updated — `dispatch_attempt` clarified as always 1, `outcome` documented as `success|failure` with `retry` marked reserved
- `docs/wos-sprint3-part2-design.md`: implementation note added to S3P2-E success criterion acknowledging `retry` was specified but not implemented
- `src/orchestration/executor.py`: `_log_dispatch_boundary` and `_dispatch_via_inbox` docstrings updated to reflect actual contract

## Test plan

- [ ] Grep `retry` in `executor.py` — confirms no code path produces `outcome="retry"`
- [ ] Grep `retry` in `dispatch-boundary.jsonl` schema docs — confirms value is marked reserved

## Completion check

`grep -n "retry" src/orchestration/executor.py` and `grep -n "retry" docs/wos-dispatch-failure-modes.md` both show only "reserved — not implemented" annotations, no live references.

WOS-UoW: uow_20260428_c36be3

🤖 Generated with [Claude Code](https://claude.com/claude-code)