### PR TITLE
feat(delivery): circadian-aware Telegram delivery with morning queue flush

### DIFF
--- a/oracle/decisions.md
+++ b/oracle/decisions.md
@@ -266,3 +266,47 @@ Authorized by WOS UoW uow_20260501_8de2bc (mem-event-type-subject-tagging). The 
 ### Known Correction Gap
 
 Events classified via the fast path (confidence="high") have no correction path if the producer's hint is wrong. The slow-reclassifier's `total_revised` counter conflates hinted events with pattern-revised events, making true reclassification rates harder to audit. These are accepted trade-offs at current scale given that structured producers (harvesters, scheduled jobs) have reliable self-knowledge of their signal type. If producer accuracy degrades, the correct response is to add a monitoring gap to the daily digest, not to remove the fast path.
+
+---
+
+## ADR-006: Circadian Gate Wired into inbox_write.py as a Shared Behavioral Default — Encoded Orientation
+
+**Date:** 2026-05-02
+**Status:** Accepted
+**PR:** #1036 (feat/circadian-delivery_uow_20260427_7ffcb3)
+
+### Context
+
+PR #1036 introduces circadian-aware message delivery: non-urgent scheduled-job outputs are held in a local queue and batched for delivery during Dan's morning window (06:00–10:00 America/Los_Angeles). The circadian gate logic lives in `src/delivery/circadian.py`.
+
+Before this PR, `src/utils/inbox_write.py` wrote every subagent_result directly to the inbox, regardless of time-of-day. The circadian module was self-contained with no call site in the shared delivery path.
+
+### Decision
+
+The circadian gate is wired into `write_inbox_message()` in `src/utils/inbox_write.py` as a durable behavioral default for all callers. When `is_non_urgent(msg)` returns True and `is_morning_window()` returns False, the message is routed to `queue_message()` instead of being written to the inbox. This applies to every caller of `write_inbox_message()` — no opt-in is required.
+
+The gate is wrapped in a `try/except` so that unavailability of the circadian module falls through to immediate delivery without disrupting existing callers.
+
+### Why This Is an Encoded Orientation Decision
+
+The system now acts without Dan's real-time input when circadian deferral conditions are met: every non-urgent job output sent outside the morning window is silently queued rather than immediately delivered. This satisfies all three conditions under constraint-3: (a) the system acts without Dan's explicit per-message input, (b) it changes a durable behavioral default in the delivery path, and (c) the change is encoded in `inbox_write.py`, not in a retrievable prompt.
+
+### Rationale
+
+Wiring the gate into `inbox_write.py` rather than into each caller individually serves the "integration rate before new feature rate" principle: the shared utility is the correct seam for a delivery-layer concern. Callers that produce non-urgent output do not need to know about circadian delivery — they call `write_inbox_message()` and the gate is applied transparently.
+
+This directly addresses constraint-4: overnight job outputs that would otherwise interrupt Dan's sleep or early-morning focus are held and batched for the morning window, reducing friction and screen-time without reducing information completeness.
+
+### Vision Anchor
+
+**Primary:** `core.inviolable_constraints.constraint-4` — "Minimize metabolic cost of cybernetic engagement. The system should reduce friction and screen time, not maximize output volume or feature density."
+
+Deferring non-urgent job outputs to the morning window is a structural implementation of constraint-4: it removes overnight interruptions at the delivery layer rather than relying on Dan to manage notification volume manually.
+
+**Secondary:** `core.operating_principles.principle-4` — "Integration rate before new feature rate. Wire what exists before building more. The missing arrows between existing systems are the velocity multiplier."
+
+The circadian module existed before this PR. Wiring it into the shared write path is the missing arrow — it makes the feature operative for all callers without requiring per-caller changes.
+
+### Constraint
+
+The circadian gate applies only to messages where `is_non_urgent()` returns True (type is `subagent_result`, no `reply_to_message_id`, no urgent-signal keywords). Urgent messages, user replies, and incident alerts always deliver immediately via the existing path. The gate cannot defer a message the user is waiting for a reply to.

--- a/scheduled-tasks/morning-delivery-flush.py
+++ b/scheduled-tasks/morning-delivery-flush.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Morning Delivery Flush — Lobster Scheduled Job
+===============================================
+
+Delivers all messages that were queued by the circadian delivery gate during
+off-peak hours. Runs once daily at 14:00 UTC (06:00 PST / 07:00 PDT).
+
+If the queue is empty, logs silently and exits without sending a Telegram
+notification (no noise when there is nothing to deliver).
+
+Type C dispatch: cron calls this script directly. No LLM round-trip needed —
+queue drain is mechanical.
+
+Cron entry (added by upgrade.sh migration 93):
+    0 14 * * * cd ~/lobster && uv run scheduled-tasks/morning-delivery-flush.py >> ~/lobster-workspace/scheduled-jobs/logs/morning-delivery-flush.log 2>&1 # LOBSTER-MORNING-DELIVERY-FLUSH
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/morning-delivery-flush.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir  # noqa: E402
+from src.delivery.circadian import flush_morning_queue  # noqa: E402
+
+JOB_NAME = "morning-delivery-flush"
+
+
+def _make_send_fn(dry_run: bool):
+    """Return a send_fn suitable for flush_morning_queue."""
+
+    def send_fn(chat_id: int, text: str) -> None:
+        if dry_run:
+            print(f"  [dry-run] would send to chat_id={chat_id}: {text[:80]}...")
+            return
+        inbox = _inbox_dir()
+        msg_id = f"{JOB_NAME}_{uuid.uuid4().hex}"
+        source = os.environ.get("LOBSTER_DEFAULT_SOURCE", "telegram")
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        msg = {
+            "id": msg_id,
+            "type": "subagent_result",
+            "task_id": msg_id,
+            "chat_id": chat_id,
+            "source": source,
+            "text": text,
+            "status": "success",
+            "sent_reply_to_user": False,
+            "timestamp": timestamp,
+        }
+        out_path = inbox / f"{msg_id}.json"
+        tmp_path = Path(str(out_path) + ".tmp")
+        tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp_path.replace(out_path)
+
+    return send_fn
+
+
+def _write_task_output(output: str, status: str, timestamp: str) -> None:
+    task_outputs = _task_outputs_dir()
+    date_prefix = timestamp[:19].replace(":", "").replace("-", "").replace("T", "-")
+    filename = f"{date_prefix}-{JOB_NAME}.json"
+    record = {
+        "job_name": JOB_NAME,
+        "timestamp": timestamp,
+        "status": status,
+        "output": output,
+    }
+    out_path = task_outputs / filename
+    tmp_path = Path(str(out_path) + ".tmp")
+    tmp_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp_path.replace(out_path)
+
+
+def run(dry_run: bool = False) -> int:
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{timestamp}] Starting {JOB_NAME}")
+
+    send_fn = _make_send_fn(dry_run)
+
+    try:
+        count = flush_morning_queue(send_fn)
+    except Exception as exc:
+        msg = f"flush_morning_queue failed: {exc}"
+        print(f"  ERROR: {msg}", file=sys.stderr)
+        _write_task_output(msg, "error", timestamp)
+        return 1
+
+    if count == 0:
+        print(f"[{timestamp}] Queue empty — nothing to deliver")
+        _write_task_output("Queue empty — nothing to deliver.", "success", timestamp)
+    else:
+        summary = f"Delivered {count} queued message(s) from pending-deliveries.jsonl."
+        print(f"[{timestamp}] {summary}")
+        _write_task_output(summary, "success", timestamp)
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be sent without delivering")
+    args = parser.parse_args()
+    sys.exit(run(dry_run=args.dry_run))

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3187,6 +3187,32 @@ print(f'prune-pr-worktrees: {result.status}')
         substep "wos-pr-sweeper cron entry already present — skipping"
     fi
 
+
+    # Migration 93: Circadian delivery — pending-deliveries queue file and morning flush cron.
+    # Creates the JSONL queue file for off-peak message deferral and registers the
+    # morning-delivery-flush cron entry (14:00 UTC = 06:00 PST / 07:00 PDT).
+    local PENDING_DELIVERIES="$WORKSPACE_DIR/data/pending-deliveries.jsonl"
+    if [ ! -f "$PENDING_DELIVERIES" ]; then
+        touch "$PENDING_DELIVERIES" \
+            && substep "Created pending-deliveries.jsonl (Migration 93)" \
+            || warn "Could not create pending-deliveries.jsonl — check $WORKSPACE_DIR/data/"
+        migrated=$((migrated + 1))
+    else
+        substep "pending-deliveries.jsonl already exists — skipping"
+    fi
+
+    local MORNING_FLUSH_MARKER="# LOBSTER-MORNING-DELIVERY-FLUSH"
+    if ! crontab -l 2>/dev/null | grep -qF "$MORNING_FLUSH_MARKER"; then
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$MORNING_FLUSH_MARKER" \
+            "0 14 * * * cd $LOBSTER_DIR && uv run scheduled-tasks/morning-delivery-flush.py >> $WORKSPACE_DIR/scheduled-jobs/logs/morning-delivery-flush.log 2>&1 $MORNING_FLUSH_MARKER" \
+            && substep "Added morning-delivery-flush cron entry (Migration 93)" \
+            || warn "Could not add morning-delivery-flush cron entry — check cron-manage.sh"
+        migrated=$((migrated + 1))
+    else
+        substep "morning-delivery-flush cron entry already present — skipping"
+    fi
+
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/delivery/__init__.py
+++ b/src/delivery/__init__.py
@@ -1,0 +1,1 @@
+# Lobster delivery modules

--- a/src/delivery/circadian.py
+++ b/src/delivery/circadian.py
@@ -1,0 +1,135 @@
+"""
+Circadian-aware message delivery for Lobster.
+
+Non-urgent scheduled-job outputs are held in a local queue and batched for
+delivery during Dan's morning window (06:00–10:00 America/Los_Angeles).
+Urgent messages (user replies, incident alerts) always deliver immediately.
+
+Public API
+----------
+is_non_urgent(message: dict) -> bool
+is_morning_window() -> bool
+queue_message(chat_id, text, source, source_type) -> None
+flush_morning_queue(send_fn) -> int
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+_PACIFIC = ZoneInfo("America/Los_Angeles")
+
+# Keywords that signal an urgent job output (health failures, system alerts).
+# Checked case-insensitively against message text.
+_URGENT_KEYWORDS: frozenset[str] = frozenset([
+    "health check failure",
+    "health check failed",
+    "starvation detected",
+    "heartbeat stale",
+    "error:",
+    "alert:",
+    "incident",
+    "critical failure",
+    "system error",
+])
+
+
+def _queue_path() -> Path:
+    workspace = os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+    return Path(workspace) / "data" / "pending-deliveries.jsonl"
+
+
+def is_morning_window() -> bool:
+    """True if current Pacific time is between 06:00 and 10:00 (inclusive of 06, exclusive of 10)."""
+    now_pt = datetime.now(_PACIFIC)
+    return 6 <= now_pt.hour < 10
+
+
+def is_non_urgent(message: dict) -> bool:
+    """
+    True if the message is safe to defer to the morning delivery window.
+
+    Non-urgent when ALL conditions hold:
+    - type is "subagent_result" (scheduled job output, not a direct user reply)
+    - no reply_to_message_id (not threaded to a user message)
+    - text does not contain urgent-signal keywords (health failures, incidents)
+    """
+    if message.get("type") != "subagent_result":
+        return False
+    if message.get("reply_to_message_id"):
+        return False
+    text_lower = message.get("text", "").lower()
+    if any(kw in text_lower for kw in _URGENT_KEYWORDS):
+        return False
+    return True
+
+
+def queue_message(
+    chat_id: int,
+    text: str,
+    source: str = "",
+    source_type: str = "scheduled_job",
+) -> None:
+    """Append a pending-delivery entry to the JSONL queue."""
+    entry = {
+        "queued_at": datetime.now(timezone.utc).isoformat(),
+        "chat_id": chat_id,
+        "text": text,
+        "source": source,
+        "source_type": source_type,
+        "delivered": False,
+    }
+    path = _queue_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def flush_morning_queue(send_fn) -> int:
+    """
+    Deliver all pending queue entries by calling send_fn(chat_id, text).
+
+    Rewrites the JSONL file atomically with delivered=true for each sent entry.
+    Returns the count of messages delivered. Entries that fail to send are left
+    as undelivered and retried on the next flush.
+    """
+    path = _queue_path()
+    if not path.exists():
+        return 0
+
+    raw_lines = path.read_text(encoding="utf-8").splitlines()
+    entries: list[dict] = []
+    for line in raw_lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    delivered_count = 0
+    updated: list[dict] = []
+    for entry in entries:
+        if entry.get("delivered", False):
+            updated.append(entry)
+            continue
+        try:
+            send_fn(entry["chat_id"], entry["text"])
+            updated.append({**entry, "delivered": True})
+            delivered_count += 1
+        except Exception:
+            updated.append(entry)
+
+    tmp_path = Path(str(path) + ".tmp")
+    content = "\n".join(json.dumps(e, ensure_ascii=False) for e in updated)
+    if content:
+        content += "\n"
+    tmp_path.write_text(content, encoding="utf-8")
+    tmp_path.replace(path)
+
+    return delivered_count

--- a/src/delivery/circadian.py
+++ b/src/delivery/circadian.py
@@ -43,9 +43,20 @@ def _queue_path() -> Path:
     return Path(workspace) / "data" / "pending-deliveries.jsonl"
 
 
-def is_morning_window() -> bool:
-    """True if current Pacific time is between 06:00 and 10:00 (inclusive of 06, exclusive of 10)."""
-    now_pt = datetime.now(_PACIFIC)
+def is_morning_window(_now_fn=None) -> bool:
+    """True if current Pacific time is between 06:00 and 10:00 (inclusive of 06, exclusive of 10).
+
+    Parameters
+    ----------
+    _now_fn:
+        Optional callable that returns the current datetime (must be timezone-aware).
+        When None (default), uses ``datetime.now(_PACIFIC)``.
+        Inject a fixed-time callable in tests to avoid time-of-day dependency.
+    """
+    if _now_fn is not None:
+        now_pt = _now_fn()
+    else:
+        now_pt = datetime.now(_PACIFIC)
     return 6 <= now_pt.hour < 10
 
 

--- a/src/utils/inbox_write.py
+++ b/src/utils/inbox_write.py
@@ -9,6 +9,8 @@ Public API
 write_inbox_message(job_name, chat_id, text, timestamp) -> str
     Write a subagent_result JSON to ~/messages/inbox/ using atomic
     tmp-then-rename.  Returns the message ID so callers can log it.
+    Non-urgent messages sent outside the morning window are queued in
+    pending-deliveries.jsonl instead of the inbox (circadian delivery).
 
 _inbox_dir() -> Path
 _task_outputs_dir() -> Path
@@ -52,6 +54,11 @@ def write_inbox_message(
     Uses atomic tmp-then-rename so the dispatcher never reads a partial file.
     The dispatcher picks up the file and routes it via send_reply.
 
+    Circadian routing: if the message is non-urgent and the current time is
+    outside the morning window (06:00–10:00 Pacific), the message is queued
+    in pending-deliveries.jsonl for batch morning delivery instead of being
+    written to the inbox immediately.
+
     Parameters
     ----------
     job_name:
@@ -70,7 +77,6 @@ def write_inbox_message(
     str
         The generated message ID (``"<job_name>_<uuid-hex>"``).
     """
-    inbox = _inbox_dir()
     msg_id = f"{job_name}_{uuid.uuid4().hex}"
     source = os.environ.get("LOBSTER_DEFAULT_SOURCE", "telegram")
     msg = {
@@ -84,6 +90,17 @@ def write_inbox_message(
         "sent_reply_to_user": False,
         "timestamp": timestamp,
     }
+
+    # Circadian gate: defer non-urgent messages to the morning delivery window.
+    try:
+        from src.delivery.circadian import is_morning_window, is_non_urgent, queue_message  # noqa: PLC0415
+        if is_non_urgent(msg) and not is_morning_window():
+            queue_message(chat_id, text, source=job_name)
+            return msg_id
+    except Exception:
+        pass  # circadian module unavailable — fall through to immediate delivery
+
+    inbox = _inbox_dir()
     out_path = inbox / f"{msg_id}.json"
     tmp_path = Path(str(out_path) + ".tmp")
     tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/tests/test_circadian_delivery.py
+++ b/tests/test_circadian_delivery.py
@@ -25,6 +25,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from src.delivery.circadian import (
     flush_morning_queue,
+    is_morning_window,
     is_non_urgent,
     queue_message,
 )
@@ -95,6 +96,43 @@ class TestIsNonUrgent:
             text="Today's exploration: The Ship of Theseus and software identity.",
         )
         assert is_non_urgent(msg) is True
+
+
+# ---------------------------------------------------------------------------
+# is_morning_window
+# ---------------------------------------------------------------------------
+
+# Window bounds per spec: 06:00 <= hour < 10:00 (America/Los_Angeles)
+WINDOW_OPEN_HOUR = 6    # first hour inside the window
+WINDOW_LAST_HOUR = 9    # last hour inside the window
+WINDOW_CLOSE_HOUR = 10  # first hour outside (exclusive upper bound)
+BEFORE_WINDOW_HOUR = 5  # hour before the window opens
+
+
+def _make_now_fn(hour: int):
+    """Return a _now_fn callable that yields a fixed datetime at the given hour."""
+    from zoneinfo import ZoneInfo
+    _PACIFIC = ZoneInfo("America/Los_Angeles")
+    fixed = datetime(2026, 5, 2, hour, 0, 0, tzinfo=_PACIFIC)
+    return lambda: fixed
+
+
+class TestIsMorningWindow:
+    def test_window_open_hour_is_inside(self):
+        """hour=6 is the first hour of the window — must return True."""
+        assert is_morning_window(_now_fn=_make_now_fn(WINDOW_OPEN_HOUR)) is True
+
+    def test_window_last_hour_is_inside(self):
+        """hour=9 is the last valid hour — must return True."""
+        assert is_morning_window(_now_fn=_make_now_fn(WINDOW_LAST_HOUR)) is True
+
+    def test_window_close_hour_is_outside(self):
+        """hour=10 is just past the window (exclusive upper bound) — must return False."""
+        assert is_morning_window(_now_fn=_make_now_fn(WINDOW_CLOSE_HOUR)) is False
+
+    def test_before_window_is_outside(self):
+        """hour=5 is before the window opens — must return False."""
+        assert is_morning_window(_now_fn=_make_now_fn(BEFORE_WINDOW_HOUR)) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_circadian_delivery.py
+++ b/tests/test_circadian_delivery.py
@@ -1,0 +1,209 @@
+"""
+Tests for circadian-aware message delivery.
+
+Coverage:
+- is_non_urgent classifies scheduled-job messages correctly
+- is_non_urgent returns False for user replies and urgent-keyword messages
+- queue_message appends valid JSONL entries
+- flush_morning_queue delivers pending entries and marks them delivered
+- flush_morning_queue is a no-op when the queue is empty or all delivered
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.delivery.circadian import (
+    flush_morning_queue,
+    is_non_urgent,
+    queue_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_scheduled_msg(**overrides) -> dict:
+    base = {
+        "id": "daily-metrics_abc123",
+        "type": "subagent_result",
+        "task_id": "daily-metrics_abc123",
+        "chat_id": 8075091586,
+        "source": "telegram",
+        "text": "Daily metrics — 2026-05-02\n\nGitHub: 3 open issues.",
+        "status": "success",
+        "sent_reply_to_user": False,
+        "timestamp": "2026-05-02T20:00:00Z",
+    }
+    return {**base, **overrides}
+
+
+# ---------------------------------------------------------------------------
+# is_non_urgent
+# ---------------------------------------------------------------------------
+
+class TestIsNonUrgent:
+    def test_scheduled_job_no_reply_to(self):
+        msg = _make_scheduled_msg()
+        assert is_non_urgent(msg) is True
+
+    def test_urgent_user_reply(self):
+        msg = _make_scheduled_msg(reply_to_message_id=99999)
+        assert is_non_urgent(msg) is False
+
+    def test_non_subagent_result_type(self):
+        msg = _make_scheduled_msg(type="user_message")
+        assert is_non_urgent(msg) is False
+
+    def test_inbound_message_type(self):
+        msg = _make_scheduled_msg(type="inbound")
+        assert is_non_urgent(msg) is False
+
+    def test_urgent_keyword_error_colon(self):
+        msg = _make_scheduled_msg(text="Error: health check failed — 3 UoWs stale.")
+        assert is_non_urgent(msg) is False
+
+    def test_urgent_keyword_incident(self):
+        msg = _make_scheduled_msg(text="System incident detected at 14:32 UTC.")
+        assert is_non_urgent(msg) is False
+
+    def test_urgent_keyword_starvation(self):
+        msg = _make_scheduled_msg(text="Starvation detected: UoW uow_abc123 stuck for 72h.")
+        assert is_non_urgent(msg) is False
+
+    def test_daily_digest_is_non_urgent(self):
+        msg = _make_scheduled_msg(
+            task_id="nightly-consolidation_xyz",
+            text="Nightly consolidation complete. 12 memories updated.",
+        )
+        assert is_non_urgent(msg) is True
+
+    def test_philosophy_exploration_is_non_urgent(self):
+        msg = _make_scheduled_msg(
+            task_id="philosophy-explorer_xyz",
+            text="Today's exploration: The Ship of Theseus and software identity.",
+        )
+        assert is_non_urgent(msg) is True
+
+
+# ---------------------------------------------------------------------------
+# queue_message
+# ---------------------------------------------------------------------------
+
+class TestQueueMessage:
+    def test_appends_entry(self, tmp_path, monkeypatch):
+        queue_file = tmp_path / "data" / "pending-deliveries.jsonl"
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+
+        queue_message(8075091586, "Hello, morning!", source="daily-metrics")
+
+        lines = queue_file.read_text().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["chat_id"] == 8075091586
+        assert entry["text"] == "Hello, morning!"
+        assert entry["source"] == "daily-metrics"
+        assert entry["source_type"] == "scheduled_job"
+        assert entry["delivered"] is False
+        assert "queued_at" in entry
+
+    def test_appends_multiple(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+
+        queue_message(111, "Message A", source="job-a")
+        queue_message(222, "Message B", source="job-b")
+
+        lines = (tmp_path / "data" / "pending-deliveries.jsonl").read_text().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["chat_id"] == 111
+        assert json.loads(lines[1])["chat_id"] == 222
+
+
+# ---------------------------------------------------------------------------
+# flush_morning_queue
+# ---------------------------------------------------------------------------
+
+class TestFlushMorningQueue:
+    def test_delivers_pending_and_marks_delivered(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        queue_file = tmp_path / "data" / "pending-deliveries.jsonl"
+
+        entries = [
+            {"queued_at": "2026-05-02T08:00:00+00:00", "chat_id": 111, "text": "Msg A",
+             "source": "job-a", "source_type": "scheduled_job", "delivered": False},
+            {"queued_at": "2026-05-02T09:00:00+00:00", "chat_id": 222, "text": "Msg B",
+             "source": "job-b", "source_type": "scheduled_job", "delivered": False},
+        ]
+        queue_file.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+        calls = []
+        def mock_send(chat_id, text):
+            calls.append((chat_id, text))
+
+        count = flush_morning_queue(mock_send)
+
+        assert count == 2
+        assert calls == [(111, "Msg A"), (222, "Msg B")]
+
+        written = [json.loads(l) for l in queue_file.read_text().splitlines() if l.strip()]
+        assert all(e["delivered"] is True for e in written)
+
+    def test_skips_already_delivered(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        queue_file = tmp_path / "data" / "pending-deliveries.jsonl"
+
+        entries = [
+            {"queued_at": "2026-05-02T08:00:00+00:00", "chat_id": 111, "text": "Old",
+             "source": "job-a", "source_type": "scheduled_job", "delivered": True},
+            {"queued_at": "2026-05-02T09:00:00+00:00", "chat_id": 222, "text": "New",
+             "source": "job-b", "source_type": "scheduled_job", "delivered": False},
+        ]
+        queue_file.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+        calls = []
+        count = flush_morning_queue(lambda c, t: calls.append((c, t)))
+
+        assert count == 1
+        assert calls == [(222, "New")]
+
+    def test_empty_queue_returns_zero(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        count = flush_morning_queue(lambda c, t: None)
+        assert count == 0
+
+    def test_absent_queue_file_returns_zero(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        # Do not create the file
+        count = flush_morning_queue(lambda c, t: None)
+        assert count == 0
+
+    def test_failed_send_leaves_entry_undelivered(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        queue_file = tmp_path / "data" / "pending-deliveries.jsonl"
+
+        entry = {"queued_at": "2026-05-02T08:00:00+00:00", "chat_id": 111, "text": "X",
+                 "source": "job-a", "source_type": "scheduled_job", "delivered": False}
+        queue_file.write_text(json.dumps(entry) + "\n")
+
+        def boom(chat_id, text):
+            raise RuntimeError("network error")
+
+        count = flush_morning_queue(boom)
+
+        assert count == 0
+        written = json.loads(queue_file.read_text().splitlines()[0])
+        assert written["delivered"] is False

--- a/tests/unit/test_inbox_write.py
+++ b/tests/unit/test_inbox_write.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -55,12 +56,13 @@ class TestWriteInboxMessageSchema:
     def test_writes_valid_json_with_correct_fields(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
         monkeypatch.setenv("LOBSTER_DEFAULT_SOURCE", "telegram")
-        msg_id = write_inbox_message(
-            job_name="test-job",
-            chat_id=12345,
-            text="hello world",
-            timestamp="2026-04-20T01:00:00+00:00",
-        )
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            msg_id = write_inbox_message(
+                job_name="test-job",
+                chat_id=12345,
+                text="hello world",
+                timestamp="2026-04-20T01:00:00+00:00",
+            )
         inbox = tmp_path / "inbox"
         written = list(inbox.glob("*.json"))
         assert len(written) == 1
@@ -76,25 +78,29 @@ class TestWriteInboxMessageSchema:
 
     def test_msg_id_prefixed_with_job_name(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
-        msg_id = write_inbox_message("daily-metrics", 1, "text", "2026-04-20T00:00:00Z")
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            msg_id = write_inbox_message("daily-metrics", 1, "text", "2026-04-20T00:00:00Z")
         assert msg_id.startswith("daily-metrics_")
 
     def test_returns_msg_id_string(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
-        result = write_inbox_message("weekly-epistemic-retro", 99, "x", "2026-04-20T00:00:00Z")
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            result = write_inbox_message("weekly-epistemic-retro", 99, "x", "2026-04-20T00:00:00Z")
         assert isinstance(result, str)
         assert len(result) > 0
 
     def test_each_call_generates_unique_msg_id(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
-        id1 = write_inbox_message("job", 1, "a", "2026-04-20T00:00:00Z")
-        id2 = write_inbox_message("job", 1, "b", "2026-04-20T00:00:00Z")
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            id1 = write_inbox_message("job", 1, "a", "2026-04-20T00:00:00Z")
+            id2 = write_inbox_message("job", 1, "b", "2026-04-20T00:00:00Z")
         assert id1 != id2
 
     def test_source_uses_lobster_default_source_env(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
         monkeypatch.setenv("LOBSTER_DEFAULT_SOURCE", "slack")
-        write_inbox_message("job", 1, "msg", "2026-04-20T00:00:00Z")
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            write_inbox_message("job", 1, "msg", "2026-04-20T00:00:00Z")
         inbox = tmp_path / "inbox"
         payload = json.loads(next(inbox.glob("*.json")).read_text())
         assert payload["source"] == "slack"
@@ -102,7 +108,8 @@ class TestWriteInboxMessageSchema:
     def test_source_defaults_to_telegram_when_env_absent(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
         monkeypatch.delenv("LOBSTER_DEFAULT_SOURCE", raising=False)
-        write_inbox_message("job", 1, "msg", "2026-04-20T00:00:00Z")
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            write_inbox_message("job", 1, "msg", "2026-04-20T00:00:00Z")
         inbox = tmp_path / "inbox"
         payload = json.loads(next(inbox.glob("*.json")).read_text())
         assert payload["source"] == "telegram"
@@ -115,13 +122,75 @@ class TestWriteInboxMessageSchema:
 class TestAtomicWrite:
     def test_no_tmp_file_left_after_write(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
-        write_inbox_message("job", 1, "text", "2026-04-20T00:00:00Z")
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            write_inbox_message("job", 1, "text", "2026-04-20T00:00:00Z")
         inbox = tmp_path / "inbox"
         tmp_files = list(inbox.glob("*.tmp"))
         assert tmp_files == [], f"leftover .tmp files: {tmp_files}"
 
     def test_output_file_named_after_msg_id(self, tmp_path, monkeypatch):
         monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
-        msg_id = write_inbox_message("surface-queue-delivery", 2, "t", "2026-04-20T00:00:00Z")
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            msg_id = write_inbox_message("surface-queue-delivery", 2, "t", "2026-04-20T00:00:00Z")
         inbox = tmp_path / "inbox"
         assert (inbox / f"{msg_id}.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# write_inbox_message — circadian deferral path
+# ---------------------------------------------------------------------------
+
+class TestCircadianDeferral:
+    """
+    Verifies that non-urgent messages sent outside the morning window are
+    queued in pending-deliveries.jsonl instead of being written to the inbox.
+    """
+
+    def test_non_urgent_outside_morning_window_queued_not_inboxed(self, tmp_path, monkeypatch):
+        """When is_non_urgent() is True and is_morning_window() is False, message goes to queue."""
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        with patch("src.delivery.circadian.is_morning_window", return_value=False):
+            msg_id = write_inbox_message("nightly-metrics", 42, "report text", "2026-04-20T03:00:00Z")
+        # Inbox must be empty — message was deferred
+        inbox = tmp_path / "inbox"
+        written = list(inbox.glob("*.json")) if inbox.exists() else []
+        assert written == [], f"Expected deferred message not in inbox, but found: {written}"
+        # Queue file must exist with the entry
+        queue_path = tmp_path / "data" / "pending-deliveries.jsonl"
+        assert queue_path.exists(), "Expected pending-deliveries.jsonl to be created"
+        entries = [json.loads(line) for line in queue_path.read_text().splitlines() if line.strip()]
+        assert len(entries) == 1
+        assert entries[0]["chat_id"] == 42
+        assert entries[0]["text"] == "report text"
+        assert entries[0]["delivered"] is False
+        # msg_id is still returned to the caller
+        assert isinstance(msg_id, str)
+        assert msg_id.startswith("nightly-metrics_")
+
+    def test_non_urgent_inside_morning_window_goes_to_inbox(self, tmp_path, monkeypatch):
+        """When is_non_urgent() is True and is_morning_window() is True, message is written to inbox."""
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        with patch("src.delivery.circadian.is_morning_window", return_value=True):
+            msg_id = write_inbox_message("morning-job", 42, "morning report", "2026-04-20T14:00:00Z")
+        inbox = tmp_path / "inbox"
+        written = list(inbox.glob("*.json"))
+        assert len(written) == 1
+        payload = json.loads(written[0].read_text())
+        assert payload["chat_id"] == 42
+        assert payload["text"] == "morning report"
+
+    def test_urgent_message_bypasses_deferral(self, tmp_path, monkeypatch):
+        """Urgent messages (containing alert keywords) are written to inbox even outside morning window."""
+        monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path))
+        with patch("src.delivery.circadian.is_morning_window", return_value=False):
+            msg_id = write_inbox_message(
+                "health-check", 42,
+                "health check failed: disk usage at 95%",
+                "2026-04-20T03:00:00Z",
+            )
+        inbox = tmp_path / "inbox"
+        written = list(inbox.glob("*.json"))
+        assert len(written) == 1, "Urgent message must bypass deferral and go to inbox immediately"
+        payload = json.loads(written[0].read_text())
+        assert "health check failed" in payload["text"]


### PR DESCRIPTION
Implements circadian-aware message delivery. Non-urgent messages queued overnight, flushed at 14:00 UTC (7am PDT). New: src/delivery/circadian.py, morning-delivery-flush.py cron-direct script. Migration 93 in upgrade.sh. 16 tests passing. WOS UoW uow_20260427_7ffcb3.