### PR TITLE
test: add unit tests for is_night4_rotation() in decay-detector.py

### DIFF
--- a/tests/unit/test_scheduled_tasks/test_decay_detector.py
+++ b/tests/unit/test_scheduled_tasks/test_decay_detector.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for is_night4_rotation() in scheduled-tasks/decay-detector.py.
+
+The function reads rotation-state.json from HYGIENE_DIR and returns True
+only when current_night == 5 (meaning Night 4 just completed — the counter
+is incremented after the sweep, so 5 is the post-Night-4 sentinel value).
+
+All tests patch decay_detector.HYGIENE_DIR to a tmp_path fixture so no
+real filesystem state is touched.
+
+Named after behaviors, not mechanisms.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script module.
+#
+# decay-detector.py is a standalone script (not an importable package
+# module), so we load it via importlib.  We do this inside a function so
+# the module-level HYGIENE_DIR is set before exec_module runs, which means
+# monkeypatching HYGIENE_DIR in individual tests is sufficient.
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = (
+    Path(__file__).parents[3] / "scheduled-tasks" / "decay-detector.py"
+)
+
+# Stub subprocess so the module-level code doesn't attempt real gh calls.
+import types as _types
+
+_subprocess_stub = _types.ModuleType("subprocess")
+_subprocess_stub.run = lambda *a, **kw: None  # type: ignore[assignment]
+_subprocess_stub.CalledProcessError = Exception  # type: ignore[assignment]
+
+
+def _load_decay_detector():
+    with patch.dict("sys.modules", {"subprocess": _subprocess_stub}):
+        spec = importlib.util.spec_from_file_location(
+            "decay_detector", SCRIPT_PATH
+        )
+        mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# Load once at module level; individual tests patch the module attribute.
+decay_detector = _load_decay_detector()
+is_night4_rotation = decay_detector.is_night4_rotation
+
+# Sentinel value defined in the spec: current_night after Night 4 completes.
+NIGHT4_SENTINEL = 5
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_state(directory: Path, payload: object) -> None:
+    """Write rotation-state.json into directory."""
+    (directory / "rotation-state.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _write_raw(directory: Path, text: str) -> None:
+    """Write raw (possibly invalid JSON) content into rotation-state.json."""
+    (directory / "rotation-state.json").write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsNight4Rotation:
+    """Behavioral tests for is_night4_rotation()."""
+
+    def test_returns_true_when_current_night_is_5(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """current_night == 5 is the only value that should return True."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        _write_state(tmp_path, {"current_night": NIGHT4_SENTINEL})
+        assert is_night4_rotation() is True
+
+    def test_returns_false_when_current_night_is_4(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Off-by-one boundary: current_night == 4 means Night 4 has not yet finished."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        _write_state(tmp_path, {"current_night": 4})
+        assert is_night4_rotation() is False
+
+    def test_returns_false_when_current_night_is_6(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Off-by-one boundary: current_night == 6 means Night 5 is now current."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        _write_state(tmp_path, {"current_night": 6})
+        assert is_night4_rotation() is False
+
+    def test_returns_false_when_current_night_is_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A typical early-rotation value should return False."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        _write_state(tmp_path, {"current_night": 1})
+        assert is_night4_rotation() is False
+
+    def test_returns_false_when_file_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absent rotation-state.json triggers the exception path → False."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        # No state file written — tmp_path is empty.
+        assert is_night4_rotation() is False
+
+    def test_returns_false_when_json_invalid(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed JSON triggers the exception path → False."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        _write_raw(tmp_path, "not-json")
+        assert is_night4_rotation() is False
+
+    def test_returns_false_when_key_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Valid JSON without 'current_night' key triggers the exception path → False."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        _write_state(tmp_path, {"other_key": NIGHT4_SENTINEL})
+        assert is_night4_rotation() is False
+
+    def test_returns_false_when_value_not_castable_to_int(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """current_night value that cannot be cast to int triggers the exception path → False."""
+        monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
+        _write_state(tmp_path, {"current_night": "abc"})
+        assert is_night4_rotation() is False


### PR DESCRIPTION
## Problem

`is_night4_rotation()` was introduced in PR #457 without unit tests. The function guards against a subtle off-by-one condition: the rotation counter is incremented *after* the sweep completes, so `current_night == 5` means Night 4 just finished (not 4, not 6). Without tests, a silent regression in this logic would not be caught.

## What this adds

A new test file `tests/unit/test_scheduled_tasks/test_decay_detector.py` with 8 behavioral pytest cases covering all spec-required cases:

| Test | Setup | Expected |
|---|---|---|
| `test_returns_true_when_current_night_is_5` | `{"current_night": 5}` | `True` |
| `test_returns_false_when_current_night_is_4` | `{"current_night": 4}` | `False` — off-by-one boundary, Night 4 not yet done |
| `test_returns_false_when_current_night_is_6` | `{"current_night": 6}` | `False` — off-by-one boundary, past Night 4 window |
| `test_returns_false_when_current_night_is_1` | `{"current_night": 1}` | `False` |
| `test_returns_false_when_file_missing` | no file | `False` |
| `test_returns_false_when_json_invalid` | `"not-json"` | `False` |
| `test_returns_false_when_key_missing` | `{"other_key": 5}` | `False` |
| `test_returns_false_when_value_not_castable_to_int` | `{"current_night": "abc"}` | `False` |

The sentinel value `NIGHT4_SENTINEL = 5` is a named constant derived directly from the spec, so the off-by-one intent is explicit without magic literals.

`decay-detector.py` is not modified. No other functions in the module are tested.

## Implementation notes

The script is loaded via `importlib.util.spec_from_file_location` (same pattern as `test_gmail_poll.py`). `subprocess` is stubbed to prevent real `gh` calls on import. `HYGIENE_DIR` is monkeypatched per-test to a `tmp_path` fixture so tests are fully isolated from real filesystem state.

## Tests run

- [x] `uv run pytest tests/unit/test_scheduled_tasks/test_decay_detector.py -v` — 8 passed, 0 failed

## Manual test

N/A — pure unit tests with no external service calls, no filesystem side effects beyond `tmp_path`.

## Definition of Done
- [x] Unit tests pass with proper isolation (no real filesystem state)
- [x] User-visible outcome: N/A — internal test coverage task
- [x] Side-effect audit: no floods, no shared state writes, no production impact
- [x] External service calls: none (subprocess stubbed in tests)

Closes #460