### PR TITLE
fix: scope quota-exhaustion check to current session only

### DIFF
--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -554,6 +554,17 @@ launch_claude() {
     local dispatcher_pid_file="$MESSAGES_DIR/config/dispatcher.pid"
     mkdir -p "$(dirname "$dispatcher_pid_file")"
 
+    # Write a session-start sentinel to the session log BEFORE launching Claude.
+    # The quota-exhaustion check reads this log after Claude exits; without a
+    # per-session boundary the check can match "You've hit your limit" lines
+    # that were written by a previous session (the log is append-only and never
+    # rotated), producing a false-positive that puts the system to sleep until
+    # midnight even when the current quota is fine.  The sentinel is a fixed
+    # string that awk uses to reset its scan window, so only lines from the
+    # current session are tested.
+    echo "=== SESSION_START attempt=$attempt ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) ===" \
+        >> "$LOG_DIR/claude-session.log"
+
     (
         echo "$BASHPID" > "$dispatcher_pid_file"
         # Write the dispatcher startup flag so inject-bootup-context.py can
@@ -643,8 +654,15 @@ with open('$tmp_state', 'w') as f:
         log "Claude exited with code $exit_code. Will restart after backoff."
         write_state "restarting" "exit_code=$exit_code"
 
-        # Detect quota exhaustion — sleep until midnight UTC before retrying
-        if tail -20 "$LOG_DIR/claude-session.log" 2>/dev/null | grep -qi "out of extra usage\|you.ve hit your limit\|hit your limit\|you.re out of"; then
+        # Detect quota exhaustion — sleep until midnight UTC before retrying.
+        # Only scan output from the *current* session to avoid false positives
+        # from stale quota messages left in the append-only log by prior sessions.
+        # awk resets its capture window each time it sees a SESSION_START sentinel,
+        # so `current_session_output` contains only what this session wrote.
+        local current_session_output
+        current_session_output=$(awk '/^=== SESSION_START /{buf=""} {buf=buf"\n"$0} END{print buf}' \
+            "$LOG_DIR/claude-session.log" 2>/dev/null)
+        if echo "$current_session_output" | grep -qi "out of extra usage\|you.ve hit your limit\|hit your limit\|you.re out of"; then
             log "QUOTA EXHAUSTED: Detected usage quota error. Sleeping until midnight UTC."
             local now midnight_utc sleep_secs wake_time_et
             now=$(date +%s)
@@ -694,8 +712,8 @@ Will auto-restart at quota reset. No action needed."
             return 1
         fi
 
-        # Detect auth failures from session log
-        if tail -5 "$LOG_DIR/claude-session.log" 2>/dev/null | grep -q "authentication_error\|OAuth token has expired\|API usage limits"; then
+        # Detect auth failures from session log (current session only)
+        if echo "$current_session_output" | grep -q "authentication_error\|OAuth token has expired\|API usage limits"; then
             AUTH_FAIL_COUNT=$((AUTH_FAIL_COUNT + 1))
             if [[ $AUTH_FAIL_COUNT -ge 3 ]] && [[ "$AUTH_FAIL_ALERTED" != "true" ]]; then
                 AUTH_FAIL_ALERTED=true


### PR DESCRIPTION
## Summary

- **Root cause**: `claude-session.log` is opened in append mode (`tee -a`) and never rotated. The quota-exhaustion check used `tail -20` on the cumulative log, which matched `You've hit your limit` lines from **previous sessions**. When the current session ended normally (e.g. max-turns hit), the check still fired because old quota messages were in the tail of the log. This sent the system into a midnight-sleep even when quota was fine.

- **Fix**: Write a `=== SESSION_START ===` sentinel line to the log immediately before each session launches. After exit, use `awk` to extract only lines written **since the last sentinel**. Old quota messages from prior sessions are never tested.

- **Bonus fix**: The auth-failure check (`tail -5`) was scoped to the same current-session window for consistency.

## Test plan

- [x] Verified awk logic with a synthetic log containing old quota messages before a sentinel and `Error: Reached max turns (150)` after — correctly returns no quota match
- [x] Verified awk logic correctly fires when a real quota message appears **after** the sentinel
- [x] Confirmed current quota state via `usage-report.sh --format full` — 9% of 5h window, not exhausted (confirms this is a false-positive scenario)
- [ ] Manual test: run a session to max-turns, confirm no quota-sleep is triggered

## Notes

The fix does not affect behavior when quota genuinely IS exhausted — if `You've hit your limit` appears in the current session's output, the sleep still triggers correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)