### PR TITLE
fix(wos): off-by-one in execution_attempts retry cap

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -4548,7 +4548,7 @@ def _process_uow(
         is_infra_event = _is_infrastructure_event(return_reason)
         new_execution_attempts = uow.execution_attempts + (0 if is_infra_event else 1)
 
-        if new_execution_attempts > MAX_RETRIES:
+        if new_execution_attempts >= MAX_RETRIES:
             # Execution retry cap exceeded — escalate to needs-human-review.
             escalation_entry = {
                 "event": "retry_cap_exceeded",


### PR DESCRIPTION
## Summary

- Changes `> MAX_RETRIES` to `>= MAX_RETRIES` in the `_process_uow` escalation gate in `steward.py`
- The prior condition required `execution_attempts` to reach MAX_RETRIES+1 (4) before escalating; the correct behavior is to escalate when confirmed attempts reach the cap (MAX_RETRIES=3)
- All 46 tests in `tests/ooda/` pass with the fix

## Test plan

- [x] `tests/ooda/test_retry_cap.py::TestRetryCapEscalation::test_steward_escalates_when_execution_attempts_at_cap` — PASSED
- [x] `tests/ooda/test_retry_accounting_discriminator.py::TestGenuineExecutionConsumesRetryBudget::test_three_genuine_failures_exhaust_retry_cap` — PASSED
- [x] Full `tests/ooda/` suite: 46 passed

WOS-UoW: uow_20260427_4cbbbf

🤖 Generated with [Claude Code](https://claude.com/claude-code)