### PR TITLE
Inject Dan's developmental register into steward prescriber prompt

### DIFF
--- a/oracle/decisions.md
+++ b/oracle/decisions.md
@@ -310,3 +310,56 @@ The circadian module existed before this PR. Wiring it into the shared write pat
 ### Constraint
 
 The circadian gate applies only to messages where `is_non_urgent()` returns True (type is `subagent_result`, no `reply_to_message_id`, no urgent-signal keywords). Urgent messages, user replies, and incident alerts always deliver immediately via the existing path. The gate cannot defer a message the user is waiting for a reply to.
+
+---
+
+## ADR-007: Developmental Register Injection into _llm_prescribe — Encoded Orientation Behavioral Default
+
+**Date:** 2026-05-02
+**Status:** Accepted
+**PR:** #1049 (feature/steward-dev-register)
+
+### Context
+
+The WOS Steward prescriber generates execution instructions for Units of Work but had no awareness of Dan's developmental arc — the current attunement stage, active capability clusters, and the Goldilocks window for expanding vs. consolidating work. Prescriptions could land correctly for the task surface while missing what the arc requires (e.g. prioritising observation-loop work over new capability surface, or flagging when a UoW would push the active cluster beyond the consolidation threshold).
+
+The oracle PR #1049 verdict (Round 1) identified this change as an Encoded Orientation decision under constraint-3: it modifies a durable behavioral default in `_llm_prescribe` that fires on every steward prescription cycle without Dan's real-time input. No logged prior existed before this ADR was written.
+
+### What Changed
+
+`_llm_prescribe` in `src/orchestration/steward.py` now calls `_load_dan_register_excerpt()` and — when the excerpt is non-empty — injects it as a `## Dan's current orientation` block positioned after the UoW context and before the dispatch conventions in the user prompt. The model sees both "what does this UoW need" and "what does Dan's arc require of how this work lands" before generating the prescription.
+
+When the excerpt is empty (file absent or anchor section missing) the prompt is unchanged. This makes the injection safe in upstream and CI environments without a user config.
+
+### Why This Is an Encoded Orientation Decision
+
+The injection fires on every `_llm_prescribe` call — a durable behavioral default change that operates without Dan's explicit per-prescription input. Per constraint-3 (`core.inviolable_constraints.constraint-3`): Encoded Orientation decisions require a prior logged decision of the same class and a traceable vision.yaml anchor. This ADR is the logged decision.
+
+### Vision Anchor
+
+**Primary:** `core.fundamental_intent` — "The system should be able to answer 'is this aligned with Dan's intent?' without asking me — because it has structural access to my intent, not just a prose reconstruction of it."
+
+The developmental register excerpt is a proxy toward this intent: it surfaces Dan's current arc to the prescriber so prescriptions can be evaluated against more than task-surface correctness. This is a stepping-stone toward the structural Orient seam (#733), not a substitute for it.
+
+**Secondary:** `core.inviolable_constraints.constraint-3` — "Every system decision traverses the full OODA loop at the appropriate register. Encoded Orientation decisions require a prior logged decision of the same class and a traceable vision.yaml anchor."
+
+This ADR satisfies constraint-3 for the `_llm_prescribe` behavioral default change.
+
+### Dual-Source Drift Risk
+
+`user.base.context.md` (the source of the developmental register excerpt) and `vision.yaml` (the structural intent anchor) have different update disciplines:
+
+- `user.base.context.md` is updated by agents and Dan's session work — higher frequency, lower ceremony
+- `vision.yaml` structural fields are Dan-authored — lower frequency, higher ceremony
+
+When the two sources diverge — a `current_focus` or developmental stage description in `user.base.context.md` that no longer aligns with `vision.yaml.current_focus` — the prescriber has no mechanism to detect the conflict or prefer one over the other. The injection silently uses whichever text is in `user.base.context.md` at call time.
+
+This is an accepted risk at current scale given: (a) the developmental map section of `user.base.context.md` is updated intentionally (not auto-generated), (b) the injection is advisory context rather than a routing decision — it enriches the prompt but does not gate prescription generation, and (c) graceful degradation (empty-string return) fires if the file or section is absent, leaving the prompt unchanged.
+
+The correct mitigation when Orient (#733) is implemented: replace the prose excerpt injection with a structured query against a vision.yaml-native orient seam, eliminating the dual-source problem structurally.
+
+### Deliberate Proxy Approach
+
+This implementation uses `user.base.context.md` as a proxy for the structural orient substrate that `current_focus.horizon.after_that` names as the next investment: "Orient implementation (#733) — the guardrail names the next structural investment once feedback loop is verifiably closed end-to-end."
+
+This ADR explicitly records that this is a proxy approach chosen for ergonomic benefit while the structural seam is not yet built. It does not foreclose the structural implementation — `_load_dan_register_excerpt` is a pure I/O boundary function that can be replaced with a vision.yaml query when Orient is ready. The behavioral default (inject orientation into prescriptions) is the durable change; the source (prose excerpt vs. structured field) is a replaceable implementation detail.

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -1845,7 +1845,7 @@ def _parse_workflow_artifact(raw_text: str) -> dict:
     }
 
 
-def _load_dan_register_excerpt(max_chars: int = 1500) -> str:
+def _load_dan_register_excerpt(max_chars: int = 8000) -> str:
     """Return a focused excerpt of Dan's developmental register from user.base.context.md.
 
     Extracts the section from "Lobster Developmental Map" through the capability
@@ -1856,6 +1856,20 @@ def _load_dan_register_excerpt(max_chars: int = 1500) -> str:
 
     The excerpt is capped at ``max_chars`` to keep the injected context tight.
     A trailing "[...truncated]" marker is appended when the cap is applied.
+
+    Anchor string: "## Lobster Developmental Map"
+    This is a prefix match against the production heading, which reads:
+    "## Lobster Developmental Map (Theory of Learning, <date>)".
+    If the heading is ever renamed, find() returns -1 and the excerpt is silently
+    absent — callers treat an empty return as optional enrichment, so no error
+    is raised. Any rename of this section heading must update this anchor.
+
+    Cap rationale: the production "Lobster Developmental Map" section is ~6,888
+    chars (as of 2026-05-02). 8000 chars safely covers the full section including
+    the "Capability ceiling and Embodiment distinction" subsection and the
+    "Attentional Budget Constraint" and "Capability Coupling Structure" subsections
+    that carry the most prescription-relevant orientation signals. The previous
+    1500-char cap truncated the section at ~22% and never reached these subsections.
     """
     register_path = Path.home() / "lobster-user-config" / "agents" / "user.base.context.md"
     try:
@@ -1863,7 +1877,9 @@ def _load_dan_register_excerpt(max_chars: int = 1500) -> str:
     except OSError:
         return ""
 
-    # Find the anchor section that starts the developmental register
+    # Find the anchor section that starts the developmental register.
+    # Exact anchor string: "## Lobster Developmental Map"
+    # Production heading: "## Lobster Developmental Map (Theory of Learning, YYYY-MM-DD)"
     anchor = "## Lobster Developmental Map"
     start = text.find(anchor)
     if start == -1:

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -1845,6 +1845,36 @@ def _parse_workflow_artifact(raw_text: str) -> dict:
     }
 
 
+def _load_dan_register_excerpt(max_chars: int = 1500) -> str:
+    """Return a focused excerpt of Dan's developmental register from user.base.context.md.
+
+    Extracts the section from "Lobster Developmental Map" through the capability
+    coupling / attentional budget sections — the part of the file that captures
+    Dan's current arc, active focus areas, and developmental posture.  Returns an
+    empty string if the file is absent or the section cannot be found, so callers
+    can treat it as optional enrichment.
+
+    The excerpt is capped at ``max_chars`` to keep the injected context tight.
+    A trailing "[...truncated]" marker is appended when the cap is applied.
+    """
+    register_path = Path.home() / "lobster-user-config" / "agents" / "user.base.context.md"
+    try:
+        text = register_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+    # Find the anchor section that starts the developmental register
+    anchor = "## Lobster Developmental Map"
+    start = text.find(anchor)
+    if start == -1:
+        return ""
+
+    excerpt = text[start:]
+    if len(excerpt) > max_chars:
+        excerpt = excerpt[:max_chars] + "\n[...truncated]"
+    return excerpt.strip()
+
+
 def _llm_prescribe(
     uow: UoW,
     reentry_posture: str,
@@ -1963,10 +1993,21 @@ Every prompt must include:
 For internal tasks (no user reply): write_result only with sent_reply_to_user=False
 """
 
+    # Load Dan's developmental register and build an optional orientation block.
+    # Placed after the UoW context so the model sees both "what this UoW needs"
+    # and "what Dan's current arc requires of how this work lands" before generating
+    # the prescription.
+    _register_excerpt = _load_dan_register_excerpt()
+    _orientation_block = (
+        f"\n## Dan's current orientation\n\n{_register_excerpt}\n"
+        if _register_excerpt
+        else ""
+    )
+
     user_prompt = f"""Given this Unit of Work, write a precise prescription for the Executor.
 
 {uow_context}
-
+{_orientation_block}
 {_DISPATCH_CONVENTIONS}
 Respond using front-matter + prose format. Output ONLY the prescription — no preamble, no explanation outside this structure:
 

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -4640,3 +4640,175 @@ class TestExecutingOrphanShortCircuit:
             "executing_orphan_failed audit event must be written when short-circuit fires; "
             f"audit entries: {entries}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for _load_dan_register_excerpt
+# ---------------------------------------------------------------------------
+
+class TestLoadDanRegisterExcerpt:
+    """Behavioural tests for _load_dan_register_excerpt."""
+
+    def test_returns_empty_string_when_file_absent(self, tmp_path, monkeypatch):
+        """Returns '' gracefully when user.base.context.md does not exist."""
+        steward = _import_steward()
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = steward._load_dan_register_excerpt()
+        assert result == ""
+
+    def test_returns_empty_string_when_anchor_missing(self, tmp_path, monkeypatch):
+        """Returns '' when file exists but lacks the developmental-map anchor section."""
+        steward = _import_steward()
+        agents_dir = tmp_path / "lobster-user-config" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "user.base.context.md").write_text(
+            "# Dan's Context\n\n## Identity\nSoftware engineer.\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = steward._load_dan_register_excerpt()
+        assert result == ""
+
+    def test_returns_excerpt_starting_at_anchor(self, tmp_path, monkeypatch):
+        """Returns content starting from the 'Lobster Developmental Map' heading."""
+        steward = _import_steward()
+        agents_dir = tmp_path / "lobster-user-config" / "agents"
+        agents_dir.mkdir(parents=True)
+        context = (
+            "# Dan's Context\n\n"
+            "## Identity\nSoftware engineer.\n\n"
+            "## Lobster Developmental Map (Theory of Learning)\n\n"
+            "Capability stages: dispatcher routing is near Embodiment.\n\n"
+            "## Other Section\nMore content here.\n"
+        )
+        (agents_dir / "user.base.context.md").write_text(context, encoding="utf-8")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = steward._load_dan_register_excerpt()
+        assert result.startswith("## Lobster Developmental Map")
+        assert "Identity" not in result
+        assert "dispatcher routing" in result
+
+    def test_truncates_at_max_chars_with_marker(self, tmp_path, monkeypatch):
+        """Excerpt is capped at max_chars with a '[...truncated]' suffix."""
+        steward = _import_steward()
+        agents_dir = tmp_path / "lobster-user-config" / "agents"
+        agents_dir.mkdir(parents=True)
+        long_content = "## Lobster Developmental Map\n\n" + ("x" * 5000)
+        (agents_dir / "user.base.context.md").write_text(long_content, encoding="utf-8")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = steward._load_dan_register_excerpt(max_chars=200)
+        assert result.endswith("[...truncated]")
+        # The excerpt proper (before marker) must be <= max_chars chars
+        assert len(result) <= 200 + len("\n[...truncated]")
+
+    def test_no_truncation_marker_when_content_fits(self, tmp_path, monkeypatch):
+        """No truncation marker is appended when content fits within max_chars."""
+        steward = _import_steward()
+        agents_dir = tmp_path / "lobster-user-config" / "agents"
+        agents_dir.mkdir(parents=True)
+        short_content = "## Lobster Developmental Map\n\nShort excerpt.\n"
+        (agents_dir / "user.base.context.md").write_text(short_content, encoding="utf-8")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = steward._load_dan_register_excerpt()
+        assert "[...truncated]" not in result
+        assert "Short excerpt." in result
+
+
+class TestLLMPrescribeIncludesOrientationBlock:
+    """Verify that _llm_prescribe injects Dan's register into the prompt."""
+
+    def _make_uow(self):
+        from src.orchestration.registry import UoW, UoWStatus
+        return UoW(
+            id="uow_orientation_test",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="Test UoW for orientation injection",
+            source="github:issue/1",
+            source_issue_number=1,
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            type="executable",
+            success_criteria="Widget works.",
+            steward_cycles=0,
+            steward_log=None,
+        )
+
+    def test_orientation_block_present_in_prompt_when_register_exists(
+        self, tmp_path, monkeypatch
+    ):
+        """When _load_dan_register_excerpt returns content the prompt contains
+        a '## Dan's current orientation' block positioned after the UoW context."""
+        import subprocess as _subprocess
+        steward = _import_steward()
+
+        # Patch the register loader to return predictable content
+        monkeypatch.setattr(
+            "src.orchestration.steward._load_dan_register_excerpt",
+            lambda **kw: "Capability stages: dispatcher routing near Embodiment.",
+        )
+
+        captured_prompts: list[str] = []
+
+        front_matter_output = (
+            "---\n"
+            "executor_type: functional-engineer\n"
+            "estimated_cycles: 1\n"
+            "success_criteria_check: Widget works.\n"
+            "---\n\n"
+            "Do the work."
+        )
+
+        def mock_run(cmd, **kwargs):
+            # The full prompt is the last positional arg passed to claude -p
+            if "-p" in cmd:
+                idx = cmd.index("-p")
+                captured_prompts.append(cmd[idx + 1])
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout=front_matter_output, stderr="")
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
+
+        uow = self._make_uow()
+        steward._llm_prescribe(uow, "diagnosing_orphan", "no prior output")
+
+        assert captured_prompts, "subprocess.run was not called"
+        prompt_text = captured_prompts[0]
+        assert "## Dan's current orientation" in prompt_text
+        assert "dispatcher routing near Embodiment" in prompt_text
+
+    def test_orientation_block_absent_when_register_empty(
+        self, tmp_path, monkeypatch
+    ):
+        """When _load_dan_register_excerpt returns '' (file absent or anchor missing)
+        the prompt does NOT contain '## Dan's current orientation'."""
+        import subprocess as _subprocess
+        steward = _import_steward()
+
+        monkeypatch.setattr(
+            "src.orchestration.steward._load_dan_register_excerpt",
+            lambda **kw: "",
+        )
+
+        captured_prompts: list[str] = []
+
+        front_matter_output = (
+            "---\n"
+            "executor_type: functional-engineer\n"
+            "estimated_cycles: 1\n"
+            "success_criteria_check: Widget works.\n"
+            "---\n\n"
+            "Do the work."
+        )
+
+        def mock_run(cmd, **kwargs):
+            if "-p" in cmd:
+                idx = cmd.index("-p")
+                captured_prompts.append(cmd[idx + 1])
+            return _subprocess.CompletedProcess(cmd, returncode=0, stdout=front_matter_output, stderr="")
+
+        monkeypatch.setattr("src.orchestration.steward.subprocess.run", mock_run)
+
+        uow = self._make_uow()
+        steward._llm_prescribe(uow, "diagnosing_orphan", "no prior output")
+
+        assert captured_prompts, "subprocess.run was not called"
+        assert "## Dan's current orientation" not in captured_prompts[0]

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -4713,6 +4713,36 @@ class TestLoadDanRegisterExcerpt:
         assert "[...truncated]" not in result
         assert "Short excerpt." in result
 
+    def test_matches_production_heading_format(self, tmp_path, monkeypatch):
+        """Anchor prefix matches the exact production heading format.
+
+        Production heading in user.base.context.md is:
+            ## Lobster Developmental Map (Theory of Learning, YYYY-MM-DD)
+
+        The anchor "## Lobster Developmental Map" is a prefix match via str.find().
+        This test verifies that the prefix correctly locates a heading in the
+        production format, so a heading with a date suffix is found — not silently
+        treated as absent.
+        """
+        steward = _import_steward()
+        agents_dir = tmp_path / "lobster-user-config" / "agents"
+        agents_dir.mkdir(parents=True)
+        # Use the exact production heading format (prefix + date suffix)
+        production_heading = "## Lobster Developmental Map (Theory of Learning, 2026-03-26)"
+        context = (
+            "# Dan's Context\n\n"
+            "## Identity\nSoftware engineer.\n\n"
+            f"{production_heading}\n\n"
+            "Capability stages: dispatcher routing near Embodiment.\n"
+        )
+        (agents_dir / "user.base.context.md").write_text(context, encoding="utf-8")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = steward._load_dan_register_excerpt()
+        # Anchor must find the production-format heading
+        assert result.startswith("## Lobster Developmental Map (Theory of Learning")
+        assert "dispatcher routing near Embodiment" in result
+        assert "Identity" not in result
+
 
 class TestLLMPrescribeIncludesOrientationBlock:
     """Verify that _llm_prescribe injects Dan's register into the prompt."""


### PR DESCRIPTION
## What problem this solves

The WOS Steward prescriber generates execution instructions in a vacuum — it knows what a UoW needs but has no awareness of Dan's current developmental arc. Prescriptions land correctly for the task but may miss what the arc requires: e.g. prioritising observation-loop work over new capability surface area, or flagging when a UoW would expand the active Attunement-stage cluster beyond the Goldilocks window. This adds that second question to every prescription call.

## What changed

`_llm_prescribe` in `src/orchestration/steward.py` now loads a focused excerpt from Dan's developmental register (`~/lobster-user-config/agents/user.base.context.md`, starting at `## Lobster Developmental Map`) and injects it as a `## Dan's current orientation` block positioned after the UoW context and before the dispatch conventions in the user prompt. The model now sees both "what does this UoW need" and "what does Dan's arc require of how this work lands" before generating the prescription.

A new pure function `_load_dan_register_excerpt` handles the I/O boundary:
- reads `user.base.context.md`, extracts from the developmental-map anchor to end-of-file
- caps at 1500 chars with a `[...truncated]` marker
- returns `''` gracefully if the file is absent or the anchor section is not found

When the excerpt is empty the prompt is unchanged — no `## Dan's current orientation` block appears. This makes the injection safe in upstream / CI environments without a user config.

The output format and downstream prescription parsing are not touched. Only the input side is modified.

## Functional patterns

Pure function (`_load_dan_register_excerpt` has no side effects, returns a value type). Side-effect boundary is isolated to `_llm_prescribe` where the subprocess call already lives. Graceful degradation via empty-string return rather than exceptions.

## No dedicated register file

`~/lobster-user-config/` has no dedicated `register`, `orientation`, or `arc` file. The most focused source is the "Lobster Developmental Map" section of `user.base.context.md`. This is noted in the workstream status file as a gap — a follow-up UoW can create a dedicated register file when warranted.

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py::TestLoadDanRegisterExcerpt tests/unit/test_orchestration/test_steward.py::TestLLMPrescribeIncludesOrientationBlock -v` — 7 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -q` — 138 collected, running at time of PR open (still in progress — pre-existing suite, no regressions expected from the isolated addition)

## Manual test
N/A — this change is entirely internal to the prescriber prompt assembly. No Telegram output, no external service calls, no file system writes at runtime (file read only). The only observable effect is in the `claude -p` subprocess argument, which is verified by the unit tests above.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (see above)
- [x] User-visible outcome — not applicable; this is internal prescriber context enrichment
- [x] Side-effect audit: read-only file access, no writes, no loops, no external service calls
- [x] External service calls: none in this change; subprocess call is the existing prescription path, mocked in tests

Closes #301