### PR TITLE
fix(footer-audit): flag side-effects: none as violation

### DIFF
--- a/lobster-shop/footer-reset/src/footer_audit.py
+++ b/lobster-shop/footer-reset/src/footer_audit.py
@@ -37,9 +37,9 @@ ACTION_PATTERNS = [
     ]
 ]
 
-# Valid forms: fenced code block with exactly "side-effects:" label, or bare null line
+# Valid form: fenced code block with exactly "side-effects:" label.
+# NOTE: bare "side-effects: none" is BANNED per PR #480 — omit the footer entirely instead.
 SIDE_EFFECTS_BLOCK_RE = re.compile(r"```side-effects:[^`]*```", re.DOTALL)
-SIDE_EFFECTS_NONE_RE = re.compile(r"^side-effects:\s*none\s*$", re.MULTILINE | re.IGNORECASE)
 
 # Wrong-label patterns — drift signatures that look footer-like but use the wrong label
 WRONG_LABEL_PATTERNS = [
@@ -47,6 +47,9 @@ WRONG_LABEL_PATTERNS = [
     (re.compile(r"```effects:[^`]*```", re.DOTALL), "wrong label: `effects:` instead of `side-effects:`"),
     (re.compile(r"```side-effects[^:\n][^`]*```", re.DOTALL), "malformed: `side-effects` missing colon"),
     (re.compile(r"^signals:\s*none\s*$", re.MULTILINE | re.IGNORECASE), "wrong label: `signals: none` instead of `side-effects: none`"),
+    # Banned null forms — per PR #480, omit the footer entirely when there are no side effects
+    (re.compile(r"^side-effects:\s*none\s*$", re.MULTILINE | re.IGNORECASE), "side-effects: none is not a valid declaration — omit the footer entirely when there are no side effects"),
+    (re.compile(r"```side-effects:\s*\nnone\s*\n```", re.DOTALL | re.IGNORECASE), "side-effects: none is not a valid declaration — omit the footer entirely when there are no side effects"),
 ]
 
 
@@ -55,7 +58,7 @@ def has_action_keywords(text: str) -> bool:
 
 
 def has_valid_footer(text: str) -> bool:
-    return bool(SIDE_EFFECTS_BLOCK_RE.search(text)) or bool(SIDE_EFFECTS_NONE_RE.search(text))
+    return bool(SIDE_EFFECTS_BLOCK_RE.search(text))
 
 
 def detect_wrong_labels(text: str) -> list[str]:
@@ -143,7 +146,7 @@ def format_report(messages: list[dict], missing: list[dict], wrong: list[dict]) 
 
     lines.append("\nCanonical forms:")
     lines.append("  With effects: ` ```side-effects:\\n✅ 🐙\\n``` `")
-    lines.append("  No effects: `side-effects: none` (bare line)")
+    lines.append("  No effects: omit the footer entirely (`side-effects: none` is banned)")
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## What this fixes

`footer_audit.py` was treating `side-effects: none` as a valid footer, producing false negatives in audit reports. This contradicts the enforcement established in `signal-footer-check.py` (PR #480 in SiderealPress/lobster): `side-effects: none` is banned — the convention is to omit the footer entirely when there are no side effects.

Before this PR, a message containing `side-effects: none` would pass the audit clean. After this PR, it is reported as a `WRONG_LABEL` violation with a clear remediation message.

## What changed

Two targeted changes to `lobster-shop/footer-reset/src/footer_audit.py`:

1. **`has_valid_footer()`** — removed the `SIDE_EFFECTS_NONE_RE` branch. Only a canonical fenced `side-effects:` block is now considered valid.

2. **`WRONG_LABEL_PATTERNS`** — added two entries for the banned null forms:
   - Bare line: matches `^side-effects:\s*none$`
   - Block form: matches a fenced block with `side-effects:` label containing only `none`
   Both produce the violation message: "side-effects: none is not a valid declaration — omit the footer entirely when there are no side effects"

3. **`format_report()` hint** — updated the "No effects" canonical-forms note from the stale `side-effects: none (bare line)` to the current convention: "omit the footer entirely (side-effects: none is banned)".

## Functional patterns

Pure-function style throughout — `detect_wrong_labels`, `has_valid_footer`, and `audit_messages` are stateless transformers. The fix adds entries to the `WRONG_LABEL_PATTERNS` constant and simplifies the `has_valid_footer` predicate without touching any side-effecting code paths.

Nothing outside `footer_audit.py` is modified. `signal-footer-check.py` is untouched.

## Tests run

- [x] Inline verification (6 assertions): bare form flagged, block form flagged, `has_valid_footer` returns False for `side-effects: none`, canonical footer still passes, `audit_messages` routes violation to `wrong_label` not `missing_footer`, action messages without any footer still flagged as missing — all 6 passed.
- [x] `uv run python3` — clean import, no errors

## Manual test

N/A — entirely internal to the audit script's pattern matching. No external services, no systemd, no file I/O beyond what was already there.

## Definition of Done

- [x] Tests pass (6/6 inline assertions)
- [x] User-visible outcome: not applicable (audit output change, no Telegram delivery in this PR)
- [x] Side-effect audit: no floods, no unscoped writes
- [x] External service calls: none