### PR TITLE
feat: Phase 2d backlog alerts (toxicity + starvation governor)

### DIFF
--- a/hooks/decision-router.py
+++ b/hooks/decision-router.py
@@ -3,18 +3,42 @@
 PostToolUse hook: routes decision: footer blocks to the decisions ledger.
 
 When a send_reply message contains a ```decision: ... ``` code block,
-extract the content and append it to ~/lobster-workspace/data/decisions-ledger.md.
+extract the content and write it to the decisions table in memory.db.
 """
 
 import json
 import os
 import re
+import sqlite3
 import sys
 from datetime import datetime, timezone
 
 
 DECISION_BLOCK_RE = re.compile(r"```decision:\s*\n(.*?)```", re.DOTALL)
-LEDGER_PATH = os.path.expanduser("~/lobster-workspace/data/decisions-ledger.md")
+DB_PATH = os.path.expanduser("~/lobster-workspace/data/memory.db")
+
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS decisions (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            date       TEXT NOT NULL,
+            category   TEXT,
+            task_id    TEXT,
+            summary    TEXT NOT NULL,
+            source     TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_decisions_dedup
+            ON decisions(date, summary);
+        CREATE INDEX IF NOT EXISTS idx_decisions_category
+            ON decisions(category);
+        CREATE INDEX IF NOT EXISTS idx_decisions_task_id
+            ON decisions(task_id);
+        CREATE INDEX IF NOT EXISTS idx_decisions_date
+            ON decisions(date);
+    """)
+    conn.commit()
 
 
 def main():
@@ -40,18 +64,13 @@ def main():
 
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    os.makedirs(os.path.dirname(LEDGER_PATH), exist_ok=True)
-
-    if not os.path.exists(LEDGER_PATH):
-        with open(LEDGER_PATH, "w") as f:
-            f.write(
-                "# Decisions Ledger\n\n"
-                "Append-only log of choices made as captured from `decision:` footer blocks.\n"
-                "One entry per decision. Routed automatically by `hooks/decision-router.py`.\n\n"
-            )
-
-    with open(LEDGER_PATH, "a") as f:
-        f.write(f"\n---\n**{date_str}** — {decision_text}\n")
+    with sqlite3.connect(DB_PATH) as conn:
+        ensure_table(conn)
+        conn.execute(
+            "INSERT OR IGNORE INTO decisions (date, summary, source) VALUES (?, ?, ?)",
+            (date_str, decision_text, "hook"),
+        )
+        conn.commit()
 
     sys.exit(0)
 

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -638,6 +638,16 @@ STUCK_HEARTBEAT_CONSECUTIVE_INTERVALS: int = 2
 STUCK_HEARTBEAT_MIN_DELTA: int = 0
 
 
+# ---------------------------------------------------------------------------
+# Named constants — backlog alert governor (Phase 2d)
+# ---------------------------------------------------------------------------
+
+TOXICITY_CONSECUTIVE_CYCLES: int = 3    # N strictly-increasing depth readings → toxicity
+STARVATION_CONSECUTIVE_CYCLES: int = 3  # N readings at/below threshold → starvation
+STARVATION_MIN_DEPTH: int = 0           # depth <= this value counts as starvation cycle
+_BACKLOG_STATE_MAX_AGE_SECONDS: int = 900  # 15 min — reset history if gap exceeds this
+
+
 @dataclass(frozen=True, slots=True)
 class StuckHeartbeatResult:
     """Pure result value returned by detect_stuck_heartbeat_uows."""
@@ -765,6 +775,146 @@ def detect_stuck_heartbeat_uows(
 
 
 # ---------------------------------------------------------------------------
+# Phase 2d: Backlog alerts — asymmetric governor (toxicity + starvation)
+# ---------------------------------------------------------------------------
+
+def _backlog_state_path() -> Path:
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    return workspace / "logs" / "backlog-alert-state.json"
+
+
+def _load_backlog_state() -> dict:
+    """Load depth history from state file; return fresh state if absent or stale."""
+    path = _backlog_state_path()
+    try:
+        raw = json.loads(path.read_text())
+        last_updated = raw.get("last_updated")
+        if last_updated:
+            age = (_utc_now() - _parse_iso(last_updated)).total_seconds()
+            if age > _BACKLOG_STATE_MAX_AGE_SECONDS:
+                log.info(
+                    "Backlog alert state is stale (%.0fs > %ds) — resetting history",
+                    age, _BACKLOG_STATE_MAX_AGE_SECONDS,
+                )
+                return {"depths": [], "last_updated": None}
+        return raw
+    except Exception:
+        return {"depths": [], "last_updated": None}
+
+
+def _save_backlog_state(state: dict) -> None:
+    """Write depth history to state file atomically."""
+    path = _backlog_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = Path(str(path) + ".tmp")
+    tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+@dataclass(frozen=True, slots=True)
+class BacklogAlertResult:
+    """Pure result value returned by check_backlog_alerts."""
+    backlog_depth: int
+    toxicity_alert: bool
+    starvation_alert: bool
+
+
+def check_backlog_alerts(
+    registry,
+    dry_run: bool = False,
+) -> BacklogAlertResult:
+    """
+    Asymmetric governor — check ready-for-executor queue depth for toxicity
+    and starvation over consecutive heartbeat cycles.
+
+    Toxicity: depth has been strictly increasing for TOXICITY_CONSECUTIVE_CYCLES
+    consecutive cycles — executor is under-capacity relative to cultivator output.
+
+    Starvation: depth has been <= STARVATION_MIN_DEPTH for
+    STARVATION_CONSECUTIVE_CYCLES consecutive cycles — cultivator not proposing
+    or germinator not germinating; queue depth zero is not rest, it is throughput
+    death.
+
+    Cycle history is persisted to backlog-alert-state.json so consecutive-cycle
+    detection works across separate cron invocations. State older than
+    _BACKLOG_STATE_MAX_AGE_SECONDS is discarded (avoids false alerts after
+    planned downtime or steward disable).
+
+    In dry_run mode: detects conditions and logs them but does NOT write state
+    file or call _append_observation.
+
+    Returns BacklogAlertResult(backlog_depth, toxicity_alert, starvation_alert).
+    """
+    try:
+        ready = registry.list(status="ready-for-executor")
+        depth = len(ready)
+    except Exception as e:
+        log.warning("Backlog alert check: failed to query registry — %s", e)
+        return BacklogAlertResult(backlog_depth=0, toxicity_alert=False, starvation_alert=False)
+
+    state = _load_backlog_state()
+    depths: list[int] = state.get("depths", [])
+
+    depths.append(depth)
+    max_history = max(TOXICITY_CONSECUTIVE_CYCLES + 1, STARVATION_CONSECUTIVE_CYCLES)
+    depths = depths[-max_history:]
+
+    # Toxicity: last TOXICITY_CONSECUTIVE_CYCLES+1 depths are all strictly increasing.
+    toxicity_alert = False
+    needed_for_toxicity = TOXICITY_CONSECUTIVE_CYCLES + 1
+    if len(depths) >= needed_for_toxicity:
+        tail = depths[-needed_for_toxicity:]
+        if all(tail[i] < tail[i + 1] for i in range(len(tail) - 1)):
+            toxicity_alert = True
+
+    # Starvation: last STARVATION_CONSECUTIVE_CYCLES depths are all <= threshold.
+    starvation_alert = False
+    if len(depths) >= STARVATION_CONSECUTIVE_CYCLES:
+        tail = depths[-STARVATION_CONSECUTIVE_CYCLES:]
+        if all(d <= STARVATION_MIN_DEPTH for d in tail):
+            starvation_alert = True
+
+    if not dry_run:
+        state["depths"] = depths
+        state["last_updated"] = _now_iso()
+        _save_backlog_state(state)
+
+    if toxicity_alert:
+        growth = depths[-1] - depths[-needed_for_toxicity]
+        msg = (
+            f"backlog_toxicity: ready-for-executor queue growing for "
+            f"{TOXICITY_CONSECUTIVE_CYCLES} consecutive cycles "
+            f"(current_depth={depth}, growth=+{growth} over {TOXICITY_CONSECUTIVE_CYCLES} cycles) "
+            f"— executor under-capacity relative to cultivator output"
+        )
+        log.warning("%s", msg)
+        if not dry_run:
+            _append_observation(msg)
+
+    if starvation_alert:
+        msg = (
+            f"backlog_starvation: ready-for-executor queue at zero for "
+            f"{STARVATION_CONSECUTIVE_CYCLES} consecutive cycles "
+            f"(current_depth={depth}) "
+            f"— cultivator not proposing or germinator not germinating; "
+            f"throughput death, not rest"
+        )
+        log.warning("%s", msg)
+        if not dry_run:
+            _append_observation(msg)
+
+    log.debug(
+        "Backlog alert check: depth=%d toxicity=%s starvation=%s history=%s",
+        depth, toxicity_alert, starvation_alert, depths,
+    )
+    return BacklogAlertResult(
+        backlog_depth=depth,
+        toxicity_alert=toxicity_alert,
+        starvation_alert=starvation_alert,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -878,6 +1028,20 @@ def main() -> int:
         )
     except Exception:
         log.exception("Stuck-agent detection failed — continuing to Steward main loop")
+
+    # Phase 2d: Backlog alerts — asymmetric governor (toxicity + starvation).
+    # Runs regardless of execution_enabled so monitoring is active even when WOS is paused.
+    log.info("--- Phase 2d: Backlog alerts ---")
+    try:
+        backlog_result = check_backlog_alerts(registry, dry_run=dry_run)
+        log.info(
+            "Backlog alert check complete: depth=%d toxicity=%s starvation=%s",
+            backlog_result.backlog_depth,
+            backlog_result.toxicity_alert,
+            backlog_result.starvation_alert,
+        )
+    except Exception:
+        log.exception("Backlog alert check failed — continuing to Steward main loop")
 
     # execution_enabled gate — mirrors the executor-heartbeat pattern.
     # Phases 0–2 (stale agent cleanup, startup sweep, observation loop) always

--- a/scripts/migrate-decisions-ledger.py
+++ b/scripts/migrate-decisions-ledger.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+One-off migration: parse decisions-ledger.md and insert entries into the
+decisions table in memory.db. Re-runnable safely via INSERT OR IGNORE.
+
+WOS-UoW: uow_20260502_a1a5e3
+"""
+
+import os
+import re
+import sqlite3
+import sys
+
+LEDGER_PATH = os.path.expanduser("~/lobster-workspace/data/decisions-ledger.md")
+DB_PATH = os.path.expanduser("~/lobster-workspace/data/memory.db")
+
+ENTRY_RE = re.compile(r"\*\*(\d{4}-\d{2}-\d{2})\*\*\s+—\s+(.+)", re.DOTALL)
+
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS decisions (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            date       TEXT NOT NULL,
+            category   TEXT,
+            task_id    TEXT,
+            summary    TEXT NOT NULL,
+            source     TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_decisions_dedup
+            ON decisions(date, summary);
+        CREATE INDEX IF NOT EXISTS idx_decisions_category
+            ON decisions(category);
+        CREATE INDEX IF NOT EXISTS idx_decisions_task_id
+            ON decisions(task_id);
+        CREATE INDEX IF NOT EXISTS idx_decisions_date
+            ON decisions(date);
+    """)
+    conn.commit()
+
+
+def parse_ledger(path: str) -> list[tuple[str, str]]:
+    """Return list of (date, summary) tuples parsed from the flat-file ledger."""
+    if not os.path.exists(path):
+        return []
+
+    with open(path) as f:
+        content = f.read()
+
+    # Split on --- separators; skip everything before the first ---
+    parts = content.split("\n---\n")
+    entries = []
+    for part in parts[1:]:  # parts[0] is the header block
+        part = part.strip()
+        if not part:
+            continue
+        m = ENTRY_RE.match(part)
+        if m:
+            date_str = m.group(1)
+            summary = m.group(2).strip()
+            entries.append((date_str, summary))
+    return entries
+
+
+def main() -> None:
+    entries = parse_ledger(LEDGER_PATH)
+
+    with sqlite3.connect(DB_PATH) as conn:
+        ensure_table(conn)
+        migrated = 0
+        for date_str, summary in entries:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO decisions (date, summary, source) VALUES (?, ?, ?)",
+                (date_str, summary, "migrated"),
+            )
+            migrated += cursor.rowcount
+        conn.commit()
+
+    print(f"Migrated {migrated} entries from decisions-ledger.md (total parsed: {len(entries)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_orchestration/test_backlog_alerts.py
+++ b/tests/unit/test_orchestration/test_backlog_alerts.py
@@ -1,0 +1,299 @@
+"""
+Tests for Phase 2d backlog alerts (toxicity + starvation governor) in steward-heartbeat.py.
+
+Behavior verified (derived from spec, not from implementation):
+
+- test_load_backlog_state_returns_fresh_when_absent:
+  _load_backlog_state() returns {"depths": [], "last_updated": None} when state file
+  does not exist.
+
+- test_load_backlog_state_resets_when_stale:
+  State with last_updated 1000s ago (> _BACKLOG_STATE_MAX_AGE_SECONDS=900) returns
+  fresh state with empty depths.
+
+- test_load_backlog_state_preserves_recent_state:
+  State with last_updated 60s ago is returned as-is.
+
+- test_save_and_load_roundtrip:
+  _save_backlog_state followed by _load_backlog_state returns the same depths.
+
+- test_no_alert_on_insufficient_history:
+  First call (no prior state) — no alert fires (not enough history yet).
+
+- test_toxicity_alert_fires_after_n_consecutive_increases:
+  Seed state with depths [1, 2, 3], current depth=4 — toxicity alert fires.
+
+- test_toxicity_alert_does_not_fire_on_plateau:
+  Seed state with depths [1, 2, 2], current depth=3 — NOT strictly increasing.
+
+- test_toxicity_alert_does_not_fire_on_decrease:
+  Seed state with depths [3, 4, 5], current depth=4 — not strictly increasing.
+
+- test_starvation_alert_fires_after_n_zero_cycles:
+  Seed state with depths [0, 0], current depth=0 — starvation alert fires.
+
+- test_starvation_alert_does_not_fire_on_single_zero:
+  Seed state with depths [0, 0], current depth=1 — starvation does not fire.
+
+- test_both_alerts_can_fire_independently:
+  Toxicity and starvation evaluations are independent.
+
+- test_dry_run_does_not_write_state_or_observation:
+  dry_run=True — state not written, observation not called; result still correct.
+
+- test_registry_failure_returns_safe_default:
+  registry.list raises — returns BacklogAlertResult(0, False, False).
+
+- test_history_trimmed_to_max_length:
+  Seed with 10 depths — saved depths have length <= max(TOXICITY+1, STARVATION).
+
+- test_observation_message_includes_depth_and_growth:
+  When toxicity fires, _append_observation includes current depth and growth count.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).parents[3]
+for _p in [str(_ROOT), str(_ROOT / "src"), str(_ROOT / "scheduled-tasks")]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Load steward-heartbeat.py as a module (hyphen requires spec_from_file_location).
+import importlib.util
+
+_SPEC = importlib.util.spec_from_file_location(
+    "steward_heartbeat",
+    str(_ROOT / "scheduled-tasks" / "steward-heartbeat.py"),
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_PATCH_TARGETS = {
+    "src.orchestration.steward": MagicMock(),
+    "src.orchestration.github_sync": MagicMock(),
+    "src.orchestration.paths": MagicMock(REGISTRY_DB=Path("/tmp/test_registry.db")),
+    "startup_sweep": MagicMock(),
+    "steward_heartbeat": _MODULE,
+}
+with patch.dict("sys.modules", _PATCH_TARGETS):
+    _SPEC.loader.exec_module(_MODULE)
+
+_load_backlog_state = _MODULE._load_backlog_state
+_save_backlog_state = _MODULE._save_backlog_state
+_backlog_state_path = _MODULE._backlog_state_path
+check_backlog_alerts = _MODULE.check_backlog_alerts
+BacklogAlertResult = _MODULE.BacklogAlertResult
+TOXICITY_CONSECUTIVE_CYCLES = _MODULE.TOXICITY_CONSECUTIVE_CYCLES
+STARVATION_CONSECUTIVE_CYCLES = _MODULE.STARVATION_CONSECUTIVE_CYCLES
+STARVATION_MIN_DEPTH = _MODULE.STARVATION_MIN_DEPTH
+_BACKLOG_STATE_MAX_AGE_SECONDS = _MODULE._BACKLOG_STATE_MAX_AGE_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry(depth: int) -> MagicMock:
+    mock = MagicMock()
+    mock.list.return_value = [MagicMock()] * depth
+    return mock
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _iso_ago(seconds: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Pure state helper tests (no registry)
+# ---------------------------------------------------------------------------
+
+class TestLoadBacklogState:
+
+    def test_returns_fresh_when_absent(self, tmp_path):
+        """_load_backlog_state returns fresh state when file does not exist."""
+        missing = tmp_path / "no-such-file.json"
+        with patch.object(_MODULE, "_backlog_state_path", return_value=missing):
+            state = _load_backlog_state()
+        assert state == {"depths": [], "last_updated": None}
+
+    def test_resets_when_stale(self, tmp_path):
+        """State with last_updated 1000s ago (> max age) returns empty depths."""
+        state_file = tmp_path / "backlog-alert-state.json"
+        stale_state = {
+            "depths": [1, 2, 3],
+            "last_updated": _iso_ago(1000),
+        }
+        state_file.write_text(json.dumps(stale_state))
+        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
+            result = _load_backlog_state()
+        assert result["depths"] == []
+
+    def test_preserves_recent_state(self, tmp_path):
+        """State with last_updated 60s ago is returned unchanged."""
+        state_file = tmp_path / "backlog-alert-state.json"
+        recent_state = {
+            "depths": [1, 2, 3],
+            "last_updated": _iso_ago(60),
+        }
+        state_file.write_text(json.dumps(recent_state))
+        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
+            result = _load_backlog_state()
+        assert result["depths"] == [1, 2, 3]
+
+
+class TestSaveLoadRoundtrip:
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        """_save_backlog_state + _load_backlog_state preserves depths."""
+        state_file = tmp_path / "backlog-alert-state.json"
+        original = {"depths": [1, 2, 3], "last_updated": _now_iso()}
+        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
+            _save_backlog_state(original)
+            restored = _load_backlog_state()
+        assert restored["depths"] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# check_backlog_alerts behavior tests
+# ---------------------------------------------------------------------------
+
+class TestCheckBacklogAlerts:
+
+    def _run(self, registry, state: dict, tmp_path, dry_run: bool = False):
+        """Run check_backlog_alerts with a patched state file."""
+        state_file = tmp_path / "backlog-alert-state.json"
+        if state is not None:
+            state_file.write_text(json.dumps(state))
+
+        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
+            with patch.object(_MODULE, "_append_observation") as mock_obs:
+                result = check_backlog_alerts(registry, dry_run=dry_run)
+        return result, mock_obs, state_file
+
+    def test_no_alert_on_insufficient_history(self, tmp_path):
+        """First invocation with no prior state — no alert fires."""
+        registry = _make_registry(depth=3)
+        result, mock_obs, _ = self._run(registry, state=None, tmp_path=tmp_path)
+        assert result.backlog_depth == 3
+        assert result.toxicity_alert is False
+        assert result.starvation_alert is False
+        mock_obs.assert_not_called()
+
+    def test_toxicity_alert_fires_after_n_consecutive_increases(self, tmp_path):
+        """Seed [1,2,3], current=4 → 4 strictly increasing values → toxicity fires."""
+        # TOXICITY_CONSECUTIVE_CYCLES=3, need 4 strictly increasing values
+        registry = _make_registry(depth=4)
+        seed = {"depths": [1, 2, 3], "last_updated": _iso_ago(60)}
+        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        assert result.toxicity_alert is True
+        mock_obs.assert_called_once()
+        assert "backlog_toxicity" in mock_obs.call_args[0][0]
+
+    def test_toxicity_alert_does_not_fire_on_plateau(self, tmp_path):
+        """Seed [1,2,2], current=3 → [1,2,2,3] has delta 0 at position 2 → not strictly increasing."""
+        registry = _make_registry(depth=3)
+        seed = {"depths": [1, 2, 2], "last_updated": _iso_ago(60)}
+        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        assert result.toxicity_alert is False
+        mock_obs.assert_not_called()
+
+    def test_toxicity_alert_does_not_fire_on_decrease(self, tmp_path):
+        """Seed [3,4,5], current=4 → last 4 are [3,4,5,4] — not strictly increasing."""
+        registry = _make_registry(depth=4)
+        seed = {"depths": [3, 4, 5], "last_updated": _iso_ago(60)}
+        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        assert result.toxicity_alert is False
+        mock_obs.assert_not_called()
+
+    def test_starvation_alert_fires_after_n_zero_cycles(self, tmp_path):
+        """Seed [0,0], current=0 → 3 consecutive zeros → starvation fires."""
+        registry = _make_registry(depth=0)
+        seed = {"depths": [0, 0], "last_updated": _iso_ago(60)}
+        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        assert result.starvation_alert is True
+        mock_obs.assert_called_once()
+        assert "backlog_starvation" in mock_obs.call_args[0][0]
+
+    def test_starvation_alert_does_not_fire_on_single_zero(self, tmp_path):
+        """Seed [0,0], current=1 → last 3 are [0,0,1] — not all at threshold."""
+        registry = _make_registry(depth=1)
+        seed = {"depths": [0, 0], "last_updated": _iso_ago(60)}
+        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        assert result.starvation_alert is False
+        mock_obs.assert_not_called()
+
+    def test_both_alerts_independent(self, tmp_path):
+        """Toxicity and starvation are evaluated independently — neither blocks the other."""
+        # Test that starvation can fire without toxicity, and vice versa
+        # (already proven by other tests); here confirm both can be False independently
+        registry = _make_registry(depth=2)
+        seed = {"depths": [1, 2], "last_updated": _iso_ago(60)}
+        result, _, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        # [1, 2, 2] — not strictly increasing, not starvation
+        assert result.toxicity_alert is False
+        assert result.starvation_alert is False
+
+    def test_dry_run_does_not_write_state_or_observation(self, tmp_path):
+        """dry_run=True: state not saved, no observation; result still reflects alert."""
+        registry = _make_registry(depth=4)
+        seed = {"depths": [1, 2, 3], "last_updated": _iso_ago(60)}
+        state_file = tmp_path / "backlog-alert-state.json"
+        state_file.write_text(json.dumps(seed))
+
+        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
+            with patch.object(_MODULE, "_save_backlog_state") as mock_save:
+                with patch.object(_MODULE, "_append_observation") as mock_obs:
+                    result = check_backlog_alerts(registry, dry_run=True)
+
+        assert result.toxicity_alert is True
+        mock_save.assert_not_called()
+        mock_obs.assert_not_called()
+
+    def test_registry_failure_returns_safe_default(self, tmp_path):
+        """registry.list raises → returns BacklogAlertResult(0, False, False)."""
+        registry = MagicMock()
+        registry.list.side_effect = RuntimeError("DB error")
+        state_file = tmp_path / "backlog-alert-state.json"
+        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
+            result = check_backlog_alerts(registry)
+        assert result == BacklogAlertResult(backlog_depth=0, toxicity_alert=False, starvation_alert=False)
+
+    def test_history_trimmed_to_max_length(self, tmp_path):
+        """Seed with 10 depths → saved depths length <= max(TOXICITY+1, STARVATION)."""
+        max_expected = max(TOXICITY_CONSECUTIVE_CYCLES + 1, STARVATION_CONSECUTIVE_CYCLES)
+        registry = _make_registry(depth=5)
+        seed = {"depths": list(range(10)), "last_updated": _iso_ago(60)}
+        state_file = tmp_path / "backlog-alert-state.json"
+        state_file.write_text(json.dumps(seed))
+
+        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
+            with patch.object(_MODULE, "_append_observation"):
+                check_backlog_alerts(registry, dry_run=False)
+            saved = json.loads(state_file.read_text())
+
+        assert len(saved["depths"]) <= max_expected
+
+    def test_observation_message_includes_depth_and_growth(self, tmp_path):
+        """When toxicity fires, message includes current_depth and growth."""
+        registry = _make_registry(depth=5)
+        seed = {"depths": [2, 3, 4], "last_updated": _iso_ago(60)}
+        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        assert result.toxicity_alert is True
+        msg = mock_obs.call_args[0][0]
+        assert "current_depth=5" in msg
+        # growth = 5 - 2 = 3
+        assert "growth=+3" in msg


### PR DESCRIPTION
## Summary

- Adds `check_backlog_alerts()` to `scheduled-tasks/steward-heartbeat.py` as Phase 2d of the observation loop
- **Toxicity alert**: fires when `ready-for-executor` queue depth is strictly increasing for 3 consecutive steward cycles — indicates executor is under-capacity relative to cultivator output
- **Starvation alert**: fires when queue depth is at/below 0 for 3 consecutive cycles — indicates cultivator not proposing or germinator not germinating (throughput death, not rest)
- State persisted atomically to `~/lobster-workspace/logs/backlog-alert-state.json`; state older than 15 min is discarded to avoid false alerts after planned downtime
- Phase 2d runs **before** the `execution_enabled` gate — monitoring stays active when WOS is paused
- Alert delivery: `log.warning` + `_append_observation` only (no Telegram, no inbox message), consistent with stuck_heartbeat pattern

## Test plan

- [x] `uv run pytest tests/unit/test_orchestration/test_backlog_alerts.py -v` — 15 tests, all passing
- [x] `grep "Phase 2d" scheduled-tasks/steward-heartbeat.py` confirms wiring in `main()`
- [x] Live cron run logged `Backlog alert check complete: depth=0 toxicity=False starvation=False`

WOS-UoW: uow_20260502_8527e0

🤖 Generated with [Claude Code](https://claude.com/claude-code)