### PR TITLE
feat(wos): add failure-breakdown CLI command

### DIFF
--- a/src/orchestration/registry_cli.py
+++ b/src/orchestration/registry_cli.py
@@ -16,6 +16,7 @@ Usage:
     uv run registry_cli.py gate-readiness
     uv run registry_cli.py trace --id <uow-id>
     uv run registry_cli.py report [--since HOURS] [--from ISO_DATE]
+    uv run registry_cli.py failure-breakdown [--since ISO_TIMESTAMP]
 
 Environment:
     REGISTRY_DB_PATH — override the default db path (~/.../orchestration/registry.db)
@@ -698,6 +699,172 @@ def _format_report(rows: list[dict], summary: dict, window_start_iso: str,
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# failure-breakdown command — cross-UoW failure pattern aggregation
+# ---------------------------------------------------------------------------
+
+# Canonical kill_type labels for the failure-breakdown command.
+# Infrastructure kills are UoWs where the agent was terminated by the platform
+# before it could complete — no execution budget was consumed.
+# Genuine failures are UoWs where execution began but the agent returned failure.
+KILL_TYPE_ORPHAN_BEFORE_START = "orphan_kill_before_start"
+KILL_TYPE_ORPHAN_DURING_EXECUTION = "orphan_kill_during_execution"
+KILL_TYPE_HARD_CAP = "hard_cap"
+KILL_TYPE_USER_CLOSED = "user_closed"
+KILL_TYPE_EXECUTION_FAILED = "execution_failed"
+KILL_TYPE_UNKNOWN = "unknown"
+
+
+def _classify_failure_kill_type(audit_entries: list[dict], close_reason: str | None) -> str:
+    """
+    Derive a kill_type label for a single failed UoW.
+
+    Classification priority (first match wins):
+    1. orphan_kill_classified audit event — infrastructure kill (before or during execution)
+    2. close_reason == 'hard_cap_cleanup' — genuine retry cap exhaustion
+    3. decide_close audit event — user explicitly closed
+    4. execution_failed audit event — executor returned failure
+    5. unknown — no matching signal
+
+    This function is a pure classifier: it reads signals and returns a label.
+    It does not query the DB.
+    """
+    # Priority 1: heartbeat-classified infrastructure kill
+    kill_classification = _extract_kill_classification(audit_entries)
+    if kill_classification:
+        kt = kill_classification.get("kill_type", "")
+        if kt == "orphan_kill_before_start":
+            return KILL_TYPE_ORPHAN_BEFORE_START
+        if kt == "orphan_kill_during_execution":
+            return KILL_TYPE_ORPHAN_DURING_EXECUTION
+
+    # Priority 2: hard cap retry exhaustion
+    if close_reason == "hard_cap_cleanup":
+        return KILL_TYPE_HARD_CAP
+
+    # Priority 3 & 4: scan audit event types
+    event_types = {entry.get("event") for entry in audit_entries}
+    if "decide_close" in event_types:
+        return KILL_TYPE_USER_CLOSED
+    if "execution_failed" in event_types:
+        return KILL_TYPE_EXECUTION_FAILED
+
+    return KILL_TYPE_UNKNOWN
+
+
+def _fetch_failed_uows_since(registry: "Registry", since_iso: str | None) -> list[dict]:
+    """
+    Return all failed UoWs as dicts, optionally filtered to those created on or
+    after since_iso. Each dict has: id, register, close_reason, created_at.
+    """
+    import sqlite3 as _sqlite3
+    conn = registry._connect()
+    try:
+        if since_iso:
+            cursor = conn.execute(
+                "SELECT id, register, close_reason, created_at FROM uow_registry "
+                "WHERE status = 'failed' AND created_at >= ? ORDER BY created_at",
+                (since_iso,),
+            )
+        else:
+            cursor = conn.execute(
+                "SELECT id, register, close_reason, created_at FROM uow_registry "
+                "WHERE status = 'failed' ORDER BY created_at",
+            )
+        rows = [dict(row) for row in cursor.fetchall()]
+    finally:
+        conn.close()
+    return rows
+
+
+def _format_failure_breakdown(
+    by_kill_type: dict[str, int],
+    by_register: dict[str, int],
+    total: int,
+    since_iso: str | None,
+) -> str:
+    """
+    Render failure counts as plain aligned text — no markdown tables.
+
+    Layout:
+      Header (total, optional since filter)
+      Blank line
+      By kill type (aligned columns: label, count, percentage)
+      Blank line
+      By register (aligned columns: label, count, percentage)
+    """
+    lines: list[str] = []
+
+    lines.append("WOS Failure Breakdown")
+    if since_iso:
+        lines.append(f"Since        : {since_iso}")
+    lines.append(f"Total failed : {total}")
+
+    if total == 0:
+        lines.append("")
+        lines.append("(no failed UoWs found)")
+        return "\n".join(lines)
+
+    def _pct(count: int) -> str:
+        return f"{100 * count / total:.0f}%"
+
+    col_w = 32  # label column width
+
+    lines.append("")
+    lines.append("By kill type:")
+    lines.append(f"  {'Kill type':<{col_w}}  {'Count':>5}  {'Pct':>5}")
+    lines.append(f"  {'-' * col_w}  {'-' * 5}  {'-' * 5}")
+    for label in sorted(by_kill_type):
+        count = by_kill_type[label]
+        lines.append(f"  {label:<{col_w}}  {count:>5}  {_pct(count):>5}")
+
+    lines.append("")
+    lines.append("By register:")
+    lines.append(f"  {'Register':<{col_w}}  {'Count':>5}  {'Pct':>5}")
+    lines.append(f"  {'-' * col_w}  {'-' * 5}  {'-' * 5}")
+    for label in sorted(by_register):
+        count = by_register[label]
+        lines.append(f"  {label:<{col_w}}  {count:>5}  {_pct(count):>5}")
+
+    return "\n".join(lines)
+
+
+def cmd_failure_breakdown(registry: "Registry", args: argparse.Namespace) -> None:
+    """
+    Aggregate failed UoWs by kill_type and register.
+
+    Kill type is derived from audit_log and close_reason — no schema changes required.
+
+    Classification priority per UoW:
+      1. orphan_kill_classified audit event → infrastructure kill (before/during execution)
+      2. close_reason == 'hard_cap_cleanup' → genuine retry cap exhaustion
+      3. decide_close audit event → user explicitly closed
+      4. execution_failed audit event → executor returned failure
+      5. unknown
+
+    Options:
+      --since ISO_TIMESTAMP  Filter to UoWs created on or after this timestamp
+    """
+    since_iso: str | None = getattr(args, "since", None)
+
+    failed_rows = _fetch_failed_uows_since(registry, since_iso)
+    total = len(failed_rows)
+
+    by_kill_type: dict[str, int] = {}
+    by_register: dict[str, int] = {}
+
+    for row in failed_rows:
+        audit_entries = registry.fetch_audit_entries(row["id"])
+        kill_type = _classify_failure_kill_type(audit_entries, row.get("close_reason"))
+        by_kill_type[kill_type] = by_kill_type.get(kill_type, 0) + 1
+
+        reg = row.get("register") or "operational"
+        by_register[reg] = by_register.get(reg, 0) + 1
+
+    report = _format_failure_breakdown(by_kill_type, by_register, total, since_iso)
+    print(report)
+
+
 def cmd_report(registry: "Registry", args: argparse.Namespace) -> None:
     """
     Print a time-windowed pipeline visibility report to stdout.
@@ -820,6 +987,24 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_trace.add_argument("--id", required=True, help="UoW id")
 
+    # failure-breakdown
+    p_failure_breakdown = subparsers.add_parser(
+        "failure-breakdown",
+        help=(
+            "Aggregate failed UoWs by kill_type and register. "
+            "Plain text output showing count + percentage per category. "
+            "Kill types: orphan_kill_before_start, orphan_kill_during_execution, "
+            "hard_cap, user_closed, execution_failed, unknown."
+        ),
+    )
+    p_failure_breakdown.add_argument(
+        "--since",
+        dest="since",
+        default=None,
+        metavar="ISO_TIMESTAMP",
+        help="Filter to UoWs created on or after this ISO 8601 timestamp",
+    )
+
     # report
     p_report = subparsers.add_parser(
         "report",
@@ -862,6 +1047,7 @@ _COMMAND_MAP = {
     "escalation-candidates": cmd_escalation_candidates,
     "stale": cmd_stale,
     "trace": cmd_trace,
+    "failure-breakdown": cmd_failure_breakdown,
     "report": cmd_report,
 }
 

--- a/tests/unit/test_orchestration/test_registry_cli.py
+++ b/tests/unit/test_orchestration/test_registry_cli.py
@@ -31,6 +31,12 @@ from orchestration.registry_cli import (
     _classify_status,
     _compute_summary,
     _window_start_iso,
+    KILL_TYPE_ORPHAN_BEFORE_START,
+    KILL_TYPE_ORPHAN_DURING_EXECUTION,
+    KILL_TYPE_HARD_CAP,
+    KILL_TYPE_USER_CLOSED,
+    KILL_TYPE_EXECUTION_FAILED,
+    KILL_TYPE_UNKNOWN,
 )
 
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
@@ -1159,3 +1165,218 @@ class TestReportCommand:
         total_line = next(l for l in output.splitlines() if l.startswith("Total UoWs"))
         total_str = total_line.split(":")[1].strip().split()[0]
         assert int(total_str) == 0
+
+
+# ---------------------------------------------------------------------------
+# failure-breakdown command
+# ---------------------------------------------------------------------------
+
+
+def _insert_failed_uow(db_path: Path, issue_number: int, register: str = "operational") -> str:
+    """Insert a UoW directly into the DB in failed status. Returns the UoW id."""
+    import uuid
+    uow_id = f"uow_{uuid.uuid4().hex[:8]}"
+    now = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+            (id, type, source, source_issue_number, sweep_date, status, posture,
+             created_at, updated_at, summary, success_criteria, register)
+        VALUES (?, 'executable', 'github', ?, ?, 'failed', 'solo', ?, ?, ?, '', ?)
+        """,
+        (uow_id, issue_number, datetime.now(timezone.utc).date().isoformat(),
+         now, now, f"Issue #{issue_number}", register),
+    )
+    conn.commit()
+    conn.close()
+    return uow_id
+
+
+def _add_audit_entry(db_path: Path, uow_id: str, event: str, note: dict | None = None) -> None:
+    """Append an audit_log entry for the given UoW."""
+    now = datetime.now(timezone.utc).isoformat()
+    note_json = json.dumps(note) if note is not None else None
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
+        VALUES (?, ?, ?, NULL, 'failed', 'test', ?)
+        """,
+        (now, uow_id, event, note_json),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _set_close_reason(db_path: Path, uow_id: str, close_reason: str) -> None:
+    """Set close_reason on a UoW row directly."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("UPDATE uow_registry SET close_reason = ? WHERE id = ?", (close_reason, uow_id))
+    conn.commit()
+    conn.close()
+
+
+class TestFailureBreakdownCommand:
+    def test_empty_db_returns_zero_failures(self, db_path):
+        """When no failed UoWs exist, output says no failures found."""
+        # Initialize the DB by inserting and removing a record
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert "0" in output or "no failed" in output.lower()
+
+    def test_execution_failed_uow_classified_correctly(self, db_path):
+        """A UoW with an execution_failed audit event is classified as execution_failed."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        uow_id = _insert_failed_uow(db_path, issue_number=100)
+        _add_audit_entry(db_path, uow_id, "execution_failed",
+                         note={"actor": "executor", "reason": "agent returned nonzero"})
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert KILL_TYPE_EXECUTION_FAILED in output
+
+    def test_hard_cap_uow_classified_correctly(self, db_path):
+        """A UoW with close_reason=hard_cap_cleanup is classified as hard_cap."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        uow_id = _insert_failed_uow(db_path, issue_number=101)
+        _set_close_reason(db_path, uow_id, "hard_cap_cleanup")
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert KILL_TYPE_HARD_CAP in output
+
+    def test_user_closed_uow_classified_correctly(self, db_path):
+        """A UoW with a decide_close audit event is classified as user_closed."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        uow_id = _insert_failed_uow(db_path, issue_number=102)
+        _add_audit_entry(db_path, uow_id, "decide_close",
+                         note={"event": "decide_close", "actor": "user", "reason": "user_closed"})
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert KILL_TYPE_USER_CLOSED in output
+
+    def test_orphan_kill_before_start_classified_correctly(self, db_path):
+        """A UoW with orphan_kill_classified event and kill_type=orphan_kill_before_start."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        uow_id = _insert_failed_uow(db_path, issue_number=103)
+        _add_audit_entry(db_path, uow_id, "orphan_kill_classified",
+                         note={"kill_type": "orphan_kill_before_start", "heartbeats_before_kill": 0})
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert KILL_TYPE_ORPHAN_BEFORE_START in output
+
+    def test_orphan_kill_during_execution_classified_correctly(self, db_path):
+        """A UoW with orphan_kill_classified event and kill_type=orphan_kill_during_execution."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        uow_id = _insert_failed_uow(db_path, issue_number=104)
+        _add_audit_entry(db_path, uow_id, "orphan_kill_classified",
+                         note={"kill_type": "orphan_kill_during_execution", "heartbeats_before_kill": 3})
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert KILL_TYPE_ORPHAN_DURING_EXECUTION in output
+
+    def test_unknown_failure_classified_as_unknown(self, db_path):
+        """A failed UoW with no classifiable audit entries is classified as unknown."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        _insert_failed_uow(db_path, issue_number=105)
+        # No audit entries added — classification must fall back to unknown
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert KILL_TYPE_UNKNOWN in output
+
+    def test_kill_type_counts_and_percentages_are_accurate(self, db_path):
+        """Two execution_failed and one hard_cap UoW produce correct counts and pct."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+
+        for issue_num in (200, 201):
+            uid = _insert_failed_uow(db_path, issue_number=issue_num)
+            _add_audit_entry(db_path, uid, "execution_failed",
+                             note={"actor": "executor", "reason": "nonzero"})
+
+        uid_cap = _insert_failed_uow(db_path, issue_number=202)
+        _set_close_reason(db_path, uid_cap, "hard_cap_cleanup")
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        lines = output.splitlines()
+
+        # Find the execution_failed line and confirm count of 2
+        exec_failed_lines = [l for l in lines if KILL_TYPE_EXECUTION_FAILED in l]
+        assert exec_failed_lines, f"Expected {KILL_TYPE_EXECUTION_FAILED} in output:\n{output}"
+        assert "2" in exec_failed_lines[0], f"Expected count 2 in line: {exec_failed_lines[0]}"
+
+        # Find the hard_cap line and confirm count of 1
+        hard_cap_lines = [l for l in lines if KILL_TYPE_HARD_CAP in l]
+        assert hard_cap_lines, f"Expected {KILL_TYPE_HARD_CAP} in output:\n{output}"
+        assert "1" in hard_cap_lines[0], f"Expected count 1 in line: {hard_cap_lines[0]}"
+
+        # Percentages present (66% and 33%, or close)
+        assert "%" in output, "Output must include percentage values"
+
+    def test_register_breakdown_section_present(self, db_path):
+        """Output includes a breakdown by register field."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+
+        uid_op = _insert_failed_uow(db_path, issue_number=300, register="operational")
+        _add_audit_entry(db_path, uid_op, "execution_failed")
+
+        uid_ic = _insert_failed_uow(db_path, issue_number=301, register="iterative-convergent")
+        _add_audit_entry(db_path, uid_ic, "execution_failed")
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        assert "operational" in output
+        assert "iterative-convergent" in output
+
+    def test_since_flag_filters_by_created_at(self, db_path):
+        """--since filters UoWs to only those created on or after the given timestamp."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+
+        # Insert an old failed UoW backdated to 2024
+        old_uid = f"uow_old_test_01"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            INSERT INTO uow_registry
+                (id, type, source, source_issue_number, sweep_date, status, posture,
+                 created_at, updated_at, summary, success_criteria, register)
+            VALUES (?, 'executable', 'github', 400, '2024-01-01', 'failed', 'solo',
+                    '2024-01-01T00:00:00+00:00', '2024-01-01T00:00:00+00:00', 'Old UoW', '', 'operational')
+            """,
+            (old_uid,),
+        )
+        conn.commit()
+        conn.close()
+
+        # Insert a recent failed UoW
+        recent_uid = _insert_failed_uow(db_path, issue_number=401)
+        _add_audit_entry(db_path, recent_uid, "execution_failed")
+
+        # Filter to only 2026 — the 2024 UoW should not appear in counts
+        output_filtered = run_cli_text(db_path, "failure-breakdown", "--since", "2026-01-01T00:00:00+00:00")
+        output_all = run_cli_text(db_path, "failure-breakdown")
+
+        # The filtered output must show fewer total failures than the unfiltered one
+        def _extract_total(text: str) -> int:
+            for line in text.splitlines():
+                if "total" in line.lower():
+                    parts = line.split()
+                    for p in parts:
+                        if p.isdigit():
+                            return int(p)
+            return 0
+
+        assert _extract_total(output_filtered) < _extract_total(output_all), (
+            f"Filtered output should have fewer failures than unfiltered.\n"
+            f"Filtered:\n{output_filtered}\nAll:\n{output_all}"
+        )
+
+    def test_output_has_no_markdown_table_syntax(self, db_path):
+        """Output must use plain aligned columns, not markdown table syntax (no | delimiters)."""
+        run_cli(db_path, "upsert", "--issue", "1", "--title", "Init", "--sweep-date", "2026-01-01")
+        uow_id = _insert_failed_uow(db_path, issue_number=500)
+        _add_audit_entry(db_path, uow_id, "execution_failed")
+
+        output = run_cli_text(db_path, "failure-breakdown")
+        # No markdown table pipe delimiter at the start of a line
+        lines_with_pipes = [l for l in output.splitlines() if l.strip().startswith("|")]
+        assert not lines_with_pipes, (
+            f"Output must not use markdown table syntax. Found: {lines_with_pipes}"
+        )


### PR DESCRIPTION
## What this solves

WOS observability Gap C: kill waves are visible per-UoW via `trace` but invisible in aggregate. The `report` command counts failed UoWs as a single number with no decomposition by cause. When a kill wave hits multiple UoWs, there is no way to see at a glance whether they are infrastructure kills (agents killed before any work was done) or genuine retry cap exhaustions (execution occurred but the task is intractable).

## What changed

Adds a `failure-breakdown` subcommand to `registry_cli.py`. It:

- Queries all failed UoWs, optionally filtered by `--since ISO_TIMESTAMP`
- Classifies each UoW's kill_type from existing audit_log and close_reason signals — no schema change
- Groups and counts by kill_type and by register
- Renders aligned plain-text columns showing count and percentage per category
- Output follows the same style as `report`: no markdown tables, no pipe delimiters

Kill type classification (priority order, first match wins):

1. `orphan_kill_classified` audit event — infrastructure kill (before or during execution)
2. `close_reason == hard_cap_cleanup` — genuine retry cap exhaustion
3. `decide_close` audit event — user explicitly closed
4. `execution_failed` audit event — executor returned failure
5. `unknown` — no matching signal

Classification is a pure function (`_classify_failure_kill_type`) — no side effects, no DB writes. The five canonical kill_type label constants (`KILL_TYPE_*`) are module-level exports so tests import them rather than mirroring raw string literals.

## Functional patterns used

Pure function composition: `_classify_failure_kill_type` takes data and returns a label; `_fetch_failed_uows_since` isolates the DB read; `_format_failure_breakdown` is a pure renderer. `cmd_failure_breakdown` composes these three with a reduce-style accumulation into `by_kill_type` and `by_register` dicts.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry_cli.py::TestFailureBreakdownCommand -v` — 11 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_registry_cli.py -v` — 86 passed, 1 failed (pre-existing: `TestApproveCommand::test_approve_idempotent_on_pending` fails on `main` before this change — verified by stashing and re-running)

## Manual test

N/A — read-only CLI command with no external service calls, no Telegram output, no file system side effects beyond querying the registry DB.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (read-only CLI, no external services)
- [x] User-visible outcome — N/A (CLI tool, not Telegram output)
- [x] Side-effect audit: read-only queries only, no writes to registry DB
- [x] External service calls: none

Closes #1028