### PR TITLE
feat: decision: footer type — first-class artifact for choices

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -203,7 +203,7 @@ See `docs/oracle-review-protocol.md` for the full frontmatter schema and when ea
 
 ## Signal Footer (Required on All Replies Referencing Completed Work)
 
-**Canonical label: `side-effects:`** — this is the only accepted label. Do not use `signals:`, `effects:`, or any other variant.
+**Valid footer labels: `side-effects:` and `decision:`.** These are the only accepted code block labels. Do not use `signals:`, `effects:`, or any other variant. Any other label is wrong and will cause drift across compaction.
 
 When a `send_reply` has side effects, include a signal footer. When there are no side effects, omit the footer entirely. The hook `hooks/signal-footer-check.py` validates footer labels and blocks `side-effects: none` in any form.
 
@@ -219,6 +219,18 @@ Your reply text here.
 
 **When you have NO side effects:** write nothing — omit the footer completely. Do NOT write `side-effects: none`.
 
+**When you are surfacing a decision:** end the message with a `decision:` code block containing the decision text. One block, one decision per reply. `decision:` and `side-effects:` can coexist in the same message when a decision also has side effects.
+
+````
+Your reply text here.
+
+```decision:
+Option B oracle gate (over Option A two-token model)
+```
+````
+
+The `💬 decide` signal (see legend below) documents that a decision was surfaced. The `decision:` footer block routes the decision text to the decisions ledger at `~/lobster-workspace/data/decisions-ledger.md` for future retrieval via `hooks/decision-router.py`.
+
 Signal legend (10-signal set):
 - `🚀 spawned  <task-name>` — agent or background task launched (include the task slug; list each on its own line)
 - `✅` done — task completed
@@ -231,7 +243,7 @@ Signal legend (10-signal set):
 - `🔧` config — configuration changed
 - `💬` decide — decision made or surfaced
 
-**The label `side-effects:` is authoritative.** The hook validates the code block label and blocks wrong labels — `side-effects:` is the only accepted label. Any other label is wrong and will cause drift across compaction.
+**Valid footer labels:** `side-effects:` and `decision:`. These are the only accepted code block labels. Any other label is wrong and will cause drift across compaction.
 
 ## Surfacing Observations (`write_observation`)
 

--- a/hooks/decision-router.py
+++ b/hooks/decision-router.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook: routes decision: footer blocks to the decisions ledger.
+
+When a send_reply message contains a ```decision: ... ``` code block,
+extract the content and append it to ~/lobster-workspace/data/decisions-ledger.md.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+
+DECISION_BLOCK_RE = re.compile(r"```decision:\s*\n(.*?)```", re.DOTALL)
+LEDGER_PATH = os.path.expanduser("~/lobster-workspace/data/decisions-ledger.md")
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if data.get("tool_name") != "mcp__lobster-inbox__send_reply":
+        sys.exit(0)
+
+    text = data.get("tool_input", {}).get("text", "")
+    if not text:
+        sys.exit(0)
+
+    match = DECISION_BLOCK_RE.search(text)
+    if not match:
+        sys.exit(0)
+
+    decision_text = match.group(1).strip()
+    if not decision_text:
+        sys.exit(0)
+
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    os.makedirs(os.path.dirname(LEDGER_PATH), exist_ok=True)
+
+    if not os.path.exists(LEDGER_PATH):
+        with open(LEDGER_PATH, "w") as f:
+            f.write(
+                "# Decisions Ledger\n\n"
+                "Append-only log of choices made as captured from `decision:` footer blocks.\n"
+                "One entry per decision. Routed automatically by `hooks/decision-router.py`.\n\n"
+            )
+
+    with open(LEDGER_PATH, "a") as f:
+        f.write(f"\n---\n**{date_str}** — {decision_text}\n")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/signal-footer-check.py
+++ b/hooks/signal-footer-check.py
@@ -6,6 +6,8 @@ Fires before mcp__lobster-inbox__send_reply tool calls.
 
 Convention:
 - When a message has side effects: end with a ```side-effects: ... ``` code block.
+- When a decision is being surfaced: end with a ```decision: ... ``` code block.
+- Both `side-effects:` and `decision:` are valid footer labels and may coexist.
 - When a message has no side effects: omit the footer entirely — write nothing.
 - `side-effects: none` in any form is BANNED. Omit the footer instead.
 - Any footer-like code block with a wrong label (signals:, effects:, etc.) is blocked.
@@ -24,6 +26,10 @@ import sys
 # Only "side-effects:" is accepted — no other label is valid.
 # This enforces the canonical format from sys.subagent.bootup.md.
 SIDE_EFFECTS_BLOCK_RE = re.compile(r"```side-effects:[^`]*```", re.DOTALL)
+
+# Match a decision code block with the canonical label.
+# "decision:" is the second accepted footer type alongside "side-effects:".
+DECISION_BLOCK_RE = re.compile(r"```decision:[^`]*```", re.DOTALL)
 
 # Match "side-effects: none" in any form:
 # 1. As a bare line: "side-effects: none"
@@ -109,15 +115,17 @@ def main():
         )
         sys.exit(2)
 
-    # Check 2: If a footer-like code block is present, its label must be exactly "side-effects:".
-    # A canonical side-effects block is valid — allow it.
+    # Check 2: If a footer-like code block is present, its label must be "side-effects:" or "decision:".
+    # A canonical side-effects or decision block is valid — allow it.
     # A wrong-label block is blocked.
-    if not SIDE_EFFECTS_BLOCK_RE.search(text):
+    has_valid_footer = SIDE_EFFECTS_BLOCK_RE.search(text) or DECISION_BLOCK_RE.search(text)
+    if not has_valid_footer:
         wrong_label = detect_wrong_label(text)
         if wrong_label is not None:
             print(
-                f"BLOCKED: Wrong footer label — must be exactly `side-effects:` (got `{wrong_label}`). "
+                f"BLOCKED: Wrong footer label — must be `side-effects:` or `decision:` (got `{wrong_label}`). "
                 "Use ```side-effects:\\n<signals>\\n``` for messages with side effects. "
+                "Use ```decision:\\n<choice>\\n``` when surfacing a decision. "
                 "Omit the footer entirely when there are no side effects.",
                 file=sys.stderr,
             )

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3213,6 +3213,27 @@ print(f'prune-pr-worktrees: {result.status}')
     fi
 
 
+    # Migration 94: Register decision-router PostToolUse hook in settings.json.
+    # Routes decision: footer blocks from send_reply messages to the decisions ledger.
+    # Appends extracted decision text to ~/lobster-workspace/data/decisions-ledger.md.
+    if [ -f "$CLAUDE_SETTINGS" ]; then
+        if ! jq -e '.hooks.PostToolUse[]? | select(.hooks[]?.command | contains("decision-router"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+            chmod +x "$LOBSTER_DIR/hooks/decision-router.py" 2>/dev/null || true
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "python3 $LOBSTER_DIR/hooks/decision-router.py" \
+               '.hooks.PostToolUse = (.hooks.PostToolUse // []) + [{
+                "matcher": "mcp__lobster-inbox__send_reply",
+                "hooks": [{
+                    "type": "command",
+                    "command": $cmd,
+                    "timeout": 5
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered decision-router PostToolUse hook in settings.json"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

When Dan approves an option in conversation, the reply carries no durable record of the choice — it evaporates into the thread. This PR adds `decision:` as a canonical second footer type alongside `side-effects:`, so every choice surfaced via a `send_reply` is automatically persisted to a decisions ledger.

## What changed

**`hooks/signal-footer-check.py`** — adds `DECISION_BLOCK_RE` and gates the main validation on `has_valid_footer = SIDE_EFFECTS_BLOCK_RE.search(text) or DECISION_BLOCK_RE.search(text)`. Messages with a `decision:` block alone, or with both footer types, now pass validation. The error message is updated to name both valid labels. `decision` is NOT added to `WRONG_LABEL_PATTERNS` — it is a valid label.

**`hooks/decision-router.py`** (new PostToolUse hook) — fires after every `mcp__lobster-inbox__send_reply` call. Extracts the content of a `decision:` code block and appends it as a dated entry to `~/lobster-workspace/data/decisions-ledger.md`. Creates the ledger file on first use if absent.

**`.claude/sys.subagent.bootup.md`** — documents `decision:` as a valid footer label with a usage example, notes that both footer types may coexist, and points to the ledger path and routing hook.

**`scripts/upgrade.sh`** — Migration 94 registers `decision-router.py` as a PostToolUse hook in `settings.json`, matching only `mcp__lobster-inbox__send_reply`.

## How it works

```
send_reply with ```decision:\nOption B\n```
       │
       ├─► signal-footer-check.py (PreToolUse)
       │     DECISION_BLOCK_RE matches → exits 0 (allowed)
       │
       └─► decision-router.py (PostToolUse)
             extracts "Option B"
             appends to decisions-ledger.md:
             ---
             **2026-05-02** — Option B
```

`side-effects:` behavior is entirely unchanged. Wrong labels (signals:, effects:, etc.) are still blocked. `decision:` is not in `WRONG_LABEL_PATTERNS`.

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 374 passed, 0 failed
- [x] Manual: `decision:` block passes `signal-footer-check.py` (exit 0)
- [x] Manual: `side-effects:` + `decision:` coexisting passes (exit 0)
- [x] Manual: wrong labels still blocked (exit 2, updated error message)
- [x] Manual: `decision-router.py` appends to ledger, creates file on first use

## Manual test
N/A — hook is a pure function that reads stdin and writes to a file. No external services, no Telegram output. Functional behavior verified via direct invocation above.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see above
- [x] User-visible outcome verified: N/A (internal hook, no direct user message)
- [x] Side-effect audit complete: writes only to decisions-ledger.md, no volume risk, idempotent per-message
- [x] External service calls: none