### PR TITLE
fix(tests): align heartbeat contract assertions with actual prompt format

### DIFF
--- a/tests/unit/test_wos_metabolic_digest.py
+++ b/tests/unit/test_wos_metabolic_digest.py
@@ -515,11 +515,18 @@ class TestHandleWosExecuteHeartbeatContract:
         assert "write_heartbeat" in prompt
 
     def test_uow_id_interpolated_in_heartbeat_call(self, prompt):
-        # The heartbeat call must use the actual UoW ID, not a placeholder
-        assert "write_heartbeat('test-uow-001')" in prompt
+        # The heartbeat call must use the actual UoW ID, not a placeholder.
+        # Both the MCP path (uow_id='test-uow-001') and the fallback path
+        # (WOSRegistry().write_heartbeat('test-uow-001', ...)) embed the UoW ID.
+        # Check that at least one form is present.
+        assert (
+            "uow_id='test-uow-001'" in prompt
+            or "write_heartbeat('test-uow-001'" in prompt
+        )
 
     def test_60_90_second_interval_documented(self, prompt):
-        assert "60-90 seconds" in prompt
+        # The prompt uses an en-dash (U+2013) between 60 and 90.
+        assert "60\u201390 seconds" in prompt
 
     def test_stop_on_zero_return_value_documented(self, prompt):
         # Agent must stop if write_heartbeat returns 0 (UoW re-queued)


### PR DESCRIPTION
## What problem does this solve?

Two tests in `TestHandleWosExecuteHeartbeatContract` were failing because they checked for exact string forms that don't match what `handle_wos_execute` actually produces. The heartbeat contract (Gap 1 from issue #849, shipped in PR #851) is correctly implemented; the test assertions were written against an earlier version of the prompt format.

## What changed

Both fixes are in `tests/unit/test_wos_metabolic_digest.py` — no production code changes.

**`test_uow_id_interpolated_in_heartbeat_call`**: The test expected `write_heartbeat('test-uow-001')` (no additional args). The actual prompt has two forms:
- MCP path: `mcp__lobster-inbox__write_wos_heartbeat(uow_id='test-uow-001', token_usage=<...>)` — matches `uow_id='test-uow-001'`
- Fallback path: `WOSRegistry().write_heartbeat('test-uow-001', token_usage=<...>)` — matches `write_heartbeat('test-uow-001'` (open paren, no close)

The fix accepts either form, which correctly verifies the UoW ID is interpolated regardless of which path the reader follows in the prompt.

**`test_60_90_second_interval_documented`**: The test expected the ASCII hyphen `"60-90 seconds"` but the prompt uses the Unicode en-dash (U+2013): `"60\u201390 seconds"`. Fixed with the correct Unicode literal.

## Functional patterns used

- Pure assertion alignment — no logic changes, only predicate corrections
- The OR in `test_uow_id_interpolated_in_heartbeat_call` is a union of valid evidence forms, not a weakened check; both forms unambiguously prove the UoW ID is interpolated

## What is out of scope

- No changes to `handle_wos_execute` or any production code
- No changes to the heartbeat contract behavior or the MCP tool wiring
- All other test assertions in `TestHandleWosExecuteHeartbeatContract` are unchanged and continue to pass

## Tests run
- [x] `uv run pytest tests/unit/test_wos_health_check.py tests/unit/test_wos_metabolic_digest.py -v` — 71 passed, 0 failed
- [x] All 7 tests in `TestHandleWosExecuteHeartbeatContract` pass including the two previously failing

## Manual test

N/A — this is a pure test-assertion fix with no runtime behavior changes.

## Definition of Done
- [x] Unit tests pass
- [x] No production code changes — no integration test needed
- [x] User-visible outcome: not applicable (test-only change)
- [x] Side-effect audit: read-only test assertions, no side effects

WOS-UoW: wos-gap-a-b-issue-849