### PR TITLE
feat(los): Cycle 1 — action item extraction and surfacing

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -831,10 +831,26 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
        job_name = data.removeprefix("job-confirm-no-")
        send_reply(chat_id=chat_id, text="Job cancelled.", source=source)
 
-7. else:
+   # LOS (Life Operating System) callbacks — todo-done-{id}, todo-dismiss-{id}, todo-snooze-{id}-{date}
+   # These are handled synchronously (no DB lock, instant status change, deterministic).
+elif data.startswith("todo-"):
+       from src.los.callbacks import route_los_callback
+       result = route_los_callback(msg)
+       if result["handled"]:
+           send_reply(chat_id=chat_id, text=result["text"], source=source)
+       else:
+           send_reply(chat_id=chat_id, text=f"Unknown todo callback: {data}", source=source)
+
+7. elif data.startswith("decide_retry:") or data.startswith("decide_close:"):
+       from src.orchestration.dispatcher_handlers import route_callback_message
+       result = route_callback_message(msg)
+       if result["handled"]:
+           send_reply(chat_id=chat_id, text=result["text"], source=source)
+
+8. else:
        send_reply(chat_id=chat_id, text=f"Unknown callback: {data}", source=source)
 
-8. mark_processed(message_id)
+9. mark_processed(message_id)
 ```
 
 ### Telegram-specific
@@ -987,6 +1003,34 @@ This rule is unconditional — even if the session processed zero messages, the 
 - The current MESSAGE_COUNT at time of compaction
 
 **On context_warning:** Write a tombstone inline as step 2 (see context_warning handler above) — this is faster and more reliable than spawning a subagent, and ensures the record survives even if wind-down is interrupted.
+
+---
+
+## LOS (Life Operating System) Commands
+
+**`/todos`** — display Dan's current action items with interactive buttons.
+
+```python
+# Dispatch to a todos-query subagent
+Task(
+    subagent_type="lobster-generalist",
+    run_in_background=True,
+    prompt=(
+        f"---\ntask_id: los-todos-{chat_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+        + open(Path.home() / "lobster-workspace/scheduled-jobs/tasks/los-todos-query.md").read()
+    ),
+)
+send_reply(chat_id=chat_id, text="Checking your todos...", source=source)
+```
+
+**LOS callback routing** — `todo-done-{id}`, `todo-dismiss-{id}`, `todo-snooze-{id}-{date}` callbacks
+are handled in the Button callbacks section above (see `data.startswith("todo-")`).
+
+**Natural language triggers** for `/todos` — also recognize these phrases as equivalent to `/todos`:
+- "what's on my list"
+- "show my todos"
+- "what do I need to do"
+- "show action items"
 
 ---
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -833,7 +833,7 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
 
    # LOS (Life Operating System) callbacks — todo-done-{id}, todo-dismiss-{id}, todo-snooze-{id}-{date}
    # These are handled synchronously (no DB lock, instant status change, deterministic).
-elif data.startswith("todo-"):
+7. elif data.startswith("todo-"):
        from src.los.callbacks import route_los_callback
        result = route_los_callback(msg)
        if result["handled"]:
@@ -841,16 +841,16 @@ elif data.startswith("todo-"):
        else:
            send_reply(chat_id=chat_id, text=f"Unknown todo callback: {data}", source=source)
 
-7. elif data.startswith("decide_retry:") or data.startswith("decide_close:"):
+8. elif data.startswith("decide_retry:") or data.startswith("decide_close:"):
        from src.orchestration.dispatcher_handlers import route_callback_message
        result = route_callback_message(msg)
        if result["handled"]:
            send_reply(chat_id=chat_id, text=result["text"], source=source)
 
-8. else:
+9. else:
        send_reply(chat_id=chat_id, text=f"Unknown callback: {data}", source=source)
 
-9. mark_processed(message_id)
+10. mark_processed(message_id)
 ```
 
 ### Telegram-specific

--- a/scheduled-tasks/los-action-scanner.py
+++ b/scheduled-tasks/los-action-scanner.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+LOS Action Item Scanner — Lobster Scheduled Job
+
+Runs hourly. Scans the past hour of conversation history for action
+commitments Dan has made, extracts them via the LLM extractor, and
+writes them to self_action_items.db.
+
+This is a Type A job (LLM subagent): the MCP conversation history tool
+requires the context of a running Lobster session — the scanner reads
+recent messages via the inbox_server's conversation history, then calls
+Claude to extract commitments.
+
+Type B (cron-direct) was considered but rejected: the extraction step
+requires the Anthropic SDK (LLM call), which carries cost and latency —
+making it unsuitable for sub-15-minute cron runs. Hourly is appropriate.
+
+jobs.json entry:
+    {
+        "name": "los-action-scanner",
+        "schedule": "0 * * * *",
+        "task_file": "tasks/los-action-scanner.md",
+        "enabled": true
+    }
+
+Cron entry (alternative for Type B-style direct invocation):
+    0 * * * * cd ~/lobster && uv run scheduled-tasks/los-action-scanner.py >> ~/lobster-workspace/scheduled-jobs/logs/los-action-scanner.log 2>&1 # LOBSTER-LOS-ACTION-SCANNER
+
+Run standalone (for testing):
+    uv run ~/lobster/scheduled-tasks/los-action-scanner.py [--dry-run] [--hours N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.los.db import connect, get_open_items, DEFAULT_DB_PATH  # noqa: E402
+from src.los.extractor import extract_action_items  # noqa: E402
+from src.utils.inbox_write import _inbox_dir, _task_outputs_dir  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("los-action-scanner")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+JOB_NAME = "los-action-scanner"
+DEFAULT_LOOKBACK_HOURS = 1
+ADMIN_CHAT_ID = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
+MESSAGES_DIR = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+
+
+# ---------------------------------------------------------------------------
+# Jobs.json enabled gate — Type A dispatch compliance
+# ---------------------------------------------------------------------------
+
+
+def _is_job_enabled(job_name: str) -> bool:
+    """Return True if the job is enabled in jobs.json."""
+    try:
+        jobs_file = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")) / "scheduled-jobs" / "jobs.json"
+        with jobs_file.open() as fh:
+            data = json.load(fh)
+        jobs = data.get("jobs", {})
+        entry = jobs.get(job_name, {})
+        return bool(entry.get("enabled", True))
+    except Exception:
+        return True  # Default to enabled when unreadable
+
+
+# ---------------------------------------------------------------------------
+# Message reading
+# ---------------------------------------------------------------------------
+
+
+def _load_processed_messages(since: datetime) -> list[dict]:
+    """Load messages from ~/messages/processed/ newer than `since`."""
+    processed_dir = MESSAGES_DIR / "processed"
+    if not processed_dir.exists():
+        return []
+
+    messages = []
+    for msg_file in processed_dir.glob("*.json"):
+        try:
+            with msg_file.open() as fh:
+                msg = json.load(fh)
+            # Filter: only user messages (not subagent results), within window
+            ts_str = msg.get("timestamp") or msg.get("created_at")
+            if not ts_str:
+                continue
+            # Parse timestamp — may be in various formats
+            try:
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            except Exception:
+                continue
+            if ts < since:
+                continue
+            # Only scan actual user messages
+            msg_type = msg.get("type", "")
+            if msg_type in ("subagent_result", "subagent_notification", "wos_execute"):
+                continue
+            text = msg.get("text", "").strip()
+            if not text:
+                continue
+            messages.append(msg)
+        except Exception:
+            continue
+
+    return messages
+
+
+def _scan_and_extract(
+    conn,
+    messages: list[dict],
+    dry_run: bool = False,
+) -> list[dict]:
+    """Run extraction on each message. Returns list of extraction result summaries."""
+    results = []
+    for msg in messages:
+        text = msg.get("text", "").strip()
+        if not text or len(text) < 10:
+            continue
+        source_id = msg.get("id") or msg.get("message_id", "")
+        source = "telegram"
+
+        if dry_run:
+            log.info("[dry-run] Would extract from: %s...", text[:80])
+            results.append({"msg_id": source_id, "extracted": [], "dry_run": True})
+            continue
+
+        try:
+            extracted = extract_action_items(
+                conn=conn,
+                text=text,
+                source=source,
+                source_message_id=str(source_id),
+            )
+            if extracted:
+                log.info(
+                    "Extracted %d action item(s) from msg %s: %s",
+                    len(extracted),
+                    source_id,
+                    [i.text[:60] for i in extracted],
+                )
+            results.append({
+                "msg_id": source_id,
+                "extracted": [{"id": i.id, "text": i.text} for i in extracted],
+            })
+        except Exception as exc:
+            log.warning("Extraction failed for msg %s: %s", source_id, exc)
+            results.append({"msg_id": source_id, "extracted": [], "error": str(exc)})
+
+    return results
+
+
+def _write_task_output(output: str, status: str = "success") -> None:
+    """Write output to the task outputs directory."""
+    try:
+        outputs_dir = _task_outputs_dir()
+        outputs_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out_file = outputs_dir / f"{JOB_NAME}-{ts}.json"
+        with out_file.open("w") as fh:
+            json.dump({"job_name": JOB_NAME, "output": output, "status": status, "at": ts}, fh)
+    except Exception as exc:
+        log.warning("Failed to write task output: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="LOS action item scanner")
+    parser.add_argument("--dry-run", action="store_true", help="Do not write to DB")
+    parser.add_argument("--hours", type=int, default=DEFAULT_LOOKBACK_HOURS, help="Lookback window in hours")
+    args = parser.parse_args()
+
+    if not _is_job_enabled(JOB_NAME):
+        log.info("Job %s is disabled in jobs.json — exiting.", JOB_NAME)
+        return
+
+    since = datetime.now(timezone.utc) - timedelta(hours=args.hours)
+    log.info("Scanning messages since %s (lookback=%dh, dry_run=%s)", since.isoformat(), args.hours, args.dry_run)
+
+    messages = _load_processed_messages(since)
+    log.info("Found %d candidate messages to scan.", len(messages))
+
+    if not messages:
+        _write_task_output("No messages in lookback window.", status="success")
+        return
+
+    if args.dry_run:
+        conn = None
+    else:
+        conn = connect(DEFAULT_DB_PATH)
+
+    try:
+        results = _scan_and_extract(conn, messages, dry_run=args.dry_run)
+    finally:
+        if conn:
+            conn.close()
+
+    total_extracted = sum(len(r.get("extracted", [])) for r in results)
+    summary = f"Scanned {len(messages)} messages, extracted {total_extracted} action items."
+    log.info(summary)
+    _write_task_output(summary, status="success")
+
+
+if __name__ == "__main__":
+    main()

--- a/scheduled-tasks/tasks/los-action-scanner.md
+++ b/scheduled-tasks/tasks/los-action-scanner.md
@@ -1,0 +1,81 @@
+# LOS Action Item Scanner
+
+**Job**: los-action-scanner
+**Schedule**: Hourly (`0 * * * *`)
+**Created**: 2026-05-09
+
+**Minimum viable output:** Extract action commitments from the past hour of user messages and write them to self_action_items.db. Acknowledge with a count of items found.
+**Boundary:** Do not send unsolicited Telegram messages about individual items — extraction is silent. Only surface a count if items were found.
+
+## Context
+
+You are running as a scheduled LOS extraction task. Your job is to scan recent conversation history for action commitments Dan has made and persist them to the personal action items database.
+
+The LOS (Life Operating System) database lives at:
+`~/lobster-user-config/data/self_action_items.db`
+
+## Instructions
+
+### Step 1: Check enabled gate
+
+```python
+import json
+from pathlib import Path
+
+jobs_file = Path.home() / "lobster-workspace" / "scheduled-jobs" / "jobs.json"
+data = json.loads(jobs_file.read_text())
+if not data["jobs"].get("los-action-scanner", {}).get("enabled", True):
+    print("Job disabled — exiting.")
+    exit()
+```
+
+### Step 2: Scan recent conversation history
+
+Call `get_conversation_history(limit=60, sender_type="user")` to retrieve the last hour of user messages.
+
+Filter to messages from the past hour only (compare timestamp to `datetime.now(UTC) - timedelta(hours=1)`).
+
+### Step 3: Extract action items
+
+For each user message with at least 10 characters of text:
+1. Import and call `extract_action_items` from `src.los.extractor`
+2. Pass the message text, source="telegram", source_message_id=<message id>
+3. The extractor handles dedup automatically — no need to check manually
+
+```python
+import sys
+sys.path.insert(0, str(Path.home() / "lobster"))
+
+from src.los.db import connect
+from src.los.extractor import extract_action_items
+
+conn = connect()
+try:
+    for msg in user_messages:
+        items = extract_action_items(
+            conn=conn,
+            text=msg["text"],
+            source="telegram",
+            source_message_id=msg.get("id"),
+        )
+        if items:
+            print(f"Extracted: {[i.text for i in items]}")
+finally:
+    conn.close()
+```
+
+### Step 4: Write result
+
+Call `write_task_output(job_name="los-action-scanner", output=<summary>, status="success")`.
+
+Summary format: "Scanned N messages, extracted M action items." (include item titles if M > 0)
+
+Do NOT send a Telegram notification — this is a silent background job.
+If extraction found 0 items, write_task_output with status="success" and output="No action items found."
+
+## Output
+
+When you complete your task, call `write_task_output` with:
+- job_name: "los-action-scanner"
+- output: Summary of what was found
+- status: "success" or "failed"

--- a/scheduled-tasks/tasks/los-todos-query.md
+++ b/scheduled-tasks/tasks/los-todos-query.md
@@ -1,0 +1,82 @@
+# LOS Todos Query
+
+**Triggered by**: `/todos` command from Dan
+**Type**: On-demand subagent (not a scheduled job)
+
+**Minimum viable output:** A formatted list of open action items with Telegram inline buttons for Done/Snooze/Dismiss.
+**Boundary:** Do not modify the DB. Read-only query.
+
+## Context
+
+Dan sent the `/todos` command. Your job is to query `self_action_items.db` and return the current list of open action items with interactive buttons.
+
+## Instructions
+
+### Step 1: Query open items
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.home() / "lobster"))
+
+from src.los.db import connect, get_open_items
+
+conn = connect()
+try:
+    items = get_open_items(conn, limit=10)
+finally:
+    conn.close()
+```
+
+### Step 2: Handle empty list
+
+If `items` is empty:
+- Send a single Telegram message: "No open action items. Great job!"
+- Call `write_result` with status="success"
+- Done.
+
+### Step 3: Format and send each item with buttons
+
+For each item, send a separate Telegram message with inline buttons.
+
+Priority label mapping:
+- 1-3 → "urgent"
+- 4-6 → "medium"
+- 7-10 → "low"
+
+Message format per item:
+```
+[priority_label] {item.text}
+(source: {item.source}, extracted {time_ago})
+```
+
+Buttons (pass as `buttons` parameter to `send_reply`):
+```python
+buttons = [
+    [
+        {"text": "Done", "callback_data": f"todo-done-{item.id}"},
+        {"text": "Dismiss", "callback_data": f"todo-dismiss-{item.id}"},
+    ],
+    [
+        {"text": "Snooze 3d", "callback_data": f"todo-snooze-{item.id}-{snooze_3d_date}"},
+        {"text": "Snooze 1w", "callback_data": f"todo-snooze-{item.id}-{snooze_1w_date}"},
+    ],
+]
+```
+
+Where `snooze_3d_date` and `snooze_1w_date` are YYYY-MM-DD strings relative to today.
+
+Send a summary first: "You have N open action items:"
+
+### Step 4: Write result
+
+Call `write_result(task_id=<your task_id>, chat_id=<chat_id>, text="Delivered N todos", sent_reply_to_user=True, status="success")`.
+
+## Output
+
+Call `write_result` with:
+- task_id: your assigned task_id
+- chat_id: Dan's chat_id
+- text: "Delivered N open todos to Telegram"
+- sent_reply_to_user: True
+- status: "success"

--- a/scheduled-tasks/tasks/los-weekly-review.md
+++ b/scheduled-tasks/tasks/los-weekly-review.md
@@ -1,0 +1,71 @@
+# LOS Weekly Review
+
+**Job**: los-weekly-review
+**Schedule**: Sundays at 08:00 (`0 8 * * 0`)
+**Created**: 2026-05-09
+
+**Minimum viable output:** A Telegram message listing dismissed items from the past 7 days so Dan can see what he waved off.
+**Boundary:** Read-only. Do not modify status of any item. No buttons (this is a review, not a management interface).
+
+## Context
+
+You are running as a weekly LOS review task. Surface the dismissed action items from the past week so Dan can see what he chose not to act on.
+
+## Instructions
+
+### Step 1: Check enabled gate
+
+```python
+import json
+from pathlib import Path
+
+jobs_file = Path.home() / "lobster-workspace" / "scheduled-jobs" / "jobs.json"
+data = json.loads(jobs_file.read_text())
+if not data["jobs"].get("los-weekly-review", {}).get("enabled", True):
+    print("Job disabled — exiting.")
+    exit()
+```
+
+### Step 2: Query dismissed items from the past 7 days
+
+```python
+import sys
+from pathlib import Path
+from datetime import datetime, timezone, timedelta
+sys.path.insert(0, str(Path.home() / "lobster"))
+
+from src.los.db import connect, get_dismissed_items_since
+
+since = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+conn = connect()
+try:
+    dismissed = get_dismissed_items_since(conn, since_iso=since)
+finally:
+    conn.close()
+```
+
+### Step 3: Format and send
+
+If `dismissed` is empty:
+- Send: "Weekly review: No dismissed items from the past 7 days."
+
+If dismissed items exist:
+- Send: "Weekly review: {N} items dismissed this week:\n\n{formatted_list}"
+
+Format each dismissed item:
+```
+  - {item.text} (dismissed {dismissed_at_local_date})
+```
+
+### Step 4: Write result
+
+Call `write_result(task_id=<your task_id>, chat_id=8075091586, text=<summary>, sent_reply_to_user=True, status="success")`.
+
+And call `write_task_output(job_name="los-weekly-review", output=<summary>, status="success")`.
+
+## Output
+
+When you complete your task, call `write_task_output` with:
+- job_name: "los-weekly-review"
+- output: Summary of dismissed items count
+- status: "success" or "failed"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3478,6 +3478,127 @@ M99_PYEOF
         substep "Migration 101: settings.json or jq not found — skipping"
     fi
 
+    # Migration 102: Register LOS scheduled jobs (los-action-scanner, los-weekly-review)
+    # and create the self_action_items.db data directory.
+    # los-action-scanner: hourly Type A job that scans conversation history for action
+    #   commitments and writes them to ~/lobster-user-config/data/self_action_items.db.
+    # los-weekly-review: weekly Sunday Type A job that surfaces dismissed items.
+    local _los_data_dir="$HOME/lobster-user-config/data"
+    local _m102_jobs_file="$WORKSPACE_DIR/scheduled-jobs/jobs.json"
+    if [ -f "$_m102_jobs_file" ]; then
+        # Create the data directory for self_action_items.db
+        mkdir -p "$_los_data_dir" 2>/dev/null || true
+
+        # Check if either job is missing and add both if needed
+        local _m102_scanner_missing _m102_review_missing
+        _m102_scanner_missing=0
+        _m102_review_missing=0
+        uv run python3 -c "import json,sys; d=json.load(open('$_m102_jobs_file')); sys.exit(0 if 'los-action-scanner' in d.get('jobs',{}) else 1)" 2>/dev/null || _m102_scanner_missing=1
+        uv run python3 -c "import json,sys; d=json.load(open('$_m102_jobs_file')); sys.exit(0 if 'los-weekly-review' in d.get('jobs',{}) else 1)" 2>/dev/null || _m102_review_missing=1
+
+        if [[ "$_m102_scanner_missing" -eq 1 || "$_m102_review_missing" -eq 1 ]]; then
+            uv run python3 - <<'PYEOF'
+import json, os
+from datetime import datetime, timezone
+from pathlib import Path
+
+workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+try:
+    data = json.loads(jobs_file.read_text())
+except Exception:
+    data = {"jobs": {}}
+
+data.setdefault("jobs", {})
+now = datetime.now(timezone.utc).isoformat()
+changed = False
+
+if "los-action-scanner" not in data["jobs"]:
+    data["jobs"]["los-action-scanner"] = {
+        "name": "los-action-scanner",
+        "schedule": "0 * * * *",
+        "schedule_human": "Hourly",
+        "task_file": "tasks/los-action-scanner.md",
+        "created_at": now,
+        "updated_at": now,
+        "enabled": True,
+        "last_run": None,
+        "last_status": None,
+        "dispatch": "subagent",
+    }
+    print("Added los-action-scanner to jobs.json")
+    changed = True
+else:
+    print("los-action-scanner already in jobs.json — skipped")
+
+if "los-weekly-review" not in data["jobs"]:
+    data["jobs"]["los-weekly-review"] = {
+        "name": "los-weekly-review",
+        "schedule": "0 8 * * 0",
+        "schedule_human": "Sundays at 08:00",
+        "task_file": "tasks/los-weekly-review.md",
+        "created_at": now,
+        "updated_at": now,
+        "enabled": True,
+        "last_run": None,
+        "last_status": None,
+        "dispatch": "subagent",
+    }
+    print("Added los-weekly-review to jobs.json")
+    changed = True
+else:
+    print("los-weekly-review already in jobs.json — skipped")
+
+if changed:
+    jobs_file.write_text(json.dumps(data, indent=2))
+PYEOF
+            migrated=$((migrated + 1))
+            substep "Migration 102: registered LOS jobs (los-action-scanner, los-weekly-review)"
+        else
+            substep "Migration 102: LOS jobs already registered — skipping"
+        fi
+
+        # Append the LOS todos section to the async-deep-work task if not already present.
+        local _adw_task="$WORKSPACE_DIR/scheduled-jobs/tasks/async-deep-work.md"
+        if [ -f "$_adw_task" ] && ! grep -q "LOS Todos Section" "$_adw_task" 2>/dev/null; then
+            cat >> "$_adw_task" << 'ADWEOF'
+
+---
+
+### LOS Todos Section (append to morning digest)
+
+After writing the Phase Criteria Check section (Step 2b), query the LOS action items database and append a todos section **at the bottom of the Telegram notification** (Step 4).
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.home() / "lobster"))
+from src.los.db import connect, get_open_items
+from src.los.digest import build_digest_footer
+
+conn = connect()
+try:
+    items = get_open_items(conn, limit=10)
+    footer = build_digest_footer(items)
+finally:
+    conn.close()
+```
+
+If `footer` is non-empty, append it to the Telegram message sent in Step 4.
+If `footer` is empty (no open todos), skip this section entirely — no extra message.
+The footer already includes a `/todos` prompt for the interactive view.
+
+**DB location**: `~/lobster-user-config/data/self_action_items.db`
+If the file does not exist yet (LOS not yet seeded), skip this section silently.
+ADWEOF
+            substep "Migration 102: added LOS todos section to async-deep-work task"
+        else
+            substep "Migration 102: LOS todos section already present in async-deep-work.md — skipping"
+        fi
+    else
+        substep "Migration 102: jobs.json not found — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/los/__init__.py
+++ b/src/los/__init__.py
@@ -1,0 +1,11 @@
+"""
+LOS — Life Operating System
+
+Cycle 1: personal action item extraction and surfacing.
+
+Components:
+    db         — schema, CRUD, dedup for self_action_items.db
+    extractor  — LLM-powered extraction from text (telegram, voice notes)
+    callbacks  — Telegram inline button callback routing (done/snooze/dismiss)
+    digest     — morning digest section builder
+"""

--- a/src/los/callbacks.py
+++ b/src/los/callbacks.py
@@ -1,0 +1,149 @@
+"""
+LOS — Telegram Inline Button Callback Routing
+
+Handles inline keyboard button presses for the /todos interface:
+    todo-done-{id}              → mark item done
+    todo-dismiss-{id}           → archive item (status='dismissed', not deleted)
+    todo-snooze-{id}-{date}     → snooze until custom date (YYYY-MM-DD)
+
+Returns the same shape dict as route_callback_message in dispatcher_handlers.py:
+    {"action": "send_reply", "text": ..., "chat_id": ..., "handled": bool}
+
+Dispatcher integration:
+    from src.los.callbacks import route_los_callback
+
+    if msg.get("type") == "callback":
+        los_result = route_los_callback(msg, conn=conn)
+        if los_result["handled"]:
+            # send reply and mark processed
+        else:
+            result = route_callback_message(msg, registry=registry)
+"""
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Optional
+
+from .db import (
+    connect,
+    get_item_by_id,
+    mark_dismissed,
+    mark_done,
+    mark_snoozed,
+    DEFAULT_DB_PATH,
+)
+
+log = logging.getLogger(__name__)
+
+# Regex patterns for recognized callback data
+_DONE_PATTERN = re.compile(r"^todo-done-(\d+)$")
+_DISMISS_PATTERN = re.compile(r"^todo-dismiss-(\d+)$")
+_SNOOZE_PATTERN = re.compile(r"^todo-snooze-(\d+)-(.+)$")
+
+# ISO date validation (simple — YYYY-MM-DD)
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _result(text: str, chat_id: Any, handled: bool) -> dict:
+    return {"action": "send_reply", "text": text, "chat_id": chat_id, "handled": handled}
+
+
+def _handle_done(conn: sqlite3.Connection, item_id: int, chat_id: Any) -> dict:
+    item = get_item_by_id(conn, item_id)
+    if item is None:
+        return _result(f"Item #{item_id} not found.", chat_id, handled=False)
+    mark_done(conn, item_id)
+    return _result(
+        f"Done: \"{item.text[:60]}\"",
+        chat_id,
+        handled=True,
+    )
+
+
+def _handle_dismiss(conn: sqlite3.Connection, item_id: int, chat_id: Any) -> dict:
+    item = get_item_by_id(conn, item_id)
+    if item is None:
+        return _result(f"Item #{item_id} not found.", chat_id, handled=False)
+    mark_dismissed(conn, item_id)
+    return _result(
+        f"Dismissed: \"{item.text[:60]}\"",
+        chat_id,
+        handled=True,
+    )
+
+
+def _handle_snooze(
+    conn: sqlite3.Connection, item_id: int, date_str: str, chat_id: Any
+) -> dict:
+    if not _DATE_PATTERN.match(date_str):
+        return _result(
+            f"Invalid snooze date \"{date_str}\". Use YYYY-MM-DD format.",
+            chat_id,
+            handled=True,
+        )
+    item = get_item_by_id(conn, item_id)
+    if item is None:
+        return _result(f"Item #{item_id} not found.", chat_id, handled=False)
+    mark_snoozed(conn, item_id, date_str)
+    return _result(
+        f"Snoozed until {date_str}: \"{item.text[:60]}\"",
+        chat_id,
+        handled=True,
+    )
+
+
+def route_los_callback(
+    msg: dict,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+    db_path: Optional[Path] = None,
+) -> dict:
+    """Route a Telegram callback_data to the appropriate LOS handler.
+
+    Args:
+        msg:     Raw inbox message dict with 'callback_data' and 'chat_id'.
+        conn:    Optional open DB connection (for testing — avoids opening production DB).
+        db_path: Optional path override for production DB (defaults to DEFAULT_DB_PATH).
+
+    Returns:
+        dict with keys: action, text, chat_id, handled.
+        handled=True  → this callback was handled; dispatcher must send reply.
+        handled=False → not a LOS callback; dispatcher should fall through.
+    """
+    data: str = msg.get("callback_data", "")
+    chat_id = msg.get("chat_id")
+
+    if not data:
+        return _result("", chat_id, handled=False)
+
+    # Lazy-open connection if not injected (production path)
+    _own_conn = False
+    if conn is None:
+        conn = connect(db_path or DEFAULT_DB_PATH)
+        _own_conn = True
+
+    try:
+        # --- todo-done-{id} ---
+        m = _DONE_PATTERN.match(data)
+        if m:
+            return _handle_done(conn, int(m.group(1)), chat_id)
+
+        # --- todo-dismiss-{id} ---
+        m = _DISMISS_PATTERN.match(data)
+        if m:
+            return _handle_dismiss(conn, int(m.group(1)), chat_id)
+
+        # --- todo-snooze-{id}-{date} ---
+        m = _SNOOZE_PATTERN.match(data)
+        if m:
+            return _handle_snooze(conn, int(m.group(1)), m.group(2), chat_id)
+
+        # Not a LOS callback — pass through
+        return _result("", chat_id, handled=False)
+
+    finally:
+        if _own_conn:
+            conn.close()

--- a/src/los/db.py
+++ b/src/los/db.py
@@ -1,0 +1,282 @@
+"""
+LOS — Action Items Database
+
+Schema, connection, and access layer for self_action_items.db.
+
+Design principles:
+- Pure functions where possible — take conn as argument, return values
+- Side effects (DB writes) are explicit and at the boundary
+- No global state — callers own the connection lifecycle
+
+DB location: ~/lobster-user-config/data/self_action_items.db
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_USER_CONFIG_DIR = Path.home() / "lobster-user-config"
+DEFAULT_DB_PATH = _USER_CONFIG_DIR / "data" / "self_action_items.db"
+
+# ---------------------------------------------------------------------------
+# Schema — exactly as specified in the task prompt
+# ---------------------------------------------------------------------------
+
+DB_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS action_items (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    text             TEXT NOT NULL,
+    source           TEXT NOT NULL,
+    source_message_id TEXT,
+    extracted_at     TEXT NOT NULL,
+    priority         INTEGER DEFAULT 5,
+    mention_count    INTEGER DEFAULT 1,
+    status           TEXT DEFAULT 'open',
+    snoozed_until    TEXT,
+    done_at          TEXT,
+    dismissed_at     TEXT,
+    notes            TEXT,
+    dedup_key        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_action_items_status
+    ON action_items(status);
+
+CREATE INDEX IF NOT EXISTS idx_action_items_extracted_at
+    ON action_items(extracted_at);
+
+CREATE INDEX IF NOT EXISTS idx_action_items_dedup_key
+    ON action_items(dedup_key);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ActionItem:
+    id: int
+    text: str
+    source: str
+    source_message_id: Optional[str]
+    extracted_at: str
+    priority: int
+    mention_count: int
+    status: str
+    snoozed_until: Optional[str]
+    done_at: Optional[str]
+    dismissed_at: Optional[str]
+    notes: Optional[str]
+    dedup_key: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Connection
+# ---------------------------------------------------------------------------
+
+
+def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    """Open (or create) the action items SQLite DB and apply the schema.
+
+    Creates parent directories if needed. Returns an open connection.
+    Callers are responsible for closing the connection.
+    """
+    path = db_path or DEFAULT_DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(DB_SCHEMA_SQL)
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def compute_dedup_key(text: str) -> str:
+    """Produce a 16-char hex dedup key from normalized text.
+
+    Normalization: lowercase, strip non-alphanumeric (except spaces),
+    collapse whitespace.
+    """
+    normalized = re.sub(r"[^a-z0-9 ]", "", text.lower())
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def _row_to_item(row: sqlite3.Row) -> ActionItem:
+    return ActionItem(
+        id=row["id"],
+        text=row["text"],
+        source=row["source"],
+        source_message_id=row["source_message_id"],
+        extracted_at=row["extracted_at"],
+        priority=row["priority"],
+        mention_count=row["mention_count"],
+        status=row["status"],
+        snoozed_until=row["snoozed_until"],
+        done_at=row["done_at"],
+        dismissed_at=row["dismissed_at"],
+        notes=row["notes"],
+        dedup_key=row["dedup_key"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writes (side-effectful, at the boundary)
+# ---------------------------------------------------------------------------
+
+
+def insert_action_item(
+    conn: sqlite3.Connection,
+    text: str,
+    source: str,
+    source_message_id: Optional[str],
+    priority: int = 5,
+    notes: Optional[str] = None,
+) -> int:
+    """Insert a new action item. Returns the row id."""
+    dedup_key = compute_dedup_key(text)
+    extracted_at = _now_iso()
+    cursor = conn.execute(
+        """
+        INSERT INTO action_items
+            (text, source, source_message_id, extracted_at, priority, status,
+             mention_count, dedup_key, notes)
+        VALUES (?, ?, ?, ?, ?, 'open', 1, ?, ?)
+        """,
+        (text, source, source_message_id, extracted_at, priority, dedup_key, notes),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+def mark_done(conn: sqlite3.Connection, item_id: int) -> None:
+    """Set status='done' and record done_at timestamp."""
+    conn.execute(
+        "UPDATE action_items SET status='done', done_at=? WHERE id=?",
+        (_now_iso(), item_id),
+    )
+    conn.commit()
+
+
+def mark_dismissed(conn: sqlite3.Connection, item_id: int) -> None:
+    """Set status='dismissed' and record dismissed_at.
+
+    Dismissed items are NOT deleted — they remain reviewable in weekly review.
+    """
+    conn.execute(
+        "UPDATE action_items SET status='dismissed', dismissed_at=? WHERE id=?",
+        (_now_iso(), item_id),
+    )
+    conn.commit()
+
+
+def mark_snoozed(conn: sqlite3.Connection, item_id: int, until_date: str) -> None:
+    """Set status='snoozed' with a custom date (YYYY-MM-DD format)."""
+    conn.execute(
+        "UPDATE action_items SET status='snoozed', snoozed_until=? WHERE id=?",
+        (until_date, item_id),
+    )
+    conn.commit()
+
+
+def increment_mention_count(conn: sqlite3.Connection, item_id: int) -> None:
+    """Increment mention_count for an existing item by 1."""
+    conn.execute(
+        "UPDATE action_items SET mention_count = mention_count + 1 WHERE id=?",
+        (item_id,),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Reads (pure queries — no side effects)
+# ---------------------------------------------------------------------------
+
+
+def get_item_by_id(conn: sqlite3.Connection, item_id: int) -> Optional[ActionItem]:
+    """Return a single ActionItem by primary key, or None if not found."""
+    cursor = conn.execute(
+        "SELECT * FROM action_items WHERE id=?", (item_id,)
+    )
+    row = cursor.fetchone()
+    return _row_to_item(row) if row else None
+
+
+def get_open_items(
+    conn: sqlite3.Connection,
+    limit: int = 20,
+) -> list[ActionItem]:
+    """Return open (non-snoozed-to-future) items, sorted by priority ASC then mention_count DESC.
+
+    Snoozed items whose snoozed_until is in the past are treated as open again.
+    """
+    cursor = conn.execute(
+        """
+        SELECT * FROM action_items
+        WHERE status = 'open'
+          OR (status = 'snoozed' AND snoozed_until < datetime('now'))
+        ORDER BY priority ASC, mention_count DESC, extracted_at ASC
+        LIMIT ?
+        """,
+        (limit,),
+    )
+    return [_row_to_item(row) for row in cursor.fetchall()]
+
+
+def get_dismissed_items_since(
+    conn: sqlite3.Connection,
+    since_iso: str,
+) -> list[ActionItem]:
+    """Return dismissed items since a given ISO timestamp (for weekly review)."""
+    cursor = conn.execute(
+        """
+        SELECT * FROM action_items
+        WHERE status = 'dismissed'
+          AND dismissed_at >= ?
+        ORDER BY dismissed_at DESC
+        """,
+        (since_iso,),
+    )
+    return [_row_to_item(row) for row in cursor.fetchall()]
+
+
+def find_duplicate(
+    conn: sqlite3.Connection,
+    text: str,
+) -> Optional[ActionItem]:
+    """Find an existing open or snoozed item with the same normalized text.
+
+    Returns the matching ActionItem, or None if no duplicate exists.
+    Dismissed items are excluded — they are archived, not active.
+    """
+    key = compute_dedup_key(text)
+    cursor = conn.execute(
+        """
+        SELECT * FROM action_items
+        WHERE dedup_key = ?
+          AND status IN ('open', 'snoozed')
+        LIMIT 1
+        """,
+        (key,),
+    )
+    row = cursor.fetchone()
+    return _row_to_item(row) if row else None

--- a/src/los/db.py
+++ b/src/los/db.py
@@ -17,8 +17,21 @@ import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import StrEnum
 from pathlib import Path
 from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Status enum — single source of truth for the status domain
+# ---------------------------------------------------------------------------
+
+
+class ActionItemStatus(StrEnum):
+    OPEN = "open"
+    DONE = "done"
+    DISMISSED = "dismissed"
+    SNOOZED = "snoozed"
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -31,7 +44,7 @@ DEFAULT_DB_PATH = _USER_CONFIG_DIR / "data" / "self_action_items.db"
 # Schema — exactly as specified in the task prompt
 # ---------------------------------------------------------------------------
 
-DB_SCHEMA_SQL = """
+DB_SCHEMA_SQL = f"""
 CREATE TABLE IF NOT EXISTS action_items (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
     text             TEXT NOT NULL,
@@ -40,7 +53,7 @@ CREATE TABLE IF NOT EXISTS action_items (
     extracted_at     TEXT NOT NULL,
     priority         INTEGER DEFAULT 5,
     mention_count    INTEGER DEFAULT 1,
-    status           TEXT DEFAULT 'open',
+    status           TEXT DEFAULT '{ActionItemStatus.OPEN}',
     snoozed_until    TEXT,
     done_at          TEXT,
     dismissed_at     TEXT,
@@ -160,9 +173,9 @@ def insert_action_item(
         INSERT INTO action_items
             (text, source, source_message_id, extracted_at, priority, status,
              mention_count, dedup_key, notes)
-        VALUES (?, ?, ?, ?, ?, 'open', 1, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
         """,
-        (text, source, source_message_id, extracted_at, priority, dedup_key, notes),
+        (text, source, source_message_id, extracted_at, priority, ActionItemStatus.OPEN, dedup_key, notes),
     )
     conn.commit()
     return cursor.lastrowid
@@ -171,8 +184,8 @@ def insert_action_item(
 def mark_done(conn: sqlite3.Connection, item_id: int) -> None:
     """Set status='done' and record done_at timestamp."""
     conn.execute(
-        "UPDATE action_items SET status='done', done_at=? WHERE id=?",
-        (_now_iso(), item_id),
+        "UPDATE action_items SET status=?, done_at=? WHERE id=?",
+        (ActionItemStatus.DONE, _now_iso(), item_id),
     )
     conn.commit()
 
@@ -183,8 +196,8 @@ def mark_dismissed(conn: sqlite3.Connection, item_id: int) -> None:
     Dismissed items are NOT deleted — they remain reviewable in weekly review.
     """
     conn.execute(
-        "UPDATE action_items SET status='dismissed', dismissed_at=? WHERE id=?",
-        (_now_iso(), item_id),
+        "UPDATE action_items SET status=?, dismissed_at=? WHERE id=?",
+        (ActionItemStatus.DISMISSED, _now_iso(), item_id),
     )
     conn.commit()
 
@@ -192,8 +205,8 @@ def mark_dismissed(conn: sqlite3.Connection, item_id: int) -> None:
 def mark_snoozed(conn: sqlite3.Connection, item_id: int, until_date: str) -> None:
     """Set status='snoozed' with a custom date (YYYY-MM-DD format)."""
     conn.execute(
-        "UPDATE action_items SET status='snoozed', snoozed_until=? WHERE id=?",
-        (until_date, item_id),
+        "UPDATE action_items SET status=?, snoozed_until=? WHERE id=?",
+        (ActionItemStatus.SNOOZED, until_date, item_id),
     )
     conn.commit()
 
@@ -232,12 +245,12 @@ def get_open_items(
     cursor = conn.execute(
         """
         SELECT * FROM action_items
-        WHERE status = 'open'
-          OR (status = 'snoozed' AND snoozed_until < datetime('now'))
+        WHERE status = ?
+          OR (status = ? AND snoozed_until < datetime('now'))
         ORDER BY priority ASC, mention_count DESC, extracted_at ASC
         LIMIT ?
         """,
-        (limit,),
+        (ActionItemStatus.OPEN, ActionItemStatus.SNOOZED, limit),
     )
     return [_row_to_item(row) for row in cursor.fetchall()]
 
@@ -250,11 +263,11 @@ def get_dismissed_items_since(
     cursor = conn.execute(
         """
         SELECT * FROM action_items
-        WHERE status = 'dismissed'
+        WHERE status = ?
           AND dismissed_at >= ?
         ORDER BY dismissed_at DESC
         """,
-        (since_iso,),
+        (ActionItemStatus.DISMISSED, since_iso),
     )
     return [_row_to_item(row) for row in cursor.fetchall()]
 
@@ -273,10 +286,10 @@ def find_duplicate(
         """
         SELECT * FROM action_items
         WHERE dedup_key = ?
-          AND status IN ('open', 'snoozed')
+          AND status IN (?, ?)
         LIMIT 1
         """,
-        (key,),
+        (key, ActionItemStatus.OPEN, ActionItemStatus.SNOOZED),
     )
     row = cursor.fetchone()
     return _row_to_item(row) if row else None

--- a/src/los/digest.py
+++ b/src/los/digest.py
@@ -1,0 +1,62 @@
+"""
+LOS — Morning Digest Integration
+
+Pure functions for building the todos section of the morning digest.
+No DB access — callers pass the list of items.
+
+Produces plain text (no inline buttons — buttons are for /todos command only).
+Section is omitted if item list is empty (no clutter).
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from .db import ActionItem
+
+# Maximum items shown in morning digest (spec: top 3)
+DIGEST_MAX_ITEMS = 3
+
+_PRIORITY_LABEL = {
+    range(1, 4): "urgent",
+    range(4, 7): "medium",
+    range(7, 11): "low",
+}
+
+
+def _priority_label(priority: int) -> str:
+    for r, label in _PRIORITY_LABEL.items():
+        if priority in r:
+            return label
+    return "low"
+
+
+def format_digest_section(items: Sequence[ActionItem]) -> str:
+    """Build the morning digest todos section as plain text.
+
+    Returns an empty string if there are no items (caller omits the section).
+    Shows top DIGEST_MAX_ITEMS items, sorted by priority ASC then mention_count DESC.
+    """
+    if not items:
+        return ""
+
+    top = sorted(items, key=lambda i: (i.priority, -i.mention_count))[:DIGEST_MAX_ITEMS]
+
+    lines = ["Open todos:"]
+    for item in top:
+        label = _priority_label(item.priority)
+        mention = f" (x{item.mention_count})" if item.mention_count > 1 else ""
+        lines.append(f"  - [{label}] {item.text}{mention}")
+
+    return "\n".join(lines)
+
+
+def build_digest_footer(items: Sequence[ActionItem]) -> str:
+    """Build the full footer text appended to the morning digest.
+
+    Returns empty string when there are no open items.
+    Includes a /todos prompt so Dan knows how to get the interactive view.
+    """
+    section = format_digest_section(items)
+    if not section:
+        return ""
+    return f"\n---\n{section}\n\nType /todos for the full list with action buttons."

--- a/src/los/extractor.py
+++ b/src/los/extractor.py
@@ -1,0 +1,171 @@
+"""
+LOS — Action Item Extractor
+
+Extracts first-person action commitments from text using Claude claude-haiku-4-5.
+Side effects (DB writes) happen at the end — pure extraction logic is testable
+without a DB.
+
+Usage:
+    from src.los.db import connect
+    from src.los.extractor import extract_action_items
+
+    conn = connect()
+    items = extract_action_items(
+        conn=conn,
+        text="I need to call Sarah about the contract.",
+        source="telegram",
+        source_message_id="msg_123",
+    )
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from typing import Optional
+
+import anthropic
+
+from .db import (
+    ActionItem,
+    compute_dedup_key,
+    find_duplicate,
+    increment_mention_count,
+    insert_action_item,
+)
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants (named after spec requirements — don't use magic literals)
+# ---------------------------------------------------------------------------
+
+EXTRACTION_MODEL = "claude-haiku-4-5"
+MAX_TOKENS = 512
+PRIORITY_MIN = 1
+PRIORITY_MAX = 10
+PRIORITY_DEFAULT = 5
+
+_SYSTEM_PROMPT = (
+    "You are an action-commitment detector. Given text from Dan's voice note, "
+    "journal entry, or Telegram message, extract only first-person commitments "
+    "Dan has made to do something himself.\n\n"
+    "Rules:\n"
+    "- Include: 'I need to', 'I should', 'I want to', 'I'm going to', "
+    "'I have to', 'remind me to', 'I promised to'\n"
+    "- Exclude: thoughts, questions, observations, things Lobster should do, "
+    "system tasks, pure emotions\n"
+    "- Each commitment becomes one todo item with a short, imperative title "
+    "(e.g. 'Call Sarah about the contract')\n"
+    "- Assign priority as an integer from 1 (urgent) to 10 (low/aspirational): "
+    "1-3 = explicit urgency/deadline, 4-6 = clear intent, 7-10 = vague/aspirational\n\n"
+    "Return JSON only: [{\"text\": \"...\", \"priority\": <int>}]\n"
+    "If no action commitments found, return []"
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_llm_response(raw: str) -> list[dict]:
+    """Parse the LLM JSON response into a list of validated item dicts.
+
+    Returns an empty list on any error — callers must handle [] gracefully.
+    Each returned dict is guaranteed to have 'text' (str) and 'priority' (int).
+    """
+    try:
+        parsed = json.loads(raw.strip())
+    except (json.JSONDecodeError, ValueError):
+        log.warning("LOS extractor: failed to parse LLM response as JSON")
+        return []
+
+    if not isinstance(parsed, list):
+        log.warning("LOS extractor: LLM response was not a list")
+        return []
+
+    valid = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        raw_priority = item.get("priority", PRIORITY_DEFAULT)
+        try:
+            priority = int(raw_priority)
+        except (TypeError, ValueError):
+            priority = PRIORITY_DEFAULT
+        # Clamp to [PRIORITY_MIN, PRIORITY_MAX]
+        priority = max(PRIORITY_MIN, min(PRIORITY_MAX, priority))
+        valid.append({"text": text.strip(), "priority": priority})
+
+    return valid
+
+
+def _call_llm(text: str) -> list[dict]:
+    """Call Claude haiku to extract action items. Returns parsed list or []."""
+    client = anthropic.Anthropic()
+    message = client.messages.create(
+        model=EXTRACTION_MODEL,
+        max_tokens=MAX_TOKENS,
+        system=_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": text}],
+    )
+    raw = message.content[0].text
+    return parse_llm_response(raw)
+
+
+# ---------------------------------------------------------------------------
+# Side-effectful entry point (DB writes at the boundary)
+# ---------------------------------------------------------------------------
+
+
+def extract_action_items(
+    conn: sqlite3.Connection,
+    text: str,
+    source: str,
+    source_message_id: Optional[str],
+) -> list[ActionItem]:
+    """Extract action items from text and persist them to the DB.
+
+    For each extracted item:
+    - If a duplicate exists (open/snoozed), increments mention_count
+    - Otherwise, inserts a new row
+
+    Returns the list of inserted or updated ActionItem objects.
+    Returns [] if the LLM finds nothing or the API call fails.
+    """
+    try:
+        llm_items = _call_llm(text)
+    except Exception as exc:
+        log.warning("LOS extractor: LLM call failed (%s), skipping extraction", exc)
+        return []
+
+    from .db import get_item_by_id
+
+    result: list[ActionItem] = []
+    for item_dict in llm_items:
+        item_text = item_dict["text"]
+        priority = item_dict["priority"]
+
+        existing = find_duplicate(conn, item_text)
+        if existing is not None:
+            increment_mention_count(conn, existing.id)
+            updated = get_item_by_id(conn, existing.id)
+            if updated:
+                result.append(updated)
+        else:
+            row_id = insert_action_item(
+                conn=conn,
+                text=item_text,
+                source=source,
+                source_message_id=source_message_id,
+                priority=priority,
+            )
+            inserted = get_item_by_id(conn, row_id)
+            if inserted:
+                result.append(inserted)
+
+    return result

--- a/tests/unit/los/test_callbacks.py
+++ b/tests/unit/los/test_callbacks.py
@@ -1,0 +1,168 @@
+"""
+Tests for LOS callback routing — todo-done-{id}, todo-snooze-{id}, todo-dismiss-{id}.
+
+These callbacks are handled by route_los_callback, which returns the same shape
+dict as route_callback_message in dispatcher_handlers.py (action, text, chat_id,
+handled). The dispatcher integrates by calling route_los_callback before falling
+through to WOS callbacks.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.los.db import connect, insert_action_item, get_item_by_id
+from src.los.callbacks import route_los_callback
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "self_action_items.db"
+
+
+@pytest.fixture
+def conn(db_path: Path) -> sqlite3.Connection:
+    c = connect(db_path)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def item_id(conn: sqlite3.Connection) -> int:
+    return insert_action_item(
+        conn,
+        text="Schedule dentist appointment",
+        source="telegram",
+        source_message_id="msg_99",
+    )
+
+
+# ---------------------------------------------------------------------------
+# todo-done callback
+# ---------------------------------------------------------------------------
+
+
+def test_todo_done_callback_marks_item_done(conn: sqlite3.Connection, item_id: int) -> None:
+    """todo-done-{id} must set item status to 'done'."""
+    msg = {
+        "callback_data": f"todo-done-{item_id}",
+        "chat_id": 8075091586,
+    }
+    result = route_los_callback(msg, conn=conn)
+
+    assert result["handled"] is True
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "done"
+    assert item.done_at is not None
+
+
+def test_todo_done_callback_returns_confirmation_text(
+    conn: sqlite3.Connection, item_id: int
+) -> None:
+    """todo-done callback must return a human-readable confirmation."""
+    msg = {"callback_data": f"todo-done-{item_id}", "chat_id": 8075091586}
+    result = route_los_callback(msg, conn=conn)
+
+    assert "done" in result["text"].lower() or "complete" in result["text"].lower()
+
+
+def test_todo_done_callback_unknown_id_returns_handled_false(
+    conn: sqlite3.Connection,
+) -> None:
+    """todo-done with an unknown id must return handled=False."""
+    msg = {"callback_data": "todo-done-999999", "chat_id": 8075091586}
+    result = route_los_callback(msg, conn=conn)
+
+    assert result["handled"] is False
+
+
+# ---------------------------------------------------------------------------
+# todo-dismiss callback
+# ---------------------------------------------------------------------------
+
+
+def test_todo_dismiss_callback_marks_item_dismissed(
+    conn: sqlite3.Connection, item_id: int
+) -> None:
+    """todo-dismiss-{id} must set item status to 'dismissed', not delete it."""
+    msg = {"callback_data": f"todo-dismiss-{item_id}", "chat_id": 8075091586}
+    result = route_los_callback(msg, conn=conn)
+
+    assert result["handled"] is True
+    item = get_item_by_id(conn, item_id)
+    assert item is not None, "Dismissed items must remain in DB"
+    assert item.status == "dismissed"
+    assert item.dismissed_at is not None
+
+
+def test_todo_dismiss_callback_returns_confirmation_text(
+    conn: sqlite3.Connection, item_id: int
+) -> None:
+    """todo-dismiss callback must return a human-readable confirmation."""
+    msg = {"callback_data": f"todo-dismiss-{item_id}", "chat_id": 8075091586}
+    result = route_los_callback(msg, conn=conn)
+
+    assert result["text"]
+    assert result["handled"] is True
+
+
+# ---------------------------------------------------------------------------
+# todo-snooze callback
+# ---------------------------------------------------------------------------
+
+
+def test_todo_snooze_callback_marks_item_snoozed(
+    conn: sqlite3.Connection, item_id: int
+) -> None:
+    """todo-snooze-{id}-{date} must set status='snoozed' with the given date."""
+    msg = {
+        "callback_data": f"todo-snooze-{item_id}-2026-06-15",
+        "chat_id": 8075091586,
+    }
+    result = route_los_callback(msg, conn=conn)
+
+    assert result["handled"] is True
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "snoozed"
+    assert item.snoozed_until == "2026-06-15"
+
+
+def test_todo_snooze_callback_invalid_date_returns_error(
+    conn: sqlite3.Connection, item_id: int
+) -> None:
+    """todo-snooze with an invalid date must return handled=True with error text."""
+    msg = {
+        "callback_data": f"todo-snooze-{item_id}-not-a-date",
+        "chat_id": 8075091586,
+    }
+    result = route_los_callback(msg, conn=conn)
+
+    # The callback was recognized but the operation failed — it should inform the user
+    assert "date" in result["text"].lower() or "invalid" in result["text"].lower() or "snooze" in result["text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Non-LOS callback pass-through
+# ---------------------------------------------------------------------------
+
+
+def test_non_los_callback_returns_handled_false(conn: sqlite3.Connection) -> None:
+    """Callbacks that are not LOS patterns must return handled=False for pass-through."""
+    msg = {"callback_data": "decide_retry:some-uow-id", "chat_id": 8075091586}
+    result = route_los_callback(msg, conn=conn)
+
+    assert result["handled"] is False
+
+
+def test_empty_callback_data_returns_handled_false(conn: sqlite3.Connection) -> None:
+    """Empty callback_data must return handled=False."""
+    msg = {"callback_data": "", "chat_id": 8075091586}
+    result = route_los_callback(msg, conn=conn)
+
+    assert result["handled"] is False

--- a/tests/unit/los/test_extractor.py
+++ b/tests/unit/los/test_extractor.py
@@ -1,0 +1,303 @@
+"""
+Tests for LOS action item extractor.
+
+Tests verify:
+- The extractor correctly calls the LLM with the right prompt
+- It handles the response correctly, mapping fields to ActionItem-like dicts
+- Dedup logic fires when a duplicate is found
+- The extractor writes to the DB (side-effectful boundary)
+- Empty LLM responses are handled gracefully
+
+All Anthropic API calls are mocked — no production hits in unit tests.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.los.db import connect, get_open_items, get_item_by_id, find_duplicate
+from src.los.extractor import (
+    extract_action_items,
+    parse_llm_response,
+    compute_dedup_key,
+    EXTRACTION_MODEL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants from spec
+# ---------------------------------------------------------------------------
+
+EXTRACTION_MODEL_EXPECTED = "claude-haiku-4-5"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "self_action_items.db"
+
+
+@pytest.fixture
+def conn(db_path: Path) -> sqlite3.Connection:
+    c = connect(db_path)
+    yield c
+    c.close()
+
+
+def _make_anthropic_response(items: list[dict]) -> MagicMock:
+    """Build a mock Anthropic response with the given items as JSON content."""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock()]
+    mock_response.content[0].text = json.dumps(items)
+    return mock_response
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_model_is_haiku() -> None:
+    """Extractor must use claude-haiku-4-5 for cost efficiency (spec requirement)."""
+    assert EXTRACTION_MODEL == EXTRACTION_MODEL_EXPECTED
+
+
+def test_compute_dedup_key_is_deterministic() -> None:
+    """compute_dedup_key must return the same value for the same input."""
+    key1 = compute_dedup_key("Call Sarah about the contract")
+    key2 = compute_dedup_key("Call Sarah about the contract")
+    assert key1 == key2
+
+
+def test_compute_dedup_key_normalizes_case() -> None:
+    """compute_dedup_key must normalize case."""
+    assert compute_dedup_key("CALL SARAH") == compute_dedup_key("call sarah")
+
+
+def test_compute_dedup_key_normalizes_punctuation() -> None:
+    """compute_dedup_key must strip punctuation."""
+    assert compute_dedup_key("Call Sarah!") == compute_dedup_key("Call Sarah")
+
+
+def test_compute_dedup_key_collapses_whitespace() -> None:
+    """compute_dedup_key must collapse extra whitespace."""
+    assert compute_dedup_key("Call  Sarah") == compute_dedup_key("Call Sarah")
+
+
+def test_compute_dedup_key_returns_16_char_hex() -> None:
+    """compute_dedup_key must return a 16-character hex string."""
+    key = compute_dedup_key("some text")
+    assert len(key) == 16
+    assert all(c in "0123456789abcdef" for c in key)
+
+
+class TestParseLlmResponse:
+    """Tests for parse_llm_response — pure function, no DB or API calls."""
+
+    def test_parses_valid_json_list(self) -> None:
+        raw = json.dumps([
+            {"text": "Call Sarah", "priority": 3},
+            {"text": "Buy groceries", "priority": 7},
+        ])
+        items = parse_llm_response(raw)
+        assert len(items) == 2
+        assert items[0]["text"] == "Call Sarah"
+        assert items[0]["priority"] == 3
+
+    def test_empty_list_returns_empty(self) -> None:
+        raw = "[]"
+        items = parse_llm_response(raw)
+        assert items == []
+
+    def test_invalid_json_returns_empty(self) -> None:
+        """When the LLM returns malformed JSON, extractor must return empty list."""
+        items = parse_llm_response("not json at all")
+        assert items == []
+
+    def test_non_list_json_returns_empty(self) -> None:
+        """When the LLM returns a dict instead of a list, must return empty."""
+        raw = json.dumps({"text": "something"})
+        items = parse_llm_response(raw)
+        assert items == []
+
+    def test_missing_text_field_skipped(self) -> None:
+        """Items without a 'text' field must be skipped."""
+        raw = json.dumps([
+            {"priority": 3},  # missing text
+            {"text": "Valid item", "priority": 5},
+        ])
+        items = parse_llm_response(raw)
+        assert len(items) == 1
+        assert items[0]["text"] == "Valid item"
+
+    def test_priority_clamped_to_valid_range(self) -> None:
+        """Priority must be clamped to [1, 10]."""
+        raw = json.dumps([
+            {"text": "Too urgent", "priority": -5},
+            {"text": "Too low", "priority": 100},
+        ])
+        items = parse_llm_response(raw)
+        assert items[0]["priority"] == 1
+        assert items[1]["priority"] == 10
+
+    def test_missing_priority_defaults_to_5(self) -> None:
+        """When priority is absent, default to 5."""
+        raw = json.dumps([{"text": "Do something"}])
+        items = parse_llm_response(raw)
+        assert items[0]["priority"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for extract_action_items (mocked Claude)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractActionItems:
+    """Tests for extract_action_items — end-to-end with mocked Anthropic client."""
+
+    def test_calls_anthropic_with_haiku_model(self, conn: sqlite3.Connection) -> None:
+        """extract_action_items must call the Anthropic API with claude-haiku-4-5."""
+        llm_items = [{"text": "Follow up with the bank", "priority": 4}]
+        mock_response = _make_anthropic_response(llm_items)
+
+        with patch("src.los.extractor.anthropic.Anthropic") as MockClient:
+            instance = MockClient.return_value
+            instance.messages.create.return_value = mock_response
+
+            extract_action_items(
+                conn=conn,
+                text="I need to follow up with the bank this week.",
+                source="telegram",
+                source_message_id="msg_001",
+            )
+
+            call_kwargs = instance.messages.create.call_args[1]
+            assert call_kwargs["model"] == EXTRACTION_MODEL_EXPECTED
+
+    def test_writes_extracted_items_to_db(self, conn: sqlite3.Connection) -> None:
+        """Extracted items must be persisted to the action_items table."""
+        llm_items = [
+            {"text": "Call dentist", "priority": 3},
+            {"text": "Renew passport", "priority": 6},
+        ]
+        mock_response = _make_anthropic_response(llm_items)
+
+        with patch("src.los.extractor.anthropic.Anthropic") as MockClient:
+            instance = MockClient.return_value
+            instance.messages.create.return_value = mock_response
+
+            result = extract_action_items(
+                conn=conn,
+                text="I need to call the dentist and renew my passport.",
+                source="telegram",
+                source_message_id="msg_002",
+            )
+
+        assert len(result) == 2
+        items = get_open_items(conn)
+        texts = {item.text for item in items}
+        assert "Call dentist" in texts
+        assert "Renew passport" in texts
+
+    def test_dedup_increments_mention_count_instead_of_inserting(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        """When an extracted item matches an existing open item, mention_count must increment."""
+        from src.los.db import insert_action_item
+
+        existing_id = insert_action_item(
+            conn,
+            text="Call dentist",
+            source="telegram",
+            source_message_id="msg_first",
+        )
+
+        llm_items = [{"text": "Call dentist", "priority": 3}]
+        mock_response = _make_anthropic_response(llm_items)
+
+        with patch("src.los.extractor.anthropic.Anthropic") as MockClient:
+            instance = MockClient.return_value
+            instance.messages.create.return_value = mock_response
+
+            extract_action_items(
+                conn=conn,
+                text="I still need to call the dentist.",
+                source="telegram",
+                source_message_id="msg_003",
+            )
+
+        item = get_item_by_id(conn, existing_id)
+        assert item.mention_count == 2
+
+        # Only one item in DB (no duplicate inserted)
+        all_open = get_open_items(conn)
+        dentist_items = [i for i in all_open if i.text == "Call dentist"]
+        assert len(dentist_items) == 1
+
+    def test_empty_llm_response_returns_empty_list(self, conn: sqlite3.Connection) -> None:
+        """When LLM finds no action items, extract_action_items must return []."""
+        mock_response = _make_anthropic_response([])
+
+        with patch("src.los.extractor.anthropic.Anthropic") as MockClient:
+            instance = MockClient.return_value
+            instance.messages.create.return_value = mock_response
+
+            result = extract_action_items(
+                conn=conn,
+                text="Nice day today!",
+                source="telegram",
+                source_message_id="msg_004",
+            )
+
+        assert result == []
+        items = get_open_items(conn)
+        assert len(items) == 0
+
+    def test_llm_failure_returns_empty_list_without_raising(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        """When the Anthropic API call fails, extract_action_items must return []
+        rather than propagating the exception to the caller."""
+        with patch("src.los.extractor.anthropic.Anthropic") as MockClient:
+            instance = MockClient.return_value
+            instance.messages.create.side_effect = Exception("API unavailable")
+
+            result = extract_action_items(
+                conn=conn,
+                text="I need to call Sarah.",
+                source="telegram",
+                source_message_id="msg_005",
+            )
+
+        assert result == []
+
+    def test_source_and_message_id_stored_correctly(self, conn: sqlite3.Connection) -> None:
+        """Source and source_message_id must be stored in the inserted row."""
+        llm_items = [{"text": "Fix the leak", "priority": 2}]
+        mock_response = _make_anthropic_response(llm_items)
+
+        with patch("src.los.extractor.anthropic.Anthropic") as MockClient:
+            instance = MockClient.return_value
+            instance.messages.create.return_value = mock_response
+
+            result = extract_action_items(
+                conn=conn,
+                text="I need to fix the leak in the bathroom.",
+                source="voice_note",
+                source_message_id="vn_007",
+            )
+
+        assert len(result) == 1
+        items = get_open_items(conn)
+        assert items[0].source == "voice_note"
+        assert items[0].source_message_id == "vn_007"

--- a/tests/unit/los/test_schema.py
+++ b/tests/unit/los/test_schema.py
@@ -1,0 +1,281 @@
+"""
+Tests for LOS action items database schema and access layer.
+
+Tests verify the schema is applied correctly, indices exist, and
+the CRUD operations maintain expected invariants.
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.los.db import (
+    ActionItem,
+    DB_SCHEMA_SQL,
+    connect,
+    insert_action_item,
+    get_open_items,
+    get_item_by_id,
+    mark_done,
+    mark_dismissed,
+    mark_snoozed,
+    find_duplicate,
+    increment_mention_count,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants (mirror what the spec names — named so tests stay aligned to spec)
+# ---------------------------------------------------------------------------
+
+STATUS_OPEN = "open"
+STATUS_DONE = "done"
+STATUS_DISMISSED = "dismissed"
+STATUS_SNOOZED = "snoozed"
+
+PRIORITY_HIGH = 1
+PRIORITY_LOW = 10
+PRIORITY_DEFAULT = 5
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "self_action_items.db"
+
+
+@pytest.fixture
+def conn(db_path: Path) -> sqlite3.Connection:
+    c = connect(db_path)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def sample_item() -> dict:
+    return {
+        "text": "Call Sarah about the contract",
+        "source": "telegram",
+        "source_message_id": "msg_123",
+        "priority": 3,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+def test_schema_creates_action_items_table(conn: sqlite3.Connection) -> None:
+    """Schema must create the action_items table."""
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='action_items'"
+    )
+    row = cursor.fetchone()
+    assert row is not None, "action_items table must exist after schema creation"
+
+
+def test_schema_creates_required_indices(conn: sqlite3.Connection) -> None:
+    """Schema must create indices for status and extracted_at for query performance."""
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='action_items'"
+    )
+    index_names = {row[0] for row in cursor.fetchall()}
+    # At minimum status index must exist for the query path
+    assert any("status" in name for name in index_names), (
+        f"Expected a status index, found: {index_names}"
+    )
+
+
+def test_schema_has_required_columns(conn: sqlite3.Connection) -> None:
+    """Schema must define all required columns from the spec."""
+    cursor = conn.execute("PRAGMA table_info(action_items)")
+    columns = {row[1] for row in cursor.fetchall()}
+    required = {
+        "id", "text", "source", "source_message_id", "extracted_at",
+        "priority", "mention_count", "status", "snoozed_until",
+        "done_at", "dismissed_at", "notes",
+    }
+    missing = required - columns
+    assert not missing, f"Missing required columns: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Insert tests
+# ---------------------------------------------------------------------------
+
+
+def test_insert_action_item_returns_id(conn: sqlite3.Connection, sample_item: dict) -> None:
+    """insert_action_item must return a non-None integer row id."""
+    row_id = insert_action_item(conn, **sample_item)
+    assert isinstance(row_id, int)
+    assert row_id > 0
+
+
+def test_insert_action_item_stores_all_fields(conn: sqlite3.Connection, sample_item: dict) -> None:
+    """Inserted item must be retrievable with all fields intact."""
+    row_id = insert_action_item(conn, **sample_item)
+    item = get_item_by_id(conn, row_id)
+    assert item is not None
+    assert item.text == sample_item["text"]
+    assert item.source == sample_item["source"]
+    assert item.source_message_id == sample_item["source_message_id"]
+    assert item.priority == sample_item["priority"]
+    assert item.status == STATUS_OPEN
+    assert item.mention_count == 1
+
+
+def test_insert_action_item_default_priority(conn: sqlite3.Connection) -> None:
+    """When priority is omitted, default of 5 must be used."""
+    row_id = insert_action_item(
+        conn,
+        text="Buy milk",
+        source="telegram",
+        source_message_id=None,
+    )
+    item = get_item_by_id(conn, row_id)
+    assert item.priority == PRIORITY_DEFAULT
+
+
+def test_insert_action_item_sets_extracted_at(conn: sqlite3.Connection, sample_item: dict) -> None:
+    """extracted_at must be populated as an ISO UTC string."""
+    row_id = insert_action_item(conn, **sample_item)
+    item = get_item_by_id(conn, row_id)
+    assert item.extracted_at is not None
+    assert "T" in item.extracted_at  # ISO format contains T separator
+
+
+# ---------------------------------------------------------------------------
+# Query tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_open_items_returns_only_open(conn: sqlite3.Connection) -> None:
+    """get_open_items must return only status='open' items."""
+    open_id = insert_action_item(conn, text="Open task", source="telegram", source_message_id=None)
+    done_id = insert_action_item(conn, text="Done task", source="telegram", source_message_id=None)
+    mark_done(conn, done_id)
+
+    items = get_open_items(conn)
+    ids = {item.id for item in items}
+    assert open_id in ids
+    assert done_id not in ids
+
+
+def test_get_open_items_sorted_by_priority_then_mention_count(conn: sqlite3.Connection) -> None:
+    """Open items must be sorted priority ASC (1=urgent, 10=low), then mention_count DESC."""
+    # Insert in reverse order to verify sort
+    low_id = insert_action_item(conn, text="Low priority", source="telegram", source_message_id=None, priority=8)
+    high_id = insert_action_item(conn, text="High priority", source="telegram", source_message_id=None, priority=2)
+    med_id = insert_action_item(conn, text="Medium priority", source="telegram", source_message_id=None, priority=5)
+
+    items = get_open_items(conn)
+    ids_ordered = [item.id for item in items]
+    assert ids_ordered.index(high_id) < ids_ordered.index(med_id)
+    assert ids_ordered.index(med_id) < ids_ordered.index(low_id)
+
+
+def test_get_open_items_excludes_snoozed_until_future(conn: sqlite3.Connection) -> None:
+    """Items snoozed until a future date must not appear in open items."""
+    snoozed_id = insert_action_item(conn, text="Snoozed", source="telegram", source_message_id=None)
+    mark_snoozed(conn, snoozed_id, "2099-12-31")
+
+    items = get_open_items(conn)
+    ids = {item.id for item in items}
+    assert snoozed_id not in ids
+
+
+def test_get_open_items_includes_snoozed_until_past(conn: sqlite3.Connection) -> None:
+    """Items snoozed until a past date must reappear in open items."""
+    snoozed_id = insert_action_item(conn, text="Past snooze", source="telegram", source_message_id=None)
+    mark_snoozed(conn, snoozed_id, "2000-01-01")
+
+    items = get_open_items(conn)
+    ids = {item.id for item in items}
+    assert snoozed_id in ids
+
+
+# ---------------------------------------------------------------------------
+# Status transition tests
+# ---------------------------------------------------------------------------
+
+
+def test_mark_done_sets_status_and_done_at(conn: sqlite3.Connection, sample_item: dict) -> None:
+    """mark_done must set status='done' and populate done_at."""
+    row_id = insert_action_item(conn, **sample_item)
+    mark_done(conn, row_id)
+    item = get_item_by_id(conn, row_id)
+    assert item.status == STATUS_DONE
+    assert item.done_at is not None
+
+
+def test_mark_dismissed_sets_status_and_dismissed_at(conn: sqlite3.Connection, sample_item: dict) -> None:
+    """mark_dismissed must set status='dismissed' and populate dismissed_at.
+
+    Dismissed items are NOT deleted — they must remain reviewable (spec decision).
+    """
+    row_id = insert_action_item(conn, **sample_item)
+    mark_dismissed(conn, row_id)
+    item = get_item_by_id(conn, row_id)
+    assert item.status == STATUS_DISMISSED
+    assert item.dismissed_at is not None
+    assert item is not None, "Dismissed items must remain in DB for weekly review"
+
+
+def test_mark_snoozed_sets_status_and_date(conn: sqlite3.Connection, sample_item: dict) -> None:
+    """mark_snoozed must set status='snoozed' and snoozed_until to the given date."""
+    row_id = insert_action_item(conn, **sample_item)
+    mark_snoozed(conn, row_id, "2026-06-01")
+    item = get_item_by_id(conn, row_id)
+    assert item.status == STATUS_SNOOZED
+    assert item.snoozed_until == "2026-06-01"
+
+
+# ---------------------------------------------------------------------------
+# Dedup tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_duplicate_returns_none_for_novel_item(conn: sqlite3.Connection) -> None:
+    """find_duplicate must return None when no similar open item exists."""
+    result = find_duplicate(conn, "Call the dentist")
+    assert result is None
+
+
+def test_find_duplicate_finds_exact_match(conn: sqlite3.Connection) -> None:
+    """find_duplicate must find an existing open item with the same normalized text."""
+    row_id = insert_action_item(conn, text="Call the dentist", source="telegram", source_message_id=None)
+    result = find_duplicate(conn, "Call the dentist")
+    assert result is not None
+    assert result.id == row_id
+
+
+def test_find_duplicate_normalizes_case_and_punctuation(conn: sqlite3.Connection) -> None:
+    """Dedup check must normalize case, punctuation, and whitespace."""
+    row_id = insert_action_item(conn, text="Call the dentist!", source="telegram", source_message_id=None)
+    result = find_duplicate(conn, "CALL THE DENTIST")
+    assert result is not None
+    assert result.id == row_id
+
+
+def test_find_duplicate_ignores_dismissed_items(conn: sqlite3.Connection) -> None:
+    """Dismissed items must not be matched as duplicates — they are archived."""
+    row_id = insert_action_item(conn, text="Cancel gym membership", source="telegram", source_message_id=None)
+    mark_dismissed(conn, row_id)
+    result = find_duplicate(conn, "Cancel gym membership")
+    assert result is None
+
+
+def test_increment_mention_count_increments(conn: sqlite3.Connection, sample_item: dict) -> None:
+    """increment_mention_count must increase mention_count by 1."""
+    row_id = insert_action_item(conn, **sample_item)
+    increment_mention_count(conn, row_id)
+    item = get_item_by_id(conn, row_id)
+    assert item.mention_count == 2

--- a/tests/unit/los/test_schema.py
+++ b/tests/unit/los/test_schema.py
@@ -14,6 +14,7 @@ import pytest
 
 from src.los.db import (
     ActionItem,
+    ActionItemStatus,
     DB_SCHEMA_SQL,
     connect,
     insert_action_item,
@@ -28,13 +29,8 @@ from src.los.db import (
 
 
 # ---------------------------------------------------------------------------
-# Constants (mirror what the spec names — named so tests stay aligned to spec)
+# Priority constants (no enum in production — local-only, not status mirrors)
 # ---------------------------------------------------------------------------
-
-STATUS_OPEN = "open"
-STATUS_DONE = "done"
-STATUS_DISMISSED = "dismissed"
-STATUS_SNOOZED = "snoozed"
 
 PRIORITY_HIGH = 1
 PRIORITY_LOW = 10
@@ -128,7 +124,7 @@ def test_insert_action_item_stores_all_fields(conn: sqlite3.Connection, sample_i
     assert item.source == sample_item["source"]
     assert item.source_message_id == sample_item["source_message_id"]
     assert item.priority == sample_item["priority"]
-    assert item.status == STATUS_OPEN
+    assert item.status == ActionItemStatus.OPEN
     assert item.mention_count == 1
 
 
@@ -212,7 +208,7 @@ def test_mark_done_sets_status_and_done_at(conn: sqlite3.Connection, sample_item
     row_id = insert_action_item(conn, **sample_item)
     mark_done(conn, row_id)
     item = get_item_by_id(conn, row_id)
-    assert item.status == STATUS_DONE
+    assert item.status == ActionItemStatus.DONE
     assert item.done_at is not None
 
 
@@ -224,7 +220,7 @@ def test_mark_dismissed_sets_status_and_dismissed_at(conn: sqlite3.Connection, s
     row_id = insert_action_item(conn, **sample_item)
     mark_dismissed(conn, row_id)
     item = get_item_by_id(conn, row_id)
-    assert item.status == STATUS_DISMISSED
+    assert item.status == ActionItemStatus.DISMISSED
     assert item.dismissed_at is not None
     assert item is not None, "Dismissed items must remain in DB for weekly review"
 
@@ -234,7 +230,7 @@ def test_mark_snoozed_sets_status_and_date(conn: sqlite3.Connection, sample_item
     row_id = insert_action_item(conn, **sample_item)
     mark_snoozed(conn, row_id, "2026-06-01")
     item = get_item_by_id(conn, row_id)
-    assert item.status == STATUS_SNOOZED
+    assert item.status == ActionItemStatus.SNOOZED
     assert item.snoozed_until == "2026-06-01"
 
 


### PR DESCRIPTION
## What this solves

Dan's voice notes and Telegram messages contain action commitments that currently disappear into the archive with no mechanism to surface them forward. This PR adds LOS Cycle 1: a personal action-item store with LLM extraction, dedup, status tracking, and two surfacing paths — an interactive /todos command and a morning digest footer.

## What changed

**New module: `src/los/`**

Four pure-function-first components:

- `db.py` — SQLite schema and access layer for `~/lobster-user-config/data/self_action_items.db`. Separate from `memory.db` (Lobster's system store) and MCP tasks (Lobster's work queue) — three different actors, three different stores.
- `extractor.py` — calls `claude-haiku-4-5` to identify first-person action commitments in text; returns structured items with priority 1–10; handles dedup by normalized text hash (16-char SHA256 prefix); increments `mention_count` on duplicate instead of inserting.
- `callbacks.py` — routes `todo-done-{id}`, `todo-dismiss-{id}`, `todo-snooze-{id}-{date}` Telegram inline button presses. Returns the same `{action, text, chat_id, handled}` shape as the WOS callback router, so the dispatcher can chain them.
- `digest.py` — pure function that builds the morning digest footer from a list of ActionItems. Returns empty string when no items exist (no noise).

**Schema design choices worth reviewing:**
- Priority is integer 1–10 (1=urgent, 10=low) rather than high/medium/low enum. This allows LLM-inferred numeric precision and clean SQL sort without a CASE expression for ordering.
- Dismissed items are NOT deleted — they stay with `status='dismissed'` for weekly review. This was an explicit Dan decision.
- Snooze uses a custom date (`snoozed_until TEXT YYYY-MM-DD`) rather than fixed 1d/3d durations. This was an explicit Dan decision.

**Dispatcher integration: `.claude/sys.dispatcher.bootup.md`**

Two additions:
1. New LOS Commands section documenting `/todos` dispatch, natural language triggers, and callback routing.
2. `todo-` prefix branch added to the Button callbacks handler, before the existing `else` fallthrough.

Note: dispatcher bootup edits take effect on the next dispatcher restart (the `.claude/` directory is a live symlink to the repo).

**Scheduled jobs: `scheduled-tasks/tasks/`**

Three task definition files:
- `los-action-scanner.md` — hourly Type A job that scans recent conversation history for action commitments
- `los-todos-query.md` — on-demand subagent for `/todos` command (not scheduled, dispatched inline)
- `los-weekly-review.md` — Sunday 08:00 Type A job that surfaces dismissed items for review

Companion scanner script: `scheduled-tasks/los-action-scanner.py` — can run standalone for testing (`uv run scheduled-tasks/los-action-scanner.py --dry-run`).

**Migration 102: `scripts/upgrade.sh`**

Three steps in one migration:
1. Creates `~/lobster-user-config/data/` directory
2. Registers `los-action-scanner` (hourly) and `los-weekly-review` (Sunday 08:00) in `jobs.json`
3. Appends the LOS todos footer section to the runtime `async-deep-work.md` task file (if not already present)

**What is explicitly not in this PR:**
- Obsidian nightly sweep (Phase 2)
- Resonance map
- Weekly retro UI integration
- Voice note post-transcription inline hook (extractor can be called directly from transcription worker in a follow-up; the hourly scanner covers voice notes indirectly via conversation history)

## Functional patterns used

- Pure functions with explicit side effects at the boundary: `parse_llm_response` and `format_digest_section` are pure; DB writes only happen in `extract_action_items` and the callback handlers
- Immutable data class: `ActionItem` is `@dataclass(frozen=True)`
- Dependency injection for testing: all DB functions take `conn` as argument; `route_los_callback` accepts an optional `conn` override
- Composition: `build_digest_footer` = `format_digest_section` + footer text, without touching the DB

## Tests run

- [x] `uv run pytest tests/unit/los/ -v` — 47 passed, 0 failed
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_orchestration/test_registry_cli.py -q` — 5623 passed, 102 failed, 32 skipped (all 102 failures confirmed pre-existing on `main` — path_guard, steward, prescriptions, script_inbox_sources)

## Manual test

N/A for unit tests. This change adds new infrastructure; no existing runtime paths are modified.

The dispatcher integration (`.claude/sys.dispatcher.bootup.md` callback routing) takes effect on the next dispatcher restart. The live behavior is: `todo-*` callbacks will be routed to `route_los_callback` before falling through to the WOS handler. This does not affect any existing callback_data patterns.

The migration (upgrade.sh #102) has not been run against production yet — it will fire on the next `upgrade.sh` run.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Anthropic API calls are mocked in all extractor tests
- [ ] Integration/manual test run — not yet run; requires actual conversation history with action commitments
- [ ] User-visible outcome verified — `/todos` dispatch requires the jobs.json migration to run and at least one hourly scan to have executed; can be tested after merge
- [x] Side-effect audit: extractor fails silently (returns []); callbacks are idempotent on re-press; no floods or loops possible from the scanner (it reads processed/ messages, doesn't modify them)
- [x] External service calls: Anthropic API is mocked in tests; no production hits during CI