### PR TITLE
refactor: replace == 5 literal with NIGHT4_ROTATION_STATE constant

### DIFF
--- a/scheduled-tasks/decay-detector.py
+++ b/scheduled-tasks/decay-detector.py
@@ -21,6 +21,8 @@ HYGIENE_DIR = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-wo
 STALE_THRESHOLD_DAYS = 60
 JACCARD_THRESHOLD = 0.7
 EXEMPT_LABELS = {"design-seed"}
+# Rotation state written *after* Night 4 sweep completes (off-by-one is intentional)
+NIGHT4_ROTATION_STATE = 5
 
 # Template noise strings — issues whose body is only these are considered empty
 TEMPLATE_DEFAULTS = {
@@ -65,7 +67,7 @@ def is_night4_rotation() -> bool:
     state_file = HYGIENE_DIR / "rotation-state.json"
     try:
         state = json.loads(state_file.read_text())
-        return int(state["current_night"]) == 5
+        return int(state["current_night"]) == NIGHT4_ROTATION_STATE
     except Exception:
         return False
 

--- a/tests/unit/test_scheduled_tasks/test_decay_detector.py
+++ b/tests/unit/test_scheduled_tasks/test_decay_detector.py
@@ -56,9 +56,6 @@ def _load_decay_detector():
 decay_detector = _load_decay_detector()
 is_night4_rotation = decay_detector.is_night4_rotation
 
-# Sentinel value defined in the spec: current_night after Night 4 completes.
-NIGHT4_SENTINEL = 5
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -90,7 +87,7 @@ class TestIsNight4Rotation:
     ) -> None:
         """current_night == 5 is the only value that should return True."""
         monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
-        _write_state(tmp_path, {"current_night": NIGHT4_SENTINEL})
+        _write_state(tmp_path, {"current_night": decay_detector.NIGHT4_ROTATION_STATE})
         assert is_night4_rotation() is True
 
     def test_returns_false_when_current_night_is_4(
@@ -138,7 +135,7 @@ class TestIsNight4Rotation:
     ) -> None:
         """Valid JSON without 'current_night' key triggers the exception path → False."""
         monkeypatch.setattr(decay_detector, "HYGIENE_DIR", tmp_path)
-        _write_state(tmp_path, {"other_key": NIGHT4_SENTINEL})
+        _write_state(tmp_path, {"other_key": decay_detector.NIGHT4_ROTATION_STATE})
         assert is_night4_rotation() is False
 
     def test_returns_false_when_value_not_castable_to_int(


### PR DESCRIPTION
Replaces the bare `== 5` literal in `is_night4_rotation()` with a named constant `NIGHT4_ROTATION_STATE = 5` defined in the module-level constants block.

The constant's comment makes the off-by-one explicit: the rotation state is incremented *after* the Night 4 sweep completes, so `current_night == 5` means Night 4 just finished.

No behavior change. All 8 existing unit tests pass.

Closes #461

WOS-UoW: uow_20260502_1adbb1