### PR TITLE
feat: migrate decisions ledger from flat file to SQLite

### DIFF
--- a/hooks/decision-router.py
+++ b/hooks/decision-router.py
@@ -3,18 +3,42 @@
 PostToolUse hook: routes decision: footer blocks to the decisions ledger.
 
 When a send_reply message contains a ```decision: ... ``` code block,
-extract the content and append it to ~/lobster-workspace/data/decisions-ledger.md.
+extract the content and write it to the decisions table in memory.db.
 """
 
 import json
 import os
 import re
+import sqlite3
 import sys
 from datetime import datetime, timezone
 
 
 DECISION_BLOCK_RE = re.compile(r"```decision:\s*\n(.*?)```", re.DOTALL)
-LEDGER_PATH = os.path.expanduser("~/lobster-workspace/data/decisions-ledger.md")
+DB_PATH = os.path.expanduser("~/lobster-workspace/data/memory.db")
+
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS decisions (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            date       TEXT NOT NULL,
+            category   TEXT,
+            task_id    TEXT,
+            summary    TEXT NOT NULL,
+            source     TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_decisions_dedup
+            ON decisions(date, summary);
+        CREATE INDEX IF NOT EXISTS idx_decisions_category
+            ON decisions(category);
+        CREATE INDEX IF NOT EXISTS idx_decisions_task_id
+            ON decisions(task_id);
+        CREATE INDEX IF NOT EXISTS idx_decisions_date
+            ON decisions(date);
+    """)
+    conn.commit()
 
 
 def main():
@@ -40,18 +64,13 @@ def main():
 
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    os.makedirs(os.path.dirname(LEDGER_PATH), exist_ok=True)
-
-    if not os.path.exists(LEDGER_PATH):
-        with open(LEDGER_PATH, "w") as f:
-            f.write(
-                "# Decisions Ledger\n\n"
-                "Append-only log of choices made as captured from `decision:` footer blocks.\n"
-                "One entry per decision. Routed automatically by `hooks/decision-router.py`.\n\n"
-            )
-
-    with open(LEDGER_PATH, "a") as f:
-        f.write(f"\n---\n**{date_str}** — {decision_text}\n")
+    with sqlite3.connect(DB_PATH) as conn:
+        ensure_table(conn)
+        conn.execute(
+            "INSERT OR IGNORE INTO decisions (date, summary, source) VALUES (?, ?, ?)",
+            (date_str, decision_text, "hook"),
+        )
+        conn.commit()
 
     sys.exit(0)
 

--- a/scripts/migrate-decisions-ledger.py
+++ b/scripts/migrate-decisions-ledger.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+One-off migration: parse decisions-ledger.md and insert entries into the
+decisions table in memory.db. Re-runnable safely via INSERT OR IGNORE.
+
+WOS-UoW: uow_20260502_a1a5e3
+"""
+
+import os
+import re
+import sqlite3
+import sys
+
+LEDGER_PATH = os.path.expanduser("~/lobster-workspace/data/decisions-ledger.md")
+DB_PATH = os.path.expanduser("~/lobster-workspace/data/memory.db")
+
+ENTRY_RE = re.compile(r"\*\*(\d{4}-\d{2}-\d{2})\*\*\s+—\s+(.+)", re.DOTALL)
+
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS decisions (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            date       TEXT NOT NULL,
+            category   TEXT,
+            task_id    TEXT,
+            summary    TEXT NOT NULL,
+            source     TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_decisions_dedup
+            ON decisions(date, summary);
+        CREATE INDEX IF NOT EXISTS idx_decisions_category
+            ON decisions(category);
+        CREATE INDEX IF NOT EXISTS idx_decisions_task_id
+            ON decisions(task_id);
+        CREATE INDEX IF NOT EXISTS idx_decisions_date
+            ON decisions(date);
+    """)
+    conn.commit()
+
+
+def parse_ledger(path: str) -> list[tuple[str, str]]:
+    """Return list of (date, summary) tuples parsed from the flat-file ledger."""
+    if not os.path.exists(path):
+        return []
+
+    with open(path) as f:
+        content = f.read()
+
+    # Split on --- separators; skip everything before the first ---
+    parts = content.split("\n---\n")
+    entries = []
+    for part in parts[1:]:  # parts[0] is the header block
+        part = part.strip()
+        if not part:
+            continue
+        m = ENTRY_RE.match(part)
+        if m:
+            date_str = m.group(1)
+            summary = m.group(2).strip()
+            entries.append((date_str, summary))
+    return entries
+
+
+def main() -> None:
+    entries = parse_ledger(LEDGER_PATH)
+
+    with sqlite3.connect(DB_PATH) as conn:
+        ensure_table(conn)
+        migrated = 0
+        for date_str, summary in entries:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO decisions (date, summary, source) VALUES (?, ?, ?)",
+                (date_str, summary, "migrated"),
+            )
+            migrated += cursor.rowcount
+        conn.commit()
+
+    print(f"Migrated {migrated} entries from decisions-ledger.md (total parsed: {len(entries)})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Replaces `hooks/decision-router.py` flat-file write path (`decisions-ledger.md`) with a `decisions` table in `memory.db`
- Table has indexed columns: `date`, `category`, `task_id` — plus a `UNIQUE(date, summary)` dedup constraint for idempotent inserts
- Adds `scripts/migrate-decisions-ledger.py` to backfill existing flat-file entries (re-runnable safely via `INSERT OR IGNORE`)
- `decisions-ledger.md` is preserved on disk as a historical artifact

## Test plan

- [x] Migration script ran and inserted 1 existing entry with `source='migrated'`
- [x] Smoke-tested hook: `echo '{"tool_name":"mcp__lobster-inbox__send_reply",...}'` piped to hook; confirmed new row with `source='hook'` appeared in DB
- [x] `decisions` table exists in `memory.db` with all four indexes
- [x] Hook input format, `decision:` block regex, and trigger mechanism unchanged

WOS-UoW: uow_20260502_a1a5e3