### PR TITLE
fix(tests): add mirror-constant lint, fix 25 violations

### DIFF
--- a/tests/test_no_mirror_constants.py
+++ b/tests/test_no_mirror_constants.py
@@ -1,0 +1,171 @@
+"""
+Lint test: detect test files that re-declare production constants as module-level
+literals instead of importing or accessing them through the production module.
+
+When a production constant changes, a mirrored test constant silently drifts,
+causing assertions to pass against a stale value. This test enforces the rule:
+always import or access constants from the production module.
+
+See oracle/learnings.md entries for PRs #696, #800, #967, #970.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent
+
+PRODUCTION_DIRS: Tuple[Path, ...] = (
+    REPO_ROOT / "src",
+    REPO_ROOT / "scheduled-tasks",
+)
+
+TEST_DIR: Path = REPO_ROOT / "tests"
+
+# Minimum 3 characters, all uppercase letters/digits/underscores
+ALL_CAPS_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{2,}$")
+
+# Names that are intentionally the same across test and production but are not
+# mirrors of production values. Add sparingly — prefer fixing the import.
+#
+# LOBSTER_JID: test files use test-specific JID values ("19995551234@c.us"),
+#   while production reads from WHATSAPP_LOBSTER_JID env var. Same name, different purpose.
+# ADMIN_CHAT_ID: test files use hardcoded test chat IDs, while production reads
+#   from LOBSTER_ADMIN_CHAT_ID env var with a different default. Same name, different purpose.
+MIRROR_CONSTANT_ALLOWLIST: frozenset[str] = frozenset({
+    "LOBSTER_JID",
+    "ADMIN_CHAT_ID",
+})
+
+
+# ---------------------------------------------------------------------------
+# AST helpers — pure functions over parsed trees
+# ---------------------------------------------------------------------------
+
+
+def _collect_module_level_constants(
+    tree: ast.Module,
+) -> Dict[str, int]:
+    """Return a mapping of ALL_CAPS names -> line number from module-level assignments.
+
+    Considers both plain assignments (ast.Assign) and annotated assignments
+    (ast.AnnAssign, e.g. ``FOO: int = 42``) at the top level — not inside
+    classes or functions. Only names matching the ALL_CAPS pattern are collected.
+    """
+    constants: Dict[str, int] = {}
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            # Every target must be a simple ALL_CAPS name
+            if not all(
+                isinstance(t, ast.Name) and ALL_CAPS_PATTERN.match(t.id)
+                for t in node.targets
+            ):
+                continue
+            for target in node.targets:
+                assert isinstance(target, ast.Name)
+                constants[target.id] = node.lineno
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            # Annotated assignment: ``FOO: int = 42``
+            target = node.target
+            if isinstance(target, ast.Name) and ALL_CAPS_PATTERN.match(target.id):
+                constants[target.id] = node.lineno
+    return constants
+
+
+def _build_production_constant_index(
+    production_dirs: Tuple[Path, ...],
+) -> Dict[str, List[Tuple[Path, int]]]:
+    """Parse all .py files in production directories and collect module-level ALL_CAPS constants.
+
+    Returns a mapping: constant_name -> [(file_path, line_number), ...].
+    """
+    index: Dict[str, List[Tuple[Path, int]]] = {}
+    for prod_dir in production_dirs:
+        if not prod_dir.exists():
+            continue
+        for py_file in sorted(prod_dir.rglob("*.py")):
+            try:
+                source = py_file.read_text(encoding="utf-8")
+                tree = ast.parse(source, filename=str(py_file))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            constants = _collect_module_level_constants(tree)
+            for name, lineno in constants.items():
+                index.setdefault(name, []).append((py_file, lineno))
+    return index
+
+
+def _scan_test_files_for_violations(
+    test_dir: Path,
+    production_index: Dict[str, List[Tuple[Path, int]]],
+    allowlist: frozenset[str],
+    self_path: Path,
+) -> List[str]:
+    """Scan all test .py files for module-level ALL_CAPS assignments that shadow production constants.
+
+    Returns a list of human-readable violation strings.
+    """
+    violations: List[str] = []
+    if not test_dir.exists():
+        return violations
+
+    for test_file in sorted(test_dir.rglob("*.py")):
+        # Skip ourselves
+        if test_file.resolve() == self_path.resolve():
+            continue
+        try:
+            source = test_file.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(test_file))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        test_constants = _collect_module_level_constants(tree)
+        for name, test_lineno in sorted(test_constants.items()):
+            if name in allowlist:
+                continue
+            if name not in production_index:
+                continue
+            # Build the violation message
+            prod_locations = production_index[name]
+            rel_test = test_file.relative_to(REPO_ROOT)
+            prod_lines = "; ".join(
+                f"{loc.relative_to(REPO_ROOT)}:{lineno}"
+                for loc, lineno in prod_locations
+            )
+            violations.append(
+                f"MIRROR CONSTANT: {rel_test}:{test_lineno} {name}\n"
+                f"  Also defined in: {prod_lines}\n"
+                f"  Fix: import or access from the production module instead of re-declaring."
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# The test
+# ---------------------------------------------------------------------------
+
+
+def test_no_mirror_constants():
+    """No test file should re-declare a production constant at module level.
+
+    Import or access the constant from the production module instead.
+    """
+    production_index = _build_production_constant_index(PRODUCTION_DIRS)
+    violations = _scan_test_files_for_violations(
+        TEST_DIR,
+        production_index,
+        MIRROR_CONSTANT_ALLOWLIST,
+        self_path=Path(__file__),
+    )
+    assert violations == [], (
+        "Test files must not re-declare production constants at module level. "
+        "Import or access them from the production module instead.\n\n"
+        + "\n\n".join(violations)
+    )

--- a/tests/unit/los/test_schema.py
+++ b/tests/unit/los/test_schema.py
@@ -26,15 +26,15 @@ from src.los.db import (
     find_duplicate,
     increment_mention_count,
 )
+from src.los.extractor import PRIORITY_DEFAULT  # noqa: F401
 
 
 # ---------------------------------------------------------------------------
-# Priority constants (no enum in production — local-only, not status mirrors)
+# Priority constants (local test-only values)
 # ---------------------------------------------------------------------------
 
 PRIORITY_HIGH = 1
 PRIORITY_LOW = 10
-PRIORITY_DEFAULT = 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
+++ b/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
@@ -13,12 +13,40 @@ These tests are written spec-first and serve as a living contract for the
 `lobstertalk-unified` task definition.
 """
 
+import importlib.util
 import json
+import os
+import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# Load the production module to access named constants
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scheduled-tasks" / "lobstertalk_unified.py"
+
+
+def _load_lobstertalk_unified():
+    # The module requires several env vars at import time; provide test stubs.
+    _tmp = tempfile.mkdtemp()
+    os.environ.setdefault("BOT_TALK_URL", "http://localhost:0/test")
+    os.environ.setdefault("BOT_TALK_SENDER", "TestLobster")
+    os.environ.setdefault("LOBSTER_ADMIN_CHAT_ID", "12345")
+    spec = importlib.util.spec_from_file_location(
+        "lobstertalk_unified_direction_test", _SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_lt = _load_lobstertalk_unified()
 
 # ---------------------------------------------------------------------------
 # Pure helper implementations mirroring the task definition's direction
@@ -79,9 +107,6 @@ def advance_cursor(messages: list[dict], current_ts: str) -> str:
     return max(m["timestamp"] for m in messages)
 
 
-HOT_MODE_TIMEOUT_SECS = 20 * 60  # 20 minutes
-
-
 def update_hot_mode(
     state: dict[str, Any],
     messages_received: int,
@@ -90,7 +115,7 @@ def update_hot_mode(
     """Return updated state with hot-mode transitions applied.
 
     Hot-mode entry: any messages received → hot_mode=True, update last_activity_ts.
-    Hot-mode exit: time-based — if now - last_activity_ts >= HOT_MODE_TIMEOUT_SECS,
+    Hot-mode exit: time-based — if now - last_activity_ts >= _lt.HOT_MODE_TIMEOUT_SECS,
     exit hot mode regardless of poll count.
     """
     if now is None:
@@ -109,7 +134,7 @@ def update_hot_mode(
                 if last_dt.tzinfo is None:
                     last_dt = last_dt.replace(tzinfo=timezone.utc)
                 idle_secs = (now - last_dt).total_seconds()
-                if idle_secs >= HOT_MODE_TIMEOUT_SECS:
+                if idle_secs >= _lt.HOT_MODE_TIMEOUT_SECS:
                     state["hot_mode"] = False
                     state["hot_mode_activated_at"] = None
             except (ValueError, TypeError):

--- a/tests/unit/test_mcp_server/test_reconciler_workstream_gate.py
+++ b/tests/unit/test_mcp_server/test_reconciler_workstream_gate.py
@@ -12,9 +12,17 @@ server.
 """
 
 import os
+import sys
 import time
+from pathlib import Path
 
 import pytest
+
+_ROOT = Path(__file__).parents[3]
+if str(_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_ROOT / "src"))
+
+from agents.session_store import WORKSTREAM_STATUS_STALE_SECONDS  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -24,7 +32,6 @@ import pytest
 DEFAULT_DEAD_THRESHOLD_SECONDS = 30 * 60
 DEFAULT_DEAD_THRESHOLD_RUNNING_SECONDS = 120 * 60
 MTIME_STALE_THRESHOLD_SECONDS = 15 * 60
-WORKSTREAM_STATUS_STALE_SECONDS = 600  # 10 min
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_backlog_alerts.py
+++ b/tests/unit/test_orchestration/test_backlog_alerts.py
@@ -98,9 +98,6 @@ _save_backlog_state = _MODULE._save_backlog_state
 _backlog_state_path = _MODULE._backlog_state_path
 check_backlog_alerts = _MODULE.check_backlog_alerts
 BacklogAlertResult = _MODULE.BacklogAlertResult
-TOXICITY_CONSECUTIVE_CYCLES = _MODULE.TOXICITY_CONSECUTIVE_CYCLES
-STARVATION_CONSECUTIVE_CYCLES = _MODULE.STARVATION_CONSECUTIVE_CYCLES
-STARVATION_MIN_DEPTH = _MODULE.STARVATION_MIN_DEPTH
 _BACKLOG_STATE_MAX_AGE_SECONDS = _MODULE._BACKLOG_STATE_MAX_AGE_SECONDS
 
 
@@ -258,7 +255,7 @@ class TestCheckBacklogAlerts:
         """After one cycle, saved depths length <= max(TOXICITY_CONSECUTIVE_CYCLES+1, STARVATION_CONSECUTIVE_CYCLES)."""
         registry = _make_registry()
         seed = list(range(10))  # 10 depths
-        expected_max = max(TOXICITY_CONSECUTIVE_CYCLES + 1, STARVATION_CONSECUTIVE_CYCLES)
+        expected_max = max(_MODULE.TOXICITY_CONSECUTIVE_CYCLES + 1, _MODULE.STARVATION_CONSECUTIVE_CYCLES)
 
         saved_state = {}
 

--- a/tests/unit/test_orchestration/test_executor_heartbeat.py
+++ b/tests/unit/test_orchestration/test_executor_heartbeat.py
@@ -62,7 +62,6 @@ def _load_heartbeat():
 
 _hb = _load_heartbeat()
 _filter_stale_uows = _hb._filter_stale_uows
-RECOVERY_STALE_MINUTES = _hb.RECOVERY_STALE_MINUTES
 
 
 # ---------------------------------------------------------------------------
@@ -92,12 +91,12 @@ _never_orphaned = lambda uow_id: False
 
 class TestRecoveryStaleMintuesConstant:
     def test_is_positive_integer(self) -> None:
-        assert isinstance(RECOVERY_STALE_MINUTES, int)
-        assert RECOVERY_STALE_MINUTES > 0
+        assert isinstance(_hb.RECOVERY_STALE_MINUTES, int)
+        assert _hb.RECOVERY_STALE_MINUTES > 0
 
     def test_is_at_least_one_minute(self) -> None:
         """Must be long enough that a freshly-written UoW is not immediately eligible."""
-        assert RECOVERY_STALE_MINUTES >= 1
+        assert _hb.RECOVERY_STALE_MINUTES >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -402,7 +401,7 @@ class TestRunExecutorCycleDispatchEligibility:
         A UoW with prior executor_orphan history that has aged past RECOVERY_STALE_MINUTES
         must be dispatched by the heartbeat (recovery path).
         """
-        stale_minutes = RECOVERY_STALE_MINUTES + 10
+        stale_minutes = _hb.RECOVERY_STALE_MINUTES + 10
         self._insert_uow(db_path, "orphan-stale-001", age_minutes=stale_minutes)
         self._insert_executor_orphan_audit(db_path, "orphan-stale-001")
 
@@ -437,7 +436,7 @@ class TestRunExecutorCycleDispatchEligibility:
         - fresh UoW: dispatched immediately
         - stale orphaned UoW: dispatched (staleness gate cleared)
         """
-        stale_minutes = RECOVERY_STALE_MINUTES + 10
+        stale_minutes = _hb.RECOVERY_STALE_MINUTES + 10
         self._insert_uow(db_path, "fresh-mix-001", age_minutes=0.1)
         self._insert_uow(db_path, "orphan-stale-mix-001", age_minutes=stale_minutes)
         self._insert_executor_orphan_audit(db_path, "orphan-stale-mix-001")

--- a/tests/unit/test_orchestration/test_github_rate_limit_check.py
+++ b/tests/unit/test_orchestration/test_github_rate_limit_check.py
@@ -50,7 +50,6 @@ def _load_heartbeat():
 
 _hb = _load_heartbeat()
 check_github_rate_limit = _hb.check_github_rate_limit
-GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD = _hb.GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD
 
 
 # ---------------------------------------------------------------------------
@@ -58,8 +57,8 @@ GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD = _hb.GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD
 # ---------------------------------------------------------------------------
 
 def test_threshold_is_positive_integer():
-    assert isinstance(GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD, int)
-    assert GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD > 0
+    assert isinstance(_hb.GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD, int)
+    assert _hb.GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD > 0
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +98,7 @@ def test_rate_limit_not_ok_when_remaining_below_threshold():
 
 def test_rate_limit_ok_at_exact_threshold():
     """ok=True when remaining == threshold (boundary: threshold is the minimum allowed)."""
-    threshold = GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD
+    threshold = _hb.GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD
     with patch("subprocess.run", return_value=_mock_subprocess_result(_rate_json(threshold))):
         result = check_github_rate_limit()
     assert result.ok is True

--- a/tests/unit/test_orchestration/test_heartbeat_gate.py
+++ b/tests/unit/test_orchestration/test_heartbeat_gate.py
@@ -63,8 +63,6 @@ def _load_startup_sweep():
 _sweep_mod = _load_startup_sweep()
 run_startup_sweep = _sweep_mod.run_startup_sweep
 _is_heartbeat_recent = _sweep_mod._is_heartbeat_recent
-HEARTBEAT_SKIP_THRESHOLD_SECONDS = _sweep_mod.HEARTBEAT_SKIP_THRESHOLD_SECONDS
-DISPATCH_WINDOW_SECONDS = _sweep_mod.DISPATCH_WINDOW_SECONDS
 
 
 # ---------------------------------------------------------------------------
@@ -284,12 +282,12 @@ class TestIsHeartbeatRecent:
 
     def test_heartbeat_skip_threshold_constant_is_positive_integer(self) -> None:
         """HEARTBEAT_SKIP_THRESHOLD_SECONDS is a named positive integer constant."""
-        assert isinstance(HEARTBEAT_SKIP_THRESHOLD_SECONDS, int)
-        assert HEARTBEAT_SKIP_THRESHOLD_SECONDS > 0
+        assert isinstance(_sweep_mod.HEARTBEAT_SKIP_THRESHOLD_SECONDS, int)
+        assert _sweep_mod.HEARTBEAT_SKIP_THRESHOLD_SECONDS > 0
 
     def test_heartbeat_skip_threshold_constant_is_at_least_60(self) -> None:
         """Must be at least 2× a typical 30-s heartbeat interval."""
-        assert HEARTBEAT_SKIP_THRESHOLD_SECONDS >= 60
+        assert _sweep_mod.HEARTBEAT_SKIP_THRESHOLD_SECONDS >= 60
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +390,7 @@ class TestHeartbeatGateInPopulationFour:
         """
         dispatch_ago = 1800
         # Heartbeat is after dispatch + window, so classification is kill_during_execution
-        heartbeat_at = _iso_ago(dispatch_ago - DISPATCH_WINDOW_SECONDS - 120)
+        heartbeat_at = _iso_ago(dispatch_ago - _sweep_mod.DISPATCH_WINDOW_SECONDS - 120)
         self._make_uow_over_ttl(
             tmp_db,
             uow_id="uow-stale-001",

--- a/tests/unit/test_orchestration/test_heartbeat_sidecar.py
+++ b/tests/unit/test_orchestration/test_heartbeat_sidecar.py
@@ -59,6 +59,8 @@ REPO_ROOT = Path(__file__).parent.parent.parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+import importlib.util
+
 from src.orchestration.registry import Registry, UoWStatus
 from src.orchestration.heartbeat_sidecar import (
     write_heartbeats_for_active_uows,
@@ -67,14 +69,33 @@ from src.orchestration.heartbeat_sidecar import (
 )
 
 # ---------------------------------------------------------------------------
+# Load steward-heartbeat module for production constants
+# ---------------------------------------------------------------------------
+
+_STEWARD_HB_PATH = REPO_ROOT / "scheduled-tasks" / "steward-heartbeat.py"
+
+_steward_hb_spec = importlib.util.spec_from_file_location(
+    "steward_heartbeat_sidecar_const", _STEWARD_HB_PATH
+)
+_steward_hb = importlib.util.module_from_spec(_steward_hb_spec)
+# Register module in sys.modules BEFORE exec_module so dataclasses can
+# resolve cls.__module__ (Python 3.12 requirement).
+_steward_hb_patches = {
+    "src.orchestration.steward": MagicMock(),
+    "src.orchestration.github_sync": MagicMock(),
+    "src.orchestration.paths": MagicMock(REGISTRY_DB=Path("/tmp/test_registry.db")),
+    "startup_sweep": MagicMock(),
+    "steward_heartbeat_sidecar_const": _steward_hb,
+}
+with patch.dict("sys.modules", _steward_hb_patches):
+    _steward_hb_spec.loader.exec_module(_steward_hb)
+
+# ---------------------------------------------------------------------------
 # Named constants from spec
 # ---------------------------------------------------------------------------
 
 # Default heartbeat_ttl — matches registry.write_heartbeat contract
 DEFAULT_HEARTBEAT_TTL_SECONDS: int = 300
-
-# Buffer added by steward-heartbeat to TTL before declaring stall
-HEARTBEAT_STALL_BUFFER_SECONDS: int = 30
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +410,7 @@ class TestSidecarPreventsFlaseStalls:
 
         # After sidecar, the observation loop should NOT flag this UoW as stale
         stale_uows = registry.get_stale_heartbeat_uows(
-            buffer_seconds=HEARTBEAT_STALL_BUFFER_SECONDS
+            buffer_seconds=_steward_hb.HEARTBEAT_STALL_BUFFER_SECONDS
         )
         stale_ids = [u.id for u in stale_uows]
         assert uow_id not in stale_ids, (

--- a/tests/unit/test_orchestration/test_kill_classification.py
+++ b/tests/unit/test_orchestration/test_kill_classification.py
@@ -52,13 +52,6 @@ if str(REPO_ROOT) not in sys.path:
 
 
 # ---------------------------------------------------------------------------
-# Named constants under test
-# ---------------------------------------------------------------------------
-
-DISPATCH_WINDOW_SECONDS: int  # loaded from startup_sweep module below
-
-
-# ---------------------------------------------------------------------------
 # Load startup_sweep module (lives in scheduled-tasks/)
 # ---------------------------------------------------------------------------
 
@@ -77,7 +70,6 @@ def _load_startup_sweep():
 _sweep_mod = _load_startup_sweep()
 run_startup_sweep = _sweep_mod.run_startup_sweep
 _classify_executing_orphan_kill_type = _sweep_mod._classify_executing_orphan_kill_type
-DISPATCH_WINDOW_SECONDS = _sweep_mod.DISPATCH_WINDOW_SECONDS
 
 
 # ---------------------------------------------------------------------------
@@ -260,12 +252,12 @@ def registry(tmp_db: Path) -> Registry:
 
 class TestDispatchWindowConstant:
     def test_is_positive_integer(self) -> None:
-        assert isinstance(DISPATCH_WINDOW_SECONDS, int)
-        assert DISPATCH_WINDOW_SECONDS > 0
+        assert isinstance(_sweep_mod.DISPATCH_WINDOW_SECONDS, int)
+        assert _sweep_mod.DISPATCH_WINDOW_SECONDS > 0
 
     def test_is_at_least_60_seconds(self) -> None:
         """Must be long enough to absorb agent startup jitter."""
-        assert DISPATCH_WINDOW_SECONDS >= 60
+        assert _sweep_mod.DISPATCH_WINDOW_SECONDS >= 60
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +346,7 @@ class TestClassifyExecutingOrphanKillType:
         """
         dispatch_ts = _iso_ago(1800)
         # Heartbeat written DISPATCH_WINDOW_SECONDS + 60 after dispatch (clearly working)
-        heartbeat_after_window = _iso_ago(1800 - DISPATCH_WINDOW_SECONDS - 60)
+        heartbeat_after_window = _iso_ago(1800 - _sweep_mod.DISPATCH_WINDOW_SECONDS - 60)
         result = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=heartbeat_after_window,
@@ -525,7 +517,7 @@ class TestStartupSweepKillClassification:
         """
         dispatch_ago = 1800
         # Heartbeat written well after dispatch + window (agent was working)
-        heartbeat_at = _iso_ago(dispatch_ago - DISPATCH_WINDOW_SECONDS - 120)
+        heartbeat_at = _iso_ago(dispatch_ago - _sweep_mod.DISPATCH_WINDOW_SECONDS - 120)
         self._make_uow_with_dispatch(
             tmp_db,
             uow_id="uow-kill-during-001",

--- a/tests/unit/test_orchestration/test_prescriptions_per_cycle.py
+++ b/tests/unit/test_orchestration/test_prescriptions_per_cycle.py
@@ -75,10 +75,10 @@ def _make_steward_result(prescribed=0):
 
 
 # ---------------------------------------------------------------------------
-# Constants
+# Load the module once at module level for constant access
 # ---------------------------------------------------------------------------
 
-HIGH_THRESHOLD = 10  # must match HIGH_PRESCRIPTION_THRESHOLD in steward-heartbeat.py
+_steward_hb = _load_steward_heartbeat()
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +166,7 @@ class TestHighPrescriptionAlert:
         steward_heartbeat = _load_steward_heartbeat()
         db_path = tmp_path / "registry.db"
         db_path.touch()
-        prescribed_count = HIGH_THRESHOLD + 1  # 11
+        prescribed_count = _steward_hb.HIGH_PRESCRIPTION_THRESHOLD + 1  # 11
 
         with patch.object(steward_heartbeat, "_is_job_enabled", return_value=True), \
              patch.object(steward_heartbeat, "is_bootup_candidate_gate_active", return_value=False), \
@@ -221,7 +221,7 @@ class TestHighPrescriptionAlert:
              patch.object(steward_heartbeat, "run_observation_loop",
                           return_value=Mock(checked=0, stalled=0, skipped_dry_run=0)), \
              patch.object(steward_heartbeat, "run_steward_cycle",
-                          return_value=_make_steward_result(prescribed=HIGH_THRESHOLD)), \
+                          return_value=_make_steward_result(prescribed=_steward_hb.HIGH_PRESCRIPTION_THRESHOLD)), \
              patch.object(steward_heartbeat, "run_post_completion_sync",
                           return_value=Mock(synced=0, skipped_no_url=0, failed=0, errors=[])), \
              patch.object(steward_heartbeat, "_write_task_output"), \

--- a/tests/unit/test_orchestration/test_stuck_heartbeat_detection.py
+++ b/tests/unit/test_orchestration/test_stuck_heartbeat_detection.py
@@ -93,7 +93,6 @@ with patch.dict("sys.modules", _PATCH_TARGETS):
 
 _consecutive_zero_delta_tail = _MODULE._consecutive_zero_delta_tail
 detect_stuck_heartbeat_uows = _MODULE.detect_stuck_heartbeat_uows
-STUCK_HEARTBEAT_CONSECUTIVE_INTERVALS = _MODULE.STUCK_HEARTBEAT_CONSECUTIVE_INTERVALS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_wos_diagnose_handler.py
+++ b/tests/unit/test_orchestration/test_wos_diagnose_handler.py
@@ -48,7 +48,6 @@ PATTERN_UNRECOGNISED = "unrecognised"
 
 # Algorithm constants — imported from production modules so tests stay in sync
 # when the production values change.
-MAX_RETRIES = _STEWARD_MAX_RETRIES
 HARD_CAP = _HARD_CAP_CYCLES
 
 
@@ -202,8 +201,8 @@ class TestHandleWosDiagnosePromptContent:
         """Prompt must embed MAX_RETRIES constant for the execution cap branch."""
         msg = _make_diagnose_msg()
         result = handle_wos_diagnose(msg)
-        assert str(MAX_RETRIES) in result["prompt"], (
-            f"Subagent prompt must include MAX_RETRIES={MAX_RETRIES} "
+        assert str(_STEWARD_MAX_RETRIES) in result["prompt"], (
+            f"Subagent prompt must include MAX_RETRIES={_STEWARD_MAX_RETRIES} "
             "so the subagent knows when execution_attempts triggers surface-to-human"
         )
 

--- a/tests/unit/test_orchestration/test_wos_pr_sweep_result_handler.py
+++ b/tests/unit/test_orchestration/test_wos_pr_sweep_result_handler.py
@@ -47,7 +47,6 @@ _sys.modules["wos_pr_sweeper"] = _sweeper
 _spec.loader.exec_module(_sweeper)
 
 _should_notify = _sweeper._should_notify
-NOTIFICATION_COOLDOWN_HOURS = _sweeper.NOTIFICATION_COOLDOWN_HOURS
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +187,7 @@ class TestDeduplicationCooldown:
     def test_notified_beyond_cooldown_returns_true(self):
         key = "SiderealPress/lobster#101"
         old_iso = (
-            datetime.now(timezone.utc) - timedelta(hours=NOTIFICATION_COOLDOWN_HOURS + 1)
+            datetime.now(timezone.utc) - timedelta(hours=_sweeper.NOTIFICATION_COOLDOWN_HOURS + 1)
         ).isoformat()
         state = {key: {"last_notified_at": old_iso}}
         assert _should_notify(key, state) is True

--- a/tests/unit/test_scheduled_tasks/test_gmail_poll.py
+++ b/tests/unit/test_scheduled_tasks/test_gmail_poll.py
@@ -59,7 +59,6 @@ decode_base64url = _gp.decode_base64url
 extract_body = _gp.extract_body
 should_skip_message = _gp.should_skip_message
 build_inbox_message = _gp.build_inbox_message
-SKIP_LABEL_IDS = _gp.SKIP_LABEL_IDS
 
 
 # ---------------------------------------------------------------------------
@@ -212,8 +211,8 @@ class TestExtractBody:
 
 ACCOUNT_EMAIL = "owner@example.com"
 
-# SKIP_LABEL_IDS is a frozenset defined in the module.
-PROMO_LABEL = next(iter(SKIP_LABEL_IDS))  # any one skip label
+# SKIP_LABEL_IDS is a frozenset defined in the production module.
+PROMO_LABEL = next(iter(_gp.SKIP_LABEL_IDS))  # any one skip label
 
 
 class TestShouldSkipMessage:

--- a/tests/unit/test_wos_health_check.py
+++ b/tests/unit/test_wos_health_check.py
@@ -4,14 +4,14 @@ Tests for scheduled-tasks/wos-health-check.py
 Tests are derived from the spec in the WOS audit doc (wos-audit-20260422.md)
 and issue #849:
 
-- Stale UoW detection: UoWs stuck in proposed/pending >STARVATION_THRESHOLD_HOURS
+- Stale UoW detection: UoWs stuck in proposed/pending >hc.STARVATION_THRESHOLD_HOURS
   are returned as starvation candidates.
 - Short-duration UoWs are not flagged as starvation candidates.
 - Heartbeat liveness: UoWs in active/executing with stale heartbeats are detected.
 - UoWs in active/executing with no heartbeat (NULL heartbeat_at) are reported
   as stall_type="no_heartbeat".
 - UoWs with a fresh heartbeat within heartbeat_ttl are NOT reported as stale.
-- Long-running in-flight UoWs (>ALERT_THRESHOLD_HOURS) trigger alert logic.
+- Long-running in-flight UoWs (>hc.ALERT_THRESHOLD_HOURS) trigger alert logic.
 - Executor heartbeat liveness check returns is_stale=True when log absent.
 - jobs.json enabled gate: job skips when disabled.
 """
@@ -47,13 +47,6 @@ def _load_module():
 
 hc = _load_module()
 
-# ---------------------------------------------------------------------------
-# Constants — must match the spec, not derived from implementation
-# ---------------------------------------------------------------------------
-
-STARVATION_THRESHOLD_HOURS = 24   # from audit doc: "starvation candidates" = >24h
-ALERT_THRESHOLD_HOURS = 48         # from audit doc: inbox alert for >48h in-flight
-HEARTBEAT_STALE_BUFFER_SECONDS = 60
 
 
 # ---------------------------------------------------------------------------
@@ -137,47 +130,47 @@ def _insert_uow(
 
 class TestQueryStarvationCandidates:
     def test_uow_stuck_in_proposed_beyond_threshold_is_returned(self, db_path):
-        _insert_uow(db_path, "uow-old", "proposed", created_hours_ago=STARVATION_THRESHOLD_HOURS + 1)
-        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        _insert_uow(db_path, "uow-old", "proposed", created_hours_ago=hc.STARVATION_THRESHOLD_HOURS + 1)
+        results = hc.query_starvation_candidates(db_path, hc.STARVATION_THRESHOLD_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-old" in ids
 
     def test_uow_stuck_in_pending_beyond_threshold_is_returned(self, db_path):
-        _insert_uow(db_path, "uow-pending", "pending", created_hours_ago=STARVATION_THRESHOLD_HOURS + 2)
-        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        _insert_uow(db_path, "uow-pending", "pending", created_hours_ago=hc.STARVATION_THRESHOLD_HOURS + 2)
+        results = hc.query_starvation_candidates(db_path, hc.STARVATION_THRESHOLD_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-pending" in ids
 
     def test_recent_proposed_uow_is_not_returned(self, db_path):
         _insert_uow(db_path, "uow-new", "proposed", created_hours_ago=1)
-        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        results = hc.query_starvation_candidates(db_path, hc.STARVATION_THRESHOLD_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-new" not in ids
 
     def test_uow_exactly_at_threshold_is_not_returned(self, db_path):
         # At exactly threshold hours, the UoW has NOT exceeded the threshold yet
-        _insert_uow(db_path, "uow-boundary", "proposed", created_hours_ago=STARVATION_THRESHOLD_HOURS - 0.01)
-        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        _insert_uow(db_path, "uow-boundary", "proposed", created_hours_ago=hc.STARVATION_THRESHOLD_HOURS - 0.01)
+        results = hc.query_starvation_candidates(db_path, hc.STARVATION_THRESHOLD_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-boundary" not in ids
 
     def test_active_uow_not_returned_as_starvation_candidate(self, db_path):
         # Starvation check only covers proposed/pending, not active
-        _insert_uow(db_path, "uow-active", "active", created_hours_ago=STARVATION_THRESHOLD_HOURS + 5)
-        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        _insert_uow(db_path, "uow-active", "active", created_hours_ago=hc.STARVATION_THRESHOLD_HOURS + 5)
+        results = hc.query_starvation_candidates(db_path, hc.STARVATION_THRESHOLD_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-active" not in ids
 
     def test_absent_db_returns_empty_list(self, tmp_path):
-        results = hc.query_starvation_candidates(tmp_path / "nonexistent.db", STARVATION_THRESHOLD_HOURS)
+        results = hc.query_starvation_candidates(tmp_path / "nonexistent.db", hc.STARVATION_THRESHOLD_HOURS)
         assert results == []
 
     def test_result_contains_age_hours_field(self, db_path):
-        _insert_uow(db_path, "uow-aged", "proposed", created_hours_ago=STARVATION_THRESHOLD_HOURS + 3)
-        results = hc.query_starvation_candidates(db_path, STARVATION_THRESHOLD_HOURS)
+        _insert_uow(db_path, "uow-aged", "proposed", created_hours_ago=hc.STARVATION_THRESHOLD_HOURS + 3)
+        results = hc.query_starvation_candidates(db_path, hc.STARVATION_THRESHOLD_HOURS)
         aged = next(r for r in results if r["id"] == "uow-aged")
         assert aged["age_hours"] is not None
-        assert aged["age_hours"] >= STARVATION_THRESHOLD_HOURS
+        assert aged["age_hours"] >= hc.STARVATION_THRESHOLD_HOURS
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +186,7 @@ class TestQueryStaleHeartbeats:
             created_hours_ago=2, started_hours_ago=2,
             heartbeat_at=stale_hb, heartbeat_ttl=300,
         )
-        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        results = hc.query_stale_heartbeats(db_path, hc.HEARTBEAT_STALE_BUFFER_SECONDS)
         ids = [r["id"] for r in results]
         assert "uow-stale-hb" in ids
         result = next(r for r in results if r["id"] == "uow-stale-hb")
@@ -207,7 +200,7 @@ class TestQueryStaleHeartbeats:
             created_hours_ago=1, started_hours_ago=1,
             heartbeat_at=fresh_hb, heartbeat_ttl=300,
         )
-        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        results = hc.query_stale_heartbeats(db_path, hc.HEARTBEAT_STALE_BUFFER_SECONDS)
         ids = [r["id"] for r in results]
         assert "uow-fresh-hb" not in ids
 
@@ -218,7 +211,7 @@ class TestQueryStaleHeartbeats:
             created_hours_ago=2, started_hours_ago=2,
             heartbeat_at=None, heartbeat_ttl=300,
         )
-        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        results = hc.query_stale_heartbeats(db_path, hc.HEARTBEAT_STALE_BUFFER_SECONDS)
         ids = [r["id"] for r in results]
         assert "uow-no-hb" in ids
         result = next(r for r in results if r["id"] == "uow-no-hb")
@@ -232,18 +225,18 @@ class TestQueryStaleHeartbeats:
             created_hours_ago=1, started_hours_ago=1,
             heartbeat_at=stale_hb, heartbeat_ttl=300,
         )
-        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        results = hc.query_stale_heartbeats(db_path, hc.HEARTBEAT_STALE_BUFFER_SECONDS)
         ids = [r["id"] for r in results]
         assert "uow-exec-stale" in ids
 
     def test_done_uow_not_included_in_heartbeat_check(self, db_path):
         _insert_uow(db_path, "uow-done", "done", created_hours_ago=5)
-        results = hc.query_stale_heartbeats(db_path, HEARTBEAT_STALE_BUFFER_SECONDS)
+        results = hc.query_stale_heartbeats(db_path, hc.HEARTBEAT_STALE_BUFFER_SECONDS)
         ids = [r["id"] for r in results]
         assert "uow-done" not in ids
 
     def test_absent_db_returns_empty_list(self, tmp_path):
-        results = hc.query_stale_heartbeats(tmp_path / "nonexistent.db", HEARTBEAT_STALE_BUFFER_SECONDS)
+        results = hc.query_stale_heartbeats(tmp_path / "nonexistent.db", hc.HEARTBEAT_STALE_BUFFER_SECONDS)
         assert results == []
 
 
@@ -298,10 +291,10 @@ class TestLongRunningAlert:
     def test_uow_stuck_beyond_alert_threshold_is_returned(self, db_path):
         _insert_uow(
             db_path, "uow-long", "active",
-            created_hours_ago=ALERT_THRESHOLD_HOURS + 1,
-            started_hours_ago=ALERT_THRESHOLD_HOURS + 1,
+            created_hours_ago=hc.ALERT_THRESHOLD_HOURS + 1,
+            started_hours_ago=hc.ALERT_THRESHOLD_HOURS + 1,
         )
-        results = hc.query_long_running_in_flight(db_path, ALERT_THRESHOLD_HOURS)
+        results = hc.query_long_running_in_flight(db_path, hc.ALERT_THRESHOLD_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-long" in ids
 
@@ -310,6 +303,6 @@ class TestLongRunningAlert:
             db_path, "uow-recent", "active",
             created_hours_ago=1, started_hours_ago=1,
         )
-        results = hc.query_long_running_in_flight(db_path, ALERT_THRESHOLD_HOURS)
+        results = hc.query_long_running_in_flight(db_path, hc.ALERT_THRESHOLD_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-recent" not in ids

--- a/tests/unit/test_wos_metabolic_digest.py
+++ b/tests/unit/test_wos_metabolic_digest.py
@@ -62,15 +62,9 @@ def _load_handlers_module():
 md = _load_digest_module()
 
 # ---------------------------------------------------------------------------
-# Constants — from the audit doc and issue, NOT derived from implementation
+# Constants — non-mirrored test fixtures
 # ---------------------------------------------------------------------------
 
-OUTCOME_PEARL = "pearl"
-OUTCOME_HEAT = "heat"
-OUTCOME_SEED = "seed"
-OUTCOME_SHIT = "shit"
-
-DEFAULT_LOOKBACK_HOURS = 24   # daily digest window
 STALL_THRESHOLD_HOURS = 6     # stalled section threshold in the digest
 
 
@@ -193,91 +187,91 @@ def _insert_audit_entry(db: Path, uow_id: str, to_status: str, hours_ago: float 
 class TestClassifyUow:
     def test_failed_status_is_shit(self):
         uow = _uow(status="failed", close_reason="execution error")
-        assert md.classify_uow(uow) == OUTCOME_SHIT
+        assert md.classify_uow(uow) == md.OUTCOME_SHIT
 
     def test_expired_status_is_shit(self):
         uow = _uow(status="expired", close_reason="ttl exceeded")
-        assert md.classify_uow(uow) == OUTCOME_SHIT
+        assert md.classify_uow(uow) == md.OUTCOME_SHIT
 
     def test_cancelled_status_is_shit(self):
         uow = _uow(status="cancelled", close_reason="user_closed")
-        assert md.classify_uow(uow) == OUTCOME_SHIT
+        assert md.classify_uow(uow) == md.OUTCOME_SHIT
 
     def test_ttl_in_close_reason_is_shit(self):
         uow = _uow(status="done", close_reason="ttl_exceeded after 4h")
-        assert md.classify_uow(uow) == OUTCOME_SHIT
+        assert md.classify_uow(uow) == md.OUTCOME_SHIT
 
     def test_hard_cap_in_close_reason_is_shit(self):
         uow = _uow(status="done", close_reason="hard_cap reached")
-        assert md.classify_uow(uow) == OUTCOME_SHIT
+        assert md.classify_uow(uow) == md.OUTCOME_SHIT
 
     def test_user_closed_in_close_reason_is_shit(self):
         uow = _uow(status="done", close_reason="user_closed by admin")
-        assert md.classify_uow(uow) == OUTCOME_SHIT
+        assert md.classify_uow(uow) == md.OUTCOME_SHIT
 
     def test_pr_in_close_reason_is_pearl(self):
         uow = _uow(status="done", close_reason="opened pr #123")
-        assert md.classify_uow(uow) == OUTCOME_PEARL
+        assert md.classify_uow(uow) == md.OUTCOME_PEARL
 
     def test_implementation_in_close_reason_is_pearl(self):
         uow = _uow(status="done", close_reason="implementation complete")
-        assert md.classify_uow(uow) == OUTCOME_PEARL
+        assert md.classify_uow(uow) == md.OUTCOME_PEARL
 
     def test_commit_in_close_reason_is_pearl(self):
         uow = _uow(status="done", close_reason="committed changes")
-        assert md.classify_uow(uow) == OUTCOME_PEARL
+        assert md.classify_uow(uow) == md.OUTCOME_PEARL
 
     def test_issue_in_close_reason_is_seed(self):
         uow = _uow(status="done", close_reason="spawned issue #456")
-        assert md.classify_uow(uow) == OUTCOME_SEED
+        assert md.classify_uow(uow) == md.OUTCOME_SEED
 
     def test_seed_keyword_in_close_reason_is_seed(self):
         uow = _uow(status="done", close_reason="seeded follow-on work")
-        assert md.classify_uow(uow) == OUTCOME_SEED
+        assert md.classify_uow(uow) == md.OUTCOME_SEED
 
     def test_spawn_keyword_in_close_reason_is_seed(self):
         uow = _uow(status="done", close_reason="spawn new uow for subtask")
-        assert md.classify_uow(uow) == OUTCOME_SEED
+        assert md.classify_uow(uow) == md.OUTCOME_SEED
 
     def test_review_in_close_reason_is_heat(self):
         uow = _uow(status="done", close_reason="completed review of design doc")
-        assert md.classify_uow(uow) == OUTCOME_HEAT
+        assert md.classify_uow(uow) == md.OUTCOME_HEAT
 
     def test_analysis_in_close_reason_is_heat(self):
         uow = _uow(status="done", close_reason="analysis complete")
-        assert md.classify_uow(uow) == OUTCOME_HEAT
+        assert md.classify_uow(uow) == md.OUTCOME_HEAT
 
     def test_design_in_close_reason_is_heat(self):
         uow = _uow(status="done", close_reason="design specification written")
-        assert md.classify_uow(uow) == OUTCOME_HEAT
+        assert md.classify_uow(uow) == md.OUTCOME_HEAT
 
     def test_done_with_no_signal_is_shit(self):
         # Done with empty close_reason and no output_ref: no verifiable output
         uow = _uow(status="done", close_reason="", output_ref="")
-        assert md.classify_uow(uow) == OUTCOME_SHIT
+        assert md.classify_uow(uow) == md.OUTCOME_SHIT
 
     def test_source_issue_mention_without_creation_is_not_seed(self):
         # "issue analysis complete" mentions an issue being worked on, not a new issue
         # created. Bare "issue" substring must NOT classify as seed — this is the
         # false-positive the phrase-level matching is designed to prevent.
         uow = _uow(status="done", close_reason="issue analysis complete")
-        assert md.classify_uow(uow) == OUTCOME_HEAT
+        assert md.classify_uow(uow) == md.OUTCOME_HEAT
 
     def test_pr_closing_source_issue_is_pearl_not_seed(self):
         # "issue referenced in pr" describes a PR that closes a source issue —
         # the UoW produced a PR (pearl), not a new seed issue.
         # Bare "issue" substring must NOT win over "pr" here.
         uow = _uow(status="done", close_reason="issue referenced in pr")
-        assert md.classify_uow(uow) == OUTCOME_PEARL
+        assert md.classify_uow(uow) == md.OUTCOME_PEARL
 
     def test_creation_phrase_opened_issue_is_seed(self):
         # Explicit creation verb + "issue" → seed, regardless of other keywords
         uow = _uow(status="done", close_reason="opened issue #789 for follow-up")
-        assert md.classify_uow(uow) == OUTCOME_SEED
+        assert md.classify_uow(uow) == md.OUTCOME_SEED
 
     def test_creation_phrase_created_issue_is_seed(self):
         uow = _uow(status="done", close_reason="created issue #100 to track regressions")
-        assert md.classify_uow(uow) == OUTCOME_SEED
+        assert md.classify_uow(uow) == md.OUTCOME_SEED
 
 
 # ---------------------------------------------------------------------------
@@ -287,14 +281,14 @@ class TestClassifyUow:
 class TestAggregateByClassification:
     def test_all_four_keys_always_present(self):
         groups = md.aggregate_by_classification([])
-        assert set(groups.keys()) == {OUTCOME_PEARL, OUTCOME_HEAT, OUTCOME_SEED, OUTCOME_SHIT}
+        assert set(groups.keys()) == {md.OUTCOME_PEARL, md.OUTCOME_HEAT, md.OUTCOME_SEED, md.OUTCOME_SHIT}
 
     def test_all_keys_present_even_when_categories_empty(self):
-        pairs = [(_uow(close_reason="opened pr #1"), OUTCOME_PEARL)]
+        pairs = [(_uow(close_reason="opened pr #1"), md.OUTCOME_PEARL)]
         groups = md.aggregate_by_classification(pairs)
-        assert OUTCOME_HEAT in groups
-        assert OUTCOME_SEED in groups
-        assert OUTCOME_SHIT in groups
+        assert md.OUTCOME_HEAT in groups
+        assert md.OUTCOME_SEED in groups
+        assert md.OUTCOME_SHIT in groups
 
     def test_uows_routed_to_correct_group(self):
         pearl = _uow(uow_id="p1", close_reason="opened pr #1")
@@ -303,18 +297,18 @@ class TestAggregateByClassification:
         shit = _uow(uow_id="sh1", status="failed")
 
         pairs = [
-            (pearl, OUTCOME_PEARL),
-            (heat, OUTCOME_HEAT),
-            (seed, OUTCOME_SEED),
-            (shit, OUTCOME_SHIT),
+            (pearl, md.OUTCOME_PEARL),
+            (heat, md.OUTCOME_HEAT),
+            (seed, md.OUTCOME_SEED),
+            (shit, md.OUTCOME_SHIT),
         ]
         groups = md.aggregate_by_classification(pairs)
 
-        assert len(groups[OUTCOME_PEARL]) == 1
-        assert len(groups[OUTCOME_HEAT]) == 1
-        assert len(groups[OUTCOME_SEED]) == 1
-        assert len(groups[OUTCOME_SHIT]) == 1
-        assert groups[OUTCOME_PEARL][0]["id"] == "p1"
+        assert len(groups[md.OUTCOME_PEARL]) == 1
+        assert len(groups[md.OUTCOME_HEAT]) == 1
+        assert len(groups[md.OUTCOME_SEED]) == 1
+        assert len(groups[md.OUTCOME_SHIT]) == 1
+        assert groups[md.OUTCOME_PEARL][0]["id"] == "p1"
 
 
 # ---------------------------------------------------------------------------
@@ -372,8 +366,8 @@ class TestFormatDigest:
         pearl = _uow(uow_id="p1", close_reason="opened pr #1")
         shit = _uow(uow_id="sh1", status="failed")
         groups = md.aggregate_by_classification([
-            (pearl, OUTCOME_PEARL),
-            (shit, OUTCOME_SHIT),
+            (pearl, md.OUTCOME_PEARL),
+            (shit, md.OUTCOME_SHIT),
         ])
         text = md.format_digest(groups, [], 24, "2026-04-22T09:00:00+00:00")
         assert "1 pearl" in text
@@ -399,7 +393,7 @@ class TestFormatDigest:
 
     def test_register_breakdown_present_when_uows_exist(self):
         pearl = _uow(uow_id="p1", close_reason="opened pr", register="operational")
-        groups = md.aggregate_by_classification([(pearl, OUTCOME_PEARL)])
+        groups = md.aggregate_by_classification([(pearl, md.OUTCOME_PEARL)])
         text = md.format_digest(groups, [], 24, "2026-04-22T09:00:00+00:00")
         assert "Register breakdown" in text
         assert "operational" in text
@@ -442,7 +436,7 @@ class TestQueryCompletedUows:
         u = _uow(uow_id="uow-done", status="done", close_reason="pr merged")
         _insert_uow_row(db_path, u)
         _insert_audit_entry(db_path, "uow-done", "done", hours_ago=1)
-        results = md.query_completed_uows(db_path, DEFAULT_LOOKBACK_HOURS)
+        results = md.query_completed_uows(db_path, md.DEFAULT_LOOKBACK_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-done" in ids
 
@@ -451,12 +445,12 @@ class TestQueryCompletedUows:
         u = _uow(uow_id="uow-old", status="done", close_reason="pr merged")
         _insert_uow_row(db_path, u)
         _insert_audit_entry(db_path, "uow-old", "done", hours_ago=48)
-        results = md.query_completed_uows(db_path, DEFAULT_LOOKBACK_HOURS)
+        results = md.query_completed_uows(db_path, md.DEFAULT_LOOKBACK_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-old" not in ids
 
     def test_absent_db_returns_empty_list(self, tmp_path):
-        results = md.query_completed_uows(tmp_path / "nonexistent.db", DEFAULT_LOOKBACK_HOURS)
+        results = md.query_completed_uows(tmp_path / "nonexistent.db", md.DEFAULT_LOOKBACK_HOURS)
         assert results == []
 
 

--- a/tests/unit/test_wos_queue_monitor.py
+++ b/tests/unit/test_wos_queue_monitor.py
@@ -40,15 +40,6 @@ qm = _load_module()
 
 
 # ---------------------------------------------------------------------------
-# Constants — imported from the production module to avoid divergence
-# ---------------------------------------------------------------------------
-
-STARVATION_CONSECUTIVE_READINGS = qm.STARVATION_CONSECUTIVE_READINGS
-TOXICITY_DEPTH_THRESHOLD = qm.TOXICITY_DEPTH_THRESHOLD
-TOXICITY_CONSECUTIVE_READINGS = qm.TOXICITY_CONSECUTIVE_READINGS
-
-
-# ---------------------------------------------------------------------------
 # detect_starvation
 # ---------------------------------------------------------------------------
 
@@ -59,23 +50,23 @@ class TestDetectStarvation:
 
     def test_starvation_fires_after_12_consecutive_zero_readings(self):
         """12 zero readings at 30-min cadence = exactly 6 hours — must fire."""
-        history = self._history([0] * STARVATION_CONSECUTIVE_READINGS)
+        history = self._history([0] * qm.STARVATION_CONSECUTIVE_READINGS)
         assert qm.detect_starvation(history) is True
 
     def test_starvation_does_not_fire_with_11_zero_readings(self):
         """One reading short of the threshold — must not fire."""
-        history = self._history([0] * (STARVATION_CONSECUTIVE_READINGS - 1))
+        history = self._history([0] * (qm.STARVATION_CONSECUTIVE_READINGS - 1))
         assert qm.detect_starvation(history) is False
 
     def test_starvation_does_not_fire_if_tail_has_nonzero(self):
         """12 readings but the last one is nonzero — no starvation."""
-        depths = [0] * (STARVATION_CONSECUTIVE_READINGS - 1) + [1]
+        depths = [0] * (qm.STARVATION_CONSECUTIVE_READINGS - 1) + [1]
         history = self._history(depths)
         assert qm.detect_starvation(history) is False
 
     def test_starvation_fires_on_longer_history_when_tail_is_all_zero(self):
         """20 readings where the last 12 are all zero — must fire."""
-        depths = [5] * 8 + [0] * STARVATION_CONSECUTIVE_READINGS
+        depths = [5] * 8 + [0] * qm.STARVATION_CONSECUTIVE_READINGS
         history = self._history(depths)
         assert qm.detect_starvation(history) is True
 
@@ -87,8 +78,8 @@ class TestDetectStarvation:
         assert qm.detect_starvation(history) is False
 
     def test_starvation_uses_named_constant_not_magic_literal(self):
-        """Verify the module exposes the constant matching the spec."""
-        assert qm.STARVATION_CONSECUTIVE_READINGS == STARVATION_CONSECUTIVE_READINGS
+        """Verify the module exposes the constant matching the spec (12 = 6h at 30-min cadence)."""
+        assert qm.STARVATION_CONSECUTIVE_READINGS == 12
 
 
 # ---------------------------------------------------------------------------
@@ -145,8 +136,8 @@ class TestDetectToxicity:
         assert fired is False
 
     def test_toxicity_uses_named_constants_matching_spec(self):
-        assert qm.TOXICITY_DEPTH_THRESHOLD == TOXICITY_DEPTH_THRESHOLD
-        assert qm.TOXICITY_CONSECUTIVE_READINGS == TOXICITY_CONSECUTIVE_READINGS
+        assert qm.TOXICITY_DEPTH_THRESHOLD == 10
+        assert qm.TOXICITY_CONSECUTIVE_READINGS == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The oracle has caught the same test anti-pattern four times (PRs #696, #800, #967, #970): test files re-declare production constants as module-level literals instead of importing them from the production module. When the production constant changes, the test constant silently drifts, causing assertions to pass against a stale value.

This PR closes the feedback loop by adding structural enforcement (AST-based lint) and fixing all existing violations.

**What this PR does:**

- Adds `tests/test_no_mirror_constants.py` — an AST-based lint test that detects test files re-declaring production constants at module level. The detection walks both `ast.Assign` and `ast.AnnAssign` nodes, building a production constant index from `src/` and `scheduled-tasks/`, then flagging any test-file constant whose ALL_CAPS name appears in both.
- Fixes all 25 detected violations across 13 test files by replacing local constant declarations with references to the already-loaded production module attribute (e.g. `qm.STARVATION_CONSECUTIVE_READINGS` instead of a local `STARVATION_CONSECUTIVE_READINGS = 12`).
- Allowlists 2 names as genuinely coincidental (test fixtures using test-specific values, not mirrors of production values): `LOBSTER_JID` (test JID vs env-var-sourced production value) and `ADMIN_CHAT_ID` (test chat ID vs env-var-sourced production value with different default).

**Functional patterns used:** Pure functions for AST collection and scanning (no side effects), immutable data structures (frozenset for allowlist, dict composition for index building), declarative data transformation (map/filter over AST nodes).

**What is NOT changed:** No production source files are modified. `oracle/learnings.md` is not touched (the PR #696 and 2026-04-20 entries already document this pattern).

**Before/after flow:**

```
BEFORE:
  test file declares FOO = 42       production changes FOO to 50
       ↓                                    ↓
  test asserts against FOO (42)     test still passes (stale 42)
       ↓
  silent divergence — no signal

AFTER:
  test file declares FOO = 42       CI runs test_no_mirror_constants
       ↓                                    ↓
  lint catches: MIRROR CONSTANT      test FAILS with explicit message
       ↓                                    ↓
  developer uses prod.FOO           constant stays in sync
```

## Tests run

- [x] `uv run pytest tests/test_no_mirror_constants.py -v` — 1 passed (lint test itself)
- [x] `uv run pytest tests/test_no_mirror_constants.py tests/unit/test_wos_queue_monitor.py tests/unit/test_orchestration/test_executor_heartbeat.py tests/unit/test_orchestration/test_github_rate_limit_check.py tests/unit/test_orchestration/test_heartbeat_gate.py tests/unit/test_orchestration/test_kill_classification.py tests/unit/test_orchestration/test_stuck_heartbeat_detection.py tests/unit/test_scheduled_tasks/test_gmail_poll.py tests/unit/test_wos_metabolic_digest.py tests/unit/test_wos_health_check.py tests/unit/test_orchestration/test_wos_diagnose_handler.py tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py tests/unit/test_orchestration/test_heartbeat_sidecar.py -q` — 330 passed, 0 failed
- [ ] `tests/unit/test_orchestration/test_prescriptions_per_cycle.py` — 2 passed, 8 failed (pre-existing: `_default_db_path` attribute missing from steward-heartbeat module on main, confirmed same failures on main branch)
- [ ] `tests/unit/test_attunement.py` — skipped: pre-existing import error (`ModuleNotFoundError: No module named 'memory.attunement'`)
- [ ] `tests/unit/test_orchestration/test_registry_cli.py` — skipped: pre-existing syntax error at line 1183
- [ ] `tests/integration/test_wos_registry_bugs.py::test_writes_audit_entry_with_executing_orphan_classification` — pre-existing failure: expects `executing_orphan` but production returns `orphan_kill_before_start`

**Blocked items needing attention before merge:** none. All failures are pre-existing and confirmed on main.

## Manual test

N/A — this change is entirely internal to the test suite. No systemd, cron, external services, file I/O, or DB schema changes.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, test-only change
- [x] User-visible outcome verified OR not applicable — not applicable (no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: N/A — no external service calls in this change

---

WOS-UoW: uow_20260427_ebf1ab