### PR TITLE
feat(#1115): per-UoW standalone drilldown HTML page

### DIFF
--- a/src/orchestration/wos_uow_detail_gen.py
+++ b/src/orchestration/wos_uow_detail_gen.py
@@ -1,0 +1,708 @@
+"""
+wos_uow_detail_gen.py — Generate a standalone per-UoW drilldown HTML page.
+
+Produces a self-contained HTML file for a single UoW showing full detail:
+token breakdown, cost estimate, API call timeline, full audit trail,
+corrective traces, heartbeat log, and status history. Uploads to the bisque
+relay and returns the public URL.
+
+Entry points:
+    generate_and_upload(uow_id, db_path?, ledger_path?) -> str
+        Build the page, write to ~/messages/bisque-uploads/, return public URL.
+
+    generate_html(uow_data, audit_trail, traces, heartbeats, token_data) -> str
+        Pure function: render HTML from pre-fetched dicts.
+
+CLI:
+    uv run src/orchestration/wos_uow_detail_gen.py --uow-id <id> [--db PATH] [--ledger PATH]
+
+Design:
+- Pure function composition: each fetch function takes an open sqlite3.Connection and
+  returns a plain Python dict or list. generate_html() composes them into HTML.
+- All DB access uses WAL mode + busy_timeout for safe concurrent access.
+- Same CSS custom properties as wos_dashboard_gen.py: same color scheme, typography,
+  badge classes, and layout primitives. Page is self-contained (no external CDN deps).
+- Priced at Sonnet 4.6 rates: $3/1M input, $15/1M output, $0.30/1M cache_read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Pricing constants — Sonnet 4.6
+# ---------------------------------------------------------------------------
+
+SONNET_4_6_INPUT_PER_MTK = 3.0        # $3.00 per 1M input tokens
+SONNET_4_6_OUTPUT_PER_MTK = 15.0      # $15.00 per 1M output tokens
+SONNET_4_6_CACHE_READ_PER_MTK = 0.30  # $0.30 per 1M cache_read tokens
+
+# ---------------------------------------------------------------------------
+# Path resolution — all through canonical sources, no inline derivation
+# ---------------------------------------------------------------------------
+
+def _registry_path() -> Path:
+    from src.orchestration.paths import REGISTRY_DB
+    return REGISTRY_DB
+
+
+def _ledger_path() -> Path:
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace")))
+    return workspace / "data" / "token-ledger.jsonl"
+
+
+def _uploads_dir() -> Path:
+    messages_dir = Path(os.environ.get("LOBSTER_INBOX_DIR", str(Path.home() / "messages" / "inbox"))).parent
+    return messages_dir / "bisque-uploads"
+
+
+def _bisque_base_url() -> str:
+    """Return the HTTP base URL of the bisque relay server.
+
+    Priority:
+    1. BISQUE_RELAY_HTTP_URL env var
+    2. LOBSTER_PUBLIC_IP env var with default port 9101
+    3. ifconfig.me curl call (fallback)
+    4. localhost fallback
+    """
+    env_url = os.environ.get("BISQUE_RELAY_HTTP_URL", "").strip()
+    if env_url:
+        return env_url.rstrip("/")
+
+    public_ip = os.environ.get("LOBSTER_PUBLIC_IP", "").strip()
+    if not public_ip:
+        config_file = Path.home() / "lobster-config" / "config.env"
+        if config_file.exists():
+            for line in config_file.read_text().splitlines():
+                stripped = line.strip()
+                if stripped.startswith("LOBSTER_PUBLIC_IP="):
+                    public_ip = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
+                if stripped.startswith("BISQUE_RELAY_HTTP_URL="):
+                    return stripped.split("=", 1)[1].strip().strip('"').strip("'").rstrip("/")
+
+    if not public_ip:
+        try:
+            result = subprocess.run(
+                ["curl", "-s", "--max-time", "5", "-4", "ifconfig.me"],
+                capture_output=True, text=True, timeout=6,
+            )
+            public_ip = result.stdout.strip()
+        except Exception:
+            pass
+
+    port = os.environ.get("BISQUE_RELAY_PORT", "9101")
+    if public_ip:
+        return f"http://{public_ip}:{port}"
+    return f"http://localhost:{port}"
+
+
+# ---------------------------------------------------------------------------
+# DB connection helper
+# ---------------------------------------------------------------------------
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Pure data-fetching functions — each takes an open connection
+# ---------------------------------------------------------------------------
+
+def _fetch_uow_data(conn: sqlite3.Connection, uow_id: str) -> dict[str, Any] | None:
+    """Return all UoW fields as a dict, or None if the UoW does not exist."""
+    row = conn.execute(
+        """
+        SELECT
+            id, summary, status, created_at, updated_at, started_at, completed_at,
+            source_issue_number, issue_url, outcome_category,
+            steward_cycles, lifetime_cycles, execution_attempts, retry_count,
+            token_usage, posture, register, close_reason, prescription_confidence,
+            success_criteria, type, source, gate_fired
+        FROM uow_registry
+        WHERE id = ?
+        """,
+        (uow_id,),
+    ).fetchone()
+
+    if row is None:
+        return None
+
+    return dict(row)
+
+
+def _fetch_audit_trail(conn: sqlite3.Connection, uow_id: str) -> list[dict]:
+    """Return the full (uncapped) audit trail for a UoW, ordered ascending by ts."""
+    rows = conn.execute(
+        "SELECT ts, event, from_status, to_status, agent, note FROM audit_log "
+        "WHERE uow_id = ? ORDER BY ts ASC",
+        (uow_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _fetch_corrective_traces(conn: sqlite3.Connection, uow_id: str) -> list[dict]:
+    """Return corrective traces for a UoW. Gracefully returns [] if table absent."""
+    try:
+        rows = conn.execute(
+            "SELECT execution_summary, surprises, prescription_delta, gate_score, summary, created_at "
+            "FROM corrective_traces WHERE uow_id = ? ORDER BY created_at DESC",
+            (uow_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except sqlite3.OperationalError:
+        return []
+
+
+def _fetch_heartbeat_log(conn: sqlite3.Connection, uow_id: str) -> list[dict]:
+    """Return heartbeat log entries for a UoW. Gracefully returns [] if table absent."""
+    try:
+        rows = conn.execute(
+            "SELECT recorded_at, token_usage FROM uow_heartbeat_log "
+            "WHERE uow_id = ? ORDER BY recorded_at ASC",
+            (uow_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except sqlite3.OperationalError:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Token ledger parsing — pure function over ledger entries list
+# ---------------------------------------------------------------------------
+
+_UOW_PATTERN = re.compile(r"uow_\d{8}_[0-9a-f]+")
+
+
+def _fetch_token_data(
+    entries: list[dict],
+    uow_id: str,
+) -> dict[str, Any] | None:
+    """Aggregate token data from ledger entries matching this UoW id.
+
+    Matches task_id values that contain the uow_id pattern anywhere in the string
+    (e.g. 'wos-uow_20260501_abc123', 'wos-executor-uow_20260501_abc123', or bare
+    'uow_20260501_abc123').
+
+    Returns None if no matching entries found.
+    """
+    totals: dict[str, int] = {
+        "input": 0, "output": 0, "cache_read": 0, "cache_write": 0, "calls": 0,
+    }
+    found = False
+
+    for entry in entries:
+        task_id = entry.get("task_id", "") or ""
+        match = _UOW_PATTERN.search(task_id)
+        if match and match.group(0) == uow_id:
+            found = True
+            totals["input"] += entry.get("input", 0) or 0
+            totals["output"] += entry.get("output", 0) or 0
+            totals["cache_read"] += entry.get("cache_read", 0) or 0
+            totals["cache_write"] += entry.get("cache_write", 0) or 0
+            totals["calls"] += 1
+
+    return totals if found else None
+
+
+def _read_ledger(ledger_path: Path) -> list[dict]:
+    """Read token ledger JSONL file into a list of dicts. Returns [] on error."""
+    if not ledger_path.exists():
+        return []
+    entries = []
+    try:
+        with ledger_path.open() as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+    except OSError:
+        return []
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Pure computation helpers
+# ---------------------------------------------------------------------------
+
+def _compute_elapsed(start: str | None, end: str | None) -> int | None:
+    """Compute elapsed seconds between two ISO timestamps.
+
+    Returns None if either timestamp is None or unparseable.
+    """
+    if start is None or end is None:
+        return None
+    try:
+        t0 = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        t1 = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        return int((t1 - t0).total_seconds())
+    except (ValueError, TypeError):
+        return None
+
+
+def _estimate_cost(
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+) -> float:
+    """Estimate USD cost using Sonnet 4.6 pricing.
+
+    Sonnet 4.6: $3/1M input, $15/1M output, $0.30/1M cache_read.
+    """
+    return (
+        input_tokens * SONNET_4_6_INPUT_PER_MTK / 1_000_000
+        + output_tokens * SONNET_4_6_OUTPUT_PER_MTK / 1_000_000
+        + cache_read_tokens * SONNET_4_6_CACHE_READ_PER_MTK / 1_000_000
+    )
+
+
+def _fmt_duration(seconds: int | None) -> str:
+    """Format elapsed seconds as human-readable string."""
+    if seconds is None or seconds < 0:
+        return "—"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60}s"
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    return f"{hours}h {minutes}m"
+
+
+# ---------------------------------------------------------------------------
+# HTML template — same CSS primitives as v4 wos_dashboard_gen.py
+# ---------------------------------------------------------------------------
+
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>UoW {uow_id}</title>
+<style>
+:root{{--bg:#f5f5f5;--surface:#fff;--surface2:#f0f0f0;--border:#ddd;--text:#1a1a1a;--text2:#555;--text3:#888;--accent:#4a7fc0;--accent-light:#e8f0fa;--done-col:#1a7a3c;--done-bg:#d4f7e0;--pend-col:#a06000;--pend-bg:#fef3cd;--fail-col:#c0392b;--fail-bg:#fde8e6;--act-col:#1565c0;--act-bg:#e3f0ff;--cl-col:#666;--cl-bg:#eee;--seed-col:#166534;--seed-bg:#dcfce7;--pearl-col:#5b21b6;--pearl-bg:#ede9fe;--heat-col:#b45309;--heat-bg:#fef3c7;--shadow:0 1px 4px rgba(0,0,0,.08)}}
+@media(prefers-color-scheme:dark){{:root{{--bg:#0f1117;--surface:#1c1f2a;--surface2:#252837;--border:#333;--text:#e8e8e8;--text2:#aaa;--text3:#666;--accent:#6fa3e0;--accent-light:#1a2540;--done-col:#4ade80;--done-bg:#0a2e1a;--pend-col:#fbbf24;--pend-bg:#2a1e00;--fail-col:#f87171;--fail-bg:#2a0a0a;--act-col:#60a5fa;--act-bg:#0a1e3a;--cl-col:#888;--cl-bg:#252525;--seed-col:#86efac;--seed-bg:#0a2a14;--pearl-col:#c4b5fd;--pearl-bg:#1e1040;--heat-col:#fcd34d;--heat-bg:#2a1a00;--shadow:0 1px 4px rgba(0,0,0,.4)}}}}
+*{{box-sizing:border-box;margin:0;padding:0}}
+body{{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--text);line-height:1.5}}
+.wrap{{max-width:1000px;margin:0 auto;padding:16px}}
+h1{{font-size:1.4rem;font-weight:700;margin-bottom:4px;word-break:break-all}}
+h2{{font-size:.85rem;font-weight:600;margin-bottom:10px;color:var(--text2);text-transform:uppercase;letter-spacing:.05em}}
+.meta{{color:var(--text3);font-size:.78rem;margin-bottom:16px}}
+.sec{{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:16px;margin-bottom:14px;box-shadow:var(--shadow)}}
+.pgrid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:10px;margin-bottom:12px}}
+.scard{{background:var(--surface2);border-radius:8px;padding:10px 12px;text-align:center}}
+.scard .n{{font-size:1.5rem;font-weight:700;color:var(--accent)}}
+.scard .l{{font-size:.65rem;color:var(--text3);text-transform:uppercase;letter-spacing:.04em}}
+.badge{{display:inline-block;padding:2px 7px;border-radius:10px;font-size:.72rem;font-weight:600;white-space:nowrap}}
+.bd{{color:var(--done-col);background:var(--done-bg)}}
+.bp{{color:var(--pend-col);background:var(--pend-bg)}}
+.bf{{color:var(--fail-col);background:var(--fail-bg)}}
+.ba{{color:var(--act-col);background:var(--act-bg)}}
+.bc{{color:var(--cl-col);background:var(--cl-bg)}}
+.bs{{color:var(--seed-col);background:var(--seed-bg)}}
+.bpe{{color:var(--pearl-col);background:var(--pearl-bg)}}
+.bh{{color:var(--heat-col);background:var(--heat-bg)}}
+.tbl{{width:100%;border-collapse:collapse;font-size:.8rem}}
+.tbl th{{text-align:left;padding:5px 8px;color:var(--text3);font-size:.68rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em;border-bottom:1px solid var(--border)}}
+.tbl td{{padding:6px 8px;border-bottom:1px solid var(--border);vertical-align:top}}
+.tbl tr:last-child td{{border-bottom:none}}
+.uid{{font-family:monospace;font-size:.78rem;color:var(--text3)}}
+.gh{{color:var(--accent);text-decoration:none;font-size:.78rem}}
+.gh:hover{{text-decoration:underline}}
+.sumtxt{{font-size:.9rem;background:var(--surface2);border:1px solid var(--border);border-radius:6px;padding:10px 12px;margin-bottom:10px}}
+.dgrid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:8px}}
+.dkv .k{{color:var(--text3);font-size:.67rem;text-transform:uppercase;letter-spacing:.04em}}
+.dkv .v{{color:var(--text);font-weight:500;font-size:.8rem}}
+.tl{{display:flex;flex-direction:column;gap:4px}}
+.tli{{display:flex;gap:8px;font-size:.75rem;align-items:flex-start}}
+.tlts{{color:var(--text3);white-space:nowrap;min-width:115px;font-size:.68rem;padding-top:1px}}
+.tlfr{{color:var(--fail-col)}}
+.tlto{{color:var(--done-col)}}
+.tlsym{{color:var(--text3);min-width:10px}}
+.tlevent{{font-family:monospace;font-size:.72rem}}
+.tlnote{{color:var(--text3);font-size:.68rem;max-width:600px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}}
+.hb-bar{{display:flex;align-items:flex-end;gap:3px;height:60px;margin-top:8px}}
+.empty{{text-align:center;padding:24px 20px;color:var(--text3);font-size:.85rem}}
+.back{{color:var(--accent);text-decoration:none;font-size:.8rem;display:inline-block;margin-bottom:14px}}
+.back:hover{{text-decoration:underline}}
+.conf-bar{{height:8px;border-radius:4px;background:var(--surface2);overflow:hidden;margin-top:4px}}
+.conf-fill{{height:100%;border-radius:4px;background:var(--accent)}}
+.tok-bar{{display:flex;gap:4px;height:16px;border-radius:6px;overflow:hidden;margin:8px 0 4px}}
+.tok-seg-out{{background:#4a7fc0}}
+.tok-seg-in{{background:#7baad0}}
+.tok-seg-cr{{background:#b0c8e0}}
+.tok-seg-cw{{background:#d0e4f4}}
+.legend{{display:flex;gap:12px;font-size:.65rem;color:var(--text3);flex-wrap:wrap;margin-top:3px}}
+.leg{{display:flex;align-items:center;gap:4px}}
+.legdot{{width:8px;height:8px;border-radius:2px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+<a class="back" href="javascript:history.back()">← Back</a>
+<h1>{uow_id_display}</h1>
+<p class="meta" id="meta-line"></p>
+
+<script>
+const D = {D_JSON};
+</script>
+
+<div id="main"></div>
+
+<script>
+(function() {{
+
+// --- Helpers ---
+function fmt(n) {{ return n == null ? '—' : Number(n).toLocaleString(); }}
+function fmtDate(s) {{
+  if (!s) return '—';
+  try {{ return new Date(s).toISOString().slice(0, 16).replace('T', ' ') + ' UTC'; }}
+  catch(e) {{ return s.slice(0, 16); }}
+}}
+function statusBadge(s) {{
+  const m = {{
+    'done':'bd','closed':'bc','expired':'bc','cancelled':'bc',
+    'failed':'bf','ready-for-steward':'ba','ready-for-executor':'ba',
+    'active':'ba','executing':'ba','proposed':'bp','pending':'bp',
+    'needs-human-review':'bf','blocked':'bf',
+  }};
+  return `<span class="badge ${{m[s]||'bc'}}">${{s}}</span>`;
+}}
+function outcomeBadge(o) {{
+  if (!o) return '';
+  const m = {{'seed':'bs','pearl':'bpe','heat':'bh'}};
+  return `<span class="badge ${{m[o]||'bc'}}">${{o}}</span>`;
+}}
+function fmtDuration(secs) {{
+  if (secs == null || secs < 0) return '—';
+  if (secs < 60) return secs + 's';
+  if (secs < 3600) return Math.floor(secs/60) + 'm ' + (secs%60) + 's';
+  const h = Math.floor(secs/3600);
+  const m = Math.floor((secs%3600)/60);
+  return h + 'h ' + m + 'm';
+}}
+function eventIcon(evt) {{
+  if (evt === 'execution_complete' || evt === 'steward_closure') return ['✓', 'tlto'];
+  if (evt === 'failed' || evt === 'execution_failed') return ['✗', 'tlfr'];
+  if (evt === 'executor_dispatch' || evt === 'dispatched') return ['→', 'tlsym'];
+  if (evt === 'created') return ['○', 'tlsym'];
+  return ['·', 'tlsym'];
+}}
+
+// --- Meta line ---
+document.getElementById('meta-line').textContent =
+  'Generated ' + new Date().toUTCString();
+
+// --- Token bar ---
+function tokenBarHtml(tok) {{
+  if (!tok) return '<span style="color:var(--text3);font-size:.78rem">No token data in ledger</span>';
+  const total = (tok.input||0) + (tok.output||0) + (tok.cache_read||0) + (tok.cache_write||0);
+  if (!total) return '<span style="color:var(--text3);font-size:.78rem">0 tokens recorded</span>';
+  function pct(n) {{ return (((n||0)/total)*100).toFixed(1) + '%'; }}
+  return `<div class="tok-bar">
+    <div class="tok-seg-out" style="width:${{pct(tok.output)}}" title="Output: ${{fmt(tok.output)}}"></div>
+    <div class="tok-seg-in" style="width:${{pct(tok.input)}}" title="Input: ${{fmt(tok.input)}}"></div>
+    <div class="tok-seg-cr" style="width:${{pct(tok.cache_read)}}" title="Cache read: ${{fmt(tok.cache_read)}}"></div>
+    <div class="tok-seg-cw" style="width:${{pct(tok.cache_write)}}" title="Cache write: ${{fmt(tok.cache_write)}}"></div>
+  </div>
+  <div class="legend">
+    <div class="leg"><div class="legdot" style="background:#4a7fc0"></div>Output ${{fmt(tok.output)}}</div>
+    <div class="leg"><div class="legdot" style="background:#7baad0"></div>Input ${{fmt(tok.input)}}</div>
+    <div class="leg"><div class="legdot" style="background:#b0c8e0"></div>Cache read ${{fmt(tok.cache_read)}}</div>
+    <div class="leg"><div class="legdot" style="background:#d0e4f4"></div>Cache write ${{fmt(tok.cache_write)}}</div>
+  </div>`;
+}}
+
+// --- Heartbeat chart ---
+function heartbeatChartHtml(beats) {{
+  if (!beats || !beats.length) return '<div class="empty" style="padding:12px">No heartbeat data</div>';
+  const vals = beats.map(b => b.token_usage || 0);
+  const maxVal = Math.max(...vals, 1);
+  const bars = beats.map((b, i) => {{
+    const h = Math.max(Math.round((b.token_usage||0) / maxVal * 56), 2);
+    const delta = i > 0 ? (b.token_usage||0) - (beats[i-1].token_usage||0) : null;
+    const deltaStr = delta != null ? ` (Δ +${{delta.toLocaleString()}})` : '';
+    return `<div style="flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;min-width:10px">
+      <div style="width:100%;height:${{h}}px;background:var(--accent);border-radius:2px 2px 0 0" title="${{b.recorded_at ? b.recorded_at.slice(11,16) : ''}} — ${{fmt(b.token_usage)}} tokens${{deltaStr}}"></div>
+    </div>`;
+  }}).join('');
+  const lastBeat = beats[beats.length - 1];
+  const firstBeat = beats[0];
+  return `<div style="font-size:.68rem;color:var(--text3);margin-bottom:4px">${{beats.length}} heartbeats — ${{firstBeat.recorded_at ? firstBeat.recorded_at.slice(11,16) : ''}} → ${{lastBeat.recorded_at ? lastBeat.recorded_at.slice(11,16) : ''}} UTC</div>
+  <div class="hb-bar">${{bars}}</div>
+  <div style="font-size:.68rem;color:var(--text3);margin-top:4px">Token growth: ${{fmt(firstBeat.token_usage||0)}} → ${{fmt(lastBeat.token_usage||0)}}</div>`;
+}}
+
+// --- Audit timeline ---
+function auditTimelineHtml(audit) {{
+  if (!audit || !audit.length) return '<div class="empty" style="padding:12px">No audit events</div>';
+  return `<div class="tl">${{audit.map(a => {{
+    const [sym, cls] = eventIcon(a.event);
+    const transition = (a.from_status && a.to_status) ? ` <span style="color:var(--text3)">${{a.from_status}} → ${{a.to_status}}</span>` : '';
+    let noteSnip = '';
+    if (a.note) {{
+      let note = a.note;
+      try {{ const obj = JSON.parse(note); note = obj.reason || obj.event || note; }} catch(e) {{}}
+      noteSnip = `<span class="tlnote" title="${{a.note.replace(/"/g,'&quot;')}}">${{note.slice(0,120)}}</span>`;
+    }}
+    return `<div class="tli">
+      <span class="tlts">${{a.ts ? a.ts.slice(0,16).replace('T',' ') : ''}}</span>
+      <span class="${{cls}} tlsym">${{sym}}</span>
+      <span><span class="tlevent">${{a.event}}</span>${{transition}} ${{noteSnip}}</span>
+    </div>`;
+  }}).join('')}}</div>`;
+}}
+
+// --- Corrective traces ---
+function tracesHtml(traces) {{
+  if (!traces || !traces.length) return '<div class="empty" style="padding:12px">No corrective traces</div>';
+  return traces.map(t => `<div class="sec" style="margin-bottom:8px;box-shadow:none;border-color:var(--border)">
+    <div style="font-size:.68rem;color:var(--text3);margin-bottom:6px">${{t.created_at ? t.created_at.slice(0,16).replace('T',' ') + ' UTC' : ''}}</div>
+    ${{t.execution_summary ? `<div style="font-size:.78rem;margin-bottom:6px">${{t.execution_summary}}</div>` : ''}}
+    ${{t.gate_score != null ? `<div style="font-size:.7rem;color:var(--text3)">Gate score: <strong>${{t.gate_score}}</strong></div>` : ''}}
+  </div>`).join('');
+}}
+
+// --- Main render ---
+const u = D.uow;
+const tok = D.token_data;
+const elapsed = D.elapsed_seconds;
+const cost = D.estimated_cost_usd;
+
+// Prescription confidence bar
+let confBar = '';
+if (u.prescription_confidence != null) {{
+  const pct = Math.round(u.prescription_confidence * 100);
+  confBar = `<div style="font-size:.7rem;color:var(--text3)">${{pct}}% confidence</div>
+  <div class="conf-bar"><div class="conf-fill" style="width:${{pct}}%"></div></div>`;
+}}
+
+const html = `
+  <div class="sec">
+    <h2>Summary</h2>
+    <div class="sumtxt">${{u.summary || '(no summary)'}}</div>
+    <div style="margin-bottom:10px">
+      ${{statusBadge(u.status)}} ${{outcomeBadge(u.outcome_category)}}
+      ${{u.gate_fired && u.gate_fired !== 'none' ? `<span class="badge bf" style="margin-left:4px">gate: ${{u.gate_fired}}</span>` : ''}}
+    </div>
+    <div class="dgrid">
+      <div class="dkv"><div class="k">ID</div><div class="v uid">${{u.id}}</div></div>
+      <div class="dkv"><div class="k">Status</div><div class="v">${{u.status}}</div></div>
+      <div class="dkv"><div class="k">Register</div><div class="v">${{u.register||'—'}}</div></div>
+      <div class="dkv"><div class="k">Posture</div><div class="v">${{u.posture||'—'}}</div></div>
+      <div class="dkv"><div class="k">Created</div><div class="v">${{fmtDate(u.created_at)}}</div></div>
+      <div class="dkv"><div class="k">Started</div><div class="v">${{fmtDate(u.started_at)}}</div></div>
+      <div class="dkv"><div class="k">Completed</div><div class="v">${{fmtDate(u.completed_at)}}</div></div>
+      <div class="dkv"><div class="k">Wall-clock</div><div class="v">${{fmtDuration(elapsed)}}</div></div>
+      ${{u.issue_url ? `<div class="dkv"><div class="k">Issue</div><div class="v"><a class="gh" href="${{u.issue_url}}" target="_blank">#${{u.source_issue_number}}</a></div></div>` : ''}}
+    </div>
+  </div>
+
+  ${{u.success_criteria ? `<div class="sec"><h2>Success Criteria</h2><div style="font-size:.83rem">${{u.success_criteria}}</div></div>` : ''}}
+
+  <div class="sec">
+    <h2>Execution Stats</h2>
+    <div class="pgrid">
+      <div class="scard"><div class="n">${{u.steward_cycles||0}}</div><div class="l">Steward Cycles</div></div>
+      <div class="scard"><div class="n">${{u.lifetime_cycles||0}}</div><div class="l">Lifetime Cycles</div></div>
+      <div class="scard"><div class="n">${{u.execution_attempts||0}}</div><div class="l">Exec Attempts</div></div>
+      <div class="scard"><div class="n">${{u.retry_count||0}}</div><div class="l">Retries</div></div>
+    </div>
+    ${{confBar ? `<div style="margin-top:8px"><div style="font-size:.68rem;color:var(--text3);margin-bottom:3px;text-transform:uppercase;letter-spacing:.04em">Prescription Confidence</div>${{confBar}}</div>` : ''}}
+    ${{u.close_reason ? `<div style="margin-top:10px"><div style="font-size:.68rem;color:var(--text3);text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Close Reason</div><div style="font-size:.8rem">${{u.close_reason}}</div></div>` : ''}}
+  </div>
+
+  <div class="sec">
+    <h2>Token Usage</h2>
+    ${{tok ? `
+    <div class="pgrid">
+      <div class="scard"><div class="n">${{fmt(tok.output)}}</div><div class="l">Output</div></div>
+      <div class="scard"><div class="n">${{fmt(tok.input)}}</div><div class="l">Input</div></div>
+      <div class="scard"><div class="n">${{fmt(tok.cache_read)}}</div><div class="l">Cache Read</div></div>
+      <div class="scard"><div class="n">${{fmt(tok.cache_write)}}</div><div class="l">Cache Write</div></div>
+      <div class="scard"><div class="n">${{tok.calls||0}}</div><div class="l">API Calls</div></div>
+      <div class="scard"><div class="n">$${{cost != null ? cost.toFixed(4) : '—'}}</div><div class="l">Est. Cost USD</div></div>
+    </div>
+    ${{tokenBarHtml(tok)}}
+    ` : '<div class="empty">No token data in ledger for this UoW</div>'}}
+  </div>
+
+  <div class="sec">
+    <h2>Heartbeat Log (Token Growth)</h2>
+    ${{heartbeatChartHtml(D.heartbeats)}}
+  </div>
+
+  <div class="sec">
+    <h2>Audit Trail (${{D.audit_trail.length}} events)</h2>
+    ${{auditTimelineHtml(D.audit_trail)}}
+  </div>
+
+  <div class="sec">
+    <h2>Corrective Traces (${{D.traces.length}})</h2>
+    ${{tracesHtml(D.traces)}}
+  </div>
+`;
+
+document.getElementById('main').innerHTML = html;
+
+}})();
+</script>
+</div>
+</body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering — pure function
+# ---------------------------------------------------------------------------
+
+def generate_html(
+    uow_data: dict[str, Any],
+    audit_trail: list[dict],
+    traces: list[dict],
+    heartbeats: list[dict],
+    token_data: dict[str, Any] | None,
+) -> str:
+    """Render the drilldown HTML page from pre-fetched data.
+
+    Pure function: no IO. All data must be passed as arguments.
+    """
+    uow_id = uow_data["id"]
+    elapsed = _compute_elapsed(uow_data.get("started_at"), uow_data.get("completed_at"))
+    cost = None
+    if token_data:
+        cost = _estimate_cost(
+            token_data.get("input", 0) or 0,
+            token_data.get("output", 0) or 0,
+            token_data.get("cache_read", 0) or 0,
+        )
+
+    payload = {
+        "uow": uow_data,
+        "audit_trail": audit_trail,
+        "traces": traces,
+        "heartbeats": heartbeats,
+        "token_data": token_data,
+        "elapsed_seconds": elapsed,
+        "estimated_cost_usd": round(cost, 6) if cost is not None else None,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    d_json = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), default=str)
+
+    return (
+        _HTML_TEMPLATE
+        .replace("{uow_id}", uow_id)
+        .replace("{uow_id_display}", uow_id)
+        .replace("{D_JSON}", d_json)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level generator
+# ---------------------------------------------------------------------------
+
+def generate_and_upload(
+    uow_id: str,
+    db_path: Path | None = None,
+    ledger_path: Path | None = None,
+) -> str:
+    """Generate a standalone HTML drilldown page for a UoW and return its public URL.
+
+    Raises ValueError if the UoW is not found in the registry.
+    Writes the HTML file to ~/messages/bisque-uploads/ (bisque relay directory).
+    """
+    if db_path is None:
+        db_path = _registry_path()
+    if ledger_path is None:
+        ledger_path = _ledger_path()
+
+    conn = _connect(db_path)
+    try:
+        uow_data = _fetch_uow_data(conn, uow_id)
+        if uow_data is None:
+            raise ValueError(f"UoW {uow_id!r} not found in registry at {db_path}")
+
+        audit_trail = _fetch_audit_trail(conn, uow_id)
+        traces = _fetch_corrective_traces(conn, uow_id)
+        heartbeats = _fetch_heartbeat_log(conn, uow_id)
+    finally:
+        conn.close()
+
+    ledger_entries = _read_ledger(ledger_path)
+    token_data = _fetch_token_data(ledger_entries, uow_id)
+
+    html = generate_html(uow_data, audit_trail, traces, heartbeats, token_data)
+
+    uploads = _uploads_dir()
+    uploads.mkdir(parents=True, exist_ok=True)
+    filename = f"{uuid.uuid4().hex}.html"
+    dest = uploads / filename
+    dest.write_text(html, encoding="utf-8")
+
+    base_url = _bisque_base_url()
+    return f"{base_url}/files/{filename}"
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a standalone HTML drilldown page for a single WOS UoW",
+    )
+    parser.add_argument(
+        "--uow-id",
+        required=True,
+        help="UoW ID (e.g. uow_20260501_abc123)",
+    )
+    parser.add_argument(
+        "--db",
+        default=None,
+        help="Override registry DB path (default: auto-detected from env)",
+    )
+    parser.add_argument(
+        "--ledger",
+        default=None,
+        help="Override token ledger path (default: auto-detected from env)",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = Path(args.db) if args.db else None
+    ledger_path = Path(args.ledger) if args.ledger else None
+
+    try:
+        url = generate_and_upload(
+            uow_id=args.uow_id,
+            db_path=db_path,
+            ledger_path=ledger_path,
+        )
+        print(url)
+        return 0
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/orchestration/wos_uow_detail_gen.py
+++ b/src/orchestration/wos_uow_detail_gen.py
@@ -609,12 +609,7 @@ def generate_html(
 
     d_json = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), default=str)
 
-    return (
-        _HTML_TEMPLATE
-        .replace("{uow_id}", uow_id)
-        .replace("{uow_id_display}", uow_id)
-        .replace("{D_JSON}", d_json)
-    )
+    return _HTML_TEMPLATE.format(uow_id=uow_id, uow_id_display=uow_id, D_JSON=d_json)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_wos_uow_detail_gen.py
+++ b/tests/unit/test_orchestration/test_wos_uow_detail_gen.py
@@ -1,0 +1,691 @@
+"""
+Unit tests for wos_uow_detail_gen.py.
+
+Tests cover behavior, not implementation detail:
+- _fetch_uow_data: returns structured dict with all UoW fields, None for missing UoW
+- _fetch_audit_trail: returns full (uncapped) list of audit events for a UoW
+- _fetch_corrective_traces: returns traces list, empty when table absent
+- _fetch_heartbeat_log: returns heartbeat list, empty when table absent
+- _fetch_token_data: extracts per-UoW token totals from ledger entries
+- _compute_elapsed: computes wall-clock duration from timestamps
+- _estimate_cost: computes USD cost from token counts using Sonnet 4.6 pricing
+- generate_html: produces valid HTML containing UoW id in output
+- generate_and_upload: writes file to uploads dir, returns URL with uow id context
+- CLI: --uow-id required, exits 1 on missing UoW, exits 0 on success
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Constants matching the spec (Sonnet 4.6 pricing)
+# ---------------------------------------------------------------------------
+
+SONNET_4_6_INPUT_PER_MTK = 3.0     # $3 per 1M input tokens
+SONNET_4_6_OUTPUT_PER_MTK = 15.0   # $15 per 1M output tokens
+SONNET_4_6_CACHE_READ_PER_MTK = 0.30  # $0.30 per 1M cache_read tokens
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — in-memory SQLite DB with sample data
+# ---------------------------------------------------------------------------
+
+def _build_db() -> tuple[sqlite3.Connection, str]:
+    """Create an in-memory SQLite DB with uow_registry, audit_log, corrective_traces,
+    and uow_heartbeat_log populated with a single sample UoW."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    conn.executescript("""
+        CREATE TABLE uow_registry (
+            id TEXT PRIMARY KEY,
+            summary TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'proposed',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            started_at TEXT,
+            completed_at TEXT,
+            source_issue_number INTEGER,
+            issue_url TEXT,
+            outcome_category TEXT,
+            steward_cycles INTEGER NOT NULL DEFAULT 0,
+            lifetime_cycles INTEGER NOT NULL DEFAULT 0,
+            execution_attempts INTEGER NOT NULL DEFAULT 0,
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            token_usage INTEGER,
+            posture TEXT NOT NULL DEFAULT 'solo',
+            register TEXT NOT NULL DEFAULT 'operational',
+            close_reason TEXT,
+            prescription_confidence REAL,
+            success_criteria TEXT NOT NULL DEFAULT '',
+            prescribed_skills TEXT,
+            type TEXT NOT NULL DEFAULT 'executable',
+            source TEXT NOT NULL DEFAULT 'github',
+            gate_fired TEXT
+        );
+
+        CREATE TABLE audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            uow_id TEXT NOT NULL,
+            event TEXT NOT NULL,
+            from_status TEXT,
+            to_status TEXT,
+            agent TEXT,
+            note TEXT
+        );
+
+        CREATE TABLE corrective_traces (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            uow_id TEXT NOT NULL,
+            register TEXT NOT NULL,
+            execution_summary TEXT,
+            surprises TEXT DEFAULT '[]',
+            prescription_delta TEXT,
+            gate_score REAL,
+            summary TEXT,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE uow_heartbeat_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            uow_id TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            token_usage INTEGER
+        );
+    """)
+
+    # Insert a sample UoW
+    conn.execute("""
+        INSERT INTO uow_registry (
+            id, summary, status, created_at, updated_at, started_at, completed_at,
+            source_issue_number, issue_url, outcome_category,
+            steward_cycles, lifetime_cycles, execution_attempts, retry_count,
+            token_usage, posture, register, close_reason, prescription_confidence,
+            success_criteria, type, source
+        ) VALUES (
+            'uow_20260501_abc123',
+            'feat: example feature implementation',
+            'done',
+            '2026-05-01T10:00:00+00:00',
+            '2026-05-01T11:30:00+00:00',
+            '2026-05-01T11:00:00+00:00',
+            '2026-05-01T11:30:00+00:00',
+            999,
+            'https://github.com/dcetlin/Lobster/issues/999',
+            'pearl',
+            2,
+            4,
+            1,
+            0,
+            50000,
+            'solo',
+            'operational',
+            'Completed successfully',
+            0.9,
+            'PR merged and tests pass',
+            'executable',
+            'github'
+        )
+    """)
+
+    # Insert audit events
+    conn.executemany(
+        "INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, note) VALUES (?,?,?,?,?,?)",
+        [
+            ('2026-05-01T10:00:00+00:00', 'uow_20260501_abc123', 'created', None, 'proposed', None),
+            ('2026-05-01T10:05:00+00:00', 'uow_20260501_abc123', 'status_change', 'proposed', 'ready-for-steward', None),
+            ('2026-05-01T11:00:00+00:00', 'uow_20260501_abc123', 'executor_dispatch', 'ready-for-executor', 'executing', None),
+            ('2026-05-01T11:30:00+00:00', 'uow_20260501_abc123', 'execution_complete', 'executing', 'ready-for-steward', None),
+            ('2026-05-01T11:35:00+00:00', 'uow_20260501_abc123', 'steward_closure', None, None, None),
+        ]
+    )
+
+    # Insert corrective trace
+    conn.execute("""
+        INSERT INTO corrective_traces (uow_id, register, execution_summary, surprises, created_at)
+        VALUES ('uow_20260501_abc123', 'operational', 'Executor completed without surprises', '[]', '2026-05-01T11:00:00+00:00')
+    """)
+
+    # Insert heartbeat entries
+    conn.executemany(
+        "INSERT INTO uow_heartbeat_log (uow_id, recorded_at, token_usage) VALUES (?,?,?)",
+        [
+            ('uow_20260501_abc123', '2026-05-01T11:10:00+00:00', 15000),
+            ('uow_20260501_abc123', '2026-05-01T11:20:00+00:00', 32000),
+            ('uow_20260501_abc123', '2026-05-01T11:30:00+00:00', 50000),
+        ]
+    )
+
+    conn.commit()
+    return conn, 'uow_20260501_abc123'
+
+
+def _build_ledger_entries(uow_id: str) -> list[dict]:
+    """Build sample token ledger entries for a UoW."""
+    return [
+        {
+            "ts": 1746097260,
+            "task_id": f"wos-{uow_id}",
+            "input": 10000,
+            "output": 20000,
+            "cache_read": 80000,
+            "cache_write": 5000,
+            "model": "claude-sonnet-4-6",
+        },
+        {
+            "ts": 1746097320,
+            "task_id": f"wos-{uow_id}",
+            "input": 5000,
+            "output": 15000,
+            "cache_read": 40000,
+            "cache_write": 2000,
+            "model": "claude-sonnet-4-6",
+        },
+        # Unrelated entry — should not be included in UoW totals
+        {
+            "ts": 1746097320,
+            "task_id": "wos-uow_20260401_other",
+            "input": 1000,
+            "output": 500,
+            "cache_read": 10000,
+            "cache_write": 1000,
+            "model": "claude-sonnet-4-6",
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _fetch_uow_data
+# ---------------------------------------------------------------------------
+
+class TestFetchUoWData:
+    def test_returns_dict_with_all_fields_for_existing_uow(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_uow_data
+        conn, uow_id = _build_db()
+        result = _fetch_uow_data(conn, uow_id)
+        assert result is not None
+        assert result["id"] == uow_id
+        assert result["summary"] == "feat: example feature implementation"
+        assert result["status"] == "done"
+        assert result["outcome_category"] == "pearl"
+        assert result["steward_cycles"] == 2
+        assert result["token_usage"] == 50000
+        assert result["issue_url"] == "https://github.com/dcetlin/Lobster/issues/999"
+        conn.close()
+
+    def test_returns_none_for_missing_uow(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_uow_data
+        conn, _ = _build_db()
+        result = _fetch_uow_data(conn, "uow_does_not_exist")
+        assert result is None
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_audit_trail — full uncapped trail
+# ---------------------------------------------------------------------------
+
+AUDIT_TRAIL_LENGTH = 5  # matches events inserted in _build_db()
+
+
+class TestFetchAuditTrail:
+    def test_returns_all_events_uncapped(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_audit_trail
+        conn, uow_id = _build_db()
+        events = _fetch_audit_trail(conn, uow_id)
+        assert len(events) == AUDIT_TRAIL_LENGTH
+        conn.close()
+
+    def test_events_ordered_ascending_by_timestamp(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_audit_trail
+        conn, uow_id = _build_db()
+        events = _fetch_audit_trail(conn, uow_id)
+        timestamps = [e["ts"] for e in events]
+        assert timestamps == sorted(timestamps)
+        conn.close()
+
+    def test_each_event_has_required_keys(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_audit_trail
+        conn, uow_id = _build_db()
+        events = _fetch_audit_trail(conn, uow_id)
+        for event in events:
+            assert "ts" in event
+            assert "event" in event
+        conn.close()
+
+    def test_returns_empty_for_unknown_uow(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_audit_trail
+        conn, _ = _build_db()
+        events = _fetch_audit_trail(conn, "no_such_uow")
+        assert events == []
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_corrective_traces
+# ---------------------------------------------------------------------------
+
+class TestFetchCorrectiveTraces:
+    def test_returns_traces_for_uow(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_corrective_traces
+        conn, uow_id = _build_db()
+        traces = _fetch_corrective_traces(conn, uow_id)
+        assert len(traces) == 1
+        assert traces[0]["execution_summary"] == "Executor completed without surprises"
+        conn.close()
+
+    def test_returns_empty_when_no_traces(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_corrective_traces
+        conn, _ = _build_db()
+        traces = _fetch_corrective_traces(conn, "no_traces_uow")
+        assert traces == []
+        conn.close()
+
+    def test_returns_empty_when_table_absent(self):
+        """Gracefully handles DBs that predate corrective_traces migration."""
+        from src.orchestration.wos_uow_detail_gen import _fetch_corrective_traces
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute("CREATE TABLE uow_registry (id TEXT PRIMARY KEY, summary TEXT NOT NULL)")
+        conn.commit()
+        traces = _fetch_corrective_traces(conn, "uow_20260501_abc123")
+        assert traces == []
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_heartbeat_log
+# ---------------------------------------------------------------------------
+
+HEARTBEAT_COUNT = 3  # matches entries inserted in _build_db()
+
+
+class TestFetchHeartbeatLog:
+    def test_returns_heartbeats_for_uow(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_heartbeat_log
+        conn, uow_id = _build_db()
+        beats = _fetch_heartbeat_log(conn, uow_id)
+        assert len(beats) == HEARTBEAT_COUNT
+        conn.close()
+
+    def test_heartbeats_have_recorded_at_and_token_usage(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_heartbeat_log
+        conn, uow_id = _build_db()
+        beats = _fetch_heartbeat_log(conn, uow_id)
+        for b in beats:
+            assert "recorded_at" in b
+            assert "token_usage" in b
+        conn.close()
+
+    def test_returns_empty_when_table_absent(self):
+        """Gracefully handles DBs that predate heartbeat migration."""
+        from src.orchestration.wos_uow_detail_gen import _fetch_heartbeat_log
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute("CREATE TABLE uow_registry (id TEXT PRIMARY KEY, summary TEXT NOT NULL)")
+        conn.commit()
+        beats = _fetch_heartbeat_log(conn, "uow_20260501_abc123")
+        assert beats == []
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_token_data
+# ---------------------------------------------------------------------------
+
+class TestFetchTokenData:
+    def test_aggregates_tokens_for_matching_uow_id(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_token_data
+        uow_id = "uow_20260501_abc123"
+        entries = _build_ledger_entries(uow_id)
+        result = _fetch_token_data(entries, uow_id)
+        assert result is not None
+        # Two matching entries: input 10000+5000=15000, output 20000+15000=35000
+        assert result["input"] == 15000
+        assert result["output"] == 35000
+        assert result["cache_read"] == 120000
+        assert result["cache_write"] == 7000
+        assert result["calls"] == 2
+
+    def test_excludes_unrelated_entries(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_token_data
+        uow_id = "uow_20260501_abc123"
+        entries = _build_ledger_entries(uow_id)
+        result = _fetch_token_data(entries, uow_id)
+        # The "other" UoW's 1000 input tokens must not appear here
+        assert result["input"] == 15000
+
+    def test_returns_none_for_uow_not_in_ledger(self):
+        from src.orchestration.wos_uow_detail_gen import _fetch_token_data
+        uow_id = "uow_20260501_abc123"
+        result = _fetch_token_data([], uow_id)
+        assert result is None
+
+    def test_matches_task_id_containing_uow_id(self):
+        """task_id can be 'wos-uow_YYYYMMDD_xxxxxx' or just the uow_id."""
+        from src.orchestration.wos_uow_detail_gen import _fetch_token_data
+        uow_id = "uow_20260501_abc123"
+        entries = [
+            {"ts": 1000, "task_id": uow_id, "input": 1, "output": 2, "cache_read": 0, "cache_write": 0},
+            {"ts": 1001, "task_id": f"wos-{uow_id}", "input": 1, "output": 2, "cache_read": 0, "cache_write": 0},
+            {"ts": 1002, "task_id": f"wos-executor-{uow_id}", "input": 1, "output": 2, "cache_read": 0, "cache_write": 0},
+        ]
+        result = _fetch_token_data(entries, uow_id)
+        assert result is not None
+        assert result["calls"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _compute_elapsed
+# ---------------------------------------------------------------------------
+
+class TestComputeElapsed:
+    def test_returns_seconds_between_start_and_end(self):
+        from src.orchestration.wos_uow_detail_gen import _compute_elapsed
+        result = _compute_elapsed(
+            "2026-05-01T11:00:00+00:00",
+            "2026-05-01T11:30:00+00:00",
+        )
+        assert result == 1800  # 30 minutes in seconds
+
+    def test_returns_none_when_either_timestamp_is_none(self):
+        from src.orchestration.wos_uow_detail_gen import _compute_elapsed
+        assert _compute_elapsed(None, "2026-05-01T11:30:00+00:00") is None
+        assert _compute_elapsed("2026-05-01T11:00:00+00:00", None) is None
+        assert _compute_elapsed(None, None) is None
+
+    def test_returns_none_for_invalid_timestamps(self):
+        from src.orchestration.wos_uow_detail_gen import _compute_elapsed
+        assert _compute_elapsed("not-a-date", "2026-05-01T11:30:00+00:00") is None
+
+
+# ---------------------------------------------------------------------------
+# _estimate_cost — Sonnet 4.6 pricing
+# ---------------------------------------------------------------------------
+
+class TestEstimateCost:
+    def test_zero_tokens_yield_zero_cost(self):
+        from src.orchestration.wos_uow_detail_gen import _estimate_cost
+        assert _estimate_cost(0, 0, 0) == 0.0
+
+    def test_input_priced_at_three_dollars_per_million(self):
+        from src.orchestration.wos_uow_detail_gen import _estimate_cost
+        cost = _estimate_cost(input_tokens=1_000_000, output_tokens=0, cache_read_tokens=0)
+        assert abs(cost - SONNET_4_6_INPUT_PER_MTK) < 0.0001
+
+    def test_output_priced_at_fifteen_dollars_per_million(self):
+        from src.orchestration.wos_uow_detail_gen import _estimate_cost
+        cost = _estimate_cost(input_tokens=0, output_tokens=1_000_000, cache_read_tokens=0)
+        assert abs(cost - SONNET_4_6_OUTPUT_PER_MTK) < 0.0001
+
+    def test_cache_read_priced_at_thirty_cents_per_million(self):
+        from src.orchestration.wos_uow_detail_gen import _estimate_cost
+        cost = _estimate_cost(input_tokens=0, output_tokens=0, cache_read_tokens=1_000_000)
+        assert abs(cost - SONNET_4_6_CACHE_READ_PER_MTK) < 0.0001
+
+    def test_combined_cost_sums_all_three_sources(self):
+        from src.orchestration.wos_uow_detail_gen import _estimate_cost
+        # 100K input: $0.30, 100K output: $1.50, 1M cache_read: $0.30
+        cost = _estimate_cost(
+            input_tokens=100_000,
+            output_tokens=100_000,
+            cache_read_tokens=1_000_000,
+        )
+        expected = (100_000 * 3 + 100_000 * 15) / 1_000_000 + 1_000_000 * 0.30 / 1_000_000
+        assert abs(cost - expected) < 0.0001
+
+
+# ---------------------------------------------------------------------------
+# generate_html
+# ---------------------------------------------------------------------------
+
+class TestGenerateHtml:
+    def test_output_is_valid_html_containing_uow_id(self):
+        from src.orchestration.wos_uow_detail_gen import generate_html
+        uow_data = {
+            "id": "uow_20260501_abc123",
+            "summary": "Test feature",
+            "status": "done",
+            "created_at": "2026-05-01T10:00:00+00:00",
+            "updated_at": "2026-05-01T11:30:00+00:00",
+            "started_at": "2026-05-01T11:00:00+00:00",
+            "completed_at": "2026-05-01T11:30:00+00:00",
+            "source_issue_number": 999,
+            "issue_url": "https://github.com/dcetlin/Lobster/issues/999",
+            "outcome_category": "pearl",
+            "steward_cycles": 2,
+            "lifetime_cycles": 4,
+            "execution_attempts": 1,
+            "retry_count": 0,
+            "token_usage": 50000,
+            "posture": "solo",
+            "register": "operational",
+            "close_reason": "Completed successfully",
+            "prescription_confidence": 0.9,
+            "success_criteria": "PR merged and tests pass",
+            "gate_fired": None,
+        }
+        audit_trail = [
+            {"ts": "2026-05-01T10:00:00+00:00", "event": "created", "from_status": None, "to_status": "proposed", "note": None, "agent": None},
+        ]
+        traces = [
+            {"execution_summary": "Clean run", "surprises": "[]", "created_at": "2026-05-01T11:00:00+00:00", "gate_score": None, "summary": ""},
+        ]
+        heartbeats = [
+            {"recorded_at": "2026-05-01T11:10:00+00:00", "token_usage": 15000},
+        ]
+        token_data = {"input": 15000, "output": 35000, "cache_read": 120000, "cache_write": 7000, "calls": 2}
+
+        html = generate_html(uow_data, audit_trail, traces, heartbeats, token_data)
+
+        assert "<!DOCTYPE html>" in html
+        assert "uow_20260501_abc123" in html
+
+    def test_html_contains_token_section_when_data_present(self):
+        from src.orchestration.wos_uow_detail_gen import generate_html
+        uow_data = {
+            "id": "uow_20260501_abc123",
+            "summary": "Test",
+            "status": "done",
+            "created_at": "2026-05-01T10:00:00+00:00",
+            "updated_at": "2026-05-01T11:30:00+00:00",
+            "started_at": None,
+            "completed_at": None,
+            "source_issue_number": None,
+            "issue_url": None,
+            "outcome_category": None,
+            "steward_cycles": 0,
+            "lifetime_cycles": 0,
+            "execution_attempts": 0,
+            "retry_count": 0,
+            "token_usage": None,
+            "posture": "solo",
+            "register": "operational",
+            "close_reason": None,
+            "prescription_confidence": None,
+            "success_criteria": "",
+            "gate_fired": None,
+        }
+        token_data = {"input": 10000, "output": 20000, "cache_read": 50000, "cache_write": 3000, "calls": 2}
+        html = generate_html(uow_data, [], [], [], token_data)
+        # Token section header must appear
+        assert "Token" in html
+
+    def test_html_handles_none_token_data_gracefully(self):
+        from src.orchestration.wos_uow_detail_gen import generate_html
+        uow_data = {
+            "id": "uow_20260501_abc123",
+            "summary": "Test",
+            "status": "proposed",
+            "created_at": "2026-05-01T10:00:00+00:00",
+            "updated_at": "2026-05-01T10:00:00+00:00",
+            "started_at": None,
+            "completed_at": None,
+            "source_issue_number": None,
+            "issue_url": None,
+            "outcome_category": None,
+            "steward_cycles": 0,
+            "lifetime_cycles": 0,
+            "execution_attempts": 0,
+            "retry_count": 0,
+            "token_usage": None,
+            "posture": "solo",
+            "register": "operational",
+            "close_reason": None,
+            "prescription_confidence": None,
+            "success_criteria": "",
+            "gate_fired": None,
+        }
+        # Should not raise
+        html = generate_html(uow_data, [], [], [], None)
+        assert "<!DOCTYPE html>" in html
+
+
+# ---------------------------------------------------------------------------
+# generate_and_upload
+# ---------------------------------------------------------------------------
+
+class TestGenerateAndUpload:
+    def test_writes_file_and_returns_url(self, tmp_path: Path):
+        from src.orchestration.wos_uow_detail_gen import generate_and_upload
+
+        # Write a minimal DB to a temp file
+        db_path = tmp_path / "registry.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        # Use the rich in-memory DB data but write it to disk
+        base_conn, uow_id = _build_db()
+        # Dump schema + data to the file DB
+        for line in base_conn.iterdump():
+            try:
+                conn.execute(line)
+            except Exception:
+                pass
+        conn.commit()
+        base_conn.close()
+
+        # Write a minimal ledger
+        ledger_path = tmp_path / "token-ledger.jsonl"
+        entries = _build_ledger_entries(uow_id)
+        with ledger_path.open("w") as fh:
+            for e in entries:
+                fh.write(json.dumps(e) + "\n")
+
+        uploads_dir = tmp_path / "bisque-uploads"
+
+        with patch("src.orchestration.wos_uow_detail_gen._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_uow_detail_gen._bisque_base_url", return_value="http://test:9101"):
+            url = generate_and_upload(uow_id=uow_id, db_path=db_path, ledger_path=ledger_path)
+
+        # File must exist
+        html_files = list(uploads_dir.glob("*.html"))
+        assert len(html_files) == 1
+
+        # URL must reference the file
+        filename = html_files[0].name
+        assert url == f"http://test:9101/files/{filename}"
+
+        # File must contain uow id
+        content = html_files[0].read_text()
+        assert uow_id in content
+
+    def test_raises_value_error_for_missing_uow(self, tmp_path: Path):
+        from src.orchestration.wos_uow_detail_gen import generate_and_upload
+
+        # Build a full-schema DB (from _build_db) so column checks pass, but
+        # request a UoW that doesn't exist — the function should raise ValueError.
+        db_path = tmp_path / "registry.db"
+        base_conn, _ = _build_db()
+        dest_conn = sqlite3.connect(str(db_path))
+        for line in base_conn.iterdump():
+            try:
+                dest_conn.execute(line)
+            except Exception:
+                pass
+        dest_conn.commit()
+        base_conn.close()
+        dest_conn.close()
+
+        ledger_path = tmp_path / "ledger.jsonl"
+        ledger_path.write_text("")
+
+        with pytest.raises(ValueError, match="not found"):
+            generate_and_upload(
+                uow_id="uow_does_not_exist",
+                db_path=db_path,
+                ledger_path=ledger_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def test_exits_1_when_no_uow_id_given(self, tmp_path: Path, capsys):
+        """--uow-id is required; missing it should exit non-zero."""
+        import sys
+        from src.orchestration.wos_uow_detail_gen import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--db", str(tmp_path / "registry.db")])
+        assert exc_info.value.code != 0
+
+    def test_exits_1_when_uow_not_found(self, tmp_path: Path):
+        from src.orchestration.wos_uow_detail_gen import main
+
+        # Build a full-schema DB so column checks pass, but request a nonexistent UoW.
+        db_path = tmp_path / "registry.db"
+        base_conn, _ = _build_db()
+        dest_conn = sqlite3.connect(str(db_path))
+        for line in base_conn.iterdump():
+            try:
+                dest_conn.execute(line)
+            except Exception:
+                pass
+        dest_conn.commit()
+        base_conn.close()
+        dest_conn.close()
+
+        # main() returns an exit code (int) when called directly.
+        result = main(["--uow-id", "uow_does_not_exist", "--db", str(db_path)])
+        assert result == 1
+
+    def test_exits_0_on_success(self, tmp_path: Path, capsys):
+        import sys
+        from src.orchestration.wos_uow_detail_gen import main
+
+        db_path = tmp_path / "registry.db"
+        conn = sqlite3.connect(str(db_path))
+        base_conn, uow_id = _build_db()
+        for line in base_conn.iterdump():
+            try:
+                conn.execute(line)
+            except Exception:
+                pass
+        conn.commit()
+        base_conn.close()
+        conn.close()
+
+        ledger_path = tmp_path / "ledger.jsonl"
+        ledger_path.write_text("")
+
+        uploads_dir = tmp_path / "bisque-uploads"
+
+        with patch("src.orchestration.wos_uow_detail_gen._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_uow_detail_gen._bisque_base_url", return_value="http://test:9101"):
+            result = main(["--uow-id", uow_id, "--db", str(db_path), "--ledger", str(ledger_path)])
+
+        assert result == 0


### PR DESCRIPTION
## What this solves

The v4 dashboard has expandable row detail for each UoW, but there is no way to share a direct link to a single UoW's complete detail view. Completion notifications, Telegram replies about costly UoWs, and investigation sessions all need a linkable, deep-driveable page — not a dashboard filter.

## What changed

Adds `src/orchestration/wos_uow_detail_gen.py` — a new generator script (added alongside the v4 dashboard, not modifying it) that accepts a UoW ID and produces a self-contained HTML drilldown page:

- **Header:** id, status badge, outcome badge, gate_fired badge (if non-none)
- **All timestamps:** created, started, completed, wall-clock elapsed
- **Execution stats stat cards:** steward cycles, lifetime cycles, execution attempts, retries
- **Prescription confidence bar** (visual fill for 0–100% scale)
- **Token breakdown:** output, input, cache_read, cache_write with a proportional stacked bar
- **Cost estimate** at Sonnet 4.6 pricing ($3/1M input, $15/1M output, $0.30/1M cache_read)
- **Heartbeat log chart:** token growth curve from `uow_heartbeat_log`
- **Full uncapped audit trail** (the v4 dashboard caps at 50 UoWs — this shows every event)
- **Corrective traces** from `corrective_traces` table

The page reuses the exact same CSS custom properties, color scheme, typography, and badge/scard/tbl class patterns as `wos_dashboard_gen.py`. It is self-contained (no external CDN dependencies). Uploads to `~/messages/bisque-uploads/` and returns the public bisque URL, same as the v4 dashboard.

Entry point:
```bash
uv run src/orchestration/wos_uow_detail_gen.py --uow-id uow_20260501_06b020
# prints: http://5.78.201.64:9101/files/<uuid>.html
```

## Functional patterns used

- **Pure functions over data:** `_fetch_uow_data`, `_fetch_audit_trail`, `_fetch_corrective_traces`, `_fetch_heartbeat_log`, `_fetch_token_data`, `_compute_elapsed`, `_estimate_cost`, `generate_html` — all take explicit arguments, no side effects
- **IO isolation at boundary:** only `generate_and_upload()` and `main()` perform IO (DB open, file write)
- **Composition:** `generate_and_upload()` composes the fetch functions and passes results to `generate_html()`, which is a pure string renderer
- **Graceful degradation:** `_fetch_corrective_traces` and `_fetch_heartbeat_log` catch `sqlite3.OperationalError` and return `[]` for pre-migration DBs missing those tables

## Changes scope

`wos_dashboard_gen.py` and `wos_dashboard.py` are not modified. This is a purely additive file.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_uow_detail_gen.py -v` — **32 passed, 0 failed**
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_dashboard.py tests/unit/test_orchestration/test_wos_metrics_report.py -q` — **47 passed** (no regressions in related files)
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_orchestration/test_registry_cli.py -q` — **598 passed, 24 skipped, 1 pre-existing failure** (`test_disabled_job_writes_no_inbox_message` in `test_dispatch_job_sh.py` — unrelated to this PR, fails on main too)
- [ ] Live bisque URL check — blocked: bisque relay is not currently running on port 9101. File was written to `~/messages/bisque-uploads/65e636dfacc34218bce897d5e1b99c7a.html` (29KB, contains `uow_20260501_06b020` 3x). URL will be serveable when relay restarts.

## Manual test

Generated a real drilldown for `uow_20260501_06b020` (done, pearl, has token data and 26 audit events + 5 heartbeats):

```bash
uv run src/orchestration/wos_uow_detail_gen.py \
  --uow-id uow_20260501_06b020 \
  --db ~/lobster-workspace/orchestration/registry.db \
  --ledger ~/lobster-workspace/data/token-ledger.jsonl
# Output: http://5.78.201.64:9101/files/65e636dfacc34218bce897d5e1b99c7a.html
```

File written to `~/messages/bisque-uploads/65e636dfacc34218bce897d5e1b99c7a.html` (29,107 bytes). Confirmed `uow_20260501_06b020` appears in the file. Bisque relay was not running at generation time; URL will be live once relay is up (same condition applies to the v4 dashboard).

User-visible outcome: not yet verified with live bisque relay. No Telegram message sent from this change (generation is on-demand by CLI).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see Manual test above
- [ ] User-visible outcome verified — bisque relay offline; URL format confirmed correct, file confirmed written
- [x] Side-effect audit: script writes one HTML file to bisque-uploads/ per invocation, no other writes, no floods, no unscoped writes
- [x] External service calls: none in automated tests; bisque relay path is write-to-filesystem (no HTTP call at generation time)

Closes #1115