### PR TITLE
chore: fix executor-heartbeat.py dispatch type label (Type B -> Type C)

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -22,7 +22,7 @@ continues for remaining UoWs.
 Cron schedule (every 3 minutes, offset by 90s from steward-heartbeat):
     */3 * * * * sleep 90 && cd ~/lobster && uv run scheduled-tasks/executor-heartbeat.py >> ~/lobster-workspace/scheduled-jobs/logs/executor-heartbeat.log 2>&1
 
-Type B dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+Type C dispatch: cron calls this script directly (no inbox/ message, no dispatcher
 involvement). The jobs.json enabled gate is checked at the top of main() so that
 runtime enable/disable (wos start/stop) is respected without touching cron.
 
@@ -70,7 +70,7 @@ log = logging.getLogger("executor-heartbeat")
 
 
 # ---------------------------------------------------------------------------
-# jobs.json enabled gate — Type B dispatch path
+# jobs.json enabled gate — Type C dispatch path
 # ---------------------------------------------------------------------------
 
 def _is_job_enabled(job_name: str) -> bool:
@@ -82,7 +82,7 @@ def _is_job_enabled(job_name: str) -> bool:
     - the job entry is missing
     - the file is unreadable or malformed
 
-    This mirrors the gate logic in dispatch-job.sh so Type B (cron → script)
+    This mirrors the gate logic in dispatch-job.sh so Type C (cron → script)
     jobs respect the same runtime enable/disable toggle as Type A jobs.
     """
     workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))


### PR DESCRIPTION
The CLAUDE.md taxonomy defines cron-direct non-LLM scripts as **Type C**, explicitly naming `executor-heartbeat.py` as an example. `steward-heartbeat.py` already carried the correct `Type C` label. This PR aligns `executor-heartbeat.py` to match.

Three comment occurrences of `Type B` were updated to `Type C` — no logic, imports, or runtime behavior was changed:
- Line 25 (module docstring): `Type B dispatch` → `Type C dispatch`
- Line 73 (section header): `Type B dispatch path` → `Type C dispatch path`
- Line 85 (function docstring): `Type B (cron → script)` → `Type C (cron → script)`

Closes #472

## Tests run
- [x] `grep -n "Type B" scheduled-tasks/executor-heartbeat.py` — 0 matches (all occurrences resolved)
- [x] Comment-only change; no executable code modified

## Manual test
N/A — this change is entirely internal to comments. No runtime behavior is affected.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, comment-only
- [x] User-visible outcome verified — N/A, comments only
- [x] Side-effect audit complete — no side effects; comment-only change
- [x] External service calls — none