### PR TITLE
fix(wos): write token_usage to result.json

### DIFF
--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -291,24 +291,29 @@ def _extract_artifact_refs(text: str) -> dict:
     }
 
 
-def _enrich_result_file(output_ref: str, result_text: str | None) -> None:
+def _enrich_result_file(
+    output_ref: str,
+    result_text: str | None,
+    token_usage: int | None = None,
+) -> None:
     """
-    Read the existing result.json at output_ref, add 'summary' and 'refs' fields,
-    and rewrite it atomically.
+    Read the existing result.json at output_ref, add 'summary', 'refs', and
+    'token_usage' fields, and rewrite it atomically.
 
     Called after a successful UoW completion (outcome=complete) to capture:
     - summary: first _RESULT_SUMMARY_MAX_CHARS chars of result_text
     - refs: extracted PR numbers, issue numbers, and file paths from result_text
+    - token_usage: cumulative input+output tokens from the subagent (issue #1033)
 
     No-op when:
-    - result_text is None or empty
+    - result_text is None or empty AND token_usage is None
     - result file does not exist (subagent skipped result_writer)
     - result file is unreadable or not valid JSON
 
     Side effects are isolated to this function. Failures are logged and swallowed
     — result file enrichment must never block the UoW transition.
     """
-    if not result_text:
+    if not result_text and token_usage is None:
         return
 
     # Derive result file path (mirrors result_writer._result_json_path)
@@ -340,14 +345,31 @@ def _enrich_result_file(output_ref: str, result_text: str | None) -> None:
         import json
         import tempfile
 
-        summary = result_text[:_RESULT_SUMMARY_MAX_CHARS]
-        refs = _extract_artifact_refs(result_text)
+        enriched = False
 
-        # Only add fields not already present (subagent may have set summary itself)
-        if "summary" not in payload:
-            payload["summary"] = summary
-        if "refs" not in payload and any(refs.values()):
-            payload["refs"] = refs
+        if result_text:
+            summary = result_text[:_RESULT_SUMMARY_MAX_CHARS]
+            refs = _extract_artifact_refs(result_text)
+
+            # Only add fields not already present (subagent may have set summary itself)
+            if "summary" not in payload:
+                payload["summary"] = summary
+                enriched = True
+            if "refs" not in payload and any(refs.values()):
+                payload["refs"] = refs
+                enriched = True
+        else:
+            refs = {}
+
+        # token_usage: always write when provided, never overwrite an existing value.
+        # This is the primary fix for issue #1033 — token_usage was stored in the
+        # registry DB but absent from the on-disk result.json.
+        if token_usage is not None and "token_usage" not in payload:
+            payload["token_usage"] = token_usage
+            enriched = True
+
+        if not enriched:
+            return
 
         # Atomic rewrite
         tmp_fd, tmp_name = tempfile.mkstemp(
@@ -361,8 +383,8 @@ def _enrich_result_file(output_ref: str, result_text: str | None) -> None:
                 fh.write(json.dumps(payload, indent=2))
             tmp_path.rename(result_path)
             log.debug(
-                "_enrich_result_file: enriched %s (summary_len=%d, refs=%s)",
-                result_path, len(summary), refs,
+                "_enrich_result_file: enriched %s (summary_len=%d, refs=%s, token_usage=%s)",
+                result_path, len(result_text or ""), refs, token_usage,
             )
         except Exception:
             try:
@@ -385,6 +407,7 @@ def _backpropagate_result_to_output_file(
     uow_id: str,
     output_ref: str,
     result_text: str | None,
+    token_usage: int | None = None,
 ) -> None:
     """
     Write the write_result payload to the executor output file when none exists.
@@ -405,6 +428,7 @@ def _backpropagate_result_to_output_file(
     - success: true
     - reason: the write_result text (truncated to 500 chars)
     - executor_id: "write_result_backprop" (identifies this synthetic record)
+    - token_usage: cumulative token count from the subagent (issue #1033)
 
     Also writes result_text to the primary output_ref path when that file is
     missing or empty (sentinel-only), so agent-status.sh and the steward have
@@ -417,6 +441,9 @@ def _backpropagate_result_to_output_file(
         uow_id: The WOS unit-of-work ID.
         output_ref: The output_ref path for this UoW (absolute path).
         result_text: The text field from the write_result call. May be None or empty.
+        token_usage: Optional cumulative token count (input + output) from the
+            subagent's write_result call. Written to the synthetic result.json
+            when provided (issue #1033).
     """
     if not output_ref:
         return
@@ -442,13 +469,17 @@ def _backpropagate_result_to_output_file(
 
         # Write a minimal conforming result.json
         reason = (result_text or "").strip()[:500] or "completed via write_result"
-        payload = {
+        payload: dict = {
             "uow_id": uow_id,
             "outcome": "complete",
             "success": True,
             "reason": reason,
             "executor_id": "write_result_backprop",
         }
+        # token_usage: include when provided so per-UoW cost is visible in the
+        # result file, not only in the registry DB (issue #1033).
+        if token_usage is not None:
+            payload["token_usage"] = token_usage
 
         result_path.parent.mkdir(parents=True, exist_ok=True)
         # Atomic write: tmp → rename so the Steward never reads a partial file
@@ -867,13 +898,15 @@ def maybe_complete_wos_uow(
         # file when the subagent did not write one itself. Must run BEFORE
         # _enrich_result_file so the file exists for enrichment to update.
         if output_ref:
-            _backpropagate_result_to_output_file(uow_id, output_ref, result_text)
+            _backpropagate_result_to_output_file(uow_id, output_ref, result_text,
+                                                 token_usage=token_usage)
 
         # Enrich result file with summary + extracted artifact refs from agent output.
+        # Also writes token_usage to the result.json (issue #1033).
         # Non-fatal — enrichment failure never blocks the UoW transition.
         if output_ref:
             try:
-                _enrich_result_file(output_ref, result_text)
+                _enrich_result_file(output_ref, result_text, token_usage=token_usage)
             except Exception as enrich_exc:
                 log.warning(
                     "maybe_complete_wos_uow: result file enrichment failed for UoW %r — %s: %s",

--- a/tests/unit/test_orchestration/test_wos_completion.py
+++ b/tests/unit/test_orchestration/test_wos_completion.py
@@ -1565,3 +1565,214 @@ class TestOutcomeCategoryForwarding:
             ).fetchone()["outcome_category"]
             conn.close()
             assert stored == label, f"Expected {label!r} stored, got {stored!r}"
+
+
+# ---------------------------------------------------------------------------
+# token_usage written to result.json (issue #1033)
+# ---------------------------------------------------------------------------
+
+#: Named constant anchoring tests to the issue spec: token_usage must appear in
+#: result.json so per-UoW cost is visible to tooling that reads files directly.
+TOKEN_USAGE_FIELD = "token_usage"
+
+
+class TestTokenUsageInResultJson:
+    """
+    token_usage must be present in result.json after a successful UoW completion
+    when the subagent reports it via write_result.
+
+    Before issue #1033, token_usage was stored only in the registry DB (SQLite).
+    The fix threads it through _enrich_result_file and _backpropagate_result_to_output_file
+    so the on-disk file matches the DB.
+    """
+
+    def _seed_executing_uow(self, registry: Registry, output_dir: Path) -> tuple[str, str]:
+        """Seed a UoW and advance it to 'executing'. Returns (uow_id, output_ref)."""
+        result = registry.upsert(
+            issue_number=9910,
+            title="Token usage result.json test UoW",
+            success_criteria="token_usage appears in result.json",
+        )
+        assert isinstance(result, UpsertInserted)
+        uow_id = result.id
+        registry.approve(uow_id)
+
+        output_ref = str(output_dir / f"{uow_id}.json")
+        registry.set_status_direct(uow_id, "active")
+        conn = sqlite3.connect(str(registry.db_path))
+        conn.execute(
+            "UPDATE uow_registry SET output_ref = ? WHERE id = ?",
+            (output_ref, uow_id),
+        )
+        conn.commit()
+        conn.close()
+        registry.transition_to_executing(uow_id, "mock-executor-token-test")
+        return uow_id, output_ref
+
+    def test_token_usage_written_to_backpropagated_result_json(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        When no result.json exists before completion and token_usage is provided,
+        _backpropagate_result_to_output_file must include token_usage in the
+        synthetic result.json it creates.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id, output_ref = self._seed_executing_uow(registry, output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        with patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            maybe_complete_wos_uow(
+                task_id,
+                WRITE_RESULT_SUCCESS_STATUS,
+                result_text="PR #99 opened on dcetlin/Lobster.",
+                token_usage=42000,
+            )
+
+        # Derive result.json path (mirrors _result_json_path convention)
+        p = Path(output_ref)
+        result_path = p.with_suffix(".result.json") if p.suffix else Path(str(p) + ".result.json")
+
+        assert result_path.exists(), f"result.json must exist at {result_path}"
+        import json
+        payload = json.loads(result_path.read_text())
+        assert TOKEN_USAGE_FIELD in payload, (
+            f"result.json must contain '{TOKEN_USAGE_FIELD}' field. "
+            f"Found keys: {list(payload.keys())}"
+        )
+        assert payload[TOKEN_USAGE_FIELD] == 42000, (
+            f"token_usage must be 42000, got {payload[TOKEN_USAGE_FIELD]!r}"
+        )
+
+    def test_token_usage_written_when_result_json_already_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        When a result.json already exists (written by the subagent via result_writer),
+        _enrich_result_file must add token_usage to it without clobbering existing fields.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id, output_ref = self._seed_executing_uow(registry, output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        # Pre-write a result.json as if the subagent used result_writer
+        p = Path(output_ref)
+        result_path = p.with_suffix(".result.json") if p.suffix else Path(str(p) + ".result.json")
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        import json
+        existing_payload = {
+            "status": "complete",
+            "outcome": "complete",
+            "success": True,
+            "summary": "PR #77 opened.",
+            "written_at": "2026-01-01T00:00:00+00:00",
+        }
+        result_path.write_text(json.dumps(existing_payload, indent=2))
+
+        with patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            maybe_complete_wos_uow(
+                task_id,
+                WRITE_RESULT_SUCCESS_STATUS,
+                result_text="PR #77 opened.",
+                token_usage=8500,
+            )
+
+        payload = json.loads(result_path.read_text())
+        assert TOKEN_USAGE_FIELD in payload, (
+            f"_enrich_result_file must add '{TOKEN_USAGE_FIELD}' to existing result.json. "
+            f"Found keys: {list(payload.keys())}"
+        )
+        assert payload[TOKEN_USAGE_FIELD] == 8500, (
+            f"token_usage must be 8500, got {payload[TOKEN_USAGE_FIELD]!r}"
+        )
+        # Existing fields must be preserved
+        assert payload.get("summary") == "PR #77 opened.", "existing summary must be preserved"
+        assert payload.get("success") is True, "existing success field must be preserved"
+
+    def test_token_usage_absent_when_not_provided(self, tmp_path: Path) -> None:
+        """
+        When write_result is called without token_usage, the result.json must not
+        contain the token_usage field — absence is correct, not zero.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id, output_ref = self._seed_executing_uow(registry, output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        with patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            maybe_complete_wos_uow(
+                task_id,
+                WRITE_RESULT_SUCCESS_STATUS,
+                result_text="Completed without token count.",
+                token_usage=None,
+            )
+
+        p = Path(output_ref)
+        result_path = p.with_suffix(".result.json") if p.suffix else Path(str(p) + ".result.json")
+
+        if result_path.exists():
+            import json
+            payload = json.loads(result_path.read_text())
+            assert TOKEN_USAGE_FIELD not in payload, (
+                f"token_usage must not appear in result.json when not provided. "
+                f"Found: {payload.get(TOKEN_USAGE_FIELD)!r}"
+            )
+
+    def test_existing_token_usage_in_result_json_is_not_overwritten(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        If a result.json already has a token_usage field (written by the subagent
+        itself via result_writer), _enrich_result_file must not overwrite it.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id, output_ref = self._seed_executing_uow(registry, output_dir)
+        task_id = f"{WOS_TASK_ID_PREFIX}{uow_id}"
+
+        p = Path(output_ref)
+        result_path = p.with_suffix(".result.json") if p.suffix else Path(str(p) + ".result.json")
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        import json
+        # Subagent pre-wrote its own token_usage = 5000
+        existing_payload = {
+            "status": "complete",
+            "outcome": "complete",
+            "success": True,
+            "summary": "Done.",
+            "written_at": "2026-01-01T00:00:00+00:00",
+            "token_usage": 5000,
+        }
+        result_path.write_text(json.dumps(existing_payload, indent=2))
+
+        with patch("orchestration.wos_completion.subprocess.run"), \
+             patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            maybe_complete_wos_uow(
+                task_id,
+                WRITE_RESULT_SUCCESS_STATUS,
+                result_text="Done.",
+                token_usage=9999,  # different value — must not overwrite the existing 5000
+            )
+
+        payload = json.loads(result_path.read_text())
+        assert payload.get(TOKEN_USAGE_FIELD) == 5000, (
+            f"Pre-existing token_usage=5000 must not be overwritten. "
+            f"Got {payload.get(TOKEN_USAGE_FIELD)!r}"
+        )


### PR DESCRIPTION
## Summary

UoW `result.json` files have been missing `token_usage` entirely, making per-UoW token cost invisible to any tooling that reads result files directly (agent-status.sh, post-hoc cost analysis scripts, the oracle). The field existed in the SQLite registry but stopped there.

**The gap:** `token_usage` entered the pipeline correctly — `handle_write_result` in `inbox_server.py` extracted it and forwarded it to `maybe_complete_wos_uow`, which passed it to `registry.complete_uow()`. It was stored in the DB. But neither `_backpropagate_result_to_output_file` (which synthesizes a result.json when the subagent didn't write one) nor `_enrich_result_file` (which enriches an existing result.json with summary/refs) accepted `token_usage` as a parameter — so the field was silently dropped before reaching the file.

**The fix:** Both helpers now accept `token_usage: int | None = None` and write it to the result.json when provided. The write is idempotent — a value already in the file (written by the subagent itself via result_writer) is never overwritten.

## What changed

- `_enrich_result_file`: new `token_usage` param; writes the field to the payload unless already present. The function now runs its atomic rewrite only when something actually changed (avoids unnecessary writes).
- `_backpropagate_result_to_output_file`: new `token_usage` param; includes the field in the synthetic result.json payload when provided.
- `maybe_complete_wos_uow`: threads `token_usage` into both call sites.
- 4 new behavior-named tests in `TestTokenUsageInResultJson` covering: backprop path, enrich path, absent-when-not-provided, and no-overwrite invariant.

## Functional patterns used

Pure function extension (optional param with `None` default) — existing callers require no changes. Side effects remain isolated to the two write helpers. No mutation of shared state.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py -v` — 85 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py::TestTokenUsageInResultJson -v` — 4 passed, 0 failed (all new tests)

## Manual test

N/A — this change is entirely internal to the write_result processing path. The user-visible outcome (token_usage appearing in result.json files) is verified by the unit tests above. No Telegram output, no external service calls, no systemd units affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal path, no external services)
- [x] User-visible outcome verified — verified via unit tests: result.json files contain token_usage after a successful UoW completion with token_usage provided
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — writes only to existing result.json file paths, never to new locations
- [x] External service calls: none in this change

Closes #1033
WOS-UoW: fix-wos-token-recording