### PR TITLE
feat(wos): HTML dashboard generation + DB path consistency fix

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1202,6 +1202,22 @@ This rule is unconditional — even if the session processed zero messages, the 
 
 ---
 
+## WOS Dashboard Command
+
+**`/wos dashboard`** (or `wos dashboard`) — generate a fresh HTML dashboard from live registry data and upload to Bisque.
+
+Detected by `parse_wos_dashboard_command(msg["text"])`. Handled inline (calls `handle_wos_dashboard()` which calls `wos_dashboard_gen.generate_and_upload()` and returns the public URL — fast enough for the main thread):
+
+```python
+from src.orchestration.dispatcher_handlers import parse_wos_dashboard_command, handle_wos_dashboard
+
+if parse_wos_dashboard_command(msg.get("text", "")):
+    result = handle_wos_dashboard()
+    send_reply(chat_id=chat_id, text=result, source=source, message_id=message_id)
+```
+
+---
+
 ## LOS (Life Operating System) Commands
 
 **`/todos`** — display Dan's current action items with interactive buttons.

--- a/docs/wos-architecture.md
+++ b/docs/wos-architecture.md
@@ -482,6 +482,7 @@ defaulting. The mechanism is in place; discipline is required to maintain it.
 /wos start                       set execution_enabled=true in wos-config.json
 /wos stop                        set execution_enabled=false in wos-config.json
 /wos unblock                     clear BOOTUP_CANDIDATE_GATE flag
+/wos dashboard                   generate fresh HTML dashboard → bisque URL
 diagnose <uow_id>                spawn diagnostic subagent via wos_diagnose
 ```
 

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -616,6 +616,25 @@ def handle_wos_status(status: str | None, *, registry: "Registry") -> str:
     return "\n".join(lines)
 
 
+def handle_wos_dashboard() -> str:
+    """
+    Generate a fresh WOS HTML dashboard from live registry data and upload to Bisque.
+
+    Calls wos_dashboard_gen.generate_and_upload() which:
+      1. Queries the registry DB for all UoW data (status counts, audit trail, etc.)
+      2. Reads the token ledger for Claude Code usage stats
+      3. Renders a self-contained HTML file with embedded JSON
+      4. Writes it to ~/messages/bisque-uploads/ with a UUID filename
+      5. Returns the public Bisque URL
+
+    Returns a formatted reply string with the URL.
+    """
+    from src.orchestration.wos_dashboard_gen import generate_and_upload
+
+    url = generate_and_upload()
+    return f"WOS Dashboard ready: {url}"
+
+
 def handle_wos_execute(uow_id: str, instructions: str, output_ref: str) -> str:
     """
     Build the Task prompt for a wos_execute inbox message.

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -13,6 +13,7 @@ The dispatcher calls these handlers when it recognizes:
   /wos unblock                         → handle_wos_unblock()
   /wos start                           → handle_wos_start()
   /wos stop                            → handle_wos_stop()
+  /wos dashboard (or "wos dashboard")  → handle_wos_dashboard()
   wos abort <uow-id>                   → handle_wos_abort(uow_id, registry)
   decide retry <uow-id>                → handle_decide_retry(uow_id, registry)
   decide close <uow-id>                → handle_decide_close(uow_id, registry)
@@ -1986,6 +1987,41 @@ def parse_wos_abort_command(text: str) -> str | None:
         if tokens:
             return tokens[0]
     return None
+
+
+def parse_wos_dashboard_command(text: str) -> bool:
+    """
+    Return True if the text matches the ``wos dashboard`` command.
+
+    Matches ``wos dashboard`` or ``/wos dashboard`` (case-insensitive, leading/trailing
+    whitespace ignored). Returns True if the command matches; False otherwise.
+
+    The dispatcher calls this to detect the "wos dashboard" text command before
+    routing to handle_wos_dashboard().
+
+    Args:
+        text: The raw Telegram message text.
+
+    Returns:
+        True if the text is the ``wos dashboard`` command; False otherwise.
+
+    Examples::
+
+        parse_wos_dashboard_command("wos dashboard")
+        # → True
+
+        parse_wos_dashboard_command("/wos dashboard")
+        # → True
+
+        parse_wos_dashboard_command("WOS DASHBOARD")
+        # → True
+
+        parse_wos_dashboard_command("wos status")
+        # → False
+    """
+    stripped = text.strip()
+    lower = stripped.lower()
+    return lower in ("wos dashboard", "/wos dashboard")
 
 
 def _load_instructions_from_artifact(uow_id: str) -> str:

--- a/src/orchestration/wos_dashboard_gen.py
+++ b/src/orchestration/wos_dashboard_gen.py
@@ -45,15 +45,6 @@ __all__ = [
 
 
 # ---------------------------------------------------------------------------
-# Sonnet 4.6 pricing constants (USD per million tokens)
-# ---------------------------------------------------------------------------
-
-SONNET_4_6_INPUT_PER_MTK: float = 3.0
-SONNET_4_6_OUTPUT_PER_MTK: float = 15.0
-SONNET_4_6_CACHE_READ_PER_MTK: float = 0.30
-
-
-# ---------------------------------------------------------------------------
 # Path resolution — all through canonical sources, no inline derivation
 # ---------------------------------------------------------------------------
 

--- a/src/orchestration/wos_dashboard_gen.py
+++ b/src/orchestration/wos_dashboard_gen.py
@@ -45,6 +45,15 @@ __all__ = [
 
 
 # ---------------------------------------------------------------------------
+# Sonnet 4.6 pricing constants (USD per million tokens)
+# ---------------------------------------------------------------------------
+
+SONNET_4_6_INPUT_PER_MTK: float = 3.0
+SONNET_4_6_OUTPUT_PER_MTK: float = 15.0
+SONNET_4_6_CACHE_READ_PER_MTK: float = 0.30
+
+
+# ---------------------------------------------------------------------------
 # Path resolution — all through canonical sources, no inline derivation
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -1078,6 +1078,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "pyyaml" },
+    { name = "ruamel-yaml" },
     { name = "sqlite-vec" },
     { name = "starlette" },
     { name = "twilio" },
@@ -1128,6 +1129,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-telegram-bot", specifier = ">=21.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18.0" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0" },
     { name = "sqlite-vec", specifier = ">=0.1.7a1" },
@@ -2331,6 +2333,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Fix 1 (DB path consistency):** `wos_dashboard._default_registry_path()` previously re-derived the registry path inline instead of using `paths.REGISTRY_DB`. Now delegates to `paths.REGISTRY_DB` via a local import, so all WOS modules resolve the path through the same env-var chain. Eliminates a silent divergence risk.

- **Fix 2 (HTML dashboard generation):** Adds `src/orchestration/wos_dashboard_gen.py` — generates a fresh self-contained HTML dashboard from live registry data and the token ledger, writes it to `~/messages/bisque-uploads/`, and returns the public Bisque URL. Wires `handle_wos_dashboard()` into `dispatcher_handlers.py` so the dispatcher can expose dashboard refresh as a command.

The HTML template mirrors the v4 dashboard structure (`const D={...}` + `const CC={...}`) with Queue, Seeds, Pearls, and Usage Stats tabs, drilldown rows, and per-UoW token data.

## Test plan

- [x] All 29 existing `test_wos_dashboard.py` unit tests pass (`pytest tests/unit/test_orchestration/test_wos_dashboard.py`)
- [ ] Smoke-test `generate_and_upload()` in a dev environment to confirm HTML file appears in bisque-uploads and URL is reachable
- [ ] Verify `wos dashboard` command routes to `handle_wos_dashboard()` in the dispatcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)