### PR TITLE
chore: remove legacy vision_ref inline SQL from upgrade scripts

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1387,6 +1387,13 @@ with open(path, 'w') as f:
         migrated=$((migrated + 1))
     fi
 
+    # NOTE: The inline SQL blocks below for agent_sessions.db and memory.db are
+    # intentionally kept here. Those databases do not yet have a numbered .sql
+    # migration system (unlike the WOS registry.db which uses src/orchestration/migrations/).
+    # Until a formal migration runner is added for each, upgrade.sh remains the
+    # only migration path. Do not add new WOS schema changes here — use a numbered
+    # .sql file in src/orchestration/migrations/ instead.
+
     # Migration 23: Add stop_reason column to agent_sessions SQLite table
     # Existing rows will have NULL for stop_reason (nullable, backward-compatible).
     local DB_PATH="${LOBSTER_MESSAGES:-$HOME/messages}/config/agent_sessions.db"

--- a/scripts/user-update.sh
+++ b/scripts/user-update.sh
@@ -669,25 +669,6 @@ ISSUE_SWEEPER_TASK
         fi
     fi
 
-    # d8a: Add vision_ref column to uow_registry (Vision Object Phase 1)
-    # Adds the intent-anchor field that connects each UoW back to a specific
-    # Vision Object layer. NULL is correct for pre-existing rows.
-    local registry_db="$WORKSPACE_DIR/orchestration/registry.db"
-    if [ -f "$registry_db" ]; then
-        if ! python3 -c "
-import sqlite3, sys
-conn = sqlite3.connect('$registry_db')
-cols = [row[1] for row in conn.execute('PRAGMA table_info(uow_registry)').fetchall()]
-conn.close()
-sys.exit(0 if 'vision_ref' in cols else 1)
-" 2>/dev/null; then
-            sqlite3 "$registry_db" "ALTER TABLE uow_registry ADD COLUMN vision_ref TEXT DEFAULT NULL;" 2>/dev/null && \
-                substep "Added vision_ref column to uow_registry" || \
-                warn "Could not add vision_ref column to uow_registry (non-fatal: column added at schema init for new installs)"
-            migrated=$((migrated + 1))
-        fi
-    fi
-
     # d8b: Normalize abbreviated legacy route_reason rows in uow_registry.
     # Canonical value is "phase1-default: no classifier" — updates abbreviated rows.
     local registry_db="$WORKSPACE_DIR/orchestration/registry.db"


### PR DESCRIPTION
## What and why

The `d8a` sub-step in `scripts/user-update.sh` added the `vision_ref` column to `uow_registry` via inline `ALTER TABLE`. That column is now managed by the numbered `.sql` migration system under `src/orchestration/migrations/`. The inline block is redundant on any install that has run Migration 56+ (confirmed by the presence of the `_migrations` table).

Before merging this: the `d8a` block would silently no-op on up-to-date installs (the column already exists), but it adds noise and misleads future contributors into thinking WOS schema is managed via inline shell. Removing it makes the migration authorship model unambiguous.

The second change adds a single explanatory comment above the first `agent_sessions.db` inline block in `upgrade.sh` (Migration 23). Documentation-only — no logic change. It explains why those blocks intentionally remain: `agent_sessions.db` and `memory.db` do not yet have a formal numbered migration runner.

## What is not touched

- The `d8b` block and all subsequent sub-steps in `user-update.sh` are untouched.
- The `agent_sessions.db` and `memory.db` inline migration blocks in `upgrade.sh` are untouched.
- No `.sql` files in `src/orchestration/migrations/` are modified.
- No schema is changed.

## Precondition verified

`_migrations` table confirmed present in the live `registry.db` before any file was touched.

## Tests run

- [x] Precondition check — exited 0, `_migrations` table confirmed present
- [x] `grep -n "d8a" scripts/user-update.sh` — no output (block is gone)
- [x] `grep -n "NOTE: The inline SQL blocks" scripts/upgrade.sh` — line 1390 (comment placed correctly)
- [x] `git diff --cached --stat` — 7 insertions (comment), 19 deletions (d8a block), 2 files

## Manual test

N/A — script cleanup only. The removed block was already a no-op on the live install (column exists). No schema is altered.

## Definition of Done

- [x] Precondition verified before deletion
- [x] No schema changes, no data changes, no service restarts
- [x] `d8b` and all other sub-steps confirmed untouched