### PR TITLE
feat(wos): Phase 2d — asymmetric backlog alerts (toxicity + starvation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,10 @@ WORKSTREAM SETUP (do this first, before any other work):
    Update: current step, % complete estimate, last completed milestone, next step.
    If you are blocked or failing, write that explicitly — stalled state is recoverable; silent state is not.
 
+4. Call write_result at completion:
+   write_result(task_id="<task-slug>", sent_reply_to_user=False, status="success", text="<one-sentence summary>")
+   If you sent a reply to the user directly: write_result(task_id="<task-slug>", sent_reply_to_user=True)
+
 Do not defer workstream creation. If you die without writing status.md, the reconciler has nothing to recover from.
 ```
 

--- a/assessments/process-snapshot-20260507.md
+++ b/assessments/process-snapshot-20260507.md
@@ -1,0 +1,119 @@
+# Process Snapshot — 2026-05-07
+
+**Generated:** 2026-05-07T00:14:33Z  
+**Purpose:** Document active Lobster/Claude processes before clean restart to address API usage consumption issue.
+
+---
+
+## Running Processes
+
+| PID | Started | CPU | Command | Category |
+|-----|---------|-----|---------|----------|
+| 840 | May01 | 0.0% | `/home/lobster/lobster/.venv/bin/python .../src/transcription/worker.py` | Infrastructure (transcription worker) |
+| 842 | May01 | 0.0% | `/home/lobster/lobster/.venv/bin/python .../src/daemons/wos_execute_router.py` | Infrastructure (WOS router daemon) |
+| 997 | May01 | 0.0% | `/usr/bin/python3 /usr/share/unattended-upgrades/unattended-upgrade-shutdown` | System (root, OS upgrade watcher) |
+| 1016 | May01 | 0.0% | `/usr/lib/systemd/systemd --user` | System (user systemd) |
+| 4626 | May01 | 0.0% | `/home/lobster/lobster/.venv/bin/python3 .../src/dashboard/server.py --host 0.0.0.0 --port 9100` | Infrastructure (dashboard server) |
+| 256579 | May02 | 0.0% | `/usr/bin/dbus-daemon --session` | System (session bus) |
+| 474896 | May02 | 0.0% | `/usr/bin/tmux -L lobster new-session ...` | Infrastructure (tmux session manager) |
+| 474897 | May02 | 0.0% | `/bin/bash .../scripts/claude-persistent.sh` | Infrastructure (Claude restart wrapper) |
+| 4050750 | May06 | 0.0% | `/home/lobster/lobster/.venv/bin/python .../src/bot/lobster_bot.py` | Infrastructure (Telegram bot) |
+| **22047** | **00:10** | **3.6%** | **`claude --dangerously-skip-permissions --model sonnet ...`** | **Dispatcher (main loop — DO NOT KILL)** |
+| 22048 | 00:10 | 0.0% | `tee -a .../logs/claude-session.log` | Infrastructure (log tee for dispatcher) |
+| 22061 | 00:10 | 1.0% | `/home/lobster/lobster/.venv/bin/python .../src/mcp/inbox_server.py` | Infrastructure (MCP inbox server) |
+
+### Observation
+There is **only one Claude process** (PID 22047) — the dispatcher itself. No orphaned Claude Code subagent processes were found. This is a clean process state.
+
+---
+
+## Running Systemd Services
+
+| Service | Status |
+|---------|--------|
+| `lobster-claude.service` | active/running — Lobster Claude main loop |
+| `lobster-router.service` | active/running — Telegram to Claude Code bridge |
+| `lobster-transcription.service` | active/running — whisper.cpp voice-to-text pipeline |
+| `lobster-wos-router.service` | active/running — WOS execute router daemon |
+
+---
+
+## Stuck Processing Messages
+
+**None found.** `~/messages/processing/` directory is empty.
+
+---
+
+## Stale In-Flight Work (inflight-work.jsonl)
+
+The inflight-work.jsonl file contains **59 tasks marked "running" that have no corresponding completion record**. These are all stale — the processes that would have completed them died in previous sessions.
+
+Date range of stale entries: 2026-04-25 through 2026-05-07 (current process-cleanup task)
+
+Notable stale task clusters:
+- **April 25-26:** WOS force-resets, negentropic sweep cron fixes, upstream merge recovery
+- **April 26-27:** WOS escalation wave (diagnosing_orphan cycle 4 — multiple UoWs)
+- **April 27:** PR merges (#986, #987, #988), morning briefing, github-issue-cultivator
+- **May 1:** WOS observability swarm (4 parallel implementation agents)
+- **May 4:** Queue token usage, toxicity answer
+- **May 7:** process-cleanup (current task, in progress)
+
+---
+
+## Active Workstreams
+
+All workstreams are directories (not process-backed): `~/lobster-workspace/workstreams/`
+
+Key active workstreams (non-archived):
+- async-deep-work
+- docs
+- epistemic-principles
+- first-principles
+- issue-lifecycle-worker
+- linear-migration
+- lobster-core
+- lobster-system
+- negentropic-sweep
+- personal-todo-system
+- phase-reference / phase-reference-architecture
+- philosophy / philosophy-explore
+- prescription-audit-v2
+- semantic-mirror
+- town-square
+- upstream-precision-merge
+- usage-observability
+- vision-object
+- wos (main WOS workstream)
+- Various WOS UoW workstreams (uow_20260502_*)
+
+---
+
+## Actions Taken
+
+### Processes Killed
+**None killed.** No orphaned Claude Code subagent processes were found. The only Claude process (PID 22047) is the dispatcher itself, which must not be killed.
+
+### Processes Preserved
+All infrastructure processes preserved:
+- Telegram bot (PID 4050750)
+- MCP inbox server (PID 22061)
+- WOS execute router (PID 842)
+- Transcription worker (PID 840)
+- Dashboard server (PID 4626)
+- Dispatcher / main loop (PID 22047)
+
+### Stale Inflight Work
+The inflight-work.jsonl contains 59 stale "running" entries. These are log artifacts from previous sessions where subagents died without writing completion records. They do not represent active processes — they are historical records only. No cleanup is required for process hygiene; they can be cleared if desired by truncating the file to only completed entries.
+
+---
+
+## Root Cause Assessment
+
+The API usage consumption pattern Dan described ("lobster sleeps, lobster wakes, then it all gets consumed so quickly") is likely caused by:
+
+1. **Context compaction effects:** After a long sleep, the dispatcher wakes into a compacted context and may trigger multiple catch-up subagents simultaneously.
+2. **Stale inflight-work.jsonl:** The reconciler or dispatcher may interpret old "running" entries as active tasks needing recovery/re-dispatch.
+3. **WOS executor:** If execution_enabled is true, the wos-execute-router may dispatch multiple UoWs in rapid succession after a session restart.
+4. **Scheduled jobs burst:** Multiple scheduled jobs may fire close together after a long sleep.
+
+**Recommendation:** After clean restart, check `wos-config.json` execution_enabled state and consider setting it false until the consumption pattern stabilizes.

--- a/assessments/wos-spigot-map-20260507.md
+++ b/assessments/wos-spigot-map-20260507.md
@@ -47,6 +47,7 @@
 | **phase2-design-review** | WOS-adjacent — was already disabled | No | Every 30 min | Already disabled — no action |
 | **philosophy-explore-1** | No — was already disabled | No | Every 4 hours | Already disabled — no action |
 | **surface-queue-delivery** | No — was already disabled | No | Daily at 08:00 | Already disabled — no action |
+| **wos-hourly-observation** | Yes — was already disabled in jobs.json | No (jobs.json) | 06:00–12:00 UTC hourly | Disabled systemd timer |
 
 ---
 

--- a/oracle/verdicts/pr-1079.md
+++ b/oracle/verdicts/pr-1079.md
@@ -1,0 +1,58 @@
+VERDICT: APPROVED
+PR: 1079
+Round: 1
+
+## Round 1 — 2026-05-08
+
+### Stage 1: Vision Alignment
+
+**Prior entering review:** This implementation is solving the wrong problem, or solving the right problem in a direction that forecloses better paths.
+
+**Finding (locked before reading implementation):** The stated gap is real: `wos stop` only halted `execution_enabled`, leaving 13 other WOS-core jobs running during a declared pause. This produced spurious health-check alerts and continued issue-sweeper activity on an intentionally stopped pipeline. The theory of change is that a stop command that doesn't actually stop the pipeline is a semantic lie that erodes operator trust. Vision.yaml `principle-1` ("proactive resilience over reactive recovery") and `principle-4` ("wire what exists before building more") support closing this gap before layering more features on top of a control surface that doesn't match its semantic.
+
+This is not the wrong problem. No cheaper test exists — the gap has been observed in production. The `wos_core: true` field approach is flexible and instance-configurable. Opportunity cost is low (one-file change in the command layer).
+
+**Alignment verdict: Confirmed.**
+
+---
+
+### Stage 2: Quality Review
+
+**Encoded Orientation check (constraint-3):** The PR expands `wos start`/`wos stop` scope from writing one config field to atomically toggling 14 jobs. This is a behavioral change in the command layer. However, it is better classified as a correctness fix (stop always intended to stop the whole pipeline) than a new autonomous decision. The operator still initiates the command; the change closes a gap between intent and implementation. No logged prior is required for this class of fix. Constraint-3 is not triggered.
+
+**Does it do what it claims?**
+
+Yes. The `toggle_wos_core_jobs` function:
+- Reads jobs.json and builds an updated dict in memory (dict comprehension, immutable transform).
+- Sets `enabled` on every entry where `entry.get("wos_core")` is truthy. An explicit `False` is falsy, so `wos_core: false` is correctly excluded — verified by `test_wos_core_false_field_is_not_toggled`.
+- Writes both files atomically via write-then-rename, consistent with the existing `_write_wos_config` pattern.
+- Returns `{toggled, not_found, new_state}`.
+
+`handle_wos_start` and `handle_wos_stop` idempotency checks read from `wos-config.json` (the authoritative "is WOS running?" signal), which is correct — they do not read from jobs.json for the idempotency gate.
+
+**One structural note — reporting gap in `toggle_wos_core_jobs`:**
+
+The dict comprehension (the actual toggle) covers all jobs in jobs.json where `entry.get("wos_core")` is truthy. The subsequent `for job_name in sorted(_WOS_CORE_JOBS)` loop covers only the 14 hardcoded names for reporting. If a job exists in jobs.json with `wos_core:true` but its name is not in `_WOS_CORE_JOBS`, it will be correctly toggled in the file but will not appear in either `toggled` or `not_found` in the return value — invisible to the operator. This is an accountability gap in the reporting layer, not a correctness bug. At current state (the frozenset matches the live instance), this gap is latent. Worth knowing but not a blocker.
+
+**Mirror-constant pattern (learnings.md, PRs #696, #800, #967, #970, #974, #980):**
+
+`WOS_CORE_JOB_COUNT = 14` in the test file is a locally-declared count constant that mirrors the length of the production `_WOS_CORE_JOBS` frozenset. This is an instance of the mirror-constant pattern. However, it is at the low-severity end of that class: the constant is a count (not a string value), and if `_WOS_CORE_JOBS` grows from 14 to 15, the assertion `len(result["not_found"]) == WOS_CORE_JOB_COUNT` will loudly fail (not silently pass the wrong value). The direction of failure is loud. Mitigation path: import `_WOS_CORE_JOBS` directly in the test (`from src.orchestration.dispatcher_handlers import _WOS_CORE_JOBS`) and assert `len(result["not_found"]) == len(_WOS_CORE_JOBS)`. Not a blocker for this PR; filing as a low-priority cleanup.
+
+The mirror-constant pattern recognition caused me to look specifically at this constant and verify whether failure is silent or loud before rating severity. It is loud. Without the pattern, I would likely have passed over `WOS_CORE_JOB_COUNT = 14` as unremarkable.
+
+**Test quality:**
+
+22 tests. Coverage is solid: enable/disable, non-core untouched, config written correctly, not_found populated, empty jobs.json, idempotent re-enable, explicit wos_core:false excluded, handle_wos_start/stop delegation and error surfacing, COMMAND_HELP content, handle_help return value. The before-state is exercised via `existing_wos_config={"execution_enabled": not enabled}` in `_run()`.
+
+Pre-existing failures (`test_registry_cli.py` SyntaxError at line 1183, `test_disabled_job_writes_no_inbox_message`) are confirmed not caused by this PR per engineer briefing. Scope of this PR is narrow (one source file, one test file).
+
+**Patterns introduced:**
+
+- `toggle_wos_core_jobs` establishes the pattern of computing mutations in memory before writing any files (pure transform, then bounded side effects). This is a good extension of the existing `_write_wos_config` atomic-write pattern and follows the principle already in the codebase.
+- `_WOS_CORE_JOBS` frozenset as the canonical gate list for a named job group. This pattern will be reused if other named job groups need collective toggle. The `wos_core: true` field in jobs.json is the live source of truth; the frozenset is the testability mirror.
+
+**What this forecloses:**
+
+Nothing significant. The `wos_core: true` field approach is additive — any job can be tagged or untagged without code change.
+
+**VERDICT: APPROVED**

--- a/oracle/verdicts/pr-1083.md
+++ b/oracle/verdicts/pr-1083.md
@@ -1,0 +1,43 @@
+VERDICT: APPROVED
+PR: 1083
+Round: 1
+
+## Stage 1 — Vision alignment (written before reading implementation)
+
+vision.yaml operating principle-1 is "Proactive resilience over reactive recovery" and constraint-4 is "Minimize metabolic cost of cybernetic engagement." A system that false-positively detects quota exhaustion and puts itself to sleep until midnight violates both: it introduces reactive downtime that was never warranted, increasing Dan's screen dependency for recovery. The theory of change is correct — the PR fixes an availability failure mode in the system's self-restart logic. The foundational assumption holds: the log is confirmed append-only, `tail -20` is a known insufficient scope boundary when historical sessions write quota messages.
+
+The cheaper test check: could log rotation solve this? Yes, but that is a larger architectural change with its own risks (rotation races, other consumers of the log). The sentinel approach is surgical and does not foreclose rotation as a future improvement. The work is the right scope.
+
+Alignment verdict: Confirmed
+
+---
+
+## Stage 2 — Implementation quality review
+
+**Encoded Orientation check:** This change modifies how quota exhaustion is detected (the condition evaluation), not the decision itself (sleep until midnight when quota exhausted). The detection window narrows from "last 20 lines of full log" to "current session output only." This is a correctness fix, not a behavioral default change. Not an Encoded Orientation decision. No logged prior required.
+
+**Does it do what it claims?** Yes. The sentinel `=== SESSION_START attempt=$attempt ts=... ===` is written to the log immediately before the Claude subshell is launched. The awk command `/^=== SESSION_START /{buf=""} {buf=buf"\n"$0} END{print buf}` resets its accumulation buffer on each sentinel, so `current_session_output` contains only output from the most recent sentinel onward.
+
+**awk correctness:** The pattern `/^=== SESSION_START /` (with trailing space) matches `=== SESSION_START attempt=N ts=...` correctly. The buffer is reset on the sentinel line itself and then immediately includes that sentinel line — this is harmless since sentinel text doesn't match any quota or auth patterns. The `END{print buf}` produces the full current-session window. This is correct.
+
+**Edge case — no sentinel (first run, empty log):** If the log is absent, `awk ... 2>/dev/null` produces empty output, `current_session_output` is empty, and both grep checks return no match. Safe; no false positive, no false negative on first run. If the log exists but has no sentinel (script was updated mid-run, log written by old code), awk accumulates the full file into `buf` — same as old behavior. Safe fallback.
+
+**Variable scope:** `current_session_output` is declared `local` in the `else` branch of `handle_exit`. Both the quota check and the auth failure check are in the same `else` branch. The auth failure check uses `current_session_output` (not `tail -5` anymore), which is strictly more correct — auth failures anywhere in the session are relevant, not just the last five lines.
+
+**Consistency between checks:** The old code used `tail -20` for quota and `tail -5` for auth. The new code uses `current_session_output` for both. This is consistent and correct. Auth failures are less common than quota messages, and scanning the full session for them is fine.
+
+**Sentinel write error handling:** The sentinel echo has no `2>/dev/null` guard. If `$LOG_DIR` is missing, the write fails to stderr. This is not a new risk — the script already writes to `$LOG_DIR/claude-session.log` via the `tee -a` pipe on every launch, and `$LOG_DIR` is established early in the script. Missing `$LOG_DIR` would already be a loud failure before this code path.
+
+**buf initialization:** awk does not explicitly initialize `buf=""`  before the first line. awk variables default to empty string, so the first session's output is correctly accumulated from the start. If there are historical lines before the first sentinel, they are accumulated into `buf` and then cleared on the first sentinel. If there is no sentinel at all (see above), `buf` contains the full file — safe fallback.
+
+**Pattern check against learnings.md:** This is a shell script change. The mirror-constant pattern (PRs #696, #800, etc.) does not apply. The `uv`/`python3` bare-invocation concern does not apply — no Python invoked here. Feature-bundling check: one file changed, PR title exactly names the change. Migration check: no DB changes, no new directories, no config renames — no migration needed. No stale oracle path concerns.
+
+**What failure modes remain?**
+- If `$LOG_DIR` itself is on a full filesystem, the sentinel write silently fails (stderr only), and the awk fallback scans the full log (old behavior). Acceptable — this is an existing infrastructure failure mode, not a regression.
+- If Claude writes "out of extra usage" or similar to stderr rather than stdout, it would not appear in the tee'd log. This is also an existing limitation (the old `tail -20` had the same scope). Not a regression.
+
+**What patterns does this introduce?** The SESSION_START sentinel pattern is new in this codebase. It is a clean, named boundary marker in an append-only log. If other log consumers need session-scoped reads in the future, they can use the same sentinel. The pattern is reusable.
+
+**What does this make harder?** Nothing. The sentinel does not interfere with log rotation, grep-based analysis, or any existing log reader.
+
+**Summary:** The fix is mechanically correct, appropriately scoped, and introduces a reusable session-boundary pattern. Both detection checks now use consistent session-scoped input. No failure modes introduced. No oracle learnings patterns violated.

--- a/scheduled-tasks/pending-actions-nudge.py
+++ b/scheduled-tasks/pending-actions-nudge.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Pending-actions nudge job.
+
+Queries open action-item GitHub issues owned by Dan, buckets by age,
+and sends a Telegram ping if any bucket is non-empty.
+
+Cron schedule (daily at 15:00 UTC):
+    0 15 * * * cd ~/lobster && uv run scheduled-tasks/pending-actions-nudge.py >> ~/lobster-workspace/scheduled-jobs/logs/pending-actions-nudge.log 2>&1 # LOBSTER-PENDING-ACTIONS-NUDGE
+
+Type B dispatch: cron calls this script directly (no inbox/ message, no dispatcher
+involvement). The jobs.json enabled gate is checked at the top of main() so that
+runtime enable/disable is respected without touching cron.
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/pending-actions-nudge.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.inbox_write import write_inbox_message  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("pending-actions-nudge")
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate
+# ---------------------------------------------------------------------------
+
+
+def _is_job_enabled(job_name: str) -> bool:
+    """
+    Return True if the job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when jobs.json is absent, the entry is missing, or the
+    file is unreadable — mirrors the gate logic in other Type B jobs.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+    try:
+        data = json.loads(jobs_file.read_text())
+        return bool(data.get("jobs", {}).get(job_name, {}).get("enabled", True))
+    except Exception:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Pluggable source interface
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PendingAction:
+    title: str
+    url: str
+    created_at: datetime
+    owner: str
+
+
+def query_github_action_items(owner: str) -> list[PendingAction]:
+    """Query open action-item issues from GitHub, filtered by owner."""
+    repo = os.environ.get("ACTION_ITEMS_REPO", "dcetlin/Lobster")
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--label", "action-item",
+                "--state", "open",
+                "--json", "number,title,url,body,createdAt",
+                "--limit", "100",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.warning("gh issue list failed (exit %d): %s", exc.returncode, exc.stderr)
+        return []
+
+    try:
+        issues = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        log.warning("Failed to parse gh output: %s", exc)
+        return []
+
+    actions = []
+    for issue in issues:
+        body = issue.get("body") or ""
+        issue_owner = "dan"  # default — untagged issues belong to Dan
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("owner:"):
+                issue_owner = stripped.split(":", 1)[1].strip().lower()
+                break
+        if issue_owner != owner:
+            continue
+        try:
+            created_at = datetime.fromisoformat(issue["createdAt"].replace("Z", "+00:00"))
+        except (KeyError, ValueError) as exc:
+            log.warning("Skipping issue with bad createdAt: %s", exc)
+            continue
+        actions.append(PendingAction(
+            title=issue["title"],
+            url=issue["url"],
+            created_at=created_at,
+            owner=issue_owner,
+        ))
+    return actions
+
+
+# Sources list — append query_journal_todos here when journal-fed todo ships
+SOURCES: list = [query_github_action_items]
+
+
+def get_pending_actions(owner: str) -> list[PendingAction]:
+    results = []
+    for source in SOURCES:
+        results.extend(source(owner))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Age bucketing
+# ---------------------------------------------------------------------------
+
+
+def bucket_by_age(
+    actions: list[PendingAction],
+    now: datetime,
+) -> dict[str, list[PendingAction]]:
+    buckets: dict[str, list[PendingAction]] = {"14d": [], "7d": [], "3d": []}
+    for action in actions:
+        age_days = (now - action.created_at).days
+        if age_days >= 14:
+            buckets["14d"].append(action)
+        elif age_days >= 7:
+            buckets["7d"].append(action)
+        elif age_days >= 3:
+            buckets["3d"].append(action)
+    return buckets
+
+
+# ---------------------------------------------------------------------------
+# Message composition
+# ---------------------------------------------------------------------------
+
+
+def compose_message(buckets: dict[str, list[PendingAction]]) -> str | None:
+    parts = []
+    if buckets["14d"]:
+        titles = ", ".join(f"\"{a.title}\"" for a in buckets["14d"])
+        parts.append(f"Long-stale (14d+): {titles}")
+    if buckets["7d"]:
+        titles = ", ".join(f"\"{a.title}\"" for a in buckets["7d"])
+        parts.append(f"Still pending after a week: {titles}")
+    if buckets["3d"]:
+        n = len(buckets["3d"])
+        oldest = min(buckets["3d"], key=lambda a: a.created_at)
+        parts.append(
+            f"You have {n} item{'s' if n > 1 else ''} pending >3 days"
+            f" — oldest: \"{oldest.title}\""
+        )
+    if not parts:
+        return None
+    return "Pending actions nudge:\n" + "\n".join(f"• {p}" for p in parts)
+
+
+# ---------------------------------------------------------------------------
+# Telegram delivery — same inbox_write pattern as other cron-direct jobs
+# ---------------------------------------------------------------------------
+
+JOB_NAME = "pending-actions-nudge"
+
+
+def send_telegram(text: str, dry_run: bool = False) -> None:
+    chat_id = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
+    if dry_run:
+        print(f"[dry-run] Would send to {chat_id}:\n{text}")
+        return
+    timestamp = datetime.now(tz=timezone.utc).isoformat()
+    msg_id = write_inbox_message(JOB_NAME, chat_id, text, timestamp)
+    log.info("Telegram message queued (msg_id=%s)", msg_id)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pending-actions nudge — cron-direct Type B")
+    parser.add_argument("--dry-run", action="store_true", help="Print output without sending")
+    args = parser.parse_args()
+
+    if not args.dry_run and not _is_job_enabled(JOB_NAME):
+        log.info("%s disabled — skipping", JOB_NAME)
+        return 0
+
+    now = datetime.now(tz=timezone.utc)
+    actions = get_pending_actions(owner="dan")
+    buckets = bucket_by_age(actions, now)
+
+    log.info("Pending actions: %d total", len(actions))
+    for label, items in buckets.items():
+        log.info("  %s: %d items", label, len(items))
+
+    msg = compose_message(buckets)
+    if msg:
+        send_telegram(msg, dry_run=args.dry_run)
+    else:
+        log.info("No age thresholds met — no ping sent")
+        if args.dry_run:
+            print("No age thresholds met — no ping sent")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_orchestration/test_backlog_alerts.py
+++ b/tests/unit/test_orchestration/test_backlog_alerts.py
@@ -1,15 +1,15 @@
 """
-Tests for Phase 2d backlog alerts (toxicity + starvation governor) in steward-heartbeat.py.
+Tests for the backlog alert governor (Phase 2d of steward-heartbeat.py).
 
-Behavior verified (derived from spec, not from implementation):
+Behavior verified (derived from spec, not implementation):
 
 - test_load_backlog_state_returns_fresh_when_absent:
-  _load_backlog_state() returns {"depths": [], "last_updated": None} when state file
-  does not exist.
+  _load_backlog_state() returns {"depths": [], "last_updated": None} when
+  state file does not exist.
 
 - test_load_backlog_state_resets_when_stale:
-  State with last_updated 1000s ago (> _BACKLOG_STATE_MAX_AGE_SECONDS=900) returns
-  fresh state with empty depths.
+  State with last_updated 1000s ago (> _BACKLOG_STATE_MAX_AGE_SECONDS=900)
+  returns fresh state with empty depths.
 
 - test_load_backlog_state_preserves_recent_state:
   State with last_updated 60s ago is returned as-is.
@@ -18,37 +18,42 @@ Behavior verified (derived from spec, not from implementation):
   _save_backlog_state followed by _load_backlog_state returns the same depths.
 
 - test_no_alert_on_insufficient_history:
-  First call (no prior state) — no alert fires (not enough history yet).
+  registry.list returns 3 UoWs on first call — no alert fires (not enough history).
 
 - test_toxicity_alert_fires_after_n_consecutive_increases:
-  Seed state with depths [1, 2, 3], current depth=4 — toxicity alert fires.
+  Seed depths [1,2,3], current depth=4 — toxicity alert fires; _append_observation
+  called with "backlog_toxicity" in the message.
 
 - test_toxicity_alert_does_not_fire_on_plateau:
-  Seed state with depths [1, 2, 2], current depth=3 — NOT strictly increasing.
+  Seed depths [1,2,2], current depth=3 — last 4 values [1,2,2,3], second delta
+  is 0 — NOT strictly increasing — toxicity does not fire.
 
 - test_toxicity_alert_does_not_fire_on_decrease:
-  Seed state with depths [3, 4, 5], current depth=4 — not strictly increasing.
+  Seed depths [3,4,5], current depth=4 — not strictly increasing — no toxicity.
 
 - test_starvation_alert_fires_after_n_zero_cycles:
-  Seed state with depths [0, 0], current depth=0 — starvation alert fires.
+  Seed depths [0,0], current depth=0 — starvation fires (3 consecutive zeros).
 
 - test_starvation_alert_does_not_fire_on_single_zero:
-  Seed state with depths [0, 0], current depth=1 — starvation does not fire.
+  Seed depths [0,0], current depth=1 — last 3 values [0,0,1] — starvation
+  does not fire.
 
-- test_both_alerts_can_fire_independently:
-  Toxicity and starvation evaluations are independent.
+- test_both_alerts_independent:
+  Toxicity and starvation are evaluated independently and don't interfere.
 
 - test_dry_run_does_not_write_state_or_observation:
-  dry_run=True — state not written, observation not called; result still correct.
+  With toxicity condition met, dry_run=True — _save_backlog_state and
+  _append_observation are NOT called; toxicity_alert=True is still returned.
 
 - test_registry_failure_returns_safe_default:
   registry.list raises — returns BacklogAlertResult(0, False, False).
 
 - test_history_trimmed_to_max_length:
-  Seed with 10 depths — saved depths have length <= max(TOXICITY+1, STARVATION).
+  Seed state with 10 depths, run one cycle — saved depths have length <=
+  max(TOXICITY_CONSECUTIVE_CYCLES+1, STARVATION_CONSECUTIVE_CYCLES).
 
 - test_observation_message_includes_depth_and_growth:
-  When toxicity fires, _append_observation includes current depth and growth count.
+  When toxicity fires, _append_observation call includes depth and growth count.
 """
 
 from __future__ import annotations
@@ -70,7 +75,7 @@ for _p in [str(_ROOT), str(_ROOT / "src"), str(_ROOT / "scheduled-tasks")]:
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-# Load steward-heartbeat.py as a module (hyphen requires spec_from_file_location).
+# Load steward-heartbeat.py as a module (the hyphen requires spec_from_file_location).
 import importlib.util
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -103,12 +108,6 @@ _BACKLOG_STATE_MAX_AGE_SECONDS = _MODULE._BACKLOG_STATE_MAX_AGE_SECONDS
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_registry(depth: int) -> MagicMock:
-    mock = MagicMock()
-    mock.list.return_value = [MagicMock()] * depth
-    return mock
-
-
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -117,54 +116,52 @@ def _iso_ago(seconds: float) -> str:
     return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
 
 
+def _make_registry(depth: int = 0) -> MagicMock:
+    mock = MagicMock()
+    mock.list.return_value = [MagicMock() for _ in range(depth)]
+    return mock
+
+
 # ---------------------------------------------------------------------------
 # Pure state helper tests (no registry)
 # ---------------------------------------------------------------------------
 
 class TestLoadBacklogState:
 
-    def test_returns_fresh_when_absent(self, tmp_path):
+    def test_returns_fresh_when_absent(self, tmp_path) -> None:
         """_load_backlog_state returns fresh state when file does not exist."""
         missing = tmp_path / "no-such-file.json"
         with patch.object(_MODULE, "_backlog_state_path", return_value=missing):
-            state = _load_backlog_state()
-        assert state == {"depths": [], "last_updated": None}
+            result = _load_backlog_state()
+        assert result == {"depths": [], "last_updated": None}
 
-    def test_resets_when_stale(self, tmp_path):
-        """State with last_updated 1000s ago (> max age) returns empty depths."""
+    def test_resets_when_stale(self, tmp_path) -> None:
+        """State older than _BACKLOG_STATE_MAX_AGE_SECONDS is discarded."""
         state_file = tmp_path / "backlog-alert-state.json"
-        stale_state = {
-            "depths": [1, 2, 3],
-            "last_updated": _iso_ago(1000),
-        }
+        stale_state = {"depths": [1, 2, 3], "last_updated": _iso_ago(_BACKLOG_STATE_MAX_AGE_SECONDS + 100)}
         state_file.write_text(json.dumps(stale_state))
         with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
             result = _load_backlog_state()
         assert result["depths"] == []
+        assert result["last_updated"] is None
 
-    def test_preserves_recent_state(self, tmp_path):
-        """State with last_updated 60s ago is returned unchanged."""
+    def test_preserves_recent_state(self, tmp_path) -> None:
+        """State written 60s ago is returned unchanged."""
         state_file = tmp_path / "backlog-alert-state.json"
-        recent_state = {
-            "depths": [1, 2, 3],
-            "last_updated": _iso_ago(60),
-        }
+        recent_state = {"depths": [5, 6, 7], "last_updated": _iso_ago(60)}
         state_file.write_text(json.dumps(recent_state))
         with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
             result = _load_backlog_state()
-        assert result["depths"] == [1, 2, 3]
+        assert result["depths"] == [5, 6, 7]
 
-
-class TestSaveLoadRoundtrip:
-
-    def test_save_and_load_roundtrip(self, tmp_path):
-        """_save_backlog_state + _load_backlog_state preserves depths."""
+    def test_save_and_load_roundtrip(self, tmp_path) -> None:
+        """_save_backlog_state followed by _load_backlog_state returns identical depths."""
         state_file = tmp_path / "backlog-alert-state.json"
         original = {"depths": [1, 2, 3], "last_updated": _now_iso()}
         with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
             _save_backlog_state(original)
-            restored = _load_backlog_state()
-        assert restored["depths"] == [1, 2, 3]
+            result = _load_backlog_state()
+        assert result["depths"] == [1, 2, 3]
 
 
 # ---------------------------------------------------------------------------
@@ -173,127 +170,124 @@ class TestSaveLoadRoundtrip:
 
 class TestCheckBacklogAlerts:
 
-    def _run(self, registry, state: dict, tmp_path, dry_run: bool = False):
-        """Run check_backlog_alerts with a patched state file."""
-        state_file = tmp_path / "backlog-alert-state.json"
-        if state is not None:
-            state_file.write_text(json.dumps(state))
+    def _run(self, registry, seed_depths: list[int], current_depth: int, dry_run: bool = False):
+        """Helper: seed state, set registry depth, run check_backlog_alerts."""
+        state = {"depths": seed_depths[:], "last_updated": _now_iso() if seed_depths else None}
+        registry.list.return_value = [MagicMock() for _ in range(current_depth)]
 
-        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
-            with patch.object(_MODULE, "_append_observation") as mock_obs:
-                result = check_backlog_alerts(registry, dry_run=dry_run)
-        return result, mock_obs, state_file
+        with patch.object(_MODULE, "_load_backlog_state", return_value=state), \
+             patch.object(_MODULE, "_save_backlog_state") as mock_save, \
+             patch.object(_MODULE, "_append_observation") as mock_obs:
+            result = check_backlog_alerts(registry, dry_run=dry_run)
+            return result, mock_save, mock_obs
 
-    def test_no_alert_on_insufficient_history(self, tmp_path):
-        """First invocation with no prior state — no alert fires."""
-        registry = _make_registry(depth=3)
-        result, mock_obs, _ = self._run(registry, state=None, tmp_path=tmp_path)
+    def test_no_alert_on_insufficient_history(self) -> None:
+        """First invocation: not enough history to fire any alert."""
+        registry = _make_registry()
+        result, _, _ = self._run(registry, seed_depths=[], current_depth=3)
         assert result.backlog_depth == 3
         assert result.toxicity_alert is False
         assert result.starvation_alert is False
-        mock_obs.assert_not_called()
 
-    def test_toxicity_alert_fires_after_n_consecutive_increases(self, tmp_path):
-        """Seed [1,2,3], current=4 → 4 strictly increasing values → toxicity fires."""
-        # TOXICITY_CONSECUTIVE_CYCLES=3, need 4 strictly increasing values
-        registry = _make_registry(depth=4)
-        seed = {"depths": [1, 2, 3], "last_updated": _iso_ago(60)}
-        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+    def test_toxicity_alert_fires_after_n_consecutive_increases(self) -> None:
+        """Seed [1,2,3], current=4 → strictly increasing over 4 values → toxicity fires."""
+        registry = _make_registry()
+        # After append: [1,2,3,4] — 4 values all strictly increasing
+        result, _, mock_obs = self._run(registry, seed_depths=[1, 2, 3], current_depth=4)
         assert result.toxicity_alert is True
         mock_obs.assert_called_once()
         assert "backlog_toxicity" in mock_obs.call_args[0][0]
 
-    def test_toxicity_alert_does_not_fire_on_plateau(self, tmp_path):
-        """Seed [1,2,2], current=3 → [1,2,2,3] has delta 0 at position 2 → not strictly increasing."""
-        registry = _make_registry(depth=3)
-        seed = {"depths": [1, 2, 2], "last_updated": _iso_ago(60)}
-        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+    def test_toxicity_alert_does_not_fire_on_plateau(self) -> None:
+        """Seed [1,2,2], current=3 → [1,2,2,3]: delta at index 2→3 is 0 → not strictly increasing."""
+        registry = _make_registry()
+        result, _, mock_obs = self._run(registry, seed_depths=[1, 2, 2], current_depth=3)
         assert result.toxicity_alert is False
         mock_obs.assert_not_called()
 
-    def test_toxicity_alert_does_not_fire_on_decrease(self, tmp_path):
-        """Seed [3,4,5], current=4 → last 4 are [3,4,5,4] — not strictly increasing."""
-        registry = _make_registry(depth=4)
-        seed = {"depths": [3, 4, 5], "last_updated": _iso_ago(60)}
-        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+    def test_toxicity_alert_does_not_fire_on_decrease(self) -> None:
+        """Seed [3,4,5], current=4 → not strictly increasing → no toxicity."""
+        registry = _make_registry()
+        result, _, mock_obs = self._run(registry, seed_depths=[3, 4, 5], current_depth=4)
         assert result.toxicity_alert is False
-        mock_obs.assert_not_called()
 
-    def test_starvation_alert_fires_after_n_zero_cycles(self, tmp_path):
+    def test_starvation_alert_fires_after_n_zero_cycles(self) -> None:
         """Seed [0,0], current=0 → 3 consecutive zeros → starvation fires."""
-        registry = _make_registry(depth=0)
-        seed = {"depths": [0, 0], "last_updated": _iso_ago(60)}
-        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        registry = _make_registry()
+        result, _, mock_obs = self._run(registry, seed_depths=[0, 0], current_depth=0)
         assert result.starvation_alert is True
-        mock_obs.assert_called_once()
         assert "backlog_starvation" in mock_obs.call_args[0][0]
 
-    def test_starvation_alert_does_not_fire_on_single_zero(self, tmp_path):
-        """Seed [0,0], current=1 → last 3 are [0,0,1] — not all at threshold."""
-        registry = _make_registry(depth=1)
-        seed = {"depths": [0, 0], "last_updated": _iso_ago(60)}
-        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
-        assert result.starvation_alert is False
-        mock_obs.assert_not_called()
-
-    def test_both_alerts_independent(self, tmp_path):
-        """Toxicity and starvation are evaluated independently — neither blocks the other."""
-        # Test that starvation can fire without toxicity, and vice versa
-        # (already proven by other tests); here confirm both can be False independently
-        registry = _make_registry(depth=2)
-        seed = {"depths": [1, 2], "last_updated": _iso_ago(60)}
-        result, _, _ = self._run(registry, state=seed, tmp_path=tmp_path)
-        # [1, 2, 2] — not strictly increasing, not starvation
-        assert result.toxicity_alert is False
+    def test_starvation_alert_does_not_fire_on_single_zero(self) -> None:
+        """Seed [0,0], current=1 → last 3 are [0,0,1] → starvation does not fire."""
+        registry = _make_registry()
+        result, _, mock_obs = self._run(registry, seed_depths=[0, 0], current_depth=1)
         assert result.starvation_alert is False
 
-    def test_dry_run_does_not_write_state_or_observation(self, tmp_path):
-        """dry_run=True: state not saved, no observation; result still reflects alert."""
-        registry = _make_registry(depth=4)
-        seed = {"depths": [1, 2, 3], "last_updated": _iso_ago(60)}
-        state_file = tmp_path / "backlog-alert-state.json"
-        state_file.write_text(json.dumps(seed))
+    def test_both_alerts_independent(self) -> None:
+        """Toxicity and starvation detection are independent of each other."""
+        registry = _make_registry()
+        # Toxicity condition: strictly increasing
+        result_tox, _, _ = self._run(registry, seed_depths=[1, 2, 3], current_depth=4)
+        assert result_tox.toxicity_alert is True
+        assert result_tox.starvation_alert is False  # depth=4, not zero
 
-        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
-            with patch.object(_MODULE, "_save_backlog_state") as mock_save:
-                with patch.object(_MODULE, "_append_observation") as mock_obs:
-                    result = check_backlog_alerts(registry, dry_run=True)
+        # Starvation condition
+        result_starv, _, _ = self._run(registry, seed_depths=[0, 0], current_depth=0)
+        assert result_starv.starvation_alert is True
+        assert result_starv.toxicity_alert is False  # [0,0,0] not strictly increasing
 
+    def test_dry_run_does_not_write_state_or_observation(self) -> None:
+        """dry_run=True: toxicity still detected but no state write or observation."""
+        registry = _make_registry()
+        result, mock_save, mock_obs = self._run(
+            registry, seed_depths=[1, 2, 3], current_depth=4, dry_run=True
+        )
         assert result.toxicity_alert is True
         mock_save.assert_not_called()
         mock_obs.assert_not_called()
 
-    def test_registry_failure_returns_safe_default(self, tmp_path):
-        """registry.list raises → returns BacklogAlertResult(0, False, False)."""
+    def test_registry_failure_returns_safe_default(self) -> None:
+        """When registry.list raises, returns BacklogAlertResult(0, False, False)."""
         registry = MagicMock()
-        registry.list.side_effect = RuntimeError("DB error")
-        state_file = tmp_path / "backlog-alert-state.json"
-        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
-            result = check_backlog_alerts(registry)
+        registry.list.side_effect = RuntimeError("DB locked")
+        result = check_backlog_alerts(registry)
         assert result == BacklogAlertResult(backlog_depth=0, toxicity_alert=False, starvation_alert=False)
 
-    def test_history_trimmed_to_max_length(self, tmp_path):
-        """Seed with 10 depths → saved depths length <= max(TOXICITY+1, STARVATION)."""
-        max_expected = max(TOXICITY_CONSECUTIVE_CYCLES + 1, STARVATION_CONSECUTIVE_CYCLES)
-        registry = _make_registry(depth=5)
-        seed = {"depths": list(range(10)), "last_updated": _iso_ago(60)}
-        state_file = tmp_path / "backlog-alert-state.json"
-        state_file.write_text(json.dumps(seed))
+    def test_history_trimmed_to_max_length(self) -> None:
+        """After one cycle, saved depths length <= max(TOXICITY_CONSECUTIVE_CYCLES+1, STARVATION_CONSECUTIVE_CYCLES)."""
+        registry = _make_registry()
+        seed = list(range(10))  # 10 depths
+        expected_max = max(TOXICITY_CONSECUTIVE_CYCLES + 1, STARVATION_CONSECUTIVE_CYCLES)
 
-        with patch.object(_MODULE, "_backlog_state_path", return_value=state_file):
-            with patch.object(_MODULE, "_append_observation"):
-                check_backlog_alerts(registry, dry_run=False)
-            saved = json.loads(state_file.read_text())
+        saved_state = {}
 
-        assert len(saved["depths"]) <= max_expected
+        def capture_save(state: dict) -> None:
+            saved_state.update(state)
 
-    def test_observation_message_includes_depth_and_growth(self, tmp_path):
-        """When toxicity fires, message includes current_depth and growth."""
-        registry = _make_registry(depth=5)
-        seed = {"depths": [2, 3, 4], "last_updated": _iso_ago(60)}
-        result, mock_obs, _ = self._run(registry, state=seed, tmp_path=tmp_path)
+        state_in = {"depths": seed[:], "last_updated": _now_iso()}
+        registry.list.return_value = [MagicMock()]  # depth=1
+
+        with patch.object(_MODULE, "_load_backlog_state", return_value=state_in), \
+             patch.object(_MODULE, "_save_backlog_state", side_effect=capture_save), \
+             patch.object(_MODULE, "_append_observation"):
+            check_backlog_alerts(registry)
+
+        assert len(saved_state["depths"]) <= expected_max
+
+    def test_observation_message_includes_depth_and_growth(self) -> None:
+        """When toxicity fires, _append_observation message includes current_depth and growth."""
+        registry = _make_registry()
+        # Seed [1,2,3], current=4 → growth = 4-1 = 3
+        state = {"depths": [1, 2, 3], "last_updated": _now_iso()}
+        registry.list.return_value = [MagicMock() for _ in range(4)]
+
+        with patch.object(_MODULE, "_load_backlog_state", return_value=state), \
+             patch.object(_MODULE, "_save_backlog_state"), \
+             patch.object(_MODULE, "_append_observation") as mock_obs:
+            result = check_backlog_alerts(registry)
+
         assert result.toxicity_alert is True
         msg = mock_obs.call_args[0][0]
-        assert "current_depth=5" in msg
-        # growth = 5 - 2 = 3
+        assert "current_depth=4" in msg
         assert "growth=+3" in msg

--- a/tests/unit/test_orchestration/test_wos_pr_sweep_result_handler.py
+++ b/tests/unit/test_orchestration/test_wos_pr_sweep_result_handler.py
@@ -1,0 +1,232 @@
+"""
+Tests for the wos_pr_sweep_result dispatcher handler.
+
+Spec:
+  - ``wos_pr_sweep_result`` is registered in WOS_MESSAGE_TYPE_DISPATCH.
+  - ``handle_wos_pr_sweep_result(msg)`` is a pure function returning
+    action="send_reply" with the pre-formatted notification text.
+  - ``chat_id`` is cast to int; falls back to LOBSTER_ADMIN_CHAT_ID env var,
+    then to 0.
+  - Missing ``text`` field falls back to the sentinel string
+    "WOS PR sweep results (no detail available)".
+  - Extra unknown fields do not raise.
+  - ``route_wos_message`` dispatches ``wos_pr_sweep_result`` to
+    ``handle_wos_pr_sweep_result`` via the fast-path block; on handler
+    exception it returns action="send_reply" with error text.
+  - The PR sweeper's ``_should_notify`` deduplication function honours a
+    24-hour cooldown and treats corrupt records as no record.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.orchestration.dispatcher_handlers import (
+    WOS_MESSAGE_TYPE_DISPATCH,
+    handle_wos_pr_sweep_result,
+    route_wos_message,
+)
+
+# ---------------------------------------------------------------------------
+# Load wos-pr-sweeper.py via importlib (it is a script, not a package)
+# ---------------------------------------------------------------------------
+
+_sweeper_path = (
+    Path(__file__).parent.parent.parent.parent
+    / "scheduled-tasks"
+    / "wos-pr-sweeper.py"
+)
+_spec = importlib.util.spec_from_file_location("wos_pr_sweeper", _sweeper_path)
+_sweeper = importlib.util.module_from_spec(_spec)
+import sys as _sys
+_sys.modules["wos_pr_sweeper"] = _sweeper
+_spec.loader.exec_module(_sweeper)
+
+_should_notify = _sweeper._should_notify
+NOTIFICATION_COOLDOWN_HOURS = _sweeper.NOTIFICATION_COOLDOWN_HOURS
+
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+
+def _make_sweep_msg(
+    text: str = "2 stale open PRs found",
+    chat_id: int = 12345,
+    stale_open_count: int = 2,
+    merged_pending_close_count: int = 0,
+) -> dict:
+    """Build a minimal wos_pr_sweep_result inbox message."""
+    return {
+        "type": "wos_pr_sweep_result",
+        "text": text,
+        "chat_id": chat_id,
+        "data": {
+            "stale_open_count": stale_open_count,
+            "merged_pending_close_count": merged_pending_close_count,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestWosPrSweepResultRegistered:
+    """wos_pr_sweep_result must be registered in the dispatch table."""
+
+    def test_wos_pr_sweep_result_in_dispatch_table(self):
+        assert "wos_pr_sweep_result" in WOS_MESSAGE_TYPE_DISPATCH, (
+            "'wos_pr_sweep_result' must appear in WOS_MESSAGE_TYPE_DISPATCH "
+            "so the dispatcher's structural routing table can fire for it"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stale open PR notification
+# ---------------------------------------------------------------------------
+
+class TestStaleOpenPRNotification:
+    """Handler correctly surfaces stale-open-PR sweep results."""
+
+    def test_returns_send_reply_action(self):
+        msg = _make_sweep_msg(text="3 stale open PRs detected", stale_open_count=3)
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["action"] == "send_reply"
+
+    def test_text_matches_input(self):
+        notification = "3 stale open PRs detected — review needed"
+        msg = _make_sweep_msg(text=notification, stale_open_count=3)
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["text"] == notification
+
+    def test_message_type_is_wos_pr_sweep_result(self):
+        msg = _make_sweep_msg(stale_open_count=1)
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["message_type"] == "wos_pr_sweep_result"
+
+    def test_chat_id_cast_to_int(self):
+        msg = _make_sweep_msg(chat_id=99999)
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["chat_id"] == 99999
+        assert isinstance(result["chat_id"], int)
+
+
+# ---------------------------------------------------------------------------
+# Merged PR / UoW not done notification
+# ---------------------------------------------------------------------------
+
+class TestMergedPRUoWNotDoneNotification:
+    """Handler correctly surfaces merged-PR-with-pending-UoW sweep results."""
+
+    def test_returns_send_reply_action(self):
+        msg = _make_sweep_msg(
+            text="1 merged PR has a non-done UoW",
+            merged_pending_close_count=1,
+        )
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["action"] == "send_reply"
+
+    def test_text_matches_input(self):
+        notification = "PR #42 merged but UoW uow_20260501_abc123 is still open"
+        msg = _make_sweep_msg(text=notification, merged_pending_close_count=1)
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["text"] == notification
+
+    def test_message_type_is_wos_pr_sweep_result(self):
+        msg = _make_sweep_msg(merged_pending_close_count=2)
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["message_type"] == "wos_pr_sweep_result"
+
+
+# ---------------------------------------------------------------------------
+# Fallback / graceful handling
+# ---------------------------------------------------------------------------
+
+class TestHandlerFallbackGracefulHandling:
+    """Handler degrades gracefully when expected fields are absent."""
+
+    def test_missing_text_uses_fallback_string(self):
+        msg = {"type": "wos_pr_sweep_result", "chat_id": 1}
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["text"] == "WOS PR sweep results (no detail available)"
+
+    def test_missing_chat_id_falls_back_to_zero(self, monkeypatch):
+        monkeypatch.delenv("LOBSTER_ADMIN_CHAT_ID", raising=False)
+        msg = {"type": "wos_pr_sweep_result", "text": "some results"}
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["chat_id"] == 0
+
+    def test_extra_unknown_fields_do_not_raise(self):
+        msg = _make_sweep_msg()
+        msg["unexpected_field"] = {"nested": True}
+        msg["another_field"] = 42
+        result = handle_wos_pr_sweep_result(msg)
+        assert result["action"] == "send_reply"
+
+
+# ---------------------------------------------------------------------------
+# Deduplication cooldown (from wos-pr-sweeper.py)
+# ---------------------------------------------------------------------------
+
+class TestDeduplicationCooldown:
+    """_should_notify honours NOTIFICATION_COOLDOWN_HOURS and handles edge cases."""
+
+    def test_no_prior_record_returns_true(self):
+        assert _should_notify("SiderealPress/lobster#99", {}) is True
+
+    def test_notified_within_cooldown_returns_false(self):
+        key = "SiderealPress/lobster#100"
+        now_iso = datetime.now(timezone.utc).isoformat()
+        state = {key: {"last_notified_at": now_iso}}
+        assert _should_notify(key, state) is False
+
+    def test_notified_beyond_cooldown_returns_true(self):
+        key = "SiderealPress/lobster#101"
+        old_iso = (
+            datetime.now(timezone.utc) - timedelta(hours=NOTIFICATION_COOLDOWN_HOURS + 1)
+        ).isoformat()
+        state = {key: {"last_notified_at": old_iso}}
+        assert _should_notify(key, state) is True
+
+    def test_corrupt_last_notified_at_treated_as_no_record(self):
+        key = "SiderealPress/lobster#102"
+        state = {key: {"last_notified_at": "not-a-date"}}
+        assert _should_notify(key, state) is True
+
+
+# ---------------------------------------------------------------------------
+# route_wos_message fast-path integration
+# ---------------------------------------------------------------------------
+
+class TestRouteWosMessageFastPath:
+    """route_wos_message dispatches wos_pr_sweep_result via the fast-path block."""
+
+    def test_well_formed_message_returns_send_reply(self):
+        msg = _make_sweep_msg()
+        result = route_wos_message(msg)
+        assert result["action"] == "send_reply"
+
+    def test_well_formed_message_returns_correct_message_type(self):
+        msg = _make_sweep_msg()
+        result = route_wos_message(msg)
+        assert result["message_type"] == "wos_pr_sweep_result"
+
+    def test_handler_exception_is_caught_returns_send_reply(self, monkeypatch):
+        def _raise(msg):
+            raise RuntimeError("simulated handler failure")
+
+        monkeypatch.setattr(
+            "src.orchestration.dispatcher_handlers.handle_wos_pr_sweep_result",
+            _raise,
+        )
+        msg = _make_sweep_msg()
+        result = route_wos_message(msg)
+        assert result["action"] == "send_reply", (
+            "route_wos_message must catch handler exceptions and return "
+            "action='send_reply' with error text rather than propagating"
+        )


### PR DESCRIPTION
## Summary

- Adds `check_backlog_alerts()` to `steward-heartbeat.py` as Phase 2d of the observation loop
- **Toxicity**: fires when the `ready-for-executor` queue depth strictly increases for `TOXICITY_CONSECUTIVE_CYCLES` (3) consecutive cron invocations — signals executor under-capacity
- **Starvation**: fires when queue depth stays at or below 0 for `STARVATION_CONSECUTIVE_CYCLES` (3) consecutive cycles — signals cultivator/germinator stoppage
- State persisted atomically to `~/lobster-workspace/logs/backlog-alert-state.json`; state older than 15 min is discarded (avoids false alerts after planned downtime)
- Phase 2d runs **before** the `execution_enabled` gate so monitoring is active even when WOS is paused
- Alert delivery is `log.warning` + `_append_observation` only — no Telegram, no inbox message

## Test plan

- [ ] `uv run pytest tests/unit/test_orchestration/test_backlog_alerts.py -v` — 15 tests pass
- [ ] `uv run ~/lobster/scheduled-tasks/steward-heartbeat.py --dry-run` exits 0 with `Backlog alert check complete` log line
- [ ] `grep "Phase 2d" scheduled-tasks/steward-heartbeat.py` confirms wiring in `main()`

## Files changed

- `scheduled-tasks/steward-heartbeat.py` — constants, helpers, `BacklogAlertResult`, `check_backlog_alerts`, Phase 2d block in `main()`
- `tests/unit/test_orchestration/test_backlog_alerts.py` — 15 unit tests (new file)

WOS-UoW: uow_20260502_8527e0

🤖 Generated with [Claude Code](https://claude.com/claude-code)