### PR TITLE
feat(registry): trigger_message_id join key + activity_timeline view

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3650,6 +3650,42 @@ print('executor_pid column added')
         substep "Migration 104: registry.db not found or sqlite3 unavailable — skipping (auto-migration will create table on next run)"
     fi
 
+    # Migration 105: Add trigger_message_id column to uow_registry (issue #1108).
+    #
+    # The column is added by src/orchestration/migrations/0022_add_trigger_message_id.sql,
+    # which runs automatically when Registry() is instantiated (via _run_migrations).
+    # This entry exists as a marker so the upgrade timeline reflects the change.
+    # No manual action needed — the migration runner is idempotent.
+    local registry_db_105
+    registry_db_105="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/orchestration/registry.db"
+    if [ -f "$registry_db_105" ] && command -v sqlite3 >/dev/null 2>&1; then
+        if ! sqlite3 "$registry_db_105" "PRAGMA table_info(uow_registry);" 2>/dev/null | grep -q "trigger_message_id"; then
+            substep "Migration 105: trigger_message_id column absent — will be added on next Registry() init (auto-migration)"
+        else
+            substep "Migration 105: trigger_message_id column already present — skipping"
+        fi
+    else
+        substep "Migration 105: registry.db not found or sqlite3 unavailable — skipping (auto-migration will add column on next run)"
+    fi
+
+    # Migration 106: Create activity_timeline SQL view (issue #1108).
+    #
+    # The view is created by src/orchestration/migrations/0023_create_activity_timeline_view.sql,
+    # which runs automatically when Registry() is instantiated (via _run_migrations).
+    # This entry exists as a marker so the upgrade timeline reflects the change.
+    # No manual action needed — the migration runner is idempotent.
+    local registry_db_106
+    registry_db_106="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/orchestration/registry.db"
+    if [ -f "$registry_db_106" ] && command -v sqlite3 >/dev/null 2>&1; then
+        if ! sqlite3 "$registry_db_106" "SELECT name FROM sqlite_master WHERE type='view' AND name='activity_timeline';" 2>/dev/null | grep -q "activity_timeline"; then
+            substep "Migration 106: activity_timeline view absent — will be created on next Registry() init (auto-migration)"
+        else
+            substep "Migration 106: activity_timeline view already present — skipping"
+        fi
+    else
+        substep "Migration 106: registry.db not found or sqlite3 unavailable — skipping (auto-migration will create view on next run)"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/orchestration/migrations/0022_add_trigger_message_id.sql
+++ b/src/orchestration/migrations/0022_add_trigger_message_id.sql
@@ -1,0 +1,18 @@
+-- Migration 0022: add trigger_message_id to uow_registry (issue #1108).
+--
+-- Purpose:
+--   trigger_message_id is the critical join key linking a Telegram inbox
+--   message to the UoW it spawned. With this column, "which conversations
+--   led to pearls?" becomes a single JOIN query rather than a manual
+--   log-scraping exercise.
+--
+-- Design:
+--   - NULL for UoWs created by the automated cultivator (GitHub-sweep path)
+--     or registry_cli commands — those have no associated Telegram message.
+--   - Populated only when a UoW is created from a user-initiated Telegram
+--     conversation (future path; the column is wired at the registry level
+--     so callers can pass it when they have it).
+--   - TEXT to match inbox message_id format (e.g. "1778365681821_8563").
+--   - No foreign key — inbox messages live in a separate SQLite DB.
+
+ALTER TABLE uow_registry ADD COLUMN trigger_message_id TEXT NULL;

--- a/src/orchestration/migrations/0023_create_activity_timeline_view.sql
+++ b/src/orchestration/migrations/0023_create_activity_timeline_view.sql
@@ -1,0 +1,42 @@
+-- Migration 0023: create activity_timeline view (issue #1108).
+--
+-- Purpose:
+--   Unified "what happened" timeline spanning UoW status transitions (audit_log)
+--   and dispatcher control events (control_events). Enables time-correlated
+--   queries like: "which wos_start event preceded this UoW's execution?", or
+--   "did we see any abort events around the time this conversation's UoW ran?".
+--
+-- Columns:
+--   ts                — ISO timestamp of the event
+--   event_type        — 'uow_status_change' for audit rows; event_type value for control rows
+--   entity_id         — uow_id for audit rows; CAST(control_events.id AS TEXT) for control rows
+--   detail            — new_status for audit rows; payload JSON for control rows
+--   outcome_category  — joined from uow_registry (NULL for control rows)
+--   token_usage       — joined from uow_registry (NULL for control rows)
+--   trigger_message_id — joined from uow_registry (NULL for control rows)
+--
+-- Note: control_events.id is an INTEGER PK (AUTOINCREMENT); cast to TEXT for
+-- consistent entity_id type across the UNION.
+
+CREATE VIEW IF NOT EXISTS activity_timeline AS
+SELECT
+    al.ts,
+    'uow_status_change'     AS event_type,
+    al.uow_id               AS entity_id,
+    al.to_status            AS detail,
+    u.outcome_category,
+    u.token_usage,
+    u.trigger_message_id
+FROM audit_log al
+JOIN uow_registry u ON al.uow_id = u.id
+UNION ALL
+SELECT
+    ce.ts,
+    ce.event_type,
+    CAST(ce.id AS TEXT)     AS entity_id,
+    ce.payload              AS detail,
+    NULL                    AS outcome_category,
+    NULL                    AS token_usage,
+    NULL                    AS trigger_message_id
+FROM control_events ce
+ORDER BY ts DESC;

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -275,6 +275,13 @@ class UoW:
     #   Computed deterministically by _compute_prescription_confidence() in steward.py.
     #   Steward-private (excluded from executor_uow_view). Data collection only.
     prescription_confidence: float | None = None
+    # trigger_message_id: inbox message_id of the Telegram conversation that caused
+    #   this UoW to be created (populated after migration 0022).
+    #   NULL for UoWs created by the automated cultivator (GitHub-sweep path) or
+    #   registry_cli commands — those have no associated Telegram message.
+    #   TEXT matches inbox message_id format: "{ts}_{telegram_msg_id}", e.g.
+    #   "1778365681821_8563". No foreign key — inbox messages live in a separate DB.
+    trigger_message_id: str | None = None
 
 
 def _now_iso() -> str:
@@ -477,6 +484,7 @@ class Registry:
             juice_quality=d.get("juice_quality"),
             juice_rationale=d.get("juice_rationale"),
             prescription_confidence=d.get("prescription_confidence"),
+            trigger_message_id=d.get("trigger_message_id"),
         )
 
     def _write_audit(
@@ -514,6 +522,7 @@ class Registry:
         register: str = "operational",
         source_ref: str | None = None,
         file_scope: list[str] | None = None,
+        trigger_message_id: str | None = None,
     ) -> UpsertResult:
         """
         Propose a UoW for a GitHub issue.
@@ -553,6 +562,10 @@ class Registry:
             file_scope: List of file/directory paths touched by this issue (extracted from
                 issue body). Used by shard_dispatch to detect overlap between concurrent UoWs.
                 None means the UoW is treated as independent (serial execution is safe default).
+            trigger_message_id: Inbox message_id of the Telegram conversation that initiated
+                this UoW (e.g. "1778365681821_8563"). NULL for cultivator-driven UoWs (no
+                associated Telegram message). Stored for dashboard join queries linking
+                Telegram conversations to execution outcomes.
         """
         if not success_criteria or not success_criteria.strip():
             raise ValueError(
@@ -564,6 +577,7 @@ class Registry:
             source_repo=source_repo, issue_url=issue_url,
             register=register, source_ref=source_ref,
             file_scope=file_scope,
+            trigger_message_id=trigger_message_id,
         )
 
     def _upsert_typed(
@@ -578,6 +592,7 @@ class Registry:
         register: str = "operational",
         source_ref: str | None = None,
         file_scope: list[str] | None = None,
+        trigger_message_id: str | None = None,
     ) -> UpsertResult:
         """Core upsert logic returning typed UpsertResult."""
         if sweep_date is None:
@@ -686,8 +701,9 @@ class Registry:
                     id, type, source, source_issue_number, sweep_date,
                     status, posture, created_at, updated_at, summary,
                     success_criteria, route_reason, route_evidence, trigger,
-                    issue_url, register, uow_mode, source_ref, file_scope
-                ) VALUES (?, ?, ?, ?, ?, 'proposed', ?, ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?, ?, ?, ?, ?)
+                    issue_url, register, uow_mode, source_ref, file_scope,
+                    trigger_message_id
+                ) VALUES (?, ?, ?, ?, ?, 'proposed', ?, ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     uow_id,
@@ -706,6 +722,7 @@ class Registry:
                     register,  # uow_mode mirrors register at germination time
                     source_ref,
                     file_scope_json,
+                    trigger_message_id,
                 ),
             )
             conn.commit()
@@ -1312,6 +1329,30 @@ class Registry:
             if row is None:
                 return None
             return row["started_at"]
+        finally:
+            conn.close()
+
+    def get_uow_trigger(self, uow_id: str) -> str | None:
+        """
+        Return the trigger_message_id for a UoW, or None if absent.
+
+        trigger_message_id is the inbox message_id of the Telegram conversation
+        that caused this UoW to be created (migration 0022). Returns None for
+        UoWs created by the automated cultivator (no associated Telegram message)
+        or for UoWs created before migration 0022 was applied.
+
+        Useful for dashboard join queries: registry.get_uow_trigger(uow_id)
+        → message_id → fetch_message(message_id) → full conversation context.
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT trigger_message_id FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            return row["trigger_message_id"]
         finally:
             conn.close()
 

--- a/tests/unit/test_orchestration/test_activity_timeline.py
+++ b/tests/unit/test_orchestration/test_activity_timeline.py
@@ -1,0 +1,321 @@
+"""
+Unit tests for the activity_timeline view (issue #1108, migration 0023).
+
+Behavior under test:
+
+Migration:
+- Migration 0023 creates the activity_timeline view in the WOS registry DB
+- The view is queryable via standard SELECT after Registry() is initialized
+
+View correctness:
+- Returns rows from audit_log (event_type='uow_status_change')
+- Returns rows from control_events (event_type as stored)
+- audit_log rows carry outcome_category, token_usage, trigger_message_id
+  joined from uow_registry
+- control_events rows carry NULL for outcome_category, token_usage, trigger_message_id
+- Rows are ordered by ts DESC (most recent first) across both sources
+- trigger_message_id flows through from uow_registry into audit rows
+
+Named constants:
+- VIEW_NAME = 'activity_timeline' — the view name as created by migration 0023
+- AUDIT_EVENT_TYPE = 'uow_status_change' — the fixed event_type for audit_log rows
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# ---------------------------------------------------------------------------
+# Named constants (spec §activity_timeline)
+# ---------------------------------------------------------------------------
+
+VIEW_NAME = "activity_timeline"
+AUDIT_EVENT_TYPE = "uow_status_change"
+EXAMPLE_TRIGGER_MESSAGE_ID = "1778365681821_8563"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry(tmp_path: Path):
+    """Create a fresh Registry backed by a temp DB with all migrations applied."""
+    from orchestration.registry import Registry
+
+    db_path = str(tmp_path / "test_registry.db")
+    os.environ["REGISTRY_DB_PATH"] = db_path
+    return Registry(db_path=db_path)
+
+
+def _upsert_uow(
+    registry,
+    issue_number: int,
+    *,
+    trigger_message_id: str | None = None,
+) -> str:
+    """Upsert a UoW and return its uow_id."""
+    from orchestration.registry import UpsertInserted
+
+    result = registry.upsert(
+        issue_number=issue_number,
+        title=f"Test issue #{issue_number}",
+        success_criteria="Tests pass with zero failures",
+        register="operational",
+        trigger_message_id=trigger_message_id,
+    )
+    assert isinstance(result, UpsertInserted)
+    return result.id
+
+
+def _query_timeline(registry) -> list[dict]:
+    """Return all rows from activity_timeline ordered by ts DESC."""
+    conn = registry._connect()
+    try:
+        rows = conn.execute(
+            f"SELECT ts, event_type, entity_id, detail, outcome_category, "
+            f"token_usage, trigger_message_id FROM {VIEW_NAME} ORDER BY ts DESC"
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def _write_control_event(registry, event_type: str, payload: dict | None = None) -> None:
+    """Write a row directly to control_events (simulates dispatcher action)."""
+    conn = registry._connect()
+    try:
+        payload_json = json.dumps(payload) if payload is not None else None
+        conn.execute(
+            "INSERT INTO control_events (event_type, payload) VALUES (?, ?)",
+            (event_type, payload_json),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration: activity_timeline view existence
+# ---------------------------------------------------------------------------
+
+class TestActivityTimelineMigration:
+    """Migration 0023 creates the activity_timeline view."""
+
+    def test_view_exists_after_registry_init(self, tmp_path):
+        """Registry() auto-applies migrations; activity_timeline view must be created."""
+        registry = _make_registry(tmp_path)
+        conn = registry._connect()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='view' AND name=?",
+                (VIEW_NAME,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None, f"View '{VIEW_NAME}' was not created by migration"
+
+    def test_view_is_queryable_with_empty_tables(self, tmp_path):
+        """activity_timeline can be SELECTed even when both source tables are empty."""
+        registry = _make_registry(tmp_path)
+        rows = _query_timeline(registry)
+        assert rows == []
+
+    def test_view_columns_present(self, tmp_path):
+        """View exposes the expected columns: ts, event_type, entity_id, detail,
+        outcome_category, token_usage, trigger_message_id."""
+        registry = _make_registry(tmp_path)
+        # Create one audit row via a UoW upsert so the view has something to return
+        _upsert_uow(registry, issue_number=1)
+        rows = _query_timeline(registry)
+        assert len(rows) >= 1
+        expected_cols = {
+            "ts", "event_type", "entity_id", "detail",
+            "outcome_category", "token_usage", "trigger_message_id",
+        }
+        assert expected_cols.issubset(rows[0].keys())
+
+
+# ---------------------------------------------------------------------------
+# View correctness: audit_log rows
+# ---------------------------------------------------------------------------
+
+class TestActivityTimelineAuditRows:
+    """activity_timeline surfaces audit_log rows as 'uow_status_change' events."""
+
+    def test_upsert_produces_audit_row_in_timeline(self, tmp_path):
+        """A UoW upsert writes an audit entry; the view returns it."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_uow(registry, issue_number=100)
+        rows = _query_timeline(registry)
+        audit_rows = [r for r in rows if r["event_type"] == AUDIT_EVENT_TYPE]
+        assert len(audit_rows) >= 1
+        entity_ids = [r["entity_id"] for r in audit_rows]
+        assert uow_id in entity_ids
+
+    def test_audit_row_event_type_is_uow_status_change(self, tmp_path):
+        """All rows sourced from audit_log appear with event_type='uow_status_change'."""
+        registry = _make_registry(tmp_path)
+        _upsert_uow(registry, issue_number=101)
+        rows = _query_timeline(registry)
+        # Every row must have a non-None event_type
+        assert all(r["event_type"] is not None for r in rows)
+        # At least one row has the audit event_type
+        assert any(r["event_type"] == AUDIT_EVENT_TYPE for r in rows)
+
+    def test_audit_row_entity_id_matches_uow_id(self, tmp_path):
+        """entity_id in audit rows matches the uow_id created by upsert."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_uow(registry, issue_number=102)
+        rows = _query_timeline(registry)
+        audit_rows = [r for r in rows if r["event_type"] == AUDIT_EVENT_TYPE]
+        matched = [r for r in audit_rows if r["entity_id"] == uow_id]
+        assert len(matched) >= 1
+
+
+# ---------------------------------------------------------------------------
+# View correctness: control_events rows
+# ---------------------------------------------------------------------------
+
+class TestActivityTimelineControlEventRows:
+    """activity_timeline surfaces control_events rows with their own event_type."""
+
+    def test_control_event_appears_in_timeline(self, tmp_path):
+        """A row inserted into control_events is returned by the view."""
+        registry = _make_registry(tmp_path)
+        _write_control_event(registry, "wos_start")
+        rows = _query_timeline(registry)
+        control_rows = [r for r in rows if r["event_type"] == "wos_start"]
+        assert len(control_rows) == 1
+
+    def test_control_event_entity_id_is_string(self, tmp_path):
+        """control_events.id (INTEGER PK) is cast to TEXT for entity_id."""
+        registry = _make_registry(tmp_path)
+        _write_control_event(registry, "wos_stop")
+        rows = _query_timeline(registry)
+        control_rows = [r for r in rows if r["event_type"] == "wos_stop"]
+        assert len(control_rows) == 1
+        # entity_id must be a non-empty string representation of the integer PK
+        entity_id = control_rows[0]["entity_id"]
+        assert isinstance(entity_id, str)
+        assert entity_id.isdigit()
+
+    def test_control_event_nulls_for_uow_fields(self, tmp_path):
+        """Control rows have NULL outcome_category, token_usage, trigger_message_id."""
+        registry = _make_registry(tmp_path)
+        _write_control_event(registry, "wos_abort", {"uow_id": "uow_abc"})
+        rows = _query_timeline(registry)
+        control_rows = [r for r in rows if r["event_type"] == "wos_abort"]
+        assert len(control_rows) == 1
+        row = control_rows[0]
+        assert row["outcome_category"] is None
+        assert row["token_usage"] is None
+        assert row["trigger_message_id"] is None
+
+    def test_control_event_detail_carries_payload(self, tmp_path):
+        """Control rows carry the payload JSON in the detail column."""
+        registry = _make_registry(tmp_path)
+        payload = {"uow_id": "uow_20260101_abc", "result": "closed"}
+        _write_control_event(registry, "wos_abort", payload)
+        rows = _query_timeline(registry)
+        control_rows = [r for r in rows if r["event_type"] == "wos_abort"]
+        assert len(control_rows) == 1
+        # detail is the raw JSON payload stored in control_events.payload
+        stored_payload = json.loads(control_rows[0]["detail"])
+        assert stored_payload == payload
+
+
+# ---------------------------------------------------------------------------
+# View correctness: mixed rows and ordering
+# ---------------------------------------------------------------------------
+
+class TestActivityTimelineMixedRows:
+    """activity_timeline returns rows from both sources, ordered by ts DESC."""
+
+    def test_both_sources_appear_when_both_populated(self, tmp_path):
+        """Rows from audit_log and control_events both appear in the view."""
+        registry = _make_registry(tmp_path)
+        _upsert_uow(registry, issue_number=200)
+        _write_control_event(registry, "wos_start")
+        rows = _query_timeline(registry)
+        event_types = {r["event_type"] for r in rows}
+        assert AUDIT_EVENT_TYPE in event_types
+        assert "wos_start" in event_types
+
+    def test_rows_ordered_ts_desc(self, tmp_path):
+        """Rows are ordered by ts descending (most recent first)."""
+        registry = _make_registry(tmp_path)
+        _upsert_uow(registry, issue_number=201)
+        _write_control_event(registry, "wos_start")
+        rows = _query_timeline(registry)
+        timestamps = [r["ts"] for r in rows]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# trigger_message_id flows through from uow_registry
+# ---------------------------------------------------------------------------
+
+class TestTriggerMessageIdInTimeline:
+    """trigger_message_id from uow_registry flows into activity_timeline audit rows."""
+
+    def test_trigger_message_id_present_in_audit_rows(self, tmp_path):
+        """When a UoW is created with trigger_message_id, it appears in timeline audit rows."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_uow(
+            registry,
+            issue_number=300,
+            trigger_message_id=EXAMPLE_TRIGGER_MESSAGE_ID,
+        )
+        rows = _query_timeline(registry)
+        audit_rows_for_uow = [
+            r for r in rows
+            if r["event_type"] == AUDIT_EVENT_TYPE and r["entity_id"] == uow_id
+        ]
+        assert len(audit_rows_for_uow) >= 1
+        # All audit rows for this UoW must carry the trigger_message_id
+        for row in audit_rows_for_uow:
+            assert row["trigger_message_id"] == EXAMPLE_TRIGGER_MESSAGE_ID
+
+    def test_trigger_message_id_null_in_audit_rows_when_not_set(self, tmp_path):
+        """When a UoW is created without trigger_message_id, NULL appears in timeline."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_uow(registry, issue_number=301)
+        rows = _query_timeline(registry)
+        audit_rows_for_uow = [
+            r for r in rows
+            if r["event_type"] == AUDIT_EVENT_TYPE and r["entity_id"] == uow_id
+        ]
+        assert len(audit_rows_for_uow) >= 1
+        for row in audit_rows_for_uow:
+            assert row["trigger_message_id"] is None
+
+    def test_two_uows_have_independent_trigger_message_ids_in_timeline(self, tmp_path):
+        """Two UoWs with different trigger_message_ids appear independently in timeline."""
+        registry = _make_registry(tmp_path)
+        msg_id_a = "1778365681821_9001"
+        msg_id_b = "1778365681821_9002"
+        uow_id_a = _upsert_uow(registry, issue_number=310, trigger_message_id=msg_id_a)
+        uow_id_b = _upsert_uow(registry, issue_number=311, trigger_message_id=msg_id_b)
+
+        rows = _query_timeline(registry)
+        rows_a = [
+            r for r in rows
+            if r["event_type"] == AUDIT_EVENT_TYPE and r["entity_id"] == uow_id_a
+        ]
+        rows_b = [
+            r for r in rows
+            if r["event_type"] == AUDIT_EVENT_TYPE and r["entity_id"] == uow_id_b
+        ]
+        assert all(r["trigger_message_id"] == msg_id_a for r in rows_a)
+        assert all(r["trigger_message_id"] == msg_id_b for r in rows_b)

--- a/tests/unit/test_orchestration/test_trigger_message_id.py
+++ b/tests/unit/test_orchestration/test_trigger_message_id.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for trigger_message_id column on uow_registry (issue #1108).
+
+Behavior under test:
+
+Migration:
+- Migration 0022 adds trigger_message_id TEXT NULL column to uow_registry
+
+Registry.upsert:
+- trigger_message_id is stored in the INSERT when provided
+- trigger_message_id is NULL when not provided (default behavior)
+- All existing callers that omit trigger_message_id are unaffected
+
+Registry.get_uow_trigger:
+- Returns the stored trigger_message_id for a known UoW
+- Returns None when trigger_message_id was not provided at creation
+- Returns None for an unknown uow_id
+
+Named constants:
+- TRIGGER_MESSAGE_ID_COLUMN = 'trigger_message_id' — column name in uow_registry
+- EXAMPLE_TRIGGER_MESSAGE_ID — representative inbox message_id string
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# ---------------------------------------------------------------------------
+# Named constants (spec §trigger_message_id)
+# ---------------------------------------------------------------------------
+
+TRIGGER_MESSAGE_ID_COLUMN = "trigger_message_id"
+
+# Representative inbox message_id: "{unix_ts_ms}_{telegram_msg_id}"
+EXAMPLE_TRIGGER_MESSAGE_ID = "1778365681821_8563"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry(tmp_path: Path):
+    """Create a fresh Registry backed by a temp DB with all migrations applied."""
+    from orchestration.registry import Registry
+
+    db_path = str(tmp_path / "test_registry.db")
+    os.environ["REGISTRY_DB_PATH"] = db_path
+    return Registry(db_path=db_path)
+
+
+def _upsert_minimal(registry, issue_number: int, *, trigger_message_id: str | None = None):
+    """Upsert a UoW with minimal required fields and optional trigger_message_id."""
+    from orchestration.registry import UpsertInserted
+
+    result = registry.upsert(
+        issue_number=issue_number,
+        title=f"Test issue #{issue_number}",
+        success_criteria="Tests pass with zero failures",
+        register="operational",
+        trigger_message_id=trigger_message_id,
+    )
+    assert isinstance(result, UpsertInserted), f"Expected UpsertInserted, got {result}"
+    return result.id
+
+
+# ---------------------------------------------------------------------------
+# Migration: trigger_message_id column schema
+# ---------------------------------------------------------------------------
+
+class TestTriggerMessageIdMigration:
+    """Migration 0022 adds trigger_message_id TEXT NULL to uow_registry."""
+
+    def test_column_exists_after_registry_init(self, tmp_path):
+        """Registry() auto-applies migrations; trigger_message_id must be present."""
+        registry = _make_registry(tmp_path)
+        conn = registry._connect()
+        try:
+            cols = conn.execute(
+                "PRAGMA table_info(uow_registry)"
+            ).fetchall()
+        finally:
+            conn.close()
+        col_names = {row["name"] for row in cols}
+        assert TRIGGER_MESSAGE_ID_COLUMN in col_names
+
+    def test_column_is_nullable(self, tmp_path):
+        """trigger_message_id column accepts NULL (new UoWs without a Telegram origin)."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(registry, issue_number=1, trigger_message_id=None)
+        conn = registry._connect()
+        try:
+            row = conn.execute(
+                f"SELECT {TRIGGER_MESSAGE_ID_COLUMN} FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[TRIGGER_MESSAGE_ID_COLUMN] is None
+
+    def test_column_accepts_text_value(self, tmp_path):
+        """trigger_message_id column stores TEXT values without error."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(
+            registry,
+            issue_number=2,
+            trigger_message_id=EXAMPLE_TRIGGER_MESSAGE_ID,
+        )
+        conn = registry._connect()
+        try:
+            row = conn.execute(
+                f"SELECT {TRIGGER_MESSAGE_ID_COLUMN} FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[TRIGGER_MESSAGE_ID_COLUMN] == EXAMPLE_TRIGGER_MESSAGE_ID
+
+
+# ---------------------------------------------------------------------------
+# Registry.upsert — trigger_message_id storage
+# ---------------------------------------------------------------------------
+
+class TestUpsertStoresTriggerMessageId:
+    """upsert() stores trigger_message_id in the INSERT."""
+
+    def test_trigger_message_id_stored_when_provided(self, tmp_path):
+        """When trigger_message_id is passed to upsert(), it is written to the DB."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(
+            registry,
+            issue_number=10,
+            trigger_message_id=EXAMPLE_TRIGGER_MESSAGE_ID,
+        )
+        conn = registry._connect()
+        try:
+            row = conn.execute(
+                f"SELECT {TRIGGER_MESSAGE_ID_COLUMN} FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[TRIGGER_MESSAGE_ID_COLUMN] == EXAMPLE_TRIGGER_MESSAGE_ID
+
+    def test_trigger_message_id_null_when_omitted(self, tmp_path):
+        """When trigger_message_id is omitted, NULL is stored (cultivator path)."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(registry, issue_number=11)
+        conn = registry._connect()
+        try:
+            row = conn.execute(
+                f"SELECT {TRIGGER_MESSAGE_ID_COLUMN} FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[TRIGGER_MESSAGE_ID_COLUMN] is None
+
+    def test_trigger_message_id_null_when_explicitly_none(self, tmp_path):
+        """When trigger_message_id=None is passed explicitly, NULL is stored."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(registry, issue_number=12, trigger_message_id=None)
+        conn = registry._connect()
+        try:
+            row = conn.execute(
+                f"SELECT {TRIGGER_MESSAGE_ID_COLUMN} FROM uow_registry WHERE id = ?",
+                (uow_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[TRIGGER_MESSAGE_ID_COLUMN] is None
+
+    def test_different_uows_have_independent_trigger_message_ids(self, tmp_path):
+        """trigger_message_id is per-UoW; two UoWs can have different values."""
+        registry = _make_registry(tmp_path)
+        msg_id_a = "1778365681821_1001"
+        msg_id_b = "1778365681821_1002"
+        uow_id_a = _upsert_minimal(registry, issue_number=20, trigger_message_id=msg_id_a)
+        uow_id_b = _upsert_minimal(registry, issue_number=21, trigger_message_id=msg_id_b)
+        assert registry.get_uow_trigger(uow_id_a) == msg_id_a
+        assert registry.get_uow_trigger(uow_id_b) == msg_id_b
+
+
+# ---------------------------------------------------------------------------
+# Registry.get_uow_trigger
+# ---------------------------------------------------------------------------
+
+class TestGetUowTrigger:
+    """get_uow_trigger() returns trigger_message_id or None."""
+
+    def test_returns_stored_trigger_message_id(self, tmp_path):
+        """get_uow_trigger returns the trigger_message_id written by upsert."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(
+            registry,
+            issue_number=30,
+            trigger_message_id=EXAMPLE_TRIGGER_MESSAGE_ID,
+        )
+        result = registry.get_uow_trigger(uow_id)
+        assert result == EXAMPLE_TRIGGER_MESSAGE_ID
+
+    def test_returns_none_when_trigger_not_set(self, tmp_path):
+        """get_uow_trigger returns None for a UoW created without trigger_message_id."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(registry, issue_number=31)
+        result = registry.get_uow_trigger(uow_id)
+        assert result is None
+
+    def test_returns_none_for_unknown_uow_id(self, tmp_path):
+        """get_uow_trigger returns None for a uow_id that does not exist in the DB."""
+        registry = _make_registry(tmp_path)
+        result = registry.get_uow_trigger("uow_nonexistent_abc123")
+        assert result is None
+
+    def test_trigger_message_id_survives_status_transitions(self, tmp_path):
+        """trigger_message_id is immutable through UoW lifecycle; status changes do not clear it."""
+        registry = _make_registry(tmp_path)
+        uow_id = _upsert_minimal(
+            registry,
+            issue_number=32,
+            trigger_message_id=EXAMPLE_TRIGGER_MESSAGE_ID,
+        )
+        # Transition to done via set_status_direct (simulates lifecycle progression)
+        registry.set_status_direct(uow_id, "done")
+        result = registry.get_uow_trigger(uow_id)
+        assert result == EXAMPLE_TRIGGER_MESSAGE_ID


### PR DESCRIPTION
## What and Why

Before this PR, there was no way to link a Telegram conversation to the WOS Unit of Work it spawned. You could see that UoW #1234 ran successfully, but not which Telegram message prompted it. The join gap made attribution impossible — "which conversations led to pearls?" required manual log-scraping across two separate systems.

This PR closes that gap with two schema additions:

**Migration 0022** adds `trigger_message_id TEXT NULL` to `uow_registry`. When a user-initiated Telegram message causes a UoW to be created, the message's inbox ID (e.g. `"1778365681821_8563"`) is stored as the join key. The column is NULL for cultivator-swept UoWs (no associated Telegram message), preserving backward compatibility across all existing callers.

**Migration 0023** creates the `activity_timeline` SQL view — a unified "what happened" timeline that unions two previously-siloed sources:
- `audit_log` × `uow_registry` → UoW status transitions with `outcome_category`, `token_usage`, and `trigger_message_id` joined in
- `control_events` → dispatcher control actions (`wos_start`, `wos_stop`, `wos_abort`)

After this migration, the query "show me every UoW spawned by this Telegram message and its final outcome" is a single `WHERE trigger_message_id = ?` against `activity_timeline`.

## What was not changed

No WOS execution logic was modified — steward, executor, and router are untouched. This is schema-only: two migrations, registry API surface, and tests.

## Schema additions

```
-- uow_registry (migration 0022)
ALTER TABLE uow_registry ADD COLUMN trigger_message_id TEXT NULL;

-- activity_timeline view (migration 0023)
CREATE VIEW IF NOT EXISTS activity_timeline AS
SELECT al.ts, 'uow_status_change' AS event_type, al.uow_id AS entity_id,
       al.to_status AS detail, u.outcome_category, u.token_usage, u.trigger_message_id
FROM audit_log al JOIN uow_registry u ON al.uow_id = u.id
UNION ALL
SELECT ce.ts, ce.event_type, CAST(ce.id AS TEXT) AS entity_id,
       ce.payload AS detail, NULL, NULL, NULL
FROM control_events ce
ORDER BY ts DESC;
```

## Flow (before/after)

**Before:**
```
Telegram msg → UoW created → audit_log entries     (no join key)
              ↘ control_events                     (separate, unlinked)
```

**After:**
```
Telegram msg → UoW created (trigger_message_id=msg_id)
              → audit_log entries  ┐
              → control_events     ├─ activity_timeline view (unified, ts DESC)
              trigger_message_id flows through to every audit row ┘
```

## API additions

- `Registry.upsert(..., trigger_message_id: str | None = None)` — new optional parameter; existing callers unchanged
- `Registry.get_uow_trigger(uow_id: str) → str | None` — read path for join queries
- `UoW.trigger_message_id: str | None` — field on the frozen dataclass

## Functional patterns

Pure functions throughout: `_upsert_typed` is extended with a new parameter threaded cleanly through without side effects. `get_uow_trigger` is a pure read with no mutation. The view definition is declarative SQL with no procedural logic.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_trigger_message_id.py tests/unit/test_orchestration/test_activity_timeline.py -v` — **26 passed, 0 failed**
- [x] `uv run pytest tests/unit/test_orchestration/ --ignore=tests/unit/test_orchestration/test_registry_cli.py -q` — **1907 passed, 23 failed** (all 23 pre-existing on main: test_failure_traces_cleanup, test_prescriptions_per_cycle, test_steward, test_steward_execution_gate; test_registry_cli.py has a pre-existing SyntaxError on main)

## Manual test

N/A — this change is entirely internal schema. No external service calls, no Telegram output, no file system effects on runtime state. The migration runner is idempotent; existing DBs will have the column and view added on next Registry() init.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (pure schema addition, migration runner is idempotent)
- [x] User-visible outcome verified — N/A (no user-visible output from this change)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume (ALTER TABLE + CREATE VIEW are DDL-only; no DML on existing rows)
- [x] External service calls: none