### PR TITLE
fix(wos-router): non-blocking Popen dispatch prevents SIGTERM kill of in-flight agents (#1091)

### DIFF
--- a/src/daemons/wos_execute_router.py
+++ b/src/daemons/wos_execute_router.py
@@ -52,6 +52,7 @@ import logging
 import os
 import shutil
 import signal
+import subprocess
 import sys
 import time
 import uuid
@@ -75,7 +76,6 @@ for _p in [str(_REPO_ROOT), str(_SRC_ROOT)]:
 # ---------------------------------------------------------------------------
 
 from orchestration.dispatcher_handlers import route_wos_message, read_wos_config  # noqa: E402
-from orchestration.executor import _dispatch_via_claude_p  # noqa: E402
 from agents.session_store import get_active_sessions  # noqa: E402
 from utils.inbox_write import write_inbox_message  # noqa: E402
 
@@ -317,6 +317,83 @@ def _write_send_reply_alert(text: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Non-blocking subprocess dispatch
+# ---------------------------------------------------------------------------
+
+#: claude binary — resolved from PATH at call time.
+_CLAUDE_BIN: str = "claude"
+
+#: Maximum turns for a dispatched claude -p agent.
+_MAX_TURNS: int = 40
+
+
+def _dispatch_via_popen(instructions: str, uow_id: str) -> str:
+    """
+    Dispatch a functional-engineer subagent via ``claude -p`` without blocking.
+
+    Uses ``subprocess.Popen`` with ``start_new_session=True`` so the child
+    process runs in its own process group and is NOT killed when systemd sends
+    SIGTERM to this daemon.
+
+    The child process runs independently.  The daemon does NOT wait for it
+    to complete — the subagent's handoff mechanism is ``write_result``
+    (called at agent completion), not the subprocess return code.
+
+    Returns a ``run_id`` string for audit correlation (``uow_id`` + timestamp).
+
+    Raises ``FileNotFoundError`` if the claude binary is not on PATH.
+    Raises ``OSError`` for other process creation errors.
+
+    This replaces the synchronous ``_dispatch_via_claude_p`` call pattern in
+    the router.  The synchronous path (``executor._dispatch_via_claude_p``)
+    is intentionally retained for the executor-heartbeat path (CI / recovery
+    scenarios where blocking is acceptable).
+
+    Design note: ``start_new_session=True`` creates a new Unix session (and
+    therefore a new process group) for the child.  This is the minimal
+    isolation required: the child is no longer in the daemon's process group,
+    so a SIGTERM or SIGKILL targeting the daemon's group does not propagate.
+    ``close_fds=True`` (the Python default) ensures the daemon's open file
+    descriptors are not inherited by the child.
+    """
+    run_id = f"{uow_id}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+
+    command = [
+        _CLAUDE_BIN,
+        "-p",
+        "--dangerously-skip-permissions",
+        "--max-turns", str(_MAX_TURNS),
+        "--",   # end-of-options sentinel: prevents prompts starting with '---'
+                # from being parsed as CLI flags
+        instructions,
+    ]
+
+    # Pass an explicit env so CLAUDE_CODE_OAUTH_TOKEN is present even when
+    # this daemon was started by systemd with a stripped environment.
+    try:
+        from orchestration.steward import _build_claude_env
+        env = _build_claude_env()
+    except Exception:
+        env = None  # Fall back to inheriting the current environment
+
+    subprocess.Popen(
+        command,
+        start_new_session=True,  # Insulates child from SIGTERM sent to daemon
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        env=env,
+    )
+
+    log.info(
+        "dispatch: spawned claude -p for uow_id=%s run_id=%s (non-blocking, new session)",
+        uow_id, run_id,
+    )
+    return run_id
+
+
+# ---------------------------------------------------------------------------
 # Core routing logic
 # ---------------------------------------------------------------------------
 
@@ -360,15 +437,15 @@ def _route_single_message(msg: dict) -> None:
         task_id: str = decision.get("task_id", f"wos-{uow_id}")
         prompt: str = decision.get("prompt", "")
         # route_wos_message returns task_id as "wos-{uow_id}"; strip prefix
-        # to get the bare uow_id expected by _dispatch_via_claude_p
+        # to get the bare uow_id expected by _dispatch_via_popen
         bare_uow_id = task_id.removeprefix("wos-")
 
         log.info("route: dispatching subagent for uow_id=%s task_id=%s", uow_id, task_id)
         try:
-            run_id = _dispatch_via_claude_p(instructions=prompt, uow_id=bare_uow_id)
+            run_id = _dispatch_via_popen(instructions=prompt, uow_id=bare_uow_id)
             log.info("route: dispatch succeeded run_id=%s uow_id=%s", run_id, uow_id)
         except Exception as exc:
-            log.error("route: _dispatch_via_claude_p raised for %s: %s", uow_id, exc)
+            log.error("route: _dispatch_via_popen raised for %s: %s", uow_id, exc)
             _release_message_failed(message_id)
             _write_alert(
                 f"wos-execute-router: subprocess dispatch failed for "

--- a/tests/test_wos_execute_router.py
+++ b/tests/test_wos_execute_router.py
@@ -21,6 +21,7 @@ Coverage:
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -41,7 +42,7 @@ def _get_router_module():
     mocks = {
         "orchestration": MagicMock(),
         "orchestration.dispatcher_handlers": MagicMock(),
-        "orchestration.executor": MagicMock(),
+        "orchestration.steward": MagicMock(),
         "agents": MagicMock(),
         "agents.session_store": MagicMock(),
         "utils": MagicMock(),
@@ -66,13 +67,11 @@ def _get_router_module():
             repo_root / "src" / "daemons" / "wos_execute_router.py",
         )
         mod = importlib.util.module_from_spec(spec)
-        # Inject mocked top-level names the module uses after import
-        mod.route_wos_message = MagicMock()
-        mod._dispatch_via_claude_p = MagicMock()
-        mod.get_active_sessions = MagicMock()
-        mod.write_inbox_message = MagicMock()
-        mod.read_wos_config = MagicMock()
         spec.loader.exec_module(mod)
+        # _dispatch_via_popen is defined in the module (not imported), so it
+        # must be replaced with a mock AFTER exec_module — doing it before would
+        # be overwritten by the def statement in the module body.
+        mod._dispatch_via_popen = MagicMock(return_value="run-id-mock")
         return mod
 
 
@@ -169,7 +168,7 @@ class TestExecutionEnabledGate:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.return_value = "run-id-1"
+        router._dispatch_via_popen.return_value = "run-id-1"
 
         result = router.run_poll_cycle()
         assert result == 1
@@ -214,7 +213,7 @@ class TestMaxAgentsGate:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.return_value = "run-id-2"
+        router._dispatch_via_popen.return_value = "run-id-2"
 
         result = router.run_poll_cycle()
         assert result == 1
@@ -256,7 +255,7 @@ class TestMessageFiltering:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.return_value = "run-id-3"
+        router._dispatch_via_popen.return_value = "run-id-3"
 
         result = router.run_poll_cycle()
 
@@ -290,7 +289,7 @@ class TestHappyPathRouting:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.return_value = "run-id"
+        router._dispatch_via_popen.return_value = "run-id"
 
         router.run_poll_cycle()
 
@@ -299,7 +298,7 @@ class TestHappyPathRouting:
         assert (router.PROCESSED_DIR / f"{msg['id']}.json").exists()
 
     def test_dispatch_called_with_stripped_uow_id(self, router):
-        """_dispatch_via_claude_p receives uow_id with 'wos-' prefix stripped."""
+        """_dispatch_via_popen receives uow_id with 'wos-' prefix stripped."""
         uow_id = "abc-456"
         msg = _make_wos_execute_msg(uow_id=uow_id)
         _write_msg(router.INBOX_DIR, msg)
@@ -311,12 +310,12 @@ class TestHappyPathRouting:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.return_value = "run-id"
+        router._dispatch_via_popen.return_value = "run-id"
 
         router.run_poll_cycle()
 
-        # uow_id passed to _dispatch_via_claude_p must NOT have "wos-" prefix
-        call_kwargs = router._dispatch_via_claude_p.call_args
+        # uow_id passed to _dispatch_via_popen must NOT have "wos-" prefix
+        call_kwargs = router._dispatch_via_popen.call_args
         assert call_kwargs is not None
         # Accept either positional or keyword argument for uow_id
         kwargs = call_kwargs.kwargs
@@ -324,7 +323,7 @@ class TestHappyPathRouting:
         passed_uow_id = kwargs.get("uow_id") or (args[1] if len(args) > 1 else None)
         assert passed_uow_id == uow_id, (
             f"Expected uow_id={uow_id!r} but got {passed_uow_id!r}. "
-            "The 'wos-' prefix must be stripped before passing to _dispatch_via_claude_p."
+            "The 'wos-' prefix must be stripped before passing to _dispatch_via_popen."
         )
 
     def test_route_wos_message_called_with_message(self, router):
@@ -339,7 +338,7 @@ class TestHappyPathRouting:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.return_value = "run-id"
+        router._dispatch_via_popen.return_value = "run-id"
 
         router.run_poll_cycle()
 
@@ -388,7 +387,7 @@ class TestSendReplyAlert:
         assert not (router.FAILED_DIR / f"{msg['id']}.json").exists()
 
     def test_dispatch_not_called_on_send_reply(self, router):
-        """_dispatch_via_claude_p is not called when action=send_reply."""
+        """_dispatch_via_popen is not called when action=send_reply."""
         msg = _make_wos_execute_msg()
         _write_msg(router.INBOX_DIR, msg)
 
@@ -400,7 +399,7 @@ class TestSendReplyAlert:
 
         router.run_poll_cycle()
 
-        router._dispatch_via_claude_p.assert_not_called()
+        router._dispatch_via_popen.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -408,7 +407,7 @@ class TestSendReplyAlert:
 # ---------------------------------------------------------------------------
 
 class TestDispatchFailure:
-    """_dispatch_via_claude_p raising moves message to failed/ and writes alert."""
+    """_dispatch_via_popen raising moves message to failed/ and writes alert."""
 
     def test_message_moved_to_failed_on_dispatch_error(self, router):
         msg = _make_wos_execute_msg()
@@ -421,7 +420,7 @@ class TestDispatchFailure:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.side_effect = RuntimeError("subprocess died")
+        router._dispatch_via_popen.side_effect = RuntimeError("subprocess died")
 
         router.run_poll_cycle()
 
@@ -439,7 +438,7 @@ class TestDispatchFailure:
             "agent_type": "functional-engineer",
             "message_type": "wos_execute",
         }
-        router._dispatch_via_claude_p.side_effect = RuntimeError("subprocess died")
+        router._dispatch_via_popen.side_effect = RuntimeError("subprocess died")
 
         router.run_poll_cycle()
 
@@ -473,7 +472,7 @@ class TestDispatchFailure:
                 "message_type": "wos_execute",
             },
         ]
-        router._dispatch_via_claude_p.side_effect = fake_dispatch
+        router._dispatch_via_popen.side_effect = fake_dispatch
 
         router.run_poll_cycle()
 
@@ -529,7 +528,7 @@ class TestClaimRaceCondition:
             result = router.run_poll_cycle()
 
         # Should not crash; dispatch never called
-        router._dispatch_via_claude_p.assert_not_called()
+        router._dispatch_via_popen.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -564,3 +563,141 @@ class TestFilterWosExecute:
         mod = _get_router_module()
         msgs = [{"type": "WOS_EXECUTE"}, {"type": "wos-execute"}]
         assert mod._filter_wos_execute(msgs) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: _dispatch_via_popen (non-blocking dispatch)
+# ---------------------------------------------------------------------------
+
+class TestDispatchViaPopen:
+    """_dispatch_via_popen uses Popen with start_new_session=True (SIGTERM safety)."""
+
+    def test_uses_popen_not_run(self):
+        """subprocess.Popen is called, not subprocess.run (non-blocking contract)."""
+        mod = _get_router_module()
+        # Restore the real _dispatch_via_popen so we can test it
+        import importlib.util
+        repo_root = Path(__file__).resolve().parent.parent
+        spec = importlib.util.spec_from_file_location(
+            "wos_execute_router_real",
+            repo_root / "src" / "daemons" / "wos_execute_router.py",
+        )
+        real_mod = importlib.util.module_from_spec(spec)
+        # Patch subprocess at module level before exec
+        mock_popen = MagicMock()
+        mock_popen.return_value = MagicMock()
+        with patch("subprocess.Popen", mock_popen):
+            # Need to also patch the orchestration imports that happen at exec time
+            from unittest.mock import patch as _patch
+            with _patch.dict("sys.modules", {
+                "orchestration": MagicMock(),
+                "orchestration.dispatcher_handlers": MagicMock(),
+                "orchestration.steward": MagicMock(),
+                "agents": MagicMock(),
+                "agents.session_store": MagicMock(),
+                "utils": MagicMock(),
+                "utils.inbox_write": MagicMock(),
+            }):
+                spec.loader.exec_module(real_mod)
+                run_id = real_mod._dispatch_via_popen("test instructions", "uow-test-123")
+
+        assert mock_popen.called, "subprocess.Popen must be called (not subprocess.run)"
+        assert run_id.startswith("uow-test-123-"), f"run_id must include uow_id prefix, got {run_id!r}"
+
+    def test_start_new_session_is_true(self):
+        """Popen is called with start_new_session=True to insulate from daemon SIGTERM."""
+        import importlib.util
+        repo_root = Path(__file__).resolve().parent.parent
+        spec = importlib.util.spec_from_file_location(
+            "wos_execute_router_sigterm",
+            repo_root / "src" / "daemons" / "wos_execute_router.py",
+        )
+        real_mod = importlib.util.module_from_spec(spec)
+
+        mock_popen = MagicMock()
+        mock_popen.return_value = MagicMock()
+        with patch("subprocess.Popen", mock_popen):
+            with patch.dict("sys.modules", {
+                "orchestration": MagicMock(),
+                "orchestration.dispatcher_handlers": MagicMock(),
+                "orchestration.steward": MagicMock(),
+                "agents": MagicMock(),
+                "agents.session_store": MagicMock(),
+                "utils": MagicMock(),
+                "utils.inbox_write": MagicMock(),
+            }):
+                spec.loader.exec_module(real_mod)
+                real_mod._dispatch_via_popen("some instructions", "uow-sigterm-test")
+
+        call_kwargs = mock_popen.call_args
+        assert call_kwargs is not None
+        # start_new_session can be passed as positional or keyword
+        kwargs = call_kwargs.kwargs
+        assert kwargs.get("start_new_session") is True, (
+            "Popen must be called with start_new_session=True to insulate from SIGTERM. "
+            f"Got kwargs: {kwargs}"
+        )
+
+    def test_stdin_stdout_stderr_devnull(self):
+        """Child process inherits no file descriptors from daemon (clean isolation)."""
+        import importlib.util
+        repo_root = Path(__file__).resolve().parent.parent
+        spec = importlib.util.spec_from_file_location(
+            "wos_execute_router_fds",
+            repo_root / "src" / "daemons" / "wos_execute_router.py",
+        )
+        real_mod = importlib.util.module_from_spec(spec)
+
+        mock_popen = MagicMock()
+        mock_popen.return_value = MagicMock()
+        with patch("subprocess.Popen", mock_popen):
+            with patch.dict("sys.modules", {
+                "orchestration": MagicMock(),
+                "orchestration.dispatcher_handlers": MagicMock(),
+                "orchestration.steward": MagicMock(),
+                "agents": MagicMock(),
+                "agents.session_store": MagicMock(),
+                "utils": MagicMock(),
+                "utils.inbox_write": MagicMock(),
+            }):
+                spec.loader.exec_module(real_mod)
+                real_mod._dispatch_via_popen("some instructions", "uow-fds-test")
+
+        kwargs = mock_popen.call_args.kwargs
+        assert kwargs.get("stdin") == subprocess.DEVNULL, "stdin must be DEVNULL"
+        assert kwargs.get("stdout") == subprocess.DEVNULL, "stdout must be DEVNULL"
+        assert kwargs.get("stderr") == subprocess.DEVNULL, "stderr must be DEVNULL"
+
+    def test_command_includes_claude_p_flags(self):
+        """Popen command includes -p, --dangerously-skip-permissions, --max-turns."""
+        import importlib.util
+        repo_root = Path(__file__).resolve().parent.parent
+        spec = importlib.util.spec_from_file_location(
+            "wos_execute_router_cmd",
+            repo_root / "src" / "daemons" / "wos_execute_router.py",
+        )
+        real_mod = importlib.util.module_from_spec(spec)
+
+        mock_popen = MagicMock()
+        mock_popen.return_value = MagicMock()
+        instructions = "follow the prescription"
+        with patch("subprocess.Popen", mock_popen):
+            with patch.dict("sys.modules", {
+                "orchestration": MagicMock(),
+                "orchestration.dispatcher_handlers": MagicMock(),
+                "orchestration.steward": MagicMock(),
+                "agents": MagicMock(),
+                "agents.session_store": MagicMock(),
+                "utils": MagicMock(),
+                "utils.inbox_write": MagicMock(),
+            }):
+                spec.loader.exec_module(real_mod)
+                real_mod._dispatch_via_popen(instructions, "uow-cmd-test")
+
+        command = mock_popen.call_args.args[0]
+        assert "-p" in command, "command must include -p flag"
+        assert "--dangerously-skip-permissions" in command, (
+            "command must include --dangerously-skip-permissions"
+        )
+        assert "--max-turns" in command, "command must include --max-turns"
+        assert instructions in command, "command must include the instructions"


### PR DESCRIPTION
## What this fixes

When systemd restarted the `wos-execute-router` daemon, it sent SIGTERM to the daemon's process group. Because the router dispatched `claude -p` agents via `subprocess.run()` (blocking, same process group), every in-flight agent was killed immediately — exit code 143 (128+SIGTERM). The CalledProcessError propagated up the call stack, the executor wrote a `failed` result.json, and UoWs were marked failed before they had any chance to run.

This is the root cause of the CalledProcessError exit 1/143 failures that caused WOS to be paused at `execution_enabled=false`. The 163 UoWs currently in `ready-for-steward` state are infrastructure-kill-wave orphans from this failure mode — their `execution_attempts` are 0 and their return reasons are `executor_orphan`.

## What changed

Added `_dispatch_via_popen()` in `src/daemons/wos_execute_router.py`:
- Uses `subprocess.Popen` with `start_new_session=True` — child process gets its own Unix session and process group, insulating it from SIGTERM sent to the daemon
- Fire-and-forget dispatch: the daemon does not wait for the agent to finish. Handoff happens via `write_result`, not subprocess return code
- `stdin/stdout/stderr` all set to `DEVNULL` so the child inherits no file descriptors from the daemon
- Explicit `env` passed via `_build_claude_env()` so `CLAUDE_CODE_OAUTH_TOKEN` is present even in stripped systemd environments

Replaced the `_dispatch_via_claude_p` call in `_route_single_message` with `_dispatch_via_popen`. The synchronous `_dispatch_via_claude_p` path in `executor.py` is retained for the executor-heartbeat recovery path and CI environments.

## Functional patterns used

Pure function addition: `_dispatch_via_popen` has no side effects beyond spawning the process (process creation is the intended effect). The module-level import of `_dispatch_via_claude_p` is removed — the router now owns its own dispatch path rather than depending on the executor's internal.

## Flow: before vs after

**Before:**
```
SIGTERM → daemon process group → kills daemon + all claude -p children
  → CalledProcessError exit 143
  → UoW marked failed (execution_attempts=0, orphan)
```

**After:**
```
SIGTERM → daemon process group → kills daemon only
  claude -p children: own session, own process group → unaffected
  → agent runs to completion, calls write_result
  → UoW transitions normally (executing → ready-for-steward)
```

## Tests run

- [x] `uv run pytest tests/test_wos_execute_router.py -v` — 30 passed, 0 failed
- [x] `uv run pytest tests/test_wos_execute_router.py tests/unit/test_orchestration/test_executor_heartbeat.py -v` — 52 passed, 0 failed

## Manual test

Not applicable. This change is entirely internal to the daemon's dispatch mechanism. The fix prevents a process-group kill that was causing agent termination; verification requires a daemon restart event which cannot be safely triggered in production before the fix is merged. The SIGTERM isolation contract is enforced structurally by `start_new_session=True` — this is a POSIX guarantee, not behavior that requires runtime observation.

The existing test `test_start_new_session_is_true` verifies that `Popen` is called with `start_new_session=True` at the call site.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (see Manual test above)
- [x] User-visible outcome: WOS will be able to restart safely after this merges; Dan enables WOS manually (`wos start`)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume — fix only changes how the child process is spawned
- [x] External service calls: `claude -p` subprocess is unchanged; only the process group isolation changes

Closes #1091
WOS-UoW: wos-subprocess-fix