### PR TITLE
feat: Option A two-token GitHub review model for oracle gate

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -180,6 +180,38 @@ Also append to `~/lobster-workspace/meta/reflective-surface-queue.json`:
 
 ---
 
+## Option A: Post official GitHub Approved review via LOBSTER_REVIEW_TOKEN
+
+**When the verdict is APPROVED and this is a PR-gated review (you have a `{pr_number}` and `{repo}`):**
+
+Check whether `LOBSTER_REVIEW_TOKEN` is set in the environment. If it is, post an official GitHub `APPROVED` review using that token. This satisfies branch protection rules requiring an approving reviewer who is not the PR author.
+
+```bash
+# Extract owner/repo and pr_number from context available at runtime
+# (the PR URL or number is passed into the oracle prompt by the dispatcher)
+
+REVIEW_TOKEN=$(grep -E '^LOBSTER_REVIEW_TOKEN=' ~/lobster/config/config.env 2>/dev/null | cut -d= -f2-)
+if [ -n "$REVIEW_TOKEN" ]; then
+    GH_TOKEN="$REVIEW_TOKEN" gh api \
+        repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+        --method POST \
+        --field event=APPROVE \
+        --field body="Oracle review passed. Verdict: APPROVED. See oracle/verdicts/pr-{pr_number}.md for details." \
+        2>&1 \
+    && echo "Option A: GitHub Approved review posted via LOBSTER_REVIEW_TOKEN" \
+    || echo "Warning: LOBSTER_REVIEW_TOKEN set but gh api review failed (see output above). Option B soft gate still applies." \
+    | tee -a ~/lobster/oracle/verdicts/pr-{pr_number}.md
+fi
+```
+
+**If `LOBSTER_REVIEW_TOKEN` is absent or empty:** skip silently. The Option B soft gate (dispatcher checks `oracle/verdicts/pr-{number}.md`) remains the active enforcement path.
+
+**If the `gh api` call fails** (invalid token, insufficient scope, self-approval attempt): a warning line is appended to the verdict file. Do not fail the oracle run — Option B is the fallback and the verdict file still governs dispatch.
+
+**Important:** The PAT in `LOBSTER_REVIEW_TOKEN` must belong to a GitHub account that is **not** the bot account that opened the PR. GitHub blocks self-approval — if the same account both opens the PR and posts the review, the review will not count toward branch protection requirements.
+
+---
+
 ## WOS Spiral Gate — emit oracle_approved audit event
 
 **When the verdict is APPROVED and a `uow_id` was provided in the task prompt:**

--- a/config/config.env.example
+++ b/config/config.env.example
@@ -129,3 +129,11 @@ LOBSTER_INSTANCE_URL=
 # BOT_TALK_HTTP_URL=http://your-bot-talk-server:4242/message
 # BOT_TALK_SSH_HOST=sharedLobster
 # BOT_TALK_SSH_LOG_PATH=/home/shared/bot-talk/log.txt
+# Option A: GitHub PAT scoped to "Pull Requests: Read & Write" for a reviewer account
+# (not the bot account that opened the PR — must be a different GitHub user)
+# When set, the oracle agent posts an official GitHub Approved review in addition to
+# writing oracle/verdicts/, satisfying branch protection rules that require a reviewer
+# who is not the PR author.
+# Leave blank to stay on Option B (Lobster-enforced soft gate only).
+# See docs/option-a-review-token.md for setup instructions.
+LOBSTER_REVIEW_TOKEN=

--- a/docs/option-a-review-token.md
+++ b/docs/option-a-review-token.md
@@ -1,0 +1,54 @@
+# Option A: GitHub Review Token Setup
+
+Lobster's PR merge gate has two enforcement modes:
+
+- **Option B (default):** Lobster-enforced soft gate. The oracle agent writes `oracle/verdicts/pr-{n}.md`; the dispatcher checks that file for `VERDICT: APPROVED` before merging. No GitHub branch protection rules involved.
+- **Option A (upgrade):** A second GitHub PAT (`LOBSTER_REVIEW_TOKEN`) scoped to review approvals on a separate reviewer account. When set, the oracle posts an official GitHub `APPROVED` review on the PR via the GitHub API, satisfying branch protection rules that require a non-author approving reviewer.
+
+Option B remains active regardless of whether Option A is configured. Option A adds GitHub-enforced approval on top.
+
+## PAT Requirements
+
+- **Scope:** `repo` (for private repos) or `public_repo` (for public repos). Specifically, the token needs "Pull requests: Read and write" under repository permissions.
+- **Account constraint:** The PAT **must belong to a GitHub account that is not the bot account that opens PRs.** GitHub blocks self-approval — a review posted by the same account that opened the PR does not count toward branch protection requirements. Use a dedicated reviewer account (e.g. a personal account or a second bot account).
+
+## Setup Steps
+
+1. **Generate the PAT** on a reviewer GitHub account (not the bot account):
+   - Go to GitHub Settings > Developer settings > Personal access tokens
+   - Classic token: select `repo` scope
+   - Fine-grained token: grant "Pull requests: Read and write" for the target repo(s)
+   - Copy the generated token
+
+2. **Add to the server env file:**
+   ```
+   LOBSTER_REVIEW_TOKEN=<your-token-here>
+   ```
+   The env file is typically `~/lobster/config/config.env`.
+
+3. **Restart the MCP server** to pick up the new env var:
+   ```bash
+   ~/lobster/scripts/restart-mcp.sh
+   ```
+   Do not run `systemctl restart` directly — use the safe wrapper script.
+
+## Verifying It Works
+
+1. Open a test PR from the bot account.
+2. Trigger an oracle review (the dispatcher dispatches the oracle agent after a PR is opened).
+3. After the oracle writes `VERDICT: APPROVED` to `oracle/verdicts/pr-{n}.md`, check the PR on GitHub — a GitHub "Approved" review should appear from the reviewer account.
+4. Confirm the PR shows "Approved" in the review status, satisfying any branch protection rule requiring a reviewer.
+
+## Failure Handling
+
+If the `gh api` call fails (e.g. token invalid, wrong scope, self-approval attempt), the oracle appends a warning line to the verdict file and continues. Option B (the `oracle/verdicts/pr-{n}.md` soft gate) still governs dispatcher behavior. No oracle run is blocked by a token failure.
+
+Check the warning output in the verdict file if the GitHub review does not appear after an APPROVED verdict:
+
+```
+oracle/verdicts/pr-{n}.md
+```
+
+## Relationship to Option B
+
+Option A does not replace Option B. The dispatcher still reads `oracle/verdicts/pr-{n}.md` to gate merges. Option A adds a GitHub-native approval on top, so teams that enable branch protection rules requiring a non-author reviewer will have those rules satisfied automatically by the oracle agent.


### PR DESCRIPTION
## What this solves

The oracle gate today operates as a Lobster-enforced soft gate: the oracle writes \`VERDICT: APPROVED\` to \`oracle/verdicts/pr-{n}.md\` and the dispatcher reads that file before merging. This works, but GitHub branch protection rules that require a non-author approving reviewer are not satisfied — GitHub has no visibility into the oracle verdict.

Option A closes that gap: when a second PAT (\`LOBSTER_REVIEW_TOKEN\`) from a non-bot reviewer account is configured, the oracle agent posts an official GitHub \`APPROVED\` review via the API immediately after writing its verdict. Branch protection rules requiring a non-author approving reviewer are then satisfied natively.

## What changed

**\`.claude/agents/lobster-oracle.md\`** — After writing \`VERDICT: APPROVED\`, the oracle now reads \`LOBSTER_REVIEW_TOKEN\` from the env file. If present, it runs:

```bash
GH_TOKEN="$REVIEW_TOKEN" gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
  --method POST --field event=APPROVE --field body="Oracle review passed..."
```

If the token is absent or empty, the step is skipped silently. If the \`gh api\` call fails (wrong scope, self-approval attempt, etc.), a warning is appended to the verdict file — the oracle run is not failed, and Option B remains the active gate.

**\`config/config.env.example\`** — Adds a commented \`LOBSTER_REVIEW_TOKEN=\` slot with a description of its purpose and a pointer to the setup doc.

**\`docs/option-a-review-token.md\`** — New setup doc covering: PAT scope requirements, the account constraint (must not be the bot account that opens PRs — GitHub blocks self-approval), setup steps, how to verify it's working, and failure handling.

## What is out of scope

- Option B soft gate is unchanged — the dispatcher still reads \`oracle/verdicts/pr-{n}.md\` before merging.
- No migration step needed — the env var is optional with an empty default.
- Activation requires Dan to generate and configure the PAT. No code work remains after this PR merges.

## Before/after flow

**Before (Option B only):**
```
oracle writes VERDICT: APPROVED to oracle/verdicts/pr-{n}.md
dispatcher reads file → APPROVED → dispatches merge agent
```

**After (Option B + Option A when token set):**
```
oracle writes VERDICT: APPROVED to oracle/verdicts/pr-{n}.md
oracle checks LOBSTER_REVIEW_TOKEN
  if set → gh api POST /reviews with event=APPROVE (GitHub-native)
  if absent or fails → log/warn, continue
dispatcher reads file → APPROVED → dispatches merge agent (unchanged)
```

## Functional patterns used

Pure conditional composition: the Option A path is an isolated side effect (the GitHub API call) that fires only when the token is present, injected at the boundary between the oracle's verdict write and the WOS Spiral Gate step. The Option B path is entirely untouched.

## Tests run

- [x] Manual inspection of oracle file: \`LOBSTER_REVIEW_TOKEN\` section inserted at correct position, bash code block is properly formatted, fallback language is accurate
- [x] \`git diff --stat\` confirmed: 3 files changed, 94 insertions, 0 deletions
- [ ] Live oracle run with token — blocked: requires Dan to supply the PAT for a reviewer account; no test PAT available in this environment

## Manual test

N/A for this PR — no systemd, cron, external service calls, or DB changes are made by the code itself. The \`gh api\` call in the oracle agent will be exercised only when the oracle runs with \`LOBSTER_REVIEW_TOKEN\` set, which requires Dan to supply the PAT. The verification steps are documented in \`docs/option-a-review-token.md\`.

## Definition of Done
- [x] Token slot documented in config.env.example with clear instructions
- [x] Oracle agent conditionally posts GitHub Approved review when token present
- [x] Falls back silently to Option B when token absent or call fails
- [x] Setup doc written at docs/option-a-review-token.md
- [ ] Live end-to-end test (PAT not yet generated — remaining prerequisite for Dan)