### PR TITLE
feat(wos): executor PID tracking and wos abort command

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3599,6 +3599,39 @@ ADWEOF
         substep "Migration 102: jobs.json not found — skipping"
     fi
 
+    # Migration 103: Add executor_pid column to uow_registry for subprocess PID tracking.
+    # Enables 'wos abort <uow_id>' to kill running subprocesses via SIGTERM.
+    # The column is nullable INTEGER — NULL means no subprocess PID is stored.
+    local _registry_db="$WORKSPACE_DIR/orchestration/registry.db"
+    if [ -f "$_registry_db" ]; then
+        local _has_pid_col
+        _has_pid_col=$(uv run python3 -c "
+import sqlite3
+conn = sqlite3.connect('$_registry_db')
+cols = [row[1] for row in conn.execute('PRAGMA table_info(uow_registry)').fetchall()]
+print('yes' if 'executor_pid' in cols else 'no')
+conn.close()
+" 2>/dev/null || echo "error")
+        if [ "$_has_pid_col" = "no" ]; then
+            uv run python3 -c "
+import sqlite3
+conn = sqlite3.connect('$_registry_db')
+conn.execute('ALTER TABLE uow_registry ADD COLUMN executor_pid INTEGER NULL')
+conn.commit()
+conn.close()
+print('executor_pid column added')
+"
+            migrated=$((migrated + 1))
+            substep "Migration 103: added executor_pid column to uow_registry"
+        elif [ "$_has_pid_col" = "yes" ]; then
+            substep "Migration 103: executor_pid column already present — skipping"
+        else
+            substep "Migration 103: could not check registry DB — skipping"
+        fi
+    else
+        substep "Migration 103: registry DB not found — skipping (will be applied on first Registry init)"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/daemons/wos_execute_router.py
+++ b/src/daemons/wos_execute_router.py
@@ -327,7 +327,11 @@ _CLAUDE_BIN: str = "claude"
 _MAX_TURNS: int = 40
 
 
-def _dispatch_via_popen(instructions: str, uow_id: str) -> str:
+def _dispatch_via_popen(
+    instructions: str,
+    uow_id: str,
+    registry: object = None,
+) -> str:
     """
     Dispatch a functional-engineer subagent via ``claude -p`` without blocking.
 
@@ -338,6 +342,12 @@ def _dispatch_via_popen(instructions: str, uow_id: str) -> str:
     The child process runs independently.  The daemon does NOT wait for it
     to complete — the subagent's handoff mechanism is ``write_result``
     (called at agent completion), not the subprocess return code.
+
+    When ``registry`` is provided, the child's PID is written to
+    ``executor_pid`` in the UoW row immediately after ``Popen`` succeeds.
+    This enables ``wos abort <uow_id>`` to send SIGTERM to the process group.
+    PID write is best-effort — any failure is logged at WARNING level and does
+    not block dispatch.
 
     Returns a ``run_id`` string for audit correlation (``uow_id`` + timestamp).
 
@@ -376,7 +386,7 @@ def _dispatch_via_popen(instructions: str, uow_id: str) -> str:
     except Exception:
         env = None  # Fall back to inheriting the current environment
 
-    subprocess.Popen(
+    proc = subprocess.Popen(
         command,
         start_new_session=True,  # Insulates child from SIGTERM sent to daemon
         stdin=subprocess.DEVNULL,
@@ -385,6 +395,22 @@ def _dispatch_via_popen(instructions: str, uow_id: str) -> str:
         close_fds=True,
         env=env,
     )
+
+    # Write PID to registry so `wos abort` can send SIGTERM to the process group.
+    # Best-effort: any failure is logged but does not abort the dispatch.
+    if registry is not None:
+        try:
+            registry.set_executor_pid(uow_id, proc.pid)
+            log.info(
+                "dispatch: stored executor_pid=%d for uow_id=%s",
+                proc.pid, uow_id,
+            )
+        except Exception as exc:
+            log.warning(
+                "dispatch: failed to store executor_pid for uow_id=%s — %s: %s "
+                "(wos abort will not work for this UoW)",
+                uow_id, type(exc).__name__, exc,
+            )
 
     log.info(
         "dispatch: spawned claude -p for uow_id=%s run_id=%s (non-blocking, new session)",
@@ -440,9 +466,26 @@ def _route_single_message(msg: dict) -> None:
         # to get the bare uow_id expected by _dispatch_via_popen
         bare_uow_id = task_id.removeprefix("wos-")
 
+        # Resolve registry for PID tracking (best-effort: None if unavailable).
+        # PID tracking enables `wos abort <uow_id>` to SIGTERM the process group.
+        # Lazily imported to avoid pulling orchestration.registry into the module
+        # namespace at load time (the router tests mock orchestration at import).
+        _registry = None
+        try:
+            from orchestration.registry import Registry as _Registry
+            from orchestration.paths import REGISTRY_DB
+            if REGISTRY_DB.exists():
+                _registry = _Registry(REGISTRY_DB)
+        except Exception as _exc:
+            log.warning(
+                "route: could not open registry for PID tracking (uow_id=%s) — %s: %s "
+                "(wos abort will not work for this UoW)",
+                uow_id, type(_exc).__name__, _exc,
+            )
+
         log.info("route: dispatching subagent for uow_id=%s task_id=%s", uow_id, task_id)
         try:
-            run_id = _dispatch_via_popen(instructions=prompt, uow_id=bare_uow_id)
+            run_id = _dispatch_via_popen(instructions=prompt, uow_id=bare_uow_id, registry=_registry)
             log.info("route: dispatch succeeded run_id=%s uow_id=%s", run_id, uow_id)
         except Exception as exc:
             log.error("route: _dispatch_via_popen raised for %s: %s", uow_id, exc)

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -686,7 +686,20 @@ def handle_wos_abort(uow_id: str, *, registry: "Registry") -> str:
             "The subprocess and its children have been signaled for termination.\n"
             "TTL/heartbeat recovery will re-queue the UoW on the next observation cycle."
         )
+
+    # kill_executor returned False — two distinct cases depending on whether the PID was retained.
+    # PermissionError: process still running but unowned → PID retained.
+    # ProcessLookupError: process already gone → PID cleared.
+    retained_pid = registry.get_executor_pid(uow_id)
+    if retained_pid is not None:
+        # PermissionError path: process alive but we cannot signal it.
+        return (
+            f"UoW `{uow_id}`: cannot kill PID {pid} — permission denied.\n"
+            "The process may still be running (owned by a different user).\n"
+            "executor_pid has been retained for future abort attempts."
+        )
     else:
+        # ProcessLookupError path: process already exited, stale PID cleared.
         return (
             f"UoW `{uow_id}`: process PID {pid} was already gone (ProcessLookupError).\n"
             "The subprocess may have exited before the abort command reached it.\n"

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -12,6 +12,7 @@ The dispatcher calls these handlers when it recognizes:
   /wos unblock                         → handle_wos_unblock()
   /wos start                           → handle_wos_start()
   /wos stop                            → handle_wos_stop()
+  wos abort <uow-id>                   → handle_wos_abort(uow_id, registry)
   decide retry <uow-id>                → handle_decide_retry(uow_id, registry)
   decide close <uow-id>                → handle_decide_close(uow_id, registry)
   type: "wos_execute"                  → handle_wos_execute(uow_id, instructions, output_ref)
@@ -638,6 +639,59 @@ def handle_wos_stop() -> str:
             f"(may be systemd-only): {', '.join(sorted(result['not_found']))}"
         )
     return "\n".join(lines)
+
+
+def handle_wos_abort(uow_id: str, *, registry: "Registry") -> str:
+    """
+    Handle 'wos abort <uow_id>'.
+
+    Sends SIGTERM to the process group of the subprocess dispatched for the
+    given UoW. This kills the running worker explicitly without waiting for
+    TTL recovery (which takes up to 24 hours).
+
+    The kill targets the entire process group (os.killpg) so that any child
+    processes spawned by the subagent (e.g. claude -p spawning shell commands)
+    are also terminated.
+
+    Flow:
+      1. Look up executor_pid via registry.get_executor_pid(uow_id).
+      2. If None (no running process): report not found — nothing to kill.
+      3. If found: call registry.kill_executor(uow_id) which sends SIGTERM
+         and clears executor_pid on success or ProcessLookupError.
+
+    Returns a human-readable Telegram message describing the outcome.
+
+    Note: The registry transition from executing/active to failed/ready-for-steward
+    is NOT performed here — the killed subprocess will fail to write its result
+    file, and TTL/heartbeat recovery will detect the missing result and re-queue
+    the UoW on the next observation cycle. This preserves the existing recovery
+    path and avoids a conflicting state transition race.
+
+    Args:
+        uow_id: The UoW identifier to abort.
+        registry: The Registry instance to query and update.
+    """
+    pid = registry.get_executor_pid(uow_id)
+    if pid is None:
+        return (
+            f"UoW `{uow_id}`: no running process found (executor_pid is not set).\n"
+            "The UoW may not have been dispatched via subprocess, or it already completed.\n"
+            "Run `/wos status active` or `/wos status executing` to check current state."
+        )
+
+    killed = registry.kill_executor(uow_id)
+    if killed:
+        return (
+            f"UoW `{uow_id}` aborted: sent SIGTERM to process group of PID {pid}.\n"
+            "The subprocess and its children have been signaled for termination.\n"
+            "TTL/heartbeat recovery will re-queue the UoW on the next observation cycle."
+        )
+    else:
+        return (
+            f"UoW `{uow_id}`: process PID {pid} was already gone (ProcessLookupError).\n"
+            "The subprocess may have exited before the abort command reached it.\n"
+            "executor_pid has been cleared. The UoW will be re-queued by heartbeat recovery."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1435,6 +1489,43 @@ def parse_diagnose_command(text: str) -> str | None:
     return None
 
 
+def parse_wos_abort_command(text: str) -> str | None:
+    """
+    Parse a ``wos abort <uow_id>`` Telegram command and return the UoW ID.
+
+    Matches ``wos abort <uow_id>`` (case-insensitive, leading/trailing whitespace
+    ignored). Returns the uow_id token if the command matches; None otherwise.
+
+    The dispatcher calls this alongside other 'wos ...' command parsers before
+    routing the command to handle_wos_abort().
+
+    Args:
+        text: The raw Telegram message text.
+
+    Returns:
+        The ``uow_id`` token if the command matches; ``None`` otherwise.
+
+    Examples::
+
+        parse_wos_abort_command("wos abort uow_20260426_abc123")
+        # → "uow_20260426_abc123"
+
+        parse_wos_abort_command("WOS ABORT uow_20260426_abc123")
+        # → "uow_20260426_abc123"
+
+        parse_wos_abort_command("wos start")
+        # → None
+    """
+    stripped = text.strip()
+    lower = stripped.lower()
+    if lower.startswith("wos abort "):
+        remainder = stripped[len("wos abort "):].strip()
+        tokens = remainder.split()
+        if tokens:
+            return tokens[0]
+    return None
+
+
 def _load_instructions_from_artifact(uow_id: str) -> str:
     """
     Load prescribed instructions from the WorkflowArtifact file for uow_id.
@@ -1914,6 +2005,7 @@ WOS control:
   wos stop   — pause WOS pipeline (all 14 WOS-core jobs + execution_enabled)
   wos status [status] — show active + queued UoWs
   wos unblock         — clear BOOTUP_CANDIDATE_GATE flag
+  wos abort <uow-id>  — send SIGTERM to running subprocess for a UoW
 
 Decision:
   /approve <uow-id>   — approve a proposed UoW

--- a/src/orchestration/migrations/0020_add_executor_pid.sql
+++ b/src/orchestration/migrations/0020_add_executor_pid.sql
@@ -1,0 +1,19 @@
+-- Migration 0020: add executor_pid column for subprocess PID tracking.
+--
+-- Problem:
+--   The WOS executor dispatches UoWs via subprocess.Popen(..., start_new_session=True).
+--   Once dispatched, there is no way to kill the subprocess explicitly because
+--   the PID is not stored. The 'wos abort <uow_id>' command needs a stored PID
+--   to send SIGTERM to the process group.
+--
+-- Fix:
+--   Add executor_pid INTEGER NULL to uow_registry.
+--   Written at dispatch time by the Executor after Popen(...) succeeds.
+--   Cleared when the UoW completes or when the abort command kills the process.
+--   Also cleared during orphan recovery (steward/heartbeat orphan path).
+--
+-- Backward compatibility:
+--   Existing UoWs get executor_pid = NULL (no PID stored). The kill path
+--   treats NULL as "no running process found" and returns False.
+
+ALTER TABLE uow_registry ADD COLUMN executor_pid INTEGER NULL;

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -2901,13 +2901,25 @@ class Registry:
             uow_id: The UoW identifier.
 
         Returns:
-            True if the process was found and SIGTERM was sent.
-            False if no PID was stored (executor_pid IS NULL) or the UoW was not found.
+            True if the process was found and SIGTERM was sent successfully.
+            False in three cases:
+              - executor_pid IS NULL (no PID stored, or UoW not found): no action taken.
+              - ProcessLookupError: process already exited; executor_pid is cleared.
+              - PermissionError: process is still running but owned by another user;
+                executor_pid is RETAINED (not cleared) so future abort attempts can
+                still see the PID. Callers that need to distinguish these two False
+                cases should call get_executor_pid() after a False return:
+                  - PID still present → PermissionError (process alive, unowned)
+                  - PID is None       → ProcessLookupError (process already gone)
 
         Note:
             ProcessLookupError is handled gracefully — the process already exited.
             In that case, executor_pid is cleared and False is returned, because no
             kill signal was actually delivered.
+
+            PermissionError is also handled gracefully — the process is running but
+            unowned. executor_pid is retained so the caller can report accurately and
+            a subsequent abort attempt is still possible (e.g., after privilege change).
         """
         import os
         import signal

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -2785,6 +2785,145 @@ class Registry:
         finally:
             conn.close()
 
+    # -----------------------------------------------------------------------
+    # Executor PID tracking methods (migration 0020)
+    # -----------------------------------------------------------------------
+
+    def set_executor_pid(self, uow_id: str, pid: int) -> None:
+        """
+        Store the OS process ID of the dispatched subprocess for a UoW.
+
+        Called by the executor immediately after Popen(...) succeeds so that
+        the process group can be killed later via kill_executor(). Stored in
+        the executor_pid column (nullable INTEGER, migration 0020).
+
+        Args:
+            uow_id: The UoW identifier.
+            pid: The OS PID returned by Popen.pid.
+        """
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE uow_registry
+                SET executor_pid = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (pid, now, uow_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def get_executor_pid(self, uow_id: str) -> int | None:
+        """
+        Return the stored executor PID for a UoW, or None if absent.
+
+        Returns None when:
+        - The UoW has no stored PID (executor_pid IS NULL).
+        - The UoW does not exist.
+        - The executor_pid column has not yet been migrated (migration 0020).
+
+        Args:
+            uow_id: The UoW identifier.
+
+        Returns:
+            Integer PID if stored, None otherwise.
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT executor_pid FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            return row["executor_pid"]
+        except Exception as exc:
+            log.debug(
+                "get_executor_pid: failed for uow_id=%s — %s: %s",
+                uow_id, type(exc).__name__, exc,
+            )
+            return None
+        finally:
+            conn.close()
+
+    def clear_executor_pid(self, uow_id: str) -> None:
+        """
+        Clear the stored executor PID for a UoW (set to NULL).
+
+        Called when:
+        - The UoW completes normally (wos_completion.py).
+        - The UoW is killed via kill_executor().
+        - The UoW is re-queued by orphan recovery.
+
+        Idempotent: no-op if executor_pid is already NULL or the UoW is not found.
+
+        Args:
+            uow_id: The UoW identifier.
+        """
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                UPDATE uow_registry
+                SET executor_pid = NULL, updated_at = ?
+                WHERE id = ?
+                """,
+                (now, uow_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def kill_executor(self, uow_id: str) -> bool:
+        """
+        Kill the subprocess associated with a UoW by sending SIGTERM to its process group.
+
+        Looks up the stored executor_pid and sends SIGTERM to the entire process group
+        via os.killpg(os.getpgid(pid), signal.SIGTERM). This reaches subprocesses that
+        spawn children (e.g. claude -p spawning shell commands).
+
+        Clears executor_pid after a successful kill or if the process is already gone
+        (ProcessLookupError — process exited between PID read and kill call).
+
+        Args:
+            uow_id: The UoW identifier.
+
+        Returns:
+            True if the process was found and SIGTERM was sent.
+            False if no PID was stored (executor_pid IS NULL) or the UoW was not found.
+
+        Note:
+            ProcessLookupError is handled gracefully — the process already exited.
+            In that case, executor_pid is cleared and False is returned, because no
+            kill signal was actually delivered.
+        """
+        import os
+        import signal
+
+        pid = self.get_executor_pid(uow_id)
+        if pid is None:
+            return False
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGTERM)
+            self.clear_executor_pid(uow_id)
+            return True
+        except ProcessLookupError:
+            # Process already exited — clean up stale PID.
+            self.clear_executor_pid(uow_id)
+            return False
+
 
 # ---------------------------------------------------------------------------
 # Steward/Executor schema validation

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -2919,6 +2919,16 @@ class Registry:
             os.killpg(os.getpgid(pid), signal.SIGTERM)
             self.clear_executor_pid(uow_id)
             return True
+        except PermissionError:
+            # Process is still running but we lack permission to signal it.
+            # Do NOT clear the PID — the process is alive; clearing would make
+            # a future abort attempt silently do nothing (False rather than error).
+            log.warning(
+                "kill_executor: PermissionError sending SIGTERM to pid=%d "
+                "(uow_id=%s) — process is still running but unowned",
+                pid, uow_id,
+            )
+            return False
         except ProcessLookupError:
             # Process already exited — clean up stale PID.
             self.clear_executor_pid(uow_id)

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -889,6 +889,17 @@ def maybe_complete_wos_uow(
             uow_id,
         )
 
+        # Clear executor PID on completion so kill_executor is a no-op
+        # for already-finished UoWs (migration 0020).
+        try:
+            registry.clear_executor_pid(uow_id)
+        except Exception as pid_exc:
+            # Non-fatal: executor_pid column may not exist on pre-0020 installs.
+            log.debug(
+                "maybe_complete_wos_uow: clear_executor_pid failed for UoW %r — %s: %s",
+                uow_id, type(pid_exc).__name__, pid_exc,
+            )
+
         # Post-completion steward trigger (issue #912): wake the steward immediately
         # so it prescribes the next UoW in seconds rather than waiting up to 3 minutes
         # for the next cron tick. Non-fatal — cron remains the recovery fallback.

--- a/tests/test_wos_execute_router.py
+++ b/tests/test_wos_execute_router.py
@@ -451,7 +451,7 @@ class TestDispatchFailure:
         _write_msg(router.INBOX_DIR, msg1)
         _write_msg(router.INBOX_DIR, msg2)
 
-        def fake_dispatch(instructions: str, uow_id: str) -> str:
+        def fake_dispatch(instructions: str, uow_id: str, registry: object = None) -> str:
             if "fail" in uow_id:
                 raise RuntimeError("dispatch failed")
             return "run-ok"

--- a/tests/unit/test_orchestration/test_executor_pid_tracking.py
+++ b/tests/unit/test_orchestration/test_executor_pid_tracking.py
@@ -375,3 +375,41 @@ def test_handle_wos_abort_process_already_gone(
     # Reply should indicate the process was already gone (not an error)
     assert "already" in reply.lower() or "gone" in reply.lower() or "exited" in reply.lower()
     assert uow_id in reply
+
+
+def test_handle_wos_abort_permission_error_on_kill(
+    registry: Registry, db_path: Path
+) -> None:
+    """handle_wos_abort reports permission denied (not ProcessLookupError) when kill_executor returns False due to PermissionError.
+
+    The PermissionError case means:
+    - The process is STILL RUNNING (not gone)
+    - executor_pid is RETAINED (not cleared)
+    - The correct message must reflect all three facts
+
+    This test guards against the pre-fix bug where both False-return cases
+    produced the ProcessLookupError message ("was already gone", "pid cleared"),
+    which was wrong on all three counts for the PermissionError path.
+    """
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg", side_effect=PermissionError("operation not permitted")):
+        reply = handle_wos_abort(uow_id, registry=registry)
+
+    # Must mention permission denial — not ProcessLookupError language
+    assert "permission" in reply.lower() or "denied" in reply.lower(), (
+        f"Expected 'permission' or 'denied' in reply, got: {reply!r}"
+    )
+    # Must NOT claim the process is gone (it isn't)
+    assert "already gone" not in reply.lower() and "processlookup" not in reply.lower(), (
+        f"Reply incorrectly used ProcessLookupError language for PermissionError: {reply!r}"
+    )
+    # Must mention the UoW ID and PID
+    assert uow_id in reply
+    assert str(FAKE_PID) in reply
+    # Must NOT claim PID was cleared (it wasn't)
+    assert "executor_pid has been cleared" not in reply, (
+        f"Reply incorrectly claimed PID cleared on PermissionError: {reply!r}"
+    )

--- a/tests/unit/test_orchestration/test_executor_pid_tracking.py
+++ b/tests/unit/test_orchestration/test_executor_pid_tracking.py
@@ -1,0 +1,342 @@
+"""
+Unit tests for executor PID tracking and wos abort command (migration 0020).
+
+Tests are derived from the spec — each test name states the behavior, not the
+mechanism. Implementation details (SQL, signal numbers) are hidden behind the
+Registry public API where possible.
+
+Behaviors tested:
+
+PID storage:
+- test_migration_adds_executor_pid_column: migration 0020 adds executor_pid column
+- test_get_executor_pid_returns_none_before_set: None returned before any write
+- test_set_executor_pid_stores_pid: set stores a retrievable integer PID
+- test_set_executor_pid_overwrites_previous: subsequent set replaces earlier PID
+- test_clear_executor_pid_removes_pid: clear sets executor_pid to NULL
+- test_clear_executor_pid_idempotent_when_null: clear is a no-op when already NULL
+- test_get_executor_pid_returns_none_for_missing_uow: None for nonexistent UoW
+
+Kill path:
+- test_kill_executor_returns_false_when_no_pid: no PID stored → False
+- test_kill_executor_sends_sigterm_to_process_group: kills via killpg and returns True
+- test_kill_executor_clears_pid_after_successful_kill: PID cleared after kill
+- test_kill_executor_handles_process_already_gone: ProcessLookupError → False, PID cleared
+- test_kill_executor_clears_pid_when_process_already_gone: PID cleared even on ProcessLookupError
+
+Dispatcher command parsing:
+- test_parse_wos_abort_extracts_uow_id: parses "wos abort <uow_id>"
+- test_parse_wos_abort_case_insensitive: matches regardless of case
+- test_parse_wos_abort_returns_none_for_non_matching: None for unrelated commands
+- test_parse_wos_abort_returns_none_for_incomplete: None for bare "wos abort"
+
+Dispatcher command handler:
+- test_handle_wos_abort_no_running_process: reply when no PID stored
+- test_handle_wos_abort_kills_running_process: kill succeeds → success reply
+- test_handle_wos_abort_process_already_gone: ProcessLookupError → already-gone reply
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.orchestration.registry import Registry
+from src.orchestration.dispatcher_handlers import (
+    parse_wos_abort_command,
+    handle_wos_abort,
+)
+
+
+# ---------------------------------------------------------------------------
+# Named constants from spec (migration 0020)
+# ---------------------------------------------------------------------------
+
+#: Column name added by migration 0020
+EXECUTOR_PID_COLUMN = "executor_pid"
+
+#: Fake PID used in tests — realistic but distinguishable from real PIDs
+FAKE_PID = 99999
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path) -> Registry:
+    """Registry with all migrations applied (including 0020 executor_pid)."""
+    return Registry(db_path)
+
+
+def _insert_uow(db_path: Path, *, status: str = "active") -> str:
+    """Insert a minimal UoW row directly via SQLite. Returns uow_id."""
+    uow_id = f"uow_test_{uuid.uuid4().hex[:8]}"
+    now = _now_iso()
+    issue_number = int(uuid.uuid4().int % 90000) + 10000
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute(
+            """
+            INSERT INTO uow_registry
+                (id, type, source, source_issue_number, sweep_date, status, posture,
+                 created_at, updated_at, summary, success_criteria, route_evidence,
+                 trigger, register, uow_mode)
+            VALUES (?, 'executable', ?, ?, '2026-01-01', ?, 'solo',
+                    ?, ?, 'Test UoW', 'Test done.', '{}',
+                    '{"type": "immediate"}', 'operational', 'operational')
+            """,
+            (
+                uow_id,
+                f"github:issue/{issue_number}",
+                issue_number,
+                status,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return uow_id
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+def test_migration_adds_executor_pid_column(registry: Registry, db_path: Path) -> None:
+    """Migration 0020 adds the executor_pid column to uow_registry."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(uow_registry)").fetchall()]
+    finally:
+        conn.close()
+    assert EXECUTOR_PID_COLUMN in cols, (
+        f"executor_pid column not found in uow_registry after migration. "
+        f"Columns present: {cols}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PID storage tests
+# ---------------------------------------------------------------------------
+
+def test_get_executor_pid_returns_none_before_set(
+    registry: Registry, db_path: Path
+) -> None:
+    """get_executor_pid returns None for a UoW that has never had a PID written."""
+    uow_id = _insert_uow(db_path)
+    assert registry.get_executor_pid(uow_id) is None
+
+
+def test_set_executor_pid_stores_pid(registry: Registry, db_path: Path) -> None:
+    """set_executor_pid writes a PID that get_executor_pid can read back."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+    assert registry.get_executor_pid(uow_id) == FAKE_PID
+
+
+def test_set_executor_pid_overwrites_previous(
+    registry: Registry, db_path: Path
+) -> None:
+    """set_executor_pid replaces an earlier PID with the new value."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+    registry.set_executor_pid(uow_id, FAKE_PID + 1)
+    assert registry.get_executor_pid(uow_id) == FAKE_PID + 1
+
+
+def test_clear_executor_pid_removes_pid(registry: Registry, db_path: Path) -> None:
+    """clear_executor_pid sets executor_pid to NULL so get returns None."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+    registry.clear_executor_pid(uow_id)
+    assert registry.get_executor_pid(uow_id) is None
+
+
+def test_clear_executor_pid_idempotent_when_null(
+    registry: Registry, db_path: Path
+) -> None:
+    """clear_executor_pid is a no-op when executor_pid is already NULL."""
+    uow_id = _insert_uow(db_path)
+    # PID is NULL from the start — clear should not raise.
+    registry.clear_executor_pid(uow_id)
+    assert registry.get_executor_pid(uow_id) is None
+
+
+def test_get_executor_pid_returns_none_for_missing_uow(registry: Registry) -> None:
+    """get_executor_pid returns None for a UoW ID that does not exist."""
+    assert registry.get_executor_pid("uow_nonexistent_000000") is None
+
+
+# ---------------------------------------------------------------------------
+# Kill path tests
+# ---------------------------------------------------------------------------
+
+def test_kill_executor_returns_false_when_no_pid(
+    registry: Registry, db_path: Path
+) -> None:
+    """kill_executor returns False when no PID is stored (executor_pid IS NULL)."""
+    uow_id = _insert_uow(db_path)
+    result = registry.kill_executor(uow_id)
+    assert result is False
+
+
+def test_kill_executor_sends_sigterm_to_process_group(
+    registry: Registry, db_path: Path
+) -> None:
+    """kill_executor calls os.killpg with SIGTERM when a PID is stored, returns True."""
+    import signal
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID) as mock_getpgid, \
+         patch("os.killpg") as mock_killpg:
+        result = registry.kill_executor(uow_id)
+
+    assert result is True
+    mock_getpgid.assert_called_once_with(FAKE_PID)
+    mock_killpg.assert_called_once_with(FAKE_PID, signal.SIGTERM)
+
+
+def test_kill_executor_clears_pid_after_successful_kill(
+    registry: Registry, db_path: Path
+) -> None:
+    """kill_executor clears executor_pid after a successful SIGTERM send."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg"):
+        registry.kill_executor(uow_id)
+
+    assert registry.get_executor_pid(uow_id) is None
+
+
+def test_kill_executor_handles_process_already_gone(
+    registry: Registry, db_path: Path
+) -> None:
+    """kill_executor returns False (not an error) when process has already exited."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg", side_effect=ProcessLookupError("no such process")):
+        result = registry.kill_executor(uow_id)
+
+    assert result is False
+
+
+def test_kill_executor_clears_pid_when_process_already_gone(
+    registry: Registry, db_path: Path
+) -> None:
+    """kill_executor clears the stale PID even when ProcessLookupError is raised."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg", side_effect=ProcessLookupError("no such process")):
+        registry.kill_executor(uow_id)
+
+    assert registry.get_executor_pid(uow_id) is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher command parsing tests
+# ---------------------------------------------------------------------------
+
+def test_parse_wos_abort_extracts_uow_id() -> None:
+    """parse_wos_abort_command extracts the uow_id from a well-formed command."""
+    uow_id = parse_wos_abort_command("wos abort uow_20260426_abc123")
+    assert uow_id == "uow_20260426_abc123"
+
+
+def test_parse_wos_abort_case_insensitive() -> None:
+    """parse_wos_abort_command matches regardless of case."""
+    uow_id = parse_wos_abort_command("WOS ABORT uow_20260426_abc123")
+    assert uow_id == "uow_20260426_abc123"
+
+
+def test_parse_wos_abort_returns_none_for_non_matching() -> None:
+    """parse_wos_abort_command returns None for unrelated commands."""
+    assert parse_wos_abort_command("wos start") is None
+    assert parse_wos_abort_command("wos stop") is None
+    assert parse_wos_abort_command("diagnose uow_20260426_abc123") is None
+    assert parse_wos_abort_command("abort uow_20260426_abc123") is None
+
+
+def test_parse_wos_abort_returns_none_for_incomplete() -> None:
+    """parse_wos_abort_command returns None when no uow_id follows 'abort'."""
+    assert parse_wos_abort_command("wos abort") is None
+    assert parse_wos_abort_command("wos abort   ") is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher command handler tests
+# ---------------------------------------------------------------------------
+
+def test_handle_wos_abort_no_running_process(
+    registry: Registry, db_path: Path
+) -> None:
+    """handle_wos_abort reports 'no running process' when executor_pid is NULL."""
+    uow_id = _insert_uow(db_path)
+    reply = handle_wos_abort(uow_id, registry=registry)
+    assert "no running process" in reply.lower()
+    assert uow_id in reply
+
+
+def test_handle_wos_abort_kills_running_process(
+    registry: Registry, db_path: Path
+) -> None:
+    """handle_wos_abort reports success when kill_executor kills the process."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg"):
+        reply = handle_wos_abort(uow_id, registry=registry)
+
+    assert "aborted" in reply.lower() or "sigterm" in reply.lower()
+    assert uow_id in reply
+    assert str(FAKE_PID) in reply
+
+
+def test_handle_wos_abort_process_already_gone(
+    registry: Registry, db_path: Path
+) -> None:
+    """handle_wos_abort reports process-already-gone when kill_executor returns False due to ProcessLookupError."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg", side_effect=ProcessLookupError("no such process")):
+        reply = handle_wos_abort(uow_id, registry=registry)
+
+    # Reply should indicate the process was already gone (not an error)
+    assert "already" in reply.lower() or "gone" in reply.lower() or "exited" in reply.lower()
+    assert uow_id in reply

--- a/tests/unit/test_orchestration/test_executor_pid_tracking.py
+++ b/tests/unit/test_orchestration/test_executor_pid_tracking.py
@@ -22,6 +22,8 @@ Kill path:
 - test_kill_executor_clears_pid_after_successful_kill: PID cleared after kill
 - test_kill_executor_handles_process_already_gone: ProcessLookupError → False, PID cleared
 - test_kill_executor_clears_pid_when_process_already_gone: PID cleared even on ProcessLookupError
+- test_kill_executor_returns_false_on_permission_error: PermissionError → False, PID retained
+- test_kill_executor_preserves_pid_on_permission_error: PID NOT cleared on PermissionError (process still alive)
 
 Dispatcher command parsing:
 - test_parse_wos_abort_extracts_uow_id: parses "wos abort <uow_id>"
@@ -264,6 +266,39 @@ def test_kill_executor_clears_pid_when_process_already_gone(
         registry.kill_executor(uow_id)
 
     assert registry.get_executor_pid(uow_id) is None
+
+
+def test_kill_executor_returns_false_on_permission_error(
+    registry: Registry, db_path: Path
+) -> None:
+    """kill_executor returns False when os.killpg raises PermissionError (process still running but unowned)."""
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg", side_effect=PermissionError("operation not permitted")):
+        result = registry.kill_executor(uow_id)
+
+    assert result is False
+
+
+def test_kill_executor_preserves_pid_on_permission_error(
+    registry: Registry, db_path: Path
+) -> None:
+    """kill_executor does NOT clear executor_pid when PermissionError is raised.
+
+    The process is still running — clearing the PID would make a future abort
+    attempt silently return False with no kill attempt (no PID stored).
+    """
+    uow_id = _insert_uow(db_path)
+    registry.set_executor_pid(uow_id, FAKE_PID)
+
+    with patch("os.getpgid", return_value=FAKE_PID), \
+         patch("os.killpg", side_effect=PermissionError("operation not permitted")):
+        registry.kill_executor(uow_id)
+
+    # PID must still be present — process is alive but unowned
+    assert registry.get_executor_pid(uow_id) == FAKE_PID
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this solves

Dispatched WOS subprocesses had no explicit kill path. Once a UoW was dispatched via `Popen(..., start_new_session=True)`, the only way to stop the worker was to wait for TTL or heartbeat recovery — up to 24 hours. There was no way to abort a running worker on demand.

This PR closes that gap by storing the subprocess PID at dispatch time and wiring a `wos abort <uow_id>` Telegram command that sends SIGTERM to the process group.

## What changed

**Schema (migration 0020 + upgrade.sh Migration 103):**
- Adds `executor_pid INTEGER NULL` to `uow_registry`. NULL = no subprocess PID stored. Existing UoWs are unaffected.

**Registry (`src/orchestration/registry.py`):**
- `set_executor_pid(uow_id, pid)` — stores PID after dispatch, using the existing `BEGIN IMMEDIATE` + connection pattern.
- `get_executor_pid(uow_id)` — returns the stored PID or None. Fail-safe: returns None on any error (pre-migration deploys, unknown UoWs).
- `clear_executor_pid(uow_id)` — sets executor_pid to NULL. Idempotent.
- `kill_executor(uow_id)` — looks up the PID, sends `SIGTERM` to the process group via `os.killpg(os.getpgid(pid), signal.SIGTERM)`, clears the PID. Returns True if SIGTERM was sent, False if no PID was stored or if the process had already exited (`ProcessLookupError`). The process-group target ensures child processes spawned by the subprocess (e.g. `claude -p` spawning shell commands) are also terminated.

**Completion path (`src/orchestration/wos_completion.py`):**
- `maybe_complete_wos_uow` calls `registry.clear_executor_pid(uow_id)` after `complete_uow` succeeds, so `kill_executor` is a no-op on already-finished workers. Non-fatal — a missing `executor_pid` column on pre-0020 installs is logged at DEBUG and ignored.

**Dispatcher (`src/orchestration/dispatcher_handlers.py`):**
- `handle_wos_abort(uow_id, registry)` — pure handler function. Looks up PID, calls `kill_executor`, returns a plain-text Telegram reply. Does NOT perform a status transition — TTL/heartbeat recovery handles re-queueing after the process is killed. This preserves the existing recovery path and avoids a conflicting state-transition race.
- `parse_wos_abort_command(text)` — parses `wos abort <uow_id>` (case-insensitive). Returns the uow_id token or None. Same pattern as `parse_diagnose_command`.
- Help text and module docstring updated to document the new command.

**No PID write in executor-heartbeat yet:** The spec calls for the PID write in `executor.py` / `Executor.execute_uow` at dispatch time. This PR adds all the infrastructure (column, registry methods, abort handler). The PID write at dispatch is a follow-on that requires touching `executor.py` — within the stated boundary ("do not modify execution logic beyond PID tracking"), that step was deferred to a follow-on PR to minimize risk surface. The abort command is safe to ship now: `get_executor_pid` returns None for UoWs without a stored PID, and `handle_wos_abort` reports "no running process found" gracefully.

## Before / After

**Before:**
```
User: wos abort uow_20260505_abc123
  → No command exists. User must wait up to 24h for TTL recovery.
```

**After:**
```
User: wos abort uow_20260505_abc123
  → (if PID stored) Aborted: SIGTERM sent to process group of PID 99999.
  → (if no PID)     No running process found — executor_pid not set.
  → (if process gone) Process PID 99999 already gone — PID cleared.
```

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_executor_pid_tracking.py -v` — 19 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_migrations.py tests/unit/test_orchestration/test_executor_heartbeat.py tests/unit/test_orchestration/test_heartbeat_locking.py -v` — 83 passed, 0 failed
- [x] Syntax check: `uv run python -c "import py_compile; ..."` — clean on all 4 changed source files
- [ ] `ruff check` — ruff not installed in this environment
- [ ] Live Telegram test — blocked: requires running dispatcher with an active UoW subprocess. No test environment available for subprocess kill verification.

**Pre-existing failure (not caused by this PR):** `tests/unit/test_orchestration/test_registry_cli.py` has a SyntaxError at line 1183 (unclosed parenthesis) that predates this branch.

## Manual test

N/A — the abort command requires a live dispatched subprocess. The kill path (os.killpg) is covered by unit tests using `patch("os.killpg")`. The user-visible outcome (Telegram reply) is verified via the handler unit tests.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test run — blocked (no live subprocess in test env; see above)
- [ ] User-visible outcome verified — not yet: requires a live dispatched subprocess and a running dispatcher. Follow-on once PID write is added to executor.py.
- [x] Side-effect audit: os.killpg only sends a signal, no shared state writes beyond executor_pid clear. No flood/loop risk.
- [x] External service calls: none. All changes are local SQLite + process signal.

## Areas to review closely

1. `kill_executor` catches only `ProcessLookupError` — are there other OS-level exceptions from `os.killpg` that should be handled (e.g. `PermissionError` if the process is owned by a different user)?
2. The PID write at dispatch time (in `executor.py`) is intentionally deferred — reviewer should confirm this is an acceptable scope boundary for this PR.
3. `wos_completion.py` clear is non-fatal (catches all exceptions). Is this the right tolerance level, or should a missing `executor_pid` column raise on prod installs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)