### PR TITLE
feat: WOS completion notification layer — per-cycle ping (wos_done)

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -690,6 +690,12 @@ WOS_MESSAGE_TYPE_DISPATCH: dict[str, str] = {
     # before the spawn-gate because this handler legitimately returns action="send_reply"
     # (surface PR attention items to Dan). No subagent spawn required.
     "wos_pr_sweep_result": "handle_wos_pr_sweep_result",
+    # Per-cycle completion ping: written by wos_completion_notifier.py when a UoW
+    # transitions to Done or Failed in _process_uow(). Fast-path — dispatched before the
+    # spawn-gate; returns action="send_reply" to deliver the pre-formatted ping to Dan.
+    # Non-fatal write: steward.py swallows inbox write errors so the Done/Failed
+    # registry transition is never blocked.
+    "wos_done": "handle_wos_done",
 }
 
 
@@ -1485,6 +1491,46 @@ def handle_wos_pr_sweep_result(msg: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def handle_wos_done(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle a ``wos_done`` inbox message — per-cycle ping for a UoW Done/Failed transition.
+
+    Called by route_wos_message when the dispatcher receives a message written by
+    wos_completion_notifier.py at the end of the Done() or fail_uow() branch.
+
+    This handler is a fast-path: it returns action="send_reply" so the dispatcher
+    delivers the pre-formatted Telegram ping to Dan directly, without spawning a
+    subagent. It is dispatched before the spawn-gate (which applies only to execution
+    message types that must always spawn a subagent).
+
+    The ping text is pre-formatted by wos_completion_notifier._select_format_and_build
+    in one of three variants:
+    - Short-form: pearl outcome with ≤1 execution attempt (two-line terse format)
+    - Rich-form: non-pearl outcome or >1 execution attempt (labelled multi-field format)
+    - Failed-form: UoW that failed (failed prefix, topology, tokens, failure summary)
+
+    Pure function — no side effects, no I/O.
+
+    Args:
+        msg: The raw wos_done inbox message dict.  Expected fields:
+            - ``text`` (str): Pre-formatted ping text from wos_completion_notifier.
+            - ``chat_id`` (str): Admin chat_id to deliver the ping to.
+            - ``uow_id`` (str): The UoW ID (included for observability).
+
+    Returns:
+        A dict with action="send_reply" and the ping text.
+    """
+    _default_chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
+    text: str = msg.get("text", "WOS UoW completion notification (no detail available)")
+    chat_id: str = str(msg.get("chat_id", _default_chat_id))
+    return {
+        "action": "send_reply",
+        "text": text,
+        "chat_id": chat_id,
+        "message_type": "wos_done",
+    }
+
+
 def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
     """
     Route an inbox message whose `type` is listed in WOS_MESSAGE_TYPE_DISPATCH.
@@ -1633,6 +1679,33 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
                     f"WOS PR sweep handler raised an error "
                     f"({type(exc).__name__}: {exc}). "
                     "PR sweep results were NOT delivered. Check logs."
+                ),
+                "message_type": msg_type,
+            }
+
+    # ---------------------------------------------------------------------------
+    # wos_done fast-path: per-cycle completion ping written by wos_completion_notifier.py
+    # at the end of the Done() or fail_uow() branch in steward._process_uow().
+    # Always returns action="send_reply" — no subagent spawn required.
+    # ---------------------------------------------------------------------------
+    if msg_type == "wos_done":
+        try:
+            done_result = handle_wos_done(msg)
+            done_result["message_type"] = msg_type
+            return done_result
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).error(
+                "route_wos_message: handle_wos_done raised %s: %s — "
+                "returning send_reply alert",
+                type(exc).__name__, exc,
+            )
+            return {
+                "action": "send_reply",
+                "text": (
+                    f"WOS completion ping handler raised an error "
+                    f"({type(exc).__name__}: {exc}). "
+                    "Completion ping was NOT delivered. Check logs."
                 ),
                 "message_type": msg_type,
             }

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -47,6 +47,7 @@ from src.orchestration.error_capture import (
 from src.orchestration.config import TimeoutConfig
 from src.orchestration.vision_routing import resolve_vision_route
 from src.ooda.fast_thorough_selector import select_path as _ooda_select_path, cite_basis as _ooda_cite_basis
+from src.orchestration.wos_completion_notifier import notify_uow_done, notify_uow_failed
 
 log = logging.getLogger("steward")
 
@@ -4437,6 +4438,24 @@ def _process_uow(
             next_action="done",
             artifact_dir=artifact_dir,
         )
+
+        # Per-cycle completion ping (spec: wos-completion-report-spec.md §Per-Cycle Ping).
+        # Non-fatal: inbox write failure must not block the Done registry transition.
+        # outcome_category is not mapped to UoW dataclass; pass None (degrades gracefully).
+        # current_log_str contains the updated steward_log including steward_closure event.
+        if not dry_run:
+            notify_uow_done(
+                uow_id=uow_id,
+                uow_title=uow.summary,
+                primary_outcome=None,  # not yet mapped to UoW dataclass; notifier falls back to 'seed'
+                steward_cycles=cycles,
+                execution_attempts=uow.execution_attempts,
+                token_usage=None,      # not yet mapped to UoW dataclass; notifier shows 'unknown'
+                artifacts=uow.artifacts,
+                steward_log=current_log_str,
+                gate_fired="none",     # not yet in schema; populated after migration 0019
+            )
+
         return Done(uow_id=uow_id)
 
     # 4b-orphan: executing_orphan short-circuit.
@@ -4486,6 +4505,20 @@ def _process_uow(
             next_action="failed",
             artifact_dir=artifact_dir,
         )
+
+        # Per-cycle failure ping (spec: wos-completion-report-spec.md §Per-Cycle Ping).
+        # Non-fatal: inbox write failure must not block the Surfaced return.
+        if not dry_run:
+            notify_uow_failed(
+                uow_id=uow_id,
+                uow_title=uow.summary,
+                gate_fired="none",         # not yet in schema; populated after migration 0019
+                steward_cycles=cycles,
+                execution_attempts=uow.execution_attempts,
+                token_usage=None,          # not yet mapped to UoW dataclass; shows 'unknown'
+                failure_summary=orphan_reason,
+            )
+
         return Surfaced(uow_id=uow_id, condition=surface_condition)
 
     # 4c: Prescribe another Executor pass

--- a/src/orchestration/wos_completion_notifier.py
+++ b/src/orchestration/wos_completion_notifier.py
@@ -1,0 +1,512 @@
+"""
+WOS completion notification layer — per-cycle ping for Done/Failed transitions.
+
+Spec: docs/wos/wos-completion-report-spec.md §Per-Cycle Ping
+
+Provides:
+- Pure builder functions for short/rich/failed Telegram message formats
+- _select_format_and_build — format selector (pure, no I/O)
+- _extract_completion_rationale — steward_log parser (pure)
+- _count_seeds_from_artifacts — seed counter from artifacts list (pure)
+- _write_wos_done_message — inbox writer (side-effecting, non-fatal)
+
+Insertion point:
+- Called by steward.py at the end of the Done() branch in _process_uow()
+- Called by steward.py at the end of fail_uow() for failed UoWs
+
+Design principles:
+- Pure builders at the core; side effects isolated to _write_wos_done_message
+- Non-fatal: inbox write failure must not block the Done/Failed registry transition
+- Degrades gracefully when gate_fired / seeds_surfaced fields are absent (not yet in schema)
+- Reads LOBSTER_ADMIN_CHAT_ID and LOBSTER_INBOX_DIR at call time (not module load time)
+  so tests can override via patch.dict(os.environ) without re-importing the module
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("wos_completion_notifier")
+
+# ---------------------------------------------------------------------------
+# Named constants — anchored to spec values
+# ---------------------------------------------------------------------------
+
+#: The only primary_outcome that qualifies for short-form (spec: "pearl outcomes").
+SHORT_FORM_TRIGGER_OUTCOME: str = "pearl"
+
+#: Maximum execution_attempts for short-form eligibility.
+#: At ">1 execution attempt" the spec requires rich-form.
+SHORT_FORM_MAX_EXECUTION_ATTEMPTS: int = 1
+
+#: Inbox message type for per-cycle completion ping.
+WOS_DONE_MESSAGE_TYPE: str = "wos_done"
+
+#: Default admin chat_id (read from env at call time; module-level default only).
+_ADMIN_CHAT_ID_DEFAULT: str = "8075091586"
+
+#: Default inbox directory (read from env at call time; overridable in tests).
+_INBOX_DIR_DEFAULT: str = "~/messages/inbox"
+
+
+# ---------------------------------------------------------------------------
+# Pure builder functions
+# ---------------------------------------------------------------------------
+
+def _build_short_form(
+    uow_title: str,
+    primary_outcome: str,
+    steward_cycles: int,
+    token_usage: int | None,
+    seeds_surfaced_count: int,
+) -> str:
+    """
+    Build the short-form per-cycle ping for pearl outcomes with ≤1 execution attempt.
+
+    Spec format:
+        UoW done: <uow_title> [<primary_outcome>]
+        <steward_cycles> cycle(s) · <token_usage> tokens · <seeds_surfaced_count> seeds surfaced
+
+    Pure function — no I/O.
+
+    Args:
+        uow_title: UoW summary string from the registry.
+        primary_outcome: Metabolic taxonomy label (pearl/heat/seed/shit).
+        steward_cycles: Number of steward cycles for this UoW.
+        token_usage: Total input+output tokens, or None if not recorded.
+        seeds_surfaced_count: Number of artifacts with category='seed'.
+
+    Returns:
+        Two-line formatted Telegram message string.
+    """
+    token_str = str(token_usage) if token_usage is not None else "unknown"
+    line1 = f"UoW done: {uow_title} [{primary_outcome}]"
+    line2 = f"{steward_cycles} cycle(s) · {token_str} tokens · {seeds_surfaced_count} seeds surfaced"
+    return f"{line1}\n{line2}"
+
+
+def _build_rich_form(
+    uow_title: str,
+    primary_outcome: str,
+    steward_cycles: int,
+    execution_attempts: int,
+    token_usage: int | None,
+    seeds_surfaced_count: int,
+    gate_fired: str,
+    completion_rationale: str,
+) -> str:
+    """
+    Build the rich-form per-cycle ping for non-pearl outcomes or >1 execution attempt.
+
+    Spec format:
+        UoW done: <uow_title>
+        Outcome : <primary_outcome>
+        Topology: <gate_fired description> (<steward_cycles> cycles, <execution_attempts> attempt(s))
+        Tokens  : <token_usage>
+        Seeds   : <seeds_surfaced_count> new item(s) surfaced
+        Rationale: <completion_rationale>
+
+    The Rationale line is omitted when completion_rationale is empty.
+
+    Pure function — no I/O.
+
+    Args:
+        uow_title: UoW summary string.
+        primary_outcome: Metabolic taxonomy label.
+        steward_cycles: Number of steward cycles.
+        execution_attempts: Number of confirmed execution dispatches.
+        token_usage: Total tokens or None.
+        seeds_surfaced_count: Seed artifact count.
+        gate_fired: Topology gate label (spiral/dead_end/burst/none), or 'none' when absent.
+        completion_rationale: Assessment from steward_closure event, or empty string.
+
+    Returns:
+        Multi-line formatted Telegram message string.
+    """
+    token_str = str(token_usage) if token_usage is not None else "unknown"
+    lines = [
+        f"UoW done: {uow_title}",
+        f"Outcome : {primary_outcome}",
+        f"Topology: {gate_fired} ({steward_cycles} cycles, {execution_attempts} attempt(s))",
+        f"Tokens  : {token_str}",
+        f"Seeds   : {seeds_surfaced_count} new item(s) surfaced",
+    ]
+    if completion_rationale:
+        lines.append(f"Rationale: {completion_rationale}")
+    return "\n".join(lines)
+
+
+def _build_failed_form(
+    uow_title: str,
+    gate_fired: str,
+    steward_cycles: int,
+    execution_attempts: int,
+    token_usage: int | None,
+    failure_summary: str,
+) -> str:
+    """
+    Build the failed-UoW per-cycle ping.
+
+    Spec format:
+        UoW failed: <uow_title>
+        Topology: <gate_fired> gate (<steward_cycles> cycles, <execution_attempts> attempts)
+        Tokens  : <token_usage or "unknown">
+        Failure : <failure_summary>
+
+    Pure function — no I/O.
+
+    Args:
+        uow_title: UoW summary string.
+        gate_fired: Topology gate label or 'none'.
+        steward_cycles: Number of steward cycles.
+        execution_attempts: Number of confirmed execution dispatches.
+        token_usage: Total tokens or None.
+        failure_summary: Close reason or audit log excerpt summarising the failure.
+
+    Returns:
+        Multi-line formatted Telegram message string.
+    """
+    token_str = str(token_usage) if token_usage is not None else "unknown"
+    lines = [
+        f"UoW failed: {uow_title}",
+        f"Topology: {gate_fired} gate ({steward_cycles} cycles, {execution_attempts} attempts)",
+        f"Tokens  : {token_str}",
+        f"Failure : {failure_summary}",
+    ]
+    return "\n".join(lines)
+
+
+def _select_format_and_build(
+    uow_title: str,
+    primary_outcome: str,
+    steward_cycles: int,
+    execution_attempts: int,
+    token_usage: int | None,
+    seeds_surfaced_count: int,
+    gate_fired: str,
+    completion_rationale: str,
+    failure_summary: str | None,
+    failed: bool,
+) -> str:
+    """
+    Select the correct message format and build the Telegram notification text.
+
+    Format selection (spec §Per-Cycle Ping):
+    - Failed form: when failed=True
+    - Short form: when primary_outcome == SHORT_FORM_TRIGGER_OUTCOME
+                  AND execution_attempts <= SHORT_FORM_MAX_EXECUTION_ATTEMPTS
+    - Rich form: all other done cases (non-pearl, or >1 attempt)
+
+    Pure function — no I/O.
+
+    Args:
+        uow_title: UoW summary string.
+        primary_outcome: Metabolic taxonomy label ('pearl'/'heat'/'seed'/'shit').
+        steward_cycles: Steward cycle count.
+        execution_attempts: Confirmed execution dispatches.
+        token_usage: Total tokens or None.
+        seeds_surfaced_count: Number of seed artifacts.
+        gate_fired: Topology gate label.
+        completion_rationale: Assessment from steward_closure event.
+        failure_summary: Failure description (required when failed=True).
+        failed: True if this is a failed UoW ping (not a done ping).
+
+    Returns:
+        Formatted Telegram message string.
+    """
+    if failed:
+        return _build_failed_form(
+            uow_title=uow_title,
+            gate_fired=gate_fired,
+            steward_cycles=steward_cycles,
+            execution_attempts=execution_attempts,
+            token_usage=token_usage,
+            failure_summary=failure_summary or "",
+        )
+
+    use_short_form = (
+        primary_outcome == SHORT_FORM_TRIGGER_OUTCOME
+        and execution_attempts <= SHORT_FORM_MAX_EXECUTION_ATTEMPTS
+    )
+
+    if use_short_form:
+        return _build_short_form(
+            uow_title=uow_title,
+            primary_outcome=primary_outcome,
+            steward_cycles=steward_cycles,
+            token_usage=token_usage,
+            seeds_surfaced_count=seeds_surfaced_count,
+        )
+
+    return _build_rich_form(
+        uow_title=uow_title,
+        primary_outcome=primary_outcome,
+        steward_cycles=steward_cycles,
+        execution_attempts=execution_attempts,
+        token_usage=token_usage,
+        seeds_surfaced_count=seeds_surfaced_count,
+        gate_fired=gate_fired,
+        completion_rationale=completion_rationale,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Steward log extraction — pure
+# ---------------------------------------------------------------------------
+
+def _extract_completion_rationale(steward_log: str | None) -> str:
+    """
+    Extract the assessment field from the last steward_closure event in steward_log.
+
+    The steward_log is a newline-delimited sequence of JSON objects.  The
+    steward_closure event (written at Done() time) carries an 'assessment'
+    field containing the Steward's completion rationale.
+
+    Pure function — no I/O.
+
+    Args:
+        steward_log: Raw steward_log string from the UoW registry, or None.
+
+    Returns:
+        The assessment string from the last steward_closure event, or '' if
+        none is found or the field is absent.
+    """
+    if not steward_log:
+        return ""
+
+    last_assessment: str = ""
+    for line in steward_log.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("event") == "steward_closure":
+            last_assessment = entry.get("assessment") or ""
+
+    return last_assessment
+
+
+# ---------------------------------------------------------------------------
+# Seeds interim count from artifacts — pure
+# ---------------------------------------------------------------------------
+
+def _count_seeds_from_artifacts(artifacts: list[dict] | None) -> int:
+    """
+    Count artifacts with category='seed' as an interim seeds_surfaced_count.
+
+    Per spec §Schema Additions §2: until the structured seeds_surfaced field is
+    implemented (Addition 2), seeds_surfaced_count is approximated by counting
+    artifacts where category='seed'.  This over-counts auto-extracted issue refs
+    but is acceptable as an interim measure.
+
+    Pure function — no I/O.
+
+    Args:
+        artifacts: List of typed ref dicts from the registry artifacts field, or None.
+
+    Returns:
+        Count of artifacts with category == 'seed'.  0 when artifacts is None or empty.
+    """
+    if not artifacts:
+        return 0
+    return sum(1 for a in artifacts if isinstance(a, dict) and a.get("category") == "seed")
+
+
+# ---------------------------------------------------------------------------
+# Inbox writer — side-effecting, non-fatal
+# ---------------------------------------------------------------------------
+
+def _write_wos_done_message(
+    uow_id: str,
+    text: str,
+    chat_id: str | None = None,
+) -> None:
+    """
+    Write a wos_done inbox message so the dispatcher can deliver it to Dan.
+
+    Called by steward.py at the end of the Done() branch and fail_uow() path.
+    Non-fatal: any write failure is logged and swallowed so that the registry
+    Done/Failed transition is never blocked by inbox write errors.
+
+    Message schema:
+        {
+            "id":       "<uuid>",
+            "source":   "system",
+            "type":     "wos_done",
+            "chat_id":  "<admin_chat_id>",
+            "uow_id":   "<uow_id>",
+            "text":     "<pre-formatted Telegram message>",
+            "timestamp": "<ISO-8601 UTC>"
+        }
+
+    Uses atomic write (tmp → rename) to avoid the dispatcher reading a partial file.
+
+    Args:
+        uow_id: The UoW ID that just completed or failed.
+        text: Pre-formatted Telegram notification text from _select_format_and_build.
+        chat_id: Admin chat_id to deliver to.  Defaults to LOBSTER_ADMIN_CHAT_ID env var,
+                 then falls back to _ADMIN_CHAT_ID_DEFAULT.
+    """
+    try:
+        resolved_chat_id = (
+            chat_id
+            or os.environ.get("LOBSTER_ADMIN_CHAT_ID", _ADMIN_CHAT_ID_DEFAULT)
+        )
+        inbox_dir_str = os.environ.get("LOBSTER_INBOX_DIR", _INBOX_DIR_DEFAULT)
+        inbox_dir = Path(os.path.expanduser(inbox_dir_str))
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+
+        msg_id = str(uuid.uuid4())
+        msg: dict[str, Any] = {
+            "id": msg_id,
+            "source": "system",
+            "type": WOS_DONE_MESSAGE_TYPE,
+            "chat_id": resolved_chat_id,
+            "uow_id": uow_id,
+            "text": text,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        tmp_path = inbox_dir / f"{msg_id}.json.tmp"
+        dest_path = inbox_dir / f"{msg_id}.json"
+        try:
+            tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+            tmp_path.rename(dest_path)
+            log.info(
+                "_write_wos_done_message: wrote %s for UoW %r → %s",
+                WOS_DONE_MESSAGE_TYPE, uow_id, dest_path,
+            )
+        except Exception:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    except Exception as exc:
+        log.warning(
+            "_write_wos_done_message: failed to write %s for UoW %r — %s: %s",
+            WOS_DONE_MESSAGE_TYPE, uow_id, type(exc).__name__, exc,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API — called by steward.py
+# ---------------------------------------------------------------------------
+
+def notify_uow_done(
+    uow_id: str,
+    uow_title: str,
+    primary_outcome: str | None,
+    steward_cycles: int,
+    execution_attempts: int,
+    token_usage: int | None,
+    artifacts: list[dict] | None,
+    steward_log: str | None,
+    gate_fired: str = "none",
+    chat_id: str | None = None,
+) -> None:
+    """
+    Compose and write the per-cycle ping for a successful (Done) UoW transition.
+
+    Orchestrates format selection, field extraction, and inbox delivery.
+    Non-fatal at every step: failures are logged and swallowed so the
+    Done() registry transition is never blocked.
+
+    Insertion point: end of the Done() branch in _process_uow(), after all
+    registry writes and _append_cycle_trace().
+
+    Args:
+        uow_id: The WOS unit-of-work ID.
+        uow_title: UoW summary from the registry.
+        primary_outcome: Metabolic taxonomy label; None falls back to 'seed'.
+        steward_cycles: Steward cycle count.
+        execution_attempts: Confirmed execution dispatch count.
+        token_usage: Total tokens or None.
+        artifacts: Registry artifacts list or None (for seed count approximation).
+        steward_log: Raw steward_log JSON string or None.
+        gate_fired: Topology gate label (populated after migration 0019).
+        chat_id: Admin chat_id; defaults to LOBSTER_ADMIN_CHAT_ID env var.
+    """
+    try:
+        resolved_outcome = primary_outcome or "seed"
+        seeds_count = _count_seeds_from_artifacts(artifacts)
+        rationale = _extract_completion_rationale(steward_log)
+
+        text = _select_format_and_build(
+            uow_title=uow_title,
+            primary_outcome=resolved_outcome,
+            steward_cycles=steward_cycles,
+            execution_attempts=execution_attempts,
+            token_usage=token_usage,
+            seeds_surfaced_count=seeds_count,
+            gate_fired=gate_fired,
+            completion_rationale=rationale,
+            failure_summary=None,
+            failed=False,
+        )
+        _write_wos_done_message(uow_id=uow_id, text=text, chat_id=chat_id)
+    except Exception as exc:
+        log.warning(
+            "notify_uow_done: failed for UoW %r — %s: %s",
+            uow_id, type(exc).__name__, exc,
+        )
+
+
+def notify_uow_failed(
+    uow_id: str,
+    uow_title: str,
+    gate_fired: str = "none",
+    steward_cycles: int = 0,
+    execution_attempts: int = 0,
+    token_usage: int | None = None,
+    failure_summary: str = "",
+    chat_id: str | None = None,
+) -> None:
+    """
+    Compose and write the per-cycle ping for a failed UoW transition.
+
+    Orchestrates failed-form format and inbox delivery.  Non-fatal.
+
+    Insertion point: end of the fail_uow() / orphan path in _process_uow().
+
+    Args:
+        uow_id: The WOS unit-of-work ID.
+        uow_title: UoW summary from the registry.
+        gate_fired: Topology gate label (populated after migration 0019).
+        steward_cycles: Steward cycle count.
+        execution_attempts: Confirmed execution dispatch count.
+        token_usage: Total tokens or None.
+        failure_summary: Close reason or audit log excerpt.
+        chat_id: Admin chat_id; defaults to LOBSTER_ADMIN_CHAT_ID env var.
+    """
+    try:
+        text = _select_format_and_build(
+            uow_title=uow_title,
+            primary_outcome="",
+            steward_cycles=steward_cycles,
+            execution_attempts=execution_attempts,
+            token_usage=token_usage,
+            seeds_surfaced_count=0,
+            gate_fired=gate_fired,
+            completion_rationale="",
+            failure_summary=failure_summary,
+            failed=True,
+        )
+        _write_wos_done_message(uow_id=uow_id, text=text, chat_id=chat_id)
+    except Exception as exc:
+        log.warning(
+            "notify_uow_failed: failed for UoW %r — %s: %s",
+            uow_id, type(exc).__name__, exc,
+        )

--- a/tests/unit/test_orchestration/test_wos_done_notifier.py
+++ b/tests/unit/test_orchestration/test_wos_done_notifier.py
@@ -1,0 +1,551 @@
+"""
+Unit tests for wos_completion_notifier.py — per-cycle ping for WOS Done/Failed transitions.
+
+Spec: docs/wos/wos-completion-report-spec.md §Per-Cycle Ping
+
+Behavior under test:
+
+Format selection:
+- Short-form used when primary_outcome is 'pearl' AND execution_attempts <= 1
+- Rich-form used when primary_outcome is not 'pearl' (any non-pearl outcome)
+- Rich-form used when execution_attempts > 1 (>1 attempt, regardless of outcome)
+- Failed-form used for failed UoWs
+
+Message content:
+- Short-form contains uow_title and primary_outcome on first line
+- Short-form second line contains steward_cycles, token_usage, seeds_surfaced_count
+- Rich-form contains Outcome, Topology (with cycles + attempts), Tokens, Seeds, Rationale
+- Failed-form contains Topology, Tokens (or "unknown"), Failure summary
+
+Inbox write:
+- _write_wos_done_message writes a JSON file to ~/messages/inbox/
+- File has type='wos_done', source='system', correct chat_id
+- Non-fatal: inbox write failure does not raise (logged and swallowed)
+
+Dispatcher handler:
+- handle_wos_done is registered in WOS_MESSAGE_TYPE_DISPATCH
+- handle_wos_done returns action='send_reply' with pre-formatted text
+- wos_done dispatched before the spawn-gate (fast-path like wos_pr_sweep_result)
+
+Steward log extraction:
+- _extract_completion_rationale extracts assessment from steward_closure event
+- Returns empty string when steward_log is None or has no steward_closure event
+
+Seeds interim count:
+- _count_seeds_from_artifacts counts artifacts where category='seed'
+- Returns 0 when artifacts is None or empty
+
+Named constants used in assertions:
+- SHORT_FORM_TRIGGER_OUTCOME: 'pearl' — the only outcome that qualifies for short-form
+- SHORT_FORM_MAX_EXECUTION_ATTEMPTS: 1 — threshold above which rich-form fires
+- WOS_DONE_MESSAGE_TYPE: 'wos_done' — the inbox message type
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from orchestration.wos_completion_notifier import (
+    SHORT_FORM_TRIGGER_OUTCOME,
+    SHORT_FORM_MAX_EXECUTION_ATTEMPTS,
+    WOS_DONE_MESSAGE_TYPE,
+    _build_short_form,
+    _build_rich_form,
+    _build_failed_form,
+    _select_format_and_build,
+    _extract_completion_rationale,
+    _count_seeds_from_artifacts,
+    _write_wos_done_message,
+)
+from orchestration.dispatcher_handlers import (
+    handle_wos_done,
+    route_wos_message,
+    WOS_MESSAGE_TYPE_DISPATCH,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants mirroring the spec
+# ---------------------------------------------------------------------------
+
+_SHORT_FORM_OUTCOME = SHORT_FORM_TRIGGER_OUTCOME          # 'pearl'
+_MAX_SHORT_FORM_ATTEMPTS = SHORT_FORM_MAX_EXECUTION_ATTEMPTS  # 1
+
+# Sample UoW data for tests
+_SAMPLE_UOW_TITLE = "Refactor WOS escalation path"
+_SAMPLE_PRIMARY_OUTCOME = "pearl"
+_SAMPLE_STEWARD_CYCLES = 2
+_SAMPLE_TOKEN_USAGE = 15000
+_SAMPLE_SEEDS_COUNT = 0
+_SAMPLE_EXECUTION_ATTEMPTS = 1
+_SAMPLE_COMPLETION_RATIONALE = "PR merged and tests green"
+_SAMPLE_FAILURE_SUMMARY = "Executor orphan after 3 attempts"
+_SAMPLE_UOW_ID = "uow_20260509_abc123"
+_SAMPLE_GATE_FIRED = "none"
+
+
+# ---------------------------------------------------------------------------
+# Short-form format tests
+# ---------------------------------------------------------------------------
+
+class TestBuildShortForm:
+    """_build_short_form produces the correct two-line Telegram message."""
+
+    def test_first_line_contains_done_prefix_and_title(self):
+        text = _build_short_form(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome=_SAMPLE_PRIMARY_OUTCOME,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            seeds_surfaced_count=_SAMPLE_SEEDS_COUNT,
+        )
+        first_line = text.splitlines()[0]
+        assert "UoW done:" in first_line
+        assert _SAMPLE_UOW_TITLE in first_line
+
+    def test_first_line_contains_primary_outcome_in_brackets(self):
+        text = _build_short_form(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome=_SAMPLE_PRIMARY_OUTCOME,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            seeds_surfaced_count=_SAMPLE_SEEDS_COUNT,
+        )
+        first_line = text.splitlines()[0]
+        assert f"[{_SAMPLE_PRIMARY_OUTCOME}]" in first_line
+
+    def test_second_line_contains_steward_cycles(self):
+        text = _build_short_form(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome=_SAMPLE_PRIMARY_OUTCOME,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            seeds_surfaced_count=_SAMPLE_SEEDS_COUNT,
+        )
+        second_line = text.splitlines()[1]
+        assert str(_SAMPLE_STEWARD_CYCLES) in second_line
+        assert "cycle" in second_line
+
+    def test_second_line_contains_token_usage(self):
+        text = _build_short_form(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome=_SAMPLE_PRIMARY_OUTCOME,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            seeds_surfaced_count=_SAMPLE_SEEDS_COUNT,
+        )
+        second_line = text.splitlines()[1]
+        assert str(_SAMPLE_TOKEN_USAGE) in second_line
+        assert "token" in second_line
+
+    def test_second_line_contains_seeds_surfaced(self):
+        text = _build_short_form(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome=_SAMPLE_PRIMARY_OUTCOME,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            seeds_surfaced_count=3,
+        )
+        second_line = text.splitlines()[1]
+        assert "3" in second_line
+        assert "seed" in second_line
+
+    def test_token_usage_none_shows_unknown(self):
+        text = _build_short_form(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome=_SAMPLE_PRIMARY_OUTCOME,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            token_usage=None,
+            seeds_surfaced_count=_SAMPLE_SEEDS_COUNT,
+        )
+        assert "unknown" in text.lower() or "?" in text
+
+
+# ---------------------------------------------------------------------------
+# Rich-form format tests
+# ---------------------------------------------------------------------------
+
+class TestBuildRichForm:
+    """_build_rich_form produces the correct multi-field Telegram message."""
+
+    def _make_rich(self, **overrides):
+        defaults = dict(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome="seed",
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            execution_attempts=_SAMPLE_EXECUTION_ATTEMPTS,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            seeds_surfaced_count=_SAMPLE_SEEDS_COUNT,
+            gate_fired=_SAMPLE_GATE_FIRED,
+            completion_rationale=_SAMPLE_COMPLETION_RATIONALE,
+        )
+        defaults.update(overrides)
+        return _build_rich_form(**defaults)
+
+    def test_first_line_is_done_prefix_with_title(self):
+        text = self._make_rich()
+        assert text.startswith("UoW done:")
+        assert _SAMPLE_UOW_TITLE in text.splitlines()[0]
+
+    def test_outcome_field_present(self):
+        text = self._make_rich(primary_outcome="seed")
+        assert "Outcome" in text
+        assert "seed" in text
+
+    def test_topology_field_contains_cycles_and_attempts(self):
+        text = self._make_rich(steward_cycles=3, execution_attempts=2)
+        assert "Topology" in text
+        assert "3" in text
+        assert "2" in text
+
+    def test_tokens_field_present(self):
+        text = self._make_rich(token_usage=12345)
+        assert "Token" in text
+        assert "12345" in text
+
+    def test_seeds_field_present(self):
+        text = self._make_rich(seeds_surfaced_count=2)
+        assert "Seed" in text
+        assert "2" in text
+
+    def test_rationale_field_present_when_nonempty(self):
+        text = self._make_rich(completion_rationale="Tests passed and PR merged")
+        assert "Rationale" in text
+        assert "Tests passed" in text
+
+    def test_rationale_field_absent_when_empty(self):
+        text = self._make_rich(completion_rationale="")
+        assert "Rationale" not in text
+
+    def test_token_usage_none_shows_unknown(self):
+        text = self._make_rich(token_usage=None)
+        assert "unknown" in text.lower() or "?" in text
+
+
+# ---------------------------------------------------------------------------
+# Failed-form format tests
+# ---------------------------------------------------------------------------
+
+class TestBuildFailedForm:
+    """_build_failed_form produces the correct failed-UoW Telegram message."""
+
+    def _make_failed(self, **overrides):
+        defaults = dict(
+            uow_title=_SAMPLE_UOW_TITLE,
+            gate_fired=_SAMPLE_GATE_FIRED,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            execution_attempts=_SAMPLE_EXECUTION_ATTEMPTS,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            failure_summary=_SAMPLE_FAILURE_SUMMARY,
+        )
+        defaults.update(overrides)
+        return _build_failed_form(**defaults)
+
+    def test_first_line_is_failed_prefix(self):
+        text = self._make_failed()
+        assert text.startswith("UoW failed:")
+        assert _SAMPLE_UOW_TITLE in text.splitlines()[0]
+
+    def test_topology_field_present(self):
+        text = self._make_failed(gate_fired="spiral", steward_cycles=5, execution_attempts=3)
+        assert "Topology" in text
+        assert "5" in text
+        assert "3" in text
+
+    def test_tokens_field_shows_unknown_when_none(self):
+        text = self._make_failed(token_usage=None)
+        assert "unknown" in text.lower()
+
+    def test_failure_field_contains_summary(self):
+        text = self._make_failed(failure_summary="Retry cap exceeded")
+        assert "Failure" in text
+        assert "Retry cap exceeded" in text
+
+
+# ---------------------------------------------------------------------------
+# Format selection tests
+# ---------------------------------------------------------------------------
+
+class TestSelectFormatAndBuild:
+    """_select_format_and_build chooses the right format based on spec rules."""
+
+    def _make_surface(self, **overrides):
+        defaults = dict(
+            uow_title=_SAMPLE_UOW_TITLE,
+            primary_outcome=_SHORT_FORM_OUTCOME,
+            steward_cycles=_SAMPLE_STEWARD_CYCLES,
+            execution_attempts=1,
+            token_usage=_SAMPLE_TOKEN_USAGE,
+            seeds_surfaced_count=0,
+            gate_fired="none",
+            completion_rationale="",
+            failure_summary=None,
+            failed=False,
+        )
+        defaults.update(overrides)
+        return _select_format_and_build(**defaults)
+
+    def test_pearl_with_one_attempt_produces_short_form(self):
+        text = self._make_surface(primary_outcome="pearl", execution_attempts=1)
+        # Short-form has exactly 2 lines; rich-form has more
+        lines = [l for l in text.splitlines() if l.strip()]
+        assert len(lines) == 2
+
+    def test_non_pearl_outcome_produces_rich_form(self):
+        text = self._make_surface(primary_outcome="seed", execution_attempts=1)
+        assert "Outcome" in text
+
+    def test_pearl_with_two_attempts_produces_rich_form(self):
+        text = self._make_surface(primary_outcome="pearl", execution_attempts=2)
+        assert "Outcome" in text
+
+    def test_heat_outcome_produces_rich_form(self):
+        text = self._make_surface(primary_outcome="heat", execution_attempts=1)
+        assert "Outcome" in text
+
+    def test_shit_outcome_produces_rich_form(self):
+        text = self._make_surface(primary_outcome="shit", execution_attempts=1)
+        assert "Outcome" in text
+
+    def test_failed_uow_produces_failed_form(self):
+        text = self._make_surface(failed=True, failure_summary="Timeout")
+        assert text.startswith("UoW failed:")
+
+    def test_failed_form_not_triggered_for_done_uow(self):
+        text = self._make_surface(failed=False, primary_outcome="pearl", execution_attempts=1)
+        assert not text.startswith("UoW failed:")
+
+
+# ---------------------------------------------------------------------------
+# Steward log extraction tests
+# ---------------------------------------------------------------------------
+
+class TestExtractCompletionRationale:
+    """_extract_completion_rationale reads assessment from steward_closure event."""
+
+    def test_returns_empty_string_when_log_is_none(self):
+        assert _extract_completion_rationale(None) == ""
+
+    def test_returns_empty_string_when_log_is_empty(self):
+        assert _extract_completion_rationale("") == ""
+
+    def test_extracts_assessment_from_steward_closure_event(self):
+        entry = {"event": "steward_closure", "assessment": "All criteria met", "timestamp": "2026-05-09T00:00:00Z"}
+        log = json.dumps(entry)
+        assert _extract_completion_rationale(log) == "All criteria met"
+
+    def test_returns_last_steward_closure_when_multiple_present(self):
+        entry1 = {"event": "steward_closure", "assessment": "First closure", "timestamp": "2026-05-09T00:00:00Z"}
+        entry2 = {"event": "steward_closure", "assessment": "Second closure", "timestamp": "2026-05-09T01:00:00Z"}
+        log = json.dumps(entry1) + "\n" + json.dumps(entry2)
+        assert _extract_completion_rationale(log) == "Second closure"
+
+    def test_returns_empty_when_no_steward_closure_event(self):
+        entry = {"event": "prescription", "completion_assessment": "nothing", "timestamp": "2026-05-09T00:00:00Z"}
+        log = json.dumps(entry)
+        assert _extract_completion_rationale(log) == ""
+
+    def test_ignores_malformed_json_lines(self):
+        good_entry = {"event": "steward_closure", "assessment": "done", "timestamp": "x"}
+        log = "not valid json\n" + json.dumps(good_entry) + "\n{also bad"
+        assert _extract_completion_rationale(log) == "done"
+
+    def test_missing_assessment_key_returns_empty_string(self):
+        entry = {"event": "steward_closure", "timestamp": "2026-05-09T00:00:00Z"}
+        log = json.dumps(entry)
+        assert _extract_completion_rationale(log) == ""
+
+
+# ---------------------------------------------------------------------------
+# Seeds count from artifacts tests
+# ---------------------------------------------------------------------------
+
+class TestCountSeedsFromArtifacts:
+    """_count_seeds_from_artifacts counts artifacts with category='seed'."""
+
+    def test_returns_zero_when_artifacts_is_none(self):
+        assert _count_seeds_from_artifacts(None) == 0
+
+    def test_returns_zero_when_artifacts_is_empty(self):
+        assert _count_seeds_from_artifacts([]) == 0
+
+    def test_counts_only_seed_category(self):
+        artifacts = [
+            {"type": "issue", "ref": "dcetlin/Lobster#42", "category": "seed"},
+            {"type": "pr", "ref": "dcetlin/Lobster#43", "category": "pearl"},
+            {"type": "issue", "ref": "dcetlin/Lobster#44", "category": "seed"},
+        ]
+        assert _count_seeds_from_artifacts(artifacts) == 2
+
+    def test_returns_zero_when_no_seeds(self):
+        artifacts = [
+            {"type": "pr", "ref": "dcetlin/Lobster#1", "category": "pearl"},
+        ]
+        assert _count_seeds_from_artifacts(artifacts) == 0
+
+    def test_handles_missing_category_key(self):
+        artifacts = [
+            {"type": "issue", "ref": "dcetlin/Lobster#1"},  # no category key
+        ]
+        assert _count_seeds_from_artifacts(artifacts) == 0
+
+
+# ---------------------------------------------------------------------------
+# Inbox write tests
+# ---------------------------------------------------------------------------
+
+class TestWriteWosDoneMessage:
+    """_write_wos_done_message writes a wos_done inbox JSON file."""
+
+    def test_writes_json_file_to_inbox_dir(self, tmp_path):
+        with patch.dict(os.environ, {"LOBSTER_INBOX_DIR": str(tmp_path)}):
+            _write_wos_done_message(
+                uow_id=_SAMPLE_UOW_ID,
+                text="UoW done: test [pearl]\n1 cycle · 100 tokens · 0 seeds surfaced",
+                chat_id="8075091586",
+            )
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) == 1
+
+    def test_written_file_has_correct_type(self, tmp_path):
+        with patch.dict(os.environ, {"LOBSTER_INBOX_DIR": str(tmp_path)}):
+            _write_wos_done_message(
+                uow_id=_SAMPLE_UOW_ID,
+                text="test text",
+                chat_id="8075091586",
+            )
+        files = list(tmp_path.glob("*.json"))
+        payload = json.loads(files[0].read_text())
+        assert payload["type"] == WOS_DONE_MESSAGE_TYPE
+
+    def test_written_file_has_correct_source(self, tmp_path):
+        with patch.dict(os.environ, {"LOBSTER_INBOX_DIR": str(tmp_path)}):
+            _write_wos_done_message(
+                uow_id=_SAMPLE_UOW_ID,
+                text="test text",
+                chat_id="8075091586",
+            )
+        files = list(tmp_path.glob("*.json"))
+        payload = json.loads(files[0].read_text())
+        assert payload["source"] == "system"
+
+    def test_written_file_contains_uow_id(self, tmp_path):
+        with patch.dict(os.environ, {"LOBSTER_INBOX_DIR": str(tmp_path)}):
+            _write_wos_done_message(
+                uow_id=_SAMPLE_UOW_ID,
+                text="test text",
+                chat_id="8075091586",
+            )
+        files = list(tmp_path.glob("*.json"))
+        payload = json.loads(files[0].read_text())
+        assert payload.get("uow_id") == _SAMPLE_UOW_ID
+
+    def test_write_failure_does_not_raise(self, tmp_path):
+        """Non-fatal: inbox write failure must not propagate to caller."""
+        # Use a non-existent path where mkdir can't help — read-only parent simulation
+        bad_dir = "/dev/null/nonexistent_inbox_path"
+        with patch.dict(os.environ, {"LOBSTER_INBOX_DIR": bad_dir}):
+            # Should not raise
+            _write_wos_done_message(
+                uow_id=_SAMPLE_UOW_ID,
+                text="test text",
+                chat_id="8075091586",
+            )
+
+    def test_uses_env_var_for_chat_id_when_not_supplied(self, tmp_path):
+        """Falls back to LOBSTER_ADMIN_CHAT_ID env var."""
+        with patch.dict(os.environ, {
+            "LOBSTER_INBOX_DIR": str(tmp_path),
+            "LOBSTER_ADMIN_CHAT_ID": "9999999999",
+        }):
+            _write_wos_done_message(
+                uow_id=_SAMPLE_UOW_ID,
+                text="test text",
+            )
+        files = list(tmp_path.glob("*.json"))
+        payload = json.loads(files[0].read_text())
+        assert payload["chat_id"] == "9999999999"
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher handler tests
+# ---------------------------------------------------------------------------
+
+class TestHandleWosDone:
+    """handle_wos_done returns action='send_reply' with the pre-formatted text."""
+
+    def _make_msg(self, **overrides):
+        defaults = {
+            "type": WOS_DONE_MESSAGE_TYPE,
+            "source": "system",
+            "chat_id": "8075091586",
+            "uow_id": _SAMPLE_UOW_ID,
+            "text": "UoW done: test [pearl]\n2 cycle(s) · 15000 tokens · 0 seeds surfaced",
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_returns_send_reply_action(self):
+        msg = self._make_msg()
+        result = handle_wos_done(msg)
+        assert result["action"] == "send_reply"
+
+    def test_returns_text_from_message(self):
+        expected_text = "UoW done: my uow [pearl]\n2 cycle(s) · 100 tokens · 0 seeds surfaced"
+        msg = self._make_msg(text=expected_text)
+        result = handle_wos_done(msg)
+        assert result["text"] == expected_text
+
+    def test_returns_chat_id_from_message(self):
+        msg = self._make_msg(chat_id="12345678")
+        result = handle_wos_done(msg)
+        assert result["chat_id"] == "12345678"
+
+    def test_falls_back_to_env_chat_id_when_missing(self):
+        msg = self._make_msg()
+        del msg["chat_id"]
+        with patch.dict(os.environ, {"LOBSTER_ADMIN_CHAT_ID": "7777777777"}):
+            result = handle_wos_done(msg)
+        assert result["chat_id"] == "7777777777"
+
+    def test_returns_message_type_wos_done(self):
+        msg = self._make_msg()
+        result = handle_wos_done(msg)
+        assert result["message_type"] == WOS_DONE_MESSAGE_TYPE
+
+    def test_missing_text_uses_fallback(self):
+        msg = self._make_msg()
+        del msg["text"]
+        result = handle_wos_done(msg)
+        assert isinstance(result["text"], str)
+        assert len(result["text"]) > 0
+
+
+class TestWosDoneInDispatchTable:
+    """wos_done is registered in WOS_MESSAGE_TYPE_DISPATCH and routed correctly."""
+
+    def test_wos_done_in_dispatch_table(self):
+        assert WOS_DONE_MESSAGE_TYPE in WOS_MESSAGE_TYPE_DISPATCH
+
+    def test_route_wos_message_routes_wos_done(self):
+        msg = {
+            "type": WOS_DONE_MESSAGE_TYPE,
+            "source": "system",
+            "chat_id": "8075091586",
+            "uow_id": _SAMPLE_UOW_ID,
+            "text": "UoW done: test [pearl]\n1 cycle(s) · 100 tokens · 0 seeds surfaced",
+        }
+        result = route_wos_message(msg)
+        assert result["action"] == "send_reply"
+        assert result["message_type"] == WOS_DONE_MESSAGE_TYPE


### PR DESCRIPTION
## Problem solved

When a UoW transitions to Done or Failed in steward.py, the audit trail is complete but nothing reaches Dan's attention stream. Operator visibility into what completed required polling `registry_cli report` — there was no push signal.

## What this does

Adds a non-fatal per-cycle Telegram ping that fires at the end of the Done() and fail_uow() branches in `_process_uow()`. Three format variants, per the approved spec (`docs/wos/wos-completion-report-spec.md §Per-Cycle Ping`):

**Short-form** (pearl outcome, ≤1 execution attempt):
```
UoW done: Refactor WOS escalation path [pearl]
2 cycle(s) · 15000 tokens · 0 seeds surfaced
```

**Rich-form** (non-pearl outcome or >1 attempt):
```
UoW done: Refactor WOS escalation path
Outcome : seed
Topology: none (3 cycles, 2 attempt(s))
Tokens  : 22000
Seeds   : 1 new item(s) surfaced
Rationale: PR merged and tests passed
```

**Failed-form** (fail_uow / orphan path):
```
UoW failed: Refactor WOS escalation path
Topology: none gate (2 cycles, 1 attempts)
Tokens  : unknown
Failure : executing_orphan: subagent exited without calling write_result
```

## Flow change

```
Before:
  Done() → registry transition → Done return (silence)

After:
  Done() → registry transition → notify_uow_done() → inbox wos_done msg
         → dispatcher handle_wos_done() → send_reply to Dan
```

The notify call is at the very end of Done(), after _append_cycle_trace. Non-fatal: any exception in the notifier is logged and swallowed. The Done return and registry transition are always unaffected.

## What changed

- **New module** `src/orchestration/wos_completion_notifier.py`: pure builders + non-fatal inbox writer
- **`dispatcher_handlers.py`**: `handle_wos_done()` registered in `WOS_MESSAGE_TYPE_DISPATCH`; fast-path in `route_wos_message()` (before the spawn-gate, like `wos_pr_sweep_result`)
- **`steward.py`**: `notify_uow_done()` inserted after `_append_cycle_trace` in Done() branch; `notify_uow_failed()` inserted in orphan fail_uow() path

## Known gaps (acceptable for this PR, noted per spec)

- `outcome_category` is not mapped to the `UoW` dataclass (available in DB only via `fetch_in_window`). Notifier falls back to `'seed'` until a follow-up maps it. Short-form will not fire correctly until this is resolved (see Areas to review below).
- `token_usage` has the same gap — not on `uow` object. Shows `'unknown'` in pings.
- `gate_fired` not yet in schema (migration 0019 is PR #1093, the immediate follow-on).

These are called out in spec §Per-Cycle Ping table with status "Present (unextracted)" — the spec explicitly permits the notification layer to launch first and gain these fields incrementally.

## Areas to review closely

1. **Short-form accuracy**: Because `outcome_category` is not yet mapped to the `UoW` dataclass, `notify_uow_done` always receives `primary_outcome=None`, which the notifier resolves to `'seed'`. This means the short-form (pearl-only) never fires in the initial PR — all done pings will use rich-form. This is an acceptable interim state per spec, but worth confirming the reviewer agrees before merge.

2. **`not dry_run` guard**: The notify calls are wrapped in `if not dry_run:` so test cycles that use `dry_run=True` don't write to the inbox. Verify this is the right guard for the test environment — `test_steward.py` uses dry_run=True extensively.

3. **Orphan fail path**: The `notify_uow_failed()` call is in the `executing_orphan` branch specifically (not in the `retry_cap` / `stuck` branches). Per spec the ping fires at `fail_uow()` transitions — the retry cap and stuck paths surface via `wos_escalate`, not `wos_done`. Confirm this scoping matches the spec intent.

## Functional patterns

Pure builder functions at the core (`_build_short_form`, `_build_rich_form`, `_build_failed_form`); composition via `_select_format_and_build`; side effects isolated to `_write_wos_done_message`. The dispatcher handler is a pure function returning a dict.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_done_notifier.py` — 51 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py tests/unit/test_orchestration/test_wos_escalate_handler.py tests/unit/test_orchestration/test_wos_surface_handler.py` — 148 passed, 0 failed
- [ ] `uv run pytest tests/unit/test_orchestration/test_steward.py` — skipped: test_steward.py takes >120s; test suite times out in this environment. The notify calls are guarded by `if not dry_run:` and all steward tests use dry_run=True, so no behavioral change in the test path
- [ ] `tests/unit/test_orchestration/test_registry_cli.py` — pre-existing SyntaxError on main, not caused by this PR

## Manual test

N/A — the notify call writes to `~/messages/inbox/` which is processed by the running dispatcher. No external service call is made from the notifier itself; the side effect is a local file write. The dispatcher's existing Telegram delivery path is unchanged.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (file write + existing dispatcher path)
- [ ] User-visible outcome verified — blocked: requires a live UoW to complete during a test window; ask Dan to confirm ping appears after next UoW done transition
- [x] Side-effect audit: no floods (one message per UoW completion), no unscoped writes, bounded volume
- [x] External service calls: notifier does not call Telegram directly; dispatcher delivers via existing path

Closes #1092