### PR TITLE
feat(cc-usage): Type B cron poller for accurate CC quota data

### DIFF
--- a/scheduled-tasks/cc-usage-poller.py
+++ b/scheduled-tasks/cc-usage-poller.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+CC Usage Poller — poll claude.ai for accurate Claude Code quota data.
+
+Hits the claude.ai internal usage API with a stored session cookie to get
+authoritative 5-hour and 7-day quota percentages. Writes results to
+~/.claude/cc-budget/state.json so the data survives idle-through-reset
+cycles that leave the statusLine hook-written data stale.
+
+Problem context: state.json is only updated when Claude Code actively
+reports quota via the statusLine hook. During idle periods — including
+weekly quota resets — the file retains pre-reset numbers indefinitely.
+Observed in production: 138h stale (2026-05-04 → 2026-05-10). This
+poller eliminates that drift.
+
+Cron schedule (every 30 minutes):
+    */30 * * * * cd ~/lobster && uv run scheduled-tasks/cc-usage-poller.py >> ~/lobster-workspace/scheduled-jobs/logs/cc-usage-poller.log 2>&1 # LOBSTER-CC-USAGE-POLLER
+
+Type B dispatch: cron calls this script directly (no inbox/ message, no
+dispatcher involvement). The jobs.json enabled gate is checked at the top
+of main() so that runtime enable/disable is respected without touching cron.
+
+Session cookie:
+    Store the sessionKey cookie value (from claude.ai DevTools → Application
+    → Cookies → sessionKey) in ~/lobster-user-config/cc-usage-session-cookie
+    as a single plain-text line with no quotes.
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/cc-usage-poller.py [--dry-run]
+
+Related issue: dcetlin/Lobster#1101
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import urllib.request
+import urllib.error
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("cc-usage-poller")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# The internal Claude API endpoint that returns quota usage.
+# Same endpoint ClaudeMeter (eddmann) uses: https://github.com/eddmann/ClaudeMeter
+USAGE_API_URL = "https://claude.ai/api/usage"
+
+# Cookie config file — stores the claude.ai sessionKey value
+COOKIE_CONFIG_PATH = Path.home() / "lobster-user-config" / "cc-usage-session-cookie"
+
+# State file — written by this script and by the statusLine hook (cc-usage-collect.sh)
+STATE_FILE_PATH = Path.home() / ".claude" / "cc-budget" / "state.json"
+
+# Source tag written into state.json to distinguish poller-written data
+# from hook-written data
+SOURCE_TAG = "cc-usage-poller"
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate
+# ---------------------------------------------------------------------------
+
+
+def _is_job_enabled(job_name: str) -> bool:
+    """
+    Return True if the job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when jobs.json is absent, the entry is missing, or the
+    file is unreadable — mirrors the gate logic in other Type B jobs.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+    try:
+        data = json.loads(jobs_file.read_text())
+        return bool(data.get("jobs", {}).get(job_name, {}).get("enabled", True))
+    except Exception:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Cookie reading — pure function, no side effects
+# ---------------------------------------------------------------------------
+
+
+def read_session_cookie(cookie_path: Path) -> str | None:
+    """
+    Read the session cookie from the config file.
+
+    Returns None (not an error) when:
+    - File does not exist — cookie not yet configured
+    - File exists but contains only comments or whitespace
+
+    Returns the cookie string when a non-comment, non-empty line is found.
+    """
+    if not cookie_path.exists():
+        return None
+    lines = cookie_path.read_text().splitlines()
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return None
+
+
+# ---------------------------------------------------------------------------
+# API call — isolated side effect
+# ---------------------------------------------------------------------------
+
+
+def fetch_usage(session_cookie: str) -> dict[str, Any]:
+    """
+    Make an authenticated GET to USAGE_API_URL.
+
+    Returns the parsed JSON response body.
+
+    Raises:
+        urllib.error.HTTPError — for 4xx/5xx responses
+        urllib.error.URLError — for network-level errors
+        json.JSONDecodeError — if the response body is not valid JSON
+        ValueError — if required keys are missing from the response
+    """
+    request = urllib.request.Request(
+        USAGE_API_URL,
+        headers={
+            "Cookie": f"sessionKey={session_cookie}",
+            "Accept": "application/json",
+            "User-Agent": "lobster-cc-usage-poller/1.0",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        body = response.read().decode("utf-8")
+    return json.loads(body)
+
+
+# ---------------------------------------------------------------------------
+# Response parsing — pure function
+# ---------------------------------------------------------------------------
+
+
+def parse_usage_response(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Extract quota fields from the API response.
+
+    The claude.ai /api/usage endpoint returns a structure like:
+    {
+      "rate_limits": {
+        "five_hour": { "used_percentage": 24.5, "resets_at": 1712345678 },
+        "seven_day":  { "used_percentage": 31.2, "resets_at": 1712987654 }
+      }
+    }
+
+    This is the same shape the statusLine hook receives, so the same field
+    paths are used. Returns a normalized dict suitable for merging into
+    state.json.
+
+    Raises ValueError if expected keys are absent.
+    """
+    rate_limits = data.get("rate_limits")
+    if not rate_limits:
+        # Try alternate response shape where usage is nested under a
+        # "usage" key — some endpoint variants return this
+        rate_limits = data.get("usage", {}).get("rate_limits")
+    if not rate_limits:
+        raise ValueError(
+            f"Expected 'rate_limits' key in response. Got keys: {list(data.keys())}"
+        )
+
+    five_hour = rate_limits.get("five_hour", {})
+    seven_day = rate_limits.get("seven_day", {})
+
+    # Normalize: accept both 'used_percentage' (API) and 'pct' (state.json) spellings
+    def _pct(obj: dict) -> float | None:
+        v = obj.get("used_percentage") or obj.get("pct")
+        return float(v) if v is not None else None
+
+    def _resets_at(obj: dict) -> int | None:
+        v = obj.get("resets_at")
+        return int(v) if v is not None else None
+
+    return {
+        "five_hour_pct": _pct(five_hour),
+        "five_hour_resets_at": _resets_at(five_hour),
+        "seven_day_pct": _pct(seven_day),
+        "seven_day_resets_at": _resets_at(seven_day),
+    }
+
+
+# ---------------------------------------------------------------------------
+# State file merge — pure function, produces new state dict
+# ---------------------------------------------------------------------------
+
+
+def merge_into_state(existing: dict[str, Any], parsed: dict[str, Any]) -> dict[str, Any]:
+    """
+    Merge parsed usage fields into the existing state.json content.
+
+    Preserves all fields not written by this script (v, session_cost_usd,
+    snapshots) so the hook-written data is not lost.
+    """
+    now_unix = int(datetime.now(tz=timezone.utc).timestamp())
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
+
+    updated = dict(existing)
+    updated["v"] = existing.get("v", 1)
+    updated["ts"] = now_unix
+    updated["rate_limits"] = {
+        "five_hour": {
+            "pct": parsed["five_hour_pct"],
+            "resets_at": parsed["five_hour_resets_at"],
+        },
+        "seven_day": {
+            "pct": parsed["seven_day_pct"],
+            "resets_at": parsed["seven_day_resets_at"],
+        },
+    }
+    updated["last_updated"] = now_iso
+    updated["source"] = SOURCE_TAG
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Atomic state write — isolated side effect
+# ---------------------------------------------------------------------------
+
+
+def write_state_atomically(state: dict[str, Any], state_path: Path) -> None:
+    """
+    Write state dict to state_path atomically via a temp file + rename.
+
+    Creates parent directories if needed. Atomic rename prevents a partial
+    write from leaving state_path in a corrupted state.
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=state_path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            json.dump(state, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_path, state_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Load existing state — handles missing file gracefully
+# ---------------------------------------------------------------------------
+
+
+def load_existing_state(state_path: Path) -> dict[str, Any]:
+    """Return the current state.json contents, or {} if absent or unreadable."""
+    try:
+        return json.loads(state_path.read_text())
+    except Exception:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(dry_run: bool = False) -> int:
+    """
+    Poll claude.ai for CC quota data and write to state.json.
+
+    Returns 0 on success, 1 on hard failure (unexpected errors).
+    Auth failures and missing cookie return 0 (graceful skip — cron retries).
+    """
+    if not _is_job_enabled("cc-usage-poller"):
+        log.info("cc-usage-poller is disabled in jobs.json — skipping")
+        return 0
+
+    # Step 1: Read session cookie
+    cookie = read_session_cookie(COOKIE_CONFIG_PATH)
+    if cookie is None:
+        log.warning(
+            "Session cookie not configured. Create %s and paste your claude.ai "
+            "sessionKey cookie value (from DevTools → Application → Cookies → sessionKey). "
+            "Skipping this run.",
+            COOKIE_CONFIG_PATH,
+        )
+        return 0
+
+    if dry_run:
+        log.info("[dry-run] Would poll %s with session cookie from %s", USAGE_API_URL, COOKIE_CONFIG_PATH)
+        log.info("[dry-run] Would write to %s", STATE_FILE_PATH)
+        return 0
+
+    # Step 2: Fetch usage from claude.ai
+    try:
+        raw_response = fetch_usage(cookie)
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            log.error(
+                "Auth error %d from %s — session cookie may be expired. "
+                "Refresh it: DevTools → Application → Cookies → sessionKey → copy value → "
+                "paste into %s",
+                exc.code,
+                USAGE_API_URL,
+                COOKIE_CONFIG_PATH,
+            )
+        else:
+            log.error("HTTP %d from %s — will retry on next cron run", exc.code, USAGE_API_URL)
+        return 0
+    except urllib.error.URLError as exc:
+        log.error("Network error polling %s: %s — will retry on next cron run", USAGE_API_URL, exc.reason)
+        return 0
+
+    # Step 3: Parse response
+    try:
+        parsed = parse_usage_response(raw_response)
+    except (ValueError, KeyError) as exc:
+        snippet = json.dumps(raw_response)[:300]
+        log.error(
+            "Failed to parse usage response: %s. Raw response snippet: %s",
+            exc,
+            snippet,
+        )
+        return 0
+
+    # Step 4: Merge into existing state
+    existing = load_existing_state(STATE_FILE_PATH)
+    new_state = merge_into_state(existing, parsed)
+
+    # Step 5: Write atomically
+    try:
+        write_state_atomically(new_state, STATE_FILE_PATH)
+    except OSError as exc:
+        log.error("Failed to write state file %s: %s", STATE_FILE_PATH, exc)
+        return 1
+
+    log.info(
+        "Updated %s — 5h: %.1f%% (resets_at: %s), 7d: %.1f%% (resets_at: %s)",
+        STATE_FILE_PATH,
+        parsed["five_hour_pct"] or 0.0,
+        parsed["five_hour_resets_at"],
+        parsed["seven_day_pct"] or 0.0,
+        parsed["seven_day_resets_at"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Poll claude.ai for CC quota data")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be done without making any HTTP requests or writing files",
+    )
+    args = parser.parse_args()
+    sys.exit(main(dry_run=args.dry_run))

--- a/scheduled-tasks/cc-usage-poller.py
+++ b/scheduled-tasks/cc-usage-poller.py
@@ -13,6 +13,20 @@ weekly quota resets — the file retains pre-reset numbers indefinitely.
 Observed in production: 138h stale (2026-05-04 → 2026-05-10). This
 poller eliminates that drift.
 
+API flow:
+    1. GET /api/bootstrap  → find the org with CC plan (seat_tier check)
+    2. GET /api/organizations/{org_id}/usage  → quota percentages
+
+Both endpoints are on claude.ai and protected by Cloudflare. The script
+uses cloudscraper to handle the CF JS challenge automatically.
+
+Response shape from /api/organizations/{org_id}/usage:
+    {
+      "five_hour":  { "utilization": 51.0, "resets_at": "<ISO8601>" },
+      "seven_day":  { "utilization": 28.0, "resets_at": "<ISO8601>" },
+      ...
+    }
+
 Cron schedule (every 30 minutes):
     */30 * * * * cd ~/lobster && uv run scheduled-tasks/cc-usage-poller.py >> ~/lobster-workspace/scheduled-jobs/logs/cc-usage-poller.log 2>&1 # LOBSTER-CC-USAGE-POLLER
 
@@ -25,11 +39,21 @@ Session cookie:
     → Cookies → sessionKey) in ~/lobster-user-config/cc-usage-session-cookie
     as a single plain-text line with no quotes.
 
+Dependencies (auto-installed by uv):
+    cloudscraper — handles Cloudflare IUAM/bot-detection challenges
+
 Run standalone:
     uv run ~/lobster/scheduled-tasks/cc-usage-poller.py [--dry-run]
 
 Related issue: dcetlin/Lobster#1101
 """
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "cloudscraper",
+# ]
+# ///
 
 from __future__ import annotations
 
@@ -43,9 +67,6 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-
-import urllib.request
-import urllib.error
 
 # ---------------------------------------------------------------------------
 # Path setup — allow running as a script or via importlib (tests)
@@ -70,9 +91,11 @@ log = logging.getLogger("cc-usage-poller")
 # Constants
 # ---------------------------------------------------------------------------
 
-# The internal Claude API endpoint that returns quota usage.
-# Same endpoint ClaudeMeter (eddmann) uses: https://github.com/eddmann/ClaudeMeter
-USAGE_API_URL = "https://claude.ai/api/usage"
+# Bootstrap endpoint — returns account info and org memberships
+BOOTSTRAP_URL = "https://claude.ai/api/bootstrap"
+
+# Org usage endpoint template — substitute org UUID
+ORG_USAGE_URL = "https://claude.ai/api/organizations/{org_id}/usage"
 
 # Cookie config file — stores the claude.ai sessionKey value
 COOKIE_CONFIG_PATH = Path.home() / "lobster-user-config" / "cc-usage-session-cookie"
@@ -93,9 +116,9 @@ COOKIE_EXPIRY_SENTINEL_PREFIX = "/tmp/cc-usage-cookie-expired-alert-"
 
 # Text of the cookie-expiry Telegram alert
 COOKIE_EXPIRY_ALERT_TEXT = (
-    "⚠️ CC usage cookie expired — paste a new session key into "
+    "CC usage cookie expired — paste a new session key into "
     "~/lobster-user-config/cc-usage-session-cookie\n\n"
-    "Get it from: claude.ai → DevTools → Application → Cookies → sessionKey"
+    "Get it from: claude.ai -> DevTools -> Application -> Cookies -> sessionKey"
 )
 
 # ---------------------------------------------------------------------------
@@ -220,33 +243,99 @@ def read_session_cookie(cookie_path: Path) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# HTTP client — cloudscraper bypasses Cloudflare IUAM/bot-detection
+# ---------------------------------------------------------------------------
+
+
+def _make_scraper(session_cookie: str):
+    """
+    Create a cloudscraper session with the sessionKey cookie set.
+
+    cloudscraper handles Cloudflare's JavaScript challenge (IUAM) automatically,
+    which plain urllib/requests cannot do. The sessionKey cookie is set on the
+    claude.ai domain.
+    """
+    import cloudscraper  # type: ignore[import-untyped]
+
+    scraper = cloudscraper.create_scraper()
+    scraper.cookies.set("sessionKey", session_cookie, domain="claude.ai")
+    return scraper
+
+
+# ---------------------------------------------------------------------------
+# Org discovery — find the org with the CC plan via /api/bootstrap
+# ---------------------------------------------------------------------------
+
+
+def discover_cc_org_id(scraper: Any) -> str:
+    """
+    Call /api/bootstrap and return the org UUID for the Claude Code plan.
+
+    Strategy: prefer the org with seat_tier containing 'claude_max' or
+    'pro' (CC plan). Fall back to the first non-individual org. If only
+    one org exists, return it.
+
+    Raises ValueError if no org can be identified.
+    Raises requests.HTTPError / CloudScraper exceptions on auth failure.
+    """
+    resp = scraper.get(BOOTSTRAP_URL, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+
+    memberships = data.get("account", {}).get("memberships", [])
+    if not memberships:
+        raise ValueError("No org memberships found in /api/bootstrap response")
+
+    # Score each membership: higher score = more likely the CC plan org
+    def _score(m: dict) -> int:
+        org = m.get("organization", {})
+        name = (org.get("name") or "").lower()
+        seat_tier = (m.get("seat_tier") or "").lower()
+        score = 0
+        # Prefer orgs with claude_max or pro tier
+        if "claude_max" in seat_tier or "max" in seat_tier:
+            score += 10
+        if "pro" in seat_tier:
+            score += 5
+        # Avoid "individual org" (usually a personal placeholder)
+        if "individual" in name:
+            score -= 3
+        return score
+
+    best = max(memberships, key=_score)
+    org_id = best.get("organization", {}).get("uuid")
+    if not org_id:
+        raise ValueError("Could not extract org UUID from bootstrap membership")
+
+    org_name = best.get("organization", {}).get("name", "unknown")
+    seat_tier = best.get("seat_tier", "unknown")
+    log.info("Using org '%s' (id=%s, seat_tier=%s)", org_name, org_id, seat_tier)
+    return org_id
+
+
+# ---------------------------------------------------------------------------
 # API call — isolated side effect
 # ---------------------------------------------------------------------------
 
 
 def fetch_usage(session_cookie: str) -> dict[str, Any]:
     """
-    Make an authenticated GET to USAGE_API_URL.
+    Discover the CC org and fetch usage from /api/organizations/{org_id}/usage.
 
     Returns the parsed JSON response body.
 
     Raises:
-        urllib.error.HTTPError — for 4xx/5xx responses
-        urllib.error.URLError — for network-level errors
+        requests.HTTPError — for 4xx/5xx responses (after CF challenge is handled)
+        requests.ConnectionError / Timeout — for network-level errors
         json.JSONDecodeError — if the response body is not valid JSON
-        ValueError — if required keys are missing from the response
+        ValueError — if org discovery fails
     """
-    request = urllib.request.Request(
-        USAGE_API_URL,
-        headers={
-            "Cookie": f"sessionKey={session_cookie}",
-            "Accept": "application/json",
-            "User-Agent": "lobster-cc-usage-poller/1.0",
-        },
-    )
-    with urllib.request.urlopen(request, timeout=30) as response:
-        body = response.read().decode("utf-8")
-    return json.loads(body)
+    scraper = _make_scraper(session_cookie)
+    org_id = discover_cc_org_id(scraper)
+    url = ORG_USAGE_URL.format(org_id=org_id)
+    resp = scraper.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
 
 
 # ---------------------------------------------------------------------------
@@ -256,43 +345,37 @@ def fetch_usage(session_cookie: str) -> dict[str, Any]:
 
 def parse_usage_response(data: dict[str, Any]) -> dict[str, Any]:
     """
-    Extract quota fields from the API response.
+    Extract quota fields from the /api/organizations/{org_id}/usage response.
 
-    The claude.ai /api/usage endpoint returns a structure like:
+    The endpoint returns a structure like:
     {
-      "rate_limits": {
-        "five_hour": { "used_percentage": 24.5, "resets_at": 1712345678 },
-        "seven_day":  { "used_percentage": 31.2, "resets_at": 1712987654 }
-      }
+      "five_hour":  { "utilization": 51.0, "resets_at": "<ISO8601>" },
+      "seven_day":  { "utilization": 28.0, "resets_at": "<ISO8601>" },
+      "seven_day_sonnet": { "utilization": 42.0, "resets_at": "<ISO8601>" },
+      ...
     }
 
-    This is the same shape the statusLine hook receives, so the same field
-    paths are used. Returns a normalized dict suitable for merging into
-    state.json.
-
+    Returns a normalized dict suitable for merging into state.json.
     Raises ValueError if expected keys are absent.
     """
-    rate_limits = data.get("rate_limits")
-    if not rate_limits:
-        # Try alternate response shape where usage is nested under a
-        # "usage" key — some endpoint variants return this
-        rate_limits = data.get("usage", {}).get("rate_limits")
-    if not rate_limits:
+    five_hour = data.get("five_hour")
+    seven_day = data.get("seven_day")
+
+    if five_hour is None and seven_day is None:
         raise ValueError(
-            f"Expected 'rate_limits' key in response. Got keys: {list(data.keys())}"
+            f"Expected 'five_hour' or 'seven_day' keys in response. Got keys: {list(data.keys())}"
         )
 
-    five_hour = rate_limits.get("five_hour", {})
-    seven_day = rate_limits.get("seven_day", {})
-
-    # Normalize: accept both 'used_percentage' (API) and 'pct' (state.json) spellings
-    def _pct(obj: dict) -> float | None:
-        v = obj.get("used_percentage") or obj.get("pct")
+    def _pct(obj: dict | None) -> float | None:
+        if obj is None:
+            return None
+        v = obj.get("utilization")
         return float(v) if v is not None else None
 
-    def _resets_at(obj: dict) -> int | None:
-        v = obj.get("resets_at")
-        return int(v) if v is not None else None
+    def _resets_at(obj: dict | None) -> str | None:
+        if obj is None:
+            return None
+        return obj.get("resets_at")
 
     return {
         "five_hour_pct": _pct(five_hour),
@@ -396,36 +479,39 @@ def main(dry_run: bool = False) -> int:
     if cookie is None:
         log.warning(
             "Session cookie not configured. Create %s and paste your claude.ai "
-            "sessionKey cookie value (from DevTools → Application → Cookies → sessionKey). "
+            "sessionKey cookie value (from DevTools -> Application -> Cookies -> sessionKey). "
             "Skipping this run.",
             COOKIE_CONFIG_PATH,
         )
         return 0
 
     if dry_run:
-        log.info("[dry-run] Would poll %s with session cookie from %s", USAGE_API_URL, COOKIE_CONFIG_PATH)
+        log.info(
+            "[dry-run] Would call %s then %s with session cookie from %s",
+            BOOTSTRAP_URL,
+            ORG_USAGE_URL,
+            COOKIE_CONFIG_PATH,
+        )
         log.info("[dry-run] Would write to %s", STATE_FILE_PATH)
         return 0
 
-    # Step 2: Fetch usage from claude.ai
+    # Step 2: Fetch usage from claude.ai (via cloudscraper to handle CF challenge)
     try:
         raw_response = fetch_usage(cookie)
-    except urllib.error.HTTPError as exc:
-        if exc.code in (401, 403):
+    except Exception as exc:
+        # Detect auth errors from requests/cloudscraper HTTPError
+        http_code = getattr(getattr(exc, "response", None), "status_code", None)
+        if http_code in (401, 403):
             log.error(
-                "Auth error %d from %s — session cookie may be expired. "
-                "Refresh it: DevTools → Application → Cookies → sessionKey → copy value → "
+                "Auth error %d from claude.ai — session cookie may be expired. "
+                "Refresh it: DevTools -> Application -> Cookies -> sessionKey -> copy value -> "
                 "paste into %s",
-                exc.code,
-                USAGE_API_URL,
+                http_code,
                 COOKIE_CONFIG_PATH,
             )
-            _write_cookie_expiry_alert(exc.code, dry_run=dry_run)
-        else:
-            log.error("HTTP %d from %s — will retry on next cron run", exc.code, USAGE_API_URL)
-        return 0
-    except urllib.error.URLError as exc:
-        log.error("Network error polling %s: %s — will retry on next cron run", USAGE_API_URL, exc.reason)
+            _write_cookie_expiry_alert(http_code, dry_run=dry_run)
+            return 0
+        log.error("Error fetching usage from claude.ai: %s — will retry on next cron run", exc)
         return 0
 
     # Step 3: Parse response

--- a/scheduled-tasks/cc-usage-poller.py
+++ b/scheduled-tasks/cc-usage-poller.py
@@ -39,6 +39,7 @@ import logging
 import os
 import sys
 import tempfile
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -82,6 +83,95 @@ STATE_FILE_PATH = Path.home() / ".claude" / "cc-budget" / "state.json"
 # Source tag written into state.json to distinguish poller-written data
 # from hook-written data
 SOURCE_TAG = "cc-usage-poller"
+
+# Telegram chat_id for cookie-expiry alert delivery
+ADMIN_CHAT_ID = 8075091586
+
+# Sentinel file prefix — one file per calendar date prevents repeated alerts
+# Format: /tmp/cc-usage-cookie-expired-alert-YYYY-MM-DD
+COOKIE_EXPIRY_SENTINEL_PREFIX = "/tmp/cc-usage-cookie-expired-alert-"
+
+# Text of the cookie-expiry Telegram alert
+COOKIE_EXPIRY_ALERT_TEXT = (
+    "⚠️ CC usage cookie expired — paste a new session key into "
+    "~/lobster-user-config/cc-usage-session-cookie\n\n"
+    "Get it from: claude.ai → DevTools → Application → Cookies → sessionKey"
+)
+
+# ---------------------------------------------------------------------------
+# Cookie-expiry alert — inbox injection with per-day rate limiting
+# ---------------------------------------------------------------------------
+
+
+def _inbox_dir() -> Path:
+    """Return the inbox directory path, respecting LOBSTER_MESSAGES env override."""
+    messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+    return messages_base / "inbox"
+
+
+def _cookie_expiry_alert_already_sent_today() -> bool:
+    """
+    Return True if a cookie-expiry alert sentinel exists for today's date.
+
+    Sentinel file format: /tmp/cc-usage-cookie-expired-alert-YYYY-MM-DD
+    Creates one sentinel per calendar day to prevent alert floods when the
+    cron runs every 30 minutes and the cookie stays expired all day.
+    """
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    return Path(f"{COOKIE_EXPIRY_SENTINEL_PREFIX}{today}").exists()
+
+
+def _write_cookie_expiry_alert(http_code: int, dry_run: bool = False) -> None:
+    """
+    Write a cookie-expiry alert to the Lobster inbox and touch the daily sentinel.
+
+    The dispatcher picks up the inbox message on its next cycle and delivers
+    it to the user via Telegram. Fire-and-forget — no delivery confirmation.
+
+    Rate-limited to one alert per calendar day via /tmp sentinel file.
+    In dry_run mode: logs the intent but does not write files.
+    """
+    if _cookie_expiry_alert_already_sent_today():
+        log.info("Cookie-expiry alert already sent today — skipping duplicate")
+        return
+
+    msg_id = str(uuid.uuid4())
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "type": "message",
+        "chat_id": ADMIN_CHAT_ID,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "text": COOKIE_EXPIRY_ALERT_TEXT,
+    }
+
+    if dry_run:
+        log.info(
+            "[dry-run] Would write cookie-expiry alert (HTTP %d) to inbox: %s",
+            http_code,
+            msg["text"][:80],
+        )
+        return
+
+    try:
+        inbox = _inbox_dir()
+        inbox.mkdir(parents=True, exist_ok=True)
+        tmp_path = inbox / f"{msg_id}.json.tmp"
+        dest_path = inbox / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+        tmp_path.rename(dest_path)
+        log.info("Wrote cookie-expiry alert %s to inbox", msg_id)
+    except Exception as exc:
+        log.warning("Failed to write cookie-expiry alert to inbox: %s", exc)
+        return
+
+    # Touch the sentinel — prevents re-alerting for the rest of today
+    try:
+        today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+        Path(f"{COOKIE_EXPIRY_SENTINEL_PREFIX}{today}").touch()
+    except Exception as exc:
+        log.warning("Failed to write cookie-expiry sentinel: %s", exc)
+
 
 # ---------------------------------------------------------------------------
 # jobs.json enabled gate
@@ -330,6 +420,7 @@ def main(dry_run: bool = False) -> int:
                 USAGE_API_URL,
                 COOKIE_CONFIG_PATH,
             )
+            _write_cookie_expiry_alert(exc.code, dry_run=dry_run)
         else:
             log.error("HTTP %d from %s — will retry on next cron run", exc.code, USAGE_API_URL)
         return 0

--- a/scheduled-tasks/cc-usage-poller.py
+++ b/scheduled-tasks/cc-usage-poller.py
@@ -85,7 +85,7 @@ STATE_FILE_PATH = Path.home() / ".claude" / "cc-budget" / "state.json"
 SOURCE_TAG = "cc-usage-poller"
 
 # Telegram chat_id for cookie-expiry alert delivery
-ADMIN_CHAT_ID = 8075091586
+ADMIN_CHAT_ID: int = int(os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586"))
 
 # Sentinel file prefix — one file per calendar date prevents repeated alerts
 # Format: /tmp/cc-usage-cookie-expired-alert-YYYY-MM-DD

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3703,6 +3703,51 @@ print('executor_pid column added')
         substep "Migration 93: context-handoff.json absent — skipping"
     fi
 
+    # Migration 107: Add cc-usage-poller cron entry and cookie config slot (issue #1101).
+    #
+    # cc-usage-poller.py is a Type B cron script that polls claude.ai/api/usage with a
+    # stored session cookie every 30 minutes, writing authoritative quota percentages to
+    # ~/.claude/cc-budget/state.json. This fixes idle-through-reset staleness: the file
+    # was previously only updated by the statusLine hook during active CC sessions.
+    #
+    # The cookie config file is created as a comment-only placeholder if it does not
+    # exist. The user must paste their claude.ai sessionKey cookie value to activate
+    # polling — the script exits gracefully (return 0) until the cookie is present.
+    local CC_USAGE_POLLER_MARKER="# LOBSTER-CC-USAGE-POLLER"
+    if ! crontab -l 2>/dev/null | grep -q "$CC_USAGE_POLLER_MARKER"; then
+        if ! $DRY_RUN; then
+            "$LOBSTER_DIR/scripts/cron-manage.sh" add "$CC_USAGE_POLLER_MARKER" \
+                "*/30 * * * * cd $HOME/lobster && uv run scheduled-tasks/cc-usage-poller.py >> ${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/scheduled-jobs/logs/cc-usage-poller.log 2>&1 $CC_USAGE_POLLER_MARKER"
+            substep "Migration 107: added cc-usage-poller cron entry (every 30 minutes)"
+        else
+            substep "Migration 107 (dry-run): would add cc-usage-poller cron entry"
+        fi
+        migrated=$((migrated + 1))
+    else
+        substep "Migration 107: cc-usage-poller cron entry already present — skipping"
+    fi
+
+    # Create the session cookie config file if it does not exist.
+    local _cookie_config="${LOBSTER_USER_CONFIG:-$HOME/lobster-user-config}/cc-usage-session-cookie"
+    if [ ! -f "$_cookie_config" ]; then
+        if ! $DRY_RUN; then
+            cat > "$_cookie_config" <<'COOKIE_EOF'
+# Paste your claude.ai session cookie here (single line, no quotes)
+# Get it from: DevTools → Application → Cookies → claude.ai → sessionKey
+# The value looks like: sk-ant-sid01-...
+COOKIE_EOF
+            substep "Migration 107: created cookie config placeholder at $_cookie_config"
+        else
+            substep "Migration 107 (dry-run): would create cookie config at $_cookie_config"
+        fi
+    fi
+
+    # Ensure log file exists.
+    local _cc_log="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/scheduled-jobs/logs/cc-usage-poller.log"
+    if [ ! -f "$_cc_log" ] && ! $DRY_RUN; then
+        touch "$_cc_log" 2>/dev/null || true
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3736,6 +3736,7 @@ print('executor_pid column added')
 # Get it from: DevTools → Application → Cookies → claude.ai → sessionKey
 # The value looks like: sk-ant-sid01-...
 COOKIE_EOF
+            chmod 600 "$_cookie_config"
             substep "Migration 107: created cookie config placeholder at $_cookie_config"
         else
             substep "Migration 107 (dry-run): would create cookie config at $_cookie_config"

--- a/tests/unit/test_cc_usage_poller_expiry_alert.py
+++ b/tests/unit/test_cc_usage_poller_expiry_alert.py
@@ -1,0 +1,268 @@
+"""
+Tests for cc-usage-poller.py — cookie-expiry alert feature.
+
+Behavioral spec (from issue #1122 / cc-poller-expiry-alert task):
+- A 401 or 403 HTTP response triggers an inbox message that delivers
+  a Telegram alert to Dan.
+- The alert is rate-limited: only one per calendar day (UTC). A second
+  401 on the same day must NOT write another inbox file.
+- Alert rate-limit resets on the next calendar day.
+- The inbox message has the required fields: id, source, type, chat_id,
+  timestamp, text.
+- In dry_run mode no inbox file is written and no sentinel is created.
+- The sentinel path respects the COOKIE_EXPIRY_SENTINEL_PREFIX constant.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import urllib.error
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the module under test from its script path
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent
+    / "scheduled-tasks"
+    / "cc-usage-poller.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cc_usage_poller", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cp = _load_module()
+
+# Named constants mirrored from module — changes here are intentional and
+# signal a spec change, not just an implementation change.
+ADMIN_CHAT_ID = 8075091586
+SENTINEL_PREFIX = "/tmp/cc-usage-cookie-expired-alert-"
+
+
+# ---------------------------------------------------------------------------
+# Helper — build a fake HTTPError for a given HTTP status code
+# ---------------------------------------------------------------------------
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://claude.ai/api/usage",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=None,
+        fp=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — _cookie_expiry_alert_already_sent_today
+# ---------------------------------------------------------------------------
+
+class TestAlreadySentToday:
+    def test_returns_false_when_no_sentinel_exists(self, tmp_path):
+        """No sentinel file → not yet sent today."""
+        today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+        # Ensure the file does not exist (it shouldn't in tmp, but be explicit)
+        sentinel = tmp_path / f"cc-usage-cookie-expired-alert-{today}"
+        assert not sentinel.exists()
+
+        with patch.object(Path, "exists", return_value=False):
+            assert cp._cookie_expiry_alert_already_sent_today() is False
+
+    def test_returns_true_when_sentinel_exists(self):
+        """Sentinel file present → already sent today."""
+        with patch.object(Path, "exists", return_value=True):
+            assert cp._cookie_expiry_alert_already_sent_today() is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — _write_cookie_expiry_alert
+# ---------------------------------------------------------------------------
+
+class TestWriteCookieExpiryAlert:
+    def test_writes_inbox_message_with_required_fields(self, tmp_path):
+        """On first call (no sentinel), inbox file is written with all required fields."""
+        inbox = tmp_path / "inbox"
+        sentinel_dir = tmp_path / "sentinels"
+        sentinel_dir.mkdir()
+
+        today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+        sentinel_path = sentinel_dir / f"cc-usage-cookie-expired-alert-{today}"
+
+        with (
+            patch.object(cp, "_inbox_dir", return_value=inbox),
+            patch.object(cp, "_cookie_expiry_alert_already_sent_today", return_value=False),
+            patch.object(cp, "COOKIE_EXPIRY_SENTINEL_PREFIX", str(sentinel_dir) + "/cc-usage-cookie-expired-alert-"),
+        ):
+            cp._write_cookie_expiry_alert(http_code=401)
+
+        # Exactly one JSON file written to inbox
+        json_files = list(inbox.glob("*.json"))
+        assert len(json_files) == 1
+
+        msg = json.loads(json_files[0].read_text())
+        assert msg["source"] == "system"
+        assert msg["type"] == "message"
+        assert msg["chat_id"] == ADMIN_CHAT_ID
+        assert "id" in msg
+        assert "timestamp" in msg
+        assert "cookie expired" in msg["text"].lower() or "cc usage" in msg["text"].lower()
+
+    def test_skips_when_already_sent_today(self, tmp_path):
+        """Second 401 on same day must not write another inbox message."""
+        inbox = tmp_path / "inbox"
+
+        with (
+            patch.object(cp, "_inbox_dir", return_value=inbox),
+            patch.object(cp, "_cookie_expiry_alert_already_sent_today", return_value=True),
+        ):
+            cp._write_cookie_expiry_alert(http_code=401)
+
+        assert not inbox.exists() or len(list(inbox.glob("*.json"))) == 0
+
+    def test_touches_sentinel_after_writing_inbox_message(self, tmp_path):
+        """After writing the inbox message, sentinel file is created."""
+        inbox = tmp_path / "inbox"
+        sentinel_dir = tmp_path / "sentinels"
+        sentinel_dir.mkdir()
+        today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+        with (
+            patch.object(cp, "_inbox_dir", return_value=inbox),
+            patch.object(cp, "_cookie_expiry_alert_already_sent_today", return_value=False),
+            patch.object(cp, "COOKIE_EXPIRY_SENTINEL_PREFIX", str(sentinel_dir) + "/cc-usage-cookie-expired-alert-"),
+        ):
+            cp._write_cookie_expiry_alert(http_code=403)
+
+        sentinel = sentinel_dir / f"cc-usage-cookie-expired-alert-{today}"
+        assert sentinel.exists()
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        """In dry_run mode: no inbox file, no sentinel."""
+        inbox = tmp_path / "inbox"
+        sentinel_dir = tmp_path / "sentinels"
+        sentinel_dir.mkdir()
+
+        with (
+            patch.object(cp, "_inbox_dir", return_value=inbox),
+            patch.object(cp, "_cookie_expiry_alert_already_sent_today", return_value=False),
+            patch.object(cp, "COOKIE_EXPIRY_SENTINEL_PREFIX", str(sentinel_dir) + "/cc-usage-cookie-expired-alert-"),
+        ):
+            cp._write_cookie_expiry_alert(http_code=401, dry_run=True)
+
+        # Nothing written
+        assert not inbox.exists() or len(list(inbox.glob("*.json"))) == 0
+        assert len(list(sentinel_dir.iterdir())) == 0
+
+    def test_inbox_file_written_atomically_via_tmp_rename(self, tmp_path):
+        """Inbox write uses .json.tmp → .json rename (no partial file visible)."""
+        inbox = tmp_path / "inbox"
+        sentinel_dir = tmp_path / "sentinels"
+        sentinel_dir.mkdir()
+
+        with (
+            patch.object(cp, "_inbox_dir", return_value=inbox),
+            patch.object(cp, "_cookie_expiry_alert_already_sent_today", return_value=False),
+            patch.object(cp, "COOKIE_EXPIRY_SENTINEL_PREFIX", str(sentinel_dir) + "/cc-usage-cookie-expired-alert-"),
+        ):
+            cp._write_cookie_expiry_alert(http_code=401)
+
+        # No .tmp files left behind
+        tmp_files = list(inbox.glob("*.tmp"))
+        assert tmp_files == []
+
+    def test_403_triggers_alert_same_as_401(self, tmp_path):
+        """Both 401 and 403 must trigger the alert (not just 401)."""
+        inbox = tmp_path / "inbox"
+        sentinel_dir = tmp_path / "sentinels"
+        sentinel_dir.mkdir()
+
+        with (
+            patch.object(cp, "_inbox_dir", return_value=inbox),
+            patch.object(cp, "_cookie_expiry_alert_already_sent_today", return_value=False),
+            patch.object(cp, "COOKIE_EXPIRY_SENTINEL_PREFIX", str(sentinel_dir) + "/cc-usage-cookie-expired-alert-"),
+        ):
+            cp._write_cookie_expiry_alert(http_code=403)
+
+        assert len(list(inbox.glob("*.json"))) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — main() integration: alert triggered on 401/403 HTTP response
+# ---------------------------------------------------------------------------
+
+class TestMainAlertOnAuthError:
+    def _make_mock_cookie(self, tmp_path: Path) -> Path:
+        cookie_file = tmp_path / "cc-usage-session-cookie"
+        cookie_file.write_text("test-session-key\n")
+        return cookie_file
+
+    def test_main_calls_alert_on_401(self, tmp_path):
+        """main() must call _write_cookie_expiry_alert when fetch returns 401."""
+        cookie_file = self._make_mock_cookie(tmp_path)
+
+        with (
+            patch.object(cp, "COOKIE_CONFIG_PATH", cookie_file),
+            patch.object(cp, "_is_job_enabled", return_value=True),
+            patch.object(cp, "fetch_usage", side_effect=_http_error(401)),
+            patch.object(cp, "_write_cookie_expiry_alert") as mock_alert,
+        ):
+            result = cp.main(dry_run=False)
+
+        assert result == 0
+        mock_alert.assert_called_once_with(401, dry_run=False)
+
+    def test_main_calls_alert_on_403(self, tmp_path):
+        """main() must call _write_cookie_expiry_alert when fetch returns 403."""
+        cookie_file = self._make_mock_cookie(tmp_path)
+
+        with (
+            patch.object(cp, "COOKIE_CONFIG_PATH", cookie_file),
+            patch.object(cp, "_is_job_enabled", return_value=True),
+            patch.object(cp, "fetch_usage", side_effect=_http_error(403)),
+            patch.object(cp, "_write_cookie_expiry_alert") as mock_alert,
+        ):
+            result = cp.main(dry_run=False)
+
+        assert result == 0
+        mock_alert.assert_called_once_with(403, dry_run=False)
+
+    def test_main_does_not_call_alert_on_500(self, tmp_path):
+        """main() must NOT call the alert for non-auth HTTP errors (e.g. 500)."""
+        cookie_file = self._make_mock_cookie(tmp_path)
+
+        with (
+            patch.object(cp, "COOKIE_CONFIG_PATH", cookie_file),
+            patch.object(cp, "_is_job_enabled", return_value=True),
+            patch.object(cp, "fetch_usage", side_effect=_http_error(500)),
+            patch.object(cp, "_write_cookie_expiry_alert") as mock_alert,
+        ):
+            result = cp.main(dry_run=False)
+
+        assert result == 0
+        mock_alert.assert_not_called()
+
+    def test_main_does_not_call_alert_on_dry_run(self, tmp_path):
+        """dry_run returns before the HTTP call — alert must not be called."""
+        cookie_file = self._make_mock_cookie(tmp_path)
+
+        with (
+            patch.object(cp, "COOKIE_CONFIG_PATH", cookie_file),
+            patch.object(cp, "_is_job_enabled", return_value=True),
+            patch.object(cp, "_write_cookie_expiry_alert") as mock_alert,
+        ):
+            result = cp.main(dry_run=True)
+
+        assert result == 0
+        mock_alert.assert_not_called()

--- a/tests/unit/test_scheduled_tasks/test_cc_usage_poller.py
+++ b/tests/unit/test_scheduled_tasks/test_cc_usage_poller.py
@@ -9,9 +9,8 @@ Named after behaviors:
   - test_skips_run_when_cookie_file_absent
   - test_skips_run_when_cookie_contains_only_comments
   - test_reads_cookie_from_first_non_comment_line
-  - test_parse_standard_rate_limits_response
-  - test_parse_response_with_alternate_used_percentage_key
-  - test_parse_response_raises_when_rate_limits_absent
+  - test_parse_standard_usage_response
+  - test_parse_response_raises_when_expected_keys_absent
   - test_merge_preserves_existing_snapshots_and_cost
   - test_merge_overwrites_rate_limits_and_timestamps
   - test_merge_sets_source_tag_to_poller
@@ -27,14 +26,22 @@ import importlib
 import importlib.util
 import json
 import textwrap
-import urllib.error
 from datetime import datetime
-from io import BytesIO
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+# requests exceptions are available at test-time through the cloudscraper
+# dependency pulled in by the poller script.
+try:
+    import requests.exceptions as _req_exc
+    _RequestsHTTPError = _req_exc.HTTPError
+    _RequestsConnectionError = _req_exc.ConnectionError
+except ImportError:  # pragma: no cover
+    _RequestsHTTPError = Exception
+    _RequestsConnectionError = Exception
 
 # ---------------------------------------------------------------------------
 # Load the script under test via importlib (it lives in scheduled-tasks/,
@@ -65,11 +72,11 @@ SOURCE_TAG = _mod.SOURCE_TAG
 # Fixtures
 # ---------------------------------------------------------------------------
 
+# Shape matches /api/organizations/{org_id}/usage as documented in cc-usage-poller.py:
+# { "five_hour": {"utilization": <float>, "resets_at": "<ISO8601>"}, "seven_day": {...}, ... }
 STANDARD_API_RESPONSE = {
-    "rate_limits": {
-        "five_hour": {"used_percentage": 24.5, "resets_at": 1712345678},
-        "seven_day": {"used_percentage": 31.2, "resets_at": 1712987654},
-    }
+    "five_hour": {"utilization": 24.5, "resets_at": "2026-05-10T12:00:00Z"},
+    "seven_day": {"utilization": 31.2, "resets_at": "2026-05-17T12:00:00Z"},
 }
 
 EXISTING_STATE = {
@@ -145,53 +152,25 @@ def test_reads_cookie_ignoring_leading_whitespace(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_standard_rate_limits_response() -> None:
-    """Standard API response with five_hour and seven_day is parsed correctly."""
+def test_parse_standard_usage_response() -> None:
+    """Standard API response with five_hour and seven_day at top level is parsed correctly."""
     result = parse_usage_response(STANDARD_API_RESPONSE)
     assert result["five_hour_pct"] == 24.5
     assert result["seven_day_pct"] == 31.2
-    assert result["five_hour_resets_at"] == 1712345678
-    assert result["seven_day_resets_at"] == 1712987654
+    assert result["five_hour_resets_at"] == "2026-05-10T12:00:00Z"
+    assert result["seven_day_resets_at"] == "2026-05-17T12:00:00Z"
 
 
-def test_parse_response_with_used_percentage_key() -> None:
-    """'used_percentage' key in API response maps to *_pct in parsed output."""
-    response = {
-        "rate_limits": {
-            "five_hour": {"used_percentage": 50.0, "resets_at": 999},
-            "seven_day": {"used_percentage": 75.0, "resets_at": 888},
-        }
-    }
-    result = parse_usage_response(response)
-    assert result["five_hour_pct"] == 50.0
-    assert result["seven_day_pct"] == 75.0
-
-
-def test_parse_response_with_pct_key_fallback() -> None:
-    """If 'used_percentage' is absent, 'pct' key is accepted as fallback."""
-    response = {
-        "rate_limits": {
-            "five_hour": {"pct": 33.0, "resets_at": 111},
-            "seven_day": {"pct": 66.0, "resets_at": 222},
-        }
-    }
-    result = parse_usage_response(response)
-    assert result["five_hour_pct"] == 33.0
-    assert result["seven_day_pct"] == 66.0
-
-
-def test_parse_response_raises_when_rate_limits_absent() -> None:
-    """Response without 'rate_limits' key raises ValueError with a descriptive message."""
-    with pytest.raises(ValueError, match="rate_limits"):
+def test_parse_response_raises_when_expected_keys_absent() -> None:
+    """Response without 'five_hour' or 'seven_day' keys raises ValueError."""
+    with pytest.raises(ValueError, match="five_hour"):
         parse_usage_response({"some_other_key": "value"})
 
 
 def test_parse_response_tolerates_missing_five_hour() -> None:
-    """If five_hour is absent from rate_limits, pct is None rather than raising."""
+    """If five_hour is absent, five_hour_pct is None rather than raising."""
     response = {
-        "rate_limits": {
-            "seven_day": {"used_percentage": 42.0, "resets_at": 333},
-        }
+        "seven_day": {"utilization": 42.0, "resets_at": "2026-05-17T12:00:00Z"},
     }
     result = parse_usage_response(response)
     assert result["five_hour_pct"] is None
@@ -204,9 +183,9 @@ def test_parse_response_tolerates_missing_five_hour() -> None:
 
 PARSED_USAGE = {
     "five_hour_pct": 24.5,
-    "five_hour_resets_at": 1712345678,
+    "five_hour_resets_at": "2026-05-10T12:00:00Z",
     "seven_day_pct": 31.2,
-    "seven_day_resets_at": 1712987654,
+    "seven_day_resets_at": "2026-05-17T12:00:00Z",
 }
 
 
@@ -222,8 +201,8 @@ def test_merge_overwrites_rate_limits_with_fresh_data() -> None:
     result = merge_into_state(EXISTING_STATE, PARSED_USAGE)
     assert result["rate_limits"]["five_hour"]["pct"] == 24.5
     assert result["rate_limits"]["seven_day"]["pct"] == 31.2
-    assert result["rate_limits"]["five_hour"]["resets_at"] == 1712345678
-    assert result["rate_limits"]["seven_day"]["resets_at"] == 1712987654
+    assert result["rate_limits"]["five_hour"]["resets_at"] == "2026-05-10T12:00:00Z"
+    assert result["rate_limits"]["seven_day"]["resets_at"] == "2026-05-17T12:00:00Z"
 
 
 def test_merge_sets_source_tag_to_poller() -> None:
@@ -294,17 +273,19 @@ def test_missing_cookie_exits_gracefully(tmp_path: Path) -> None:
 
 
 def test_auth_error_returns_0_not_1(tmp_path: Path) -> None:
-    """A 401 auth error is handled gracefully — returns 0 so cron does not stop retrying."""
+    """A 401 auth error is handled gracefully — returns 0 so cron does not stop retrying.
+
+    Production code detects auth errors via `exc.response.status_code` (the
+    requests/cloudscraper interface), so we inject a requests.HTTPError with a
+    mock response object carrying status_code=401.
+    """
     cookie_path = tmp_path / "cc-usage-session-cookie"
     cookie_path.write_text("sk-ant-fake-cookie\n")
 
-    http_error = urllib.error.HTTPError(
-        url="https://claude.ai/api/usage",
-        code=401,
-        msg="Unauthorized",
-        hdrs=None,  # type: ignore[arg-type]
-        fp=BytesIO(b""),
-    )
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    http_error = _RequestsHTTPError(response=mock_response)
+
     with (
         patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
         patch.object(_mod, "fetch_usage", side_effect=http_error),
@@ -314,14 +295,14 @@ def test_auth_error_returns_0_not_1(tmp_path: Path) -> None:
 
 
 def test_network_error_returns_0_not_1(tmp_path: Path) -> None:
-    """A network error is handled gracefully — returns 0 so cron does not stop retrying."""
+    """A network-level connection error is handled gracefully — returns 0."""
     cookie_path = tmp_path / "cc-usage-session-cookie"
     cookie_path.write_text("sk-ant-fake-cookie\n")
 
-    url_error = urllib.error.URLError(reason="Name or service not known")
+    conn_error = _RequestsConnectionError("Name or service not known")
     with (
         patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
-        patch.object(_mod, "fetch_usage", side_effect=url_error),
+        patch.object(_mod, "fetch_usage", side_effect=conn_error),
     ):
         result = main()
     assert result == 0

--- a/tests/unit/test_scheduled_tasks/test_cc_usage_poller.py
+++ b/tests/unit/test_scheduled_tasks/test_cc_usage_poller.py
@@ -1,0 +1,379 @@
+"""
+Unit tests for scheduled-tasks/cc-usage-poller.py.
+
+Tests are named after the behaviors they verify, not the implementation
+mechanisms. All network I/O and filesystem writes are absent from pure
+function tests — behaviors are isolated using in-memory data.
+
+Named after behaviors:
+  - test_skips_run_when_cookie_file_absent
+  - test_skips_run_when_cookie_contains_only_comments
+  - test_reads_cookie_from_first_non_comment_line
+  - test_parse_standard_rate_limits_response
+  - test_parse_response_with_alternate_used_percentage_key
+  - test_parse_response_raises_when_rate_limits_absent
+  - test_merge_preserves_existing_snapshots_and_cost
+  - test_merge_overwrites_rate_limits_and_timestamps
+  - test_merge_sets_source_tag_to_poller
+  - test_disabled_job_exits_without_polling
+  - test_auth_error_returns_0_not_1
+  - test_network_error_returns_0_not_1
+  - test_parse_error_returns_0_not_1
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import textwrap
+import urllib.error
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script under test via importlib (it lives in scheduled-tasks/,
+# not a package). The script uses only stdlib — no stubs needed.
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "scheduled-tasks"
+    / "cc-usage-poller.py"
+)
+
+spec = importlib.util.spec_from_file_location("cc_usage_poller", SCRIPT_PATH)
+_mod: ModuleType = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+# Pull names into local scope.
+read_session_cookie = _mod.read_session_cookie
+fetch_usage = _mod.fetch_usage
+parse_usage_response = _mod.parse_usage_response
+merge_into_state = _mod.merge_into_state
+write_state_atomically = _mod.write_state_atomically
+load_existing_state = _mod.load_existing_state
+main = _mod.main
+SOURCE_TAG = _mod.SOURCE_TAG
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+STANDARD_API_RESPONSE = {
+    "rate_limits": {
+        "five_hour": {"used_percentage": 24.5, "resets_at": 1712345678},
+        "seven_day": {"used_percentage": 31.2, "resets_at": 1712987654},
+    }
+}
+
+EXISTING_STATE = {
+    "v": 1,
+    "ts": 1777859892,
+    "rate_limits": {
+        "five_hour": {"pct": 9, "resets_at": 1777873200},
+        "seven_day": {"pct": 57.0, "resets_at": 1778256000},
+    },
+    "session_cost_usd": 1.75,
+    "snapshots": {
+        "abc123": {
+            "five_hour_pct": 10,
+            "seven_day_pct": 41,
+            "session_cost_usd": 0.31,
+            "ts": 1777824895000,
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# read_session_cookie — pure function tests
+# ---------------------------------------------------------------------------
+
+
+def test_skips_run_when_cookie_file_absent(tmp_path: Path) -> None:
+    """Missing cookie file returns None — treated as graceful unconfigured state."""
+    nonexistent = tmp_path / "cc-usage-session-cookie"
+    assert read_session_cookie(nonexistent) is None
+
+
+def test_skips_run_when_cookie_contains_only_comments(tmp_path: Path) -> None:
+    """Cookie file with only comment lines returns None."""
+    cookie_file = tmp_path / "cc-usage-session-cookie"
+    cookie_file.write_text(
+        textwrap.dedent("""\
+            # Paste your claude.ai session cookie here
+            # Get it from: DevTools → Application → Cookies → sessionKey
+        """)
+    )
+    assert read_session_cookie(cookie_file) is None
+
+
+def test_skips_run_when_cookie_file_is_empty(tmp_path: Path) -> None:
+    """Empty cookie file returns None."""
+    cookie_file = tmp_path / "cc-usage-session-cookie"
+    cookie_file.write_text("")
+    assert read_session_cookie(cookie_file) is None
+
+
+def test_reads_cookie_from_first_non_comment_line(tmp_path: Path) -> None:
+    """Valid cookie value is returned from the first non-comment line."""
+    cookie_file = tmp_path / "cc-usage-session-cookie"
+    cookie_file.write_text(
+        textwrap.dedent("""\
+            # Paste your claude.ai session cookie here
+            sk-ant-session-abc123xyz
+        """)
+    )
+    assert read_session_cookie(cookie_file) == "sk-ant-session-abc123xyz"
+
+
+def test_reads_cookie_ignoring_leading_whitespace(tmp_path: Path) -> None:
+    """Cookie value is stripped of leading/trailing whitespace."""
+    cookie_file = tmp_path / "cc-usage-session-cookie"
+    cookie_file.write_text("  sk-ant-session-whitespace  \n")
+    assert read_session_cookie(cookie_file) == "sk-ant-session-whitespace"
+
+
+# ---------------------------------------------------------------------------
+# parse_usage_response — pure function tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_standard_rate_limits_response() -> None:
+    """Standard API response with five_hour and seven_day is parsed correctly."""
+    result = parse_usage_response(STANDARD_API_RESPONSE)
+    assert result["five_hour_pct"] == 24.5
+    assert result["seven_day_pct"] == 31.2
+    assert result["five_hour_resets_at"] == 1712345678
+    assert result["seven_day_resets_at"] == 1712987654
+
+
+def test_parse_response_with_used_percentage_key() -> None:
+    """'used_percentage' key in API response maps to *_pct in parsed output."""
+    response = {
+        "rate_limits": {
+            "five_hour": {"used_percentage": 50.0, "resets_at": 999},
+            "seven_day": {"used_percentage": 75.0, "resets_at": 888},
+        }
+    }
+    result = parse_usage_response(response)
+    assert result["five_hour_pct"] == 50.0
+    assert result["seven_day_pct"] == 75.0
+
+
+def test_parse_response_with_pct_key_fallback() -> None:
+    """If 'used_percentage' is absent, 'pct' key is accepted as fallback."""
+    response = {
+        "rate_limits": {
+            "five_hour": {"pct": 33.0, "resets_at": 111},
+            "seven_day": {"pct": 66.0, "resets_at": 222},
+        }
+    }
+    result = parse_usage_response(response)
+    assert result["five_hour_pct"] == 33.0
+    assert result["seven_day_pct"] == 66.0
+
+
+def test_parse_response_raises_when_rate_limits_absent() -> None:
+    """Response without 'rate_limits' key raises ValueError with a descriptive message."""
+    with pytest.raises(ValueError, match="rate_limits"):
+        parse_usage_response({"some_other_key": "value"})
+
+
+def test_parse_response_tolerates_missing_five_hour() -> None:
+    """If five_hour is absent from rate_limits, pct is None rather than raising."""
+    response = {
+        "rate_limits": {
+            "seven_day": {"used_percentage": 42.0, "resets_at": 333},
+        }
+    }
+    result = parse_usage_response(response)
+    assert result["five_hour_pct"] is None
+    assert result["seven_day_pct"] == 42.0
+
+
+# ---------------------------------------------------------------------------
+# merge_into_state — pure function tests
+# ---------------------------------------------------------------------------
+
+PARSED_USAGE = {
+    "five_hour_pct": 24.5,
+    "five_hour_resets_at": 1712345678,
+    "seven_day_pct": 31.2,
+    "seven_day_resets_at": 1712987654,
+}
+
+
+def test_merge_preserves_existing_snapshots_and_cost() -> None:
+    """Merge does not destroy session snapshots or cost data from the hook-written state."""
+    result = merge_into_state(EXISTING_STATE, PARSED_USAGE)
+    assert result["snapshots"] == EXISTING_STATE["snapshots"]
+    assert result["session_cost_usd"] == EXISTING_STATE["session_cost_usd"]
+
+
+def test_merge_overwrites_rate_limits_with_fresh_data() -> None:
+    """Rate limit percentages and resets_at are replaced with poller-fetched values."""
+    result = merge_into_state(EXISTING_STATE, PARSED_USAGE)
+    assert result["rate_limits"]["five_hour"]["pct"] == 24.5
+    assert result["rate_limits"]["seven_day"]["pct"] == 31.2
+    assert result["rate_limits"]["five_hour"]["resets_at"] == 1712345678
+    assert result["rate_limits"]["seven_day"]["resets_at"] == 1712987654
+
+
+def test_merge_sets_source_tag_to_poller() -> None:
+    """Merged state carries source='cc-usage-poller' to distinguish from hook writes."""
+    result = merge_into_state(EXISTING_STATE, PARSED_USAGE)
+    assert result["source"] == SOURCE_TAG
+
+
+def test_merge_sets_last_updated_iso_timestamp() -> None:
+    """Merged state carries last_updated as an ISO 8601 UTC string."""
+    result = merge_into_state(EXISTING_STATE, PARSED_USAGE)
+    assert "last_updated" in result
+    # Must be parseable as ISO 8601
+    dt = datetime.fromisoformat(result["last_updated"])
+    assert dt.tzinfo is not None
+
+
+def test_merge_updates_ts_unix_timestamp() -> None:
+    """Merged state has ts updated to approximately now (within 5 seconds)."""
+    import time
+    before = int(time.time())
+    result = merge_into_state(EXISTING_STATE, PARSED_USAGE)
+    after = int(time.time())
+    assert before <= result["ts"] <= after
+
+
+def test_merge_on_empty_existing_state() -> None:
+    """Merge works correctly when called with an empty existing state (first run)."""
+    result = merge_into_state({}, PARSED_USAGE)
+    assert result["v"] == 1
+    assert result["rate_limits"]["five_hour"]["pct"] == 24.5
+    assert result["source"] == SOURCE_TAG
+
+
+# ---------------------------------------------------------------------------
+# main() integration tests — mock all I/O
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_job_exits_without_polling(tmp_path: Path) -> None:
+    """main() returns 0 without hitting the network when job is disabled in jobs.json."""
+    jobs_json = tmp_path / "scheduled-jobs" / "jobs.json"
+    jobs_json.parent.mkdir(parents=True)
+    jobs_json.write_text(json.dumps({
+        "jobs": {
+            "cc-usage-poller": {"enabled": False}
+        }
+    }))
+    with (
+        patch.dict("os.environ", {"LOBSTER_WORKSPACE": str(tmp_path)}),
+        patch.object(_mod, "fetch_usage") as mock_fetch,
+    ):
+        result = main()
+    assert result == 0
+    mock_fetch.assert_not_called()
+
+
+def test_missing_cookie_exits_gracefully(tmp_path: Path) -> None:
+    """main() returns 0 (not an error) when cookie file is absent."""
+    cookie_path = tmp_path / "cc-usage-session-cookie"
+    with (
+        patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
+        patch.object(_mod, "fetch_usage") as mock_fetch,
+    ):
+        result = main()
+    assert result == 0
+    mock_fetch.assert_not_called()
+
+
+def test_auth_error_returns_0_not_1(tmp_path: Path) -> None:
+    """A 401 auth error is handled gracefully — returns 0 so cron does not stop retrying."""
+    cookie_path = tmp_path / "cc-usage-session-cookie"
+    cookie_path.write_text("sk-ant-fake-cookie\n")
+
+    http_error = urllib.error.HTTPError(
+        url="https://claude.ai/api/usage",
+        code=401,
+        msg="Unauthorized",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=BytesIO(b""),
+    )
+    with (
+        patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
+        patch.object(_mod, "fetch_usage", side_effect=http_error),
+    ):
+        result = main()
+    assert result == 0
+
+
+def test_network_error_returns_0_not_1(tmp_path: Path) -> None:
+    """A network error is handled gracefully — returns 0 so cron does not stop retrying."""
+    cookie_path = tmp_path / "cc-usage-session-cookie"
+    cookie_path.write_text("sk-ant-fake-cookie\n")
+
+    url_error = urllib.error.URLError(reason="Name or service not known")
+    with (
+        patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
+        patch.object(_mod, "fetch_usage", side_effect=url_error),
+    ):
+        result = main()
+    assert result == 0
+
+
+def test_parse_error_returns_0_not_1(tmp_path: Path) -> None:
+    """A parse failure (unexpected response schema) returns 0 — cron retries next interval."""
+    cookie_path = tmp_path / "cc-usage-session-cookie"
+    cookie_path.write_text("sk-ant-fake-cookie\n")
+
+    with (
+        patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
+        patch.object(_mod, "fetch_usage", return_value={"unexpected": "shape"}),
+    ):
+        result = main()
+    assert result == 0
+
+
+def test_successful_run_writes_state_file(tmp_path: Path) -> None:
+    """A successful poll writes updated rate limits and source tag to state.json."""
+    cookie_path = tmp_path / "cc-usage-session-cookie"
+    cookie_path.write_text("sk-ant-fake-cookie\n")
+    state_path = tmp_path / ".claude" / "cc-budget" / "state.json"
+
+    with (
+        patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
+        patch.object(_mod, "STATE_FILE_PATH", state_path),
+        patch.object(_mod, "fetch_usage", return_value=STANDARD_API_RESPONSE),
+    ):
+        result = main()
+
+    assert result == 0
+    assert state_path.exists()
+    written = json.loads(state_path.read_text())
+    assert written["source"] == SOURCE_TAG
+    assert written["rate_limits"]["five_hour"]["pct"] == 24.5
+    assert written["rate_limits"]["seven_day"]["pct"] == 31.2
+
+
+def test_dry_run_skips_network_and_disk(tmp_path: Path) -> None:
+    """--dry-run returns 0 without making HTTP calls or writing files."""
+    cookie_path = tmp_path / "cc-usage-session-cookie"
+    cookie_path.write_text("sk-ant-fake-cookie\n")
+    state_path = tmp_path / ".claude" / "cc-budget" / "state.json"
+
+    with (
+        patch.object(_mod, "COOKIE_CONFIG_PATH", cookie_path),
+        patch.object(_mod, "STATE_FILE_PATH", state_path),
+        patch.object(_mod, "fetch_usage") as mock_fetch,
+    ):
+        result = main(dry_run=True)
+
+    assert result == 0
+    assert not state_path.exists()
+    mock_fetch.assert_not_called()

--- a/tests/unit/test_scheduled_tasks/test_cc_usage_poller_expiry_alert.py
+++ b/tests/unit/test_scheduled_tasks/test_cc_usage_poller_expiry_alert.py
@@ -30,7 +30,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 SCRIPT_PATH = (
-    Path(__file__).parent.parent.parent
+    Path(__file__).parent.parent.parent.parent
     / "scheduled-tasks"
     / "cc-usage-poller.py"
 )
@@ -45,10 +45,10 @@ def _load_module():
 
 cp = _load_module()
 
-# Named constants mirrored from module — changes here are intentional and
-# signal a spec change, not just an implementation change.
-ADMIN_CHAT_ID = 8075091586
-SENTINEL_PREFIX = "/tmp/cc-usage-cookie-expired-alert-"
+# Constants imported from production module — importing rather than
+# re-declaring prevents silent divergence when values change in the module.
+ADMIN_CHAT_ID = cp.ADMIN_CHAT_ID
+SENTINEL_PREFIX = cp.COOKIE_EXPIRY_SENTINEL_PREFIX
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scheduled_tasks/test_cc_usage_poller_expiry_alert.py
+++ b/tests/unit/test_scheduled_tasks/test_cc_usage_poller_expiry_alert.py
@@ -21,9 +21,14 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-import urllib.error
 
 import pytest
+
+try:
+    import requests.exceptions as _req_exc
+    _RequestsHTTPError = _req_exc.HTTPError
+except ImportError:  # pragma: no cover
+    _RequestsHTTPError = Exception
 
 # ---------------------------------------------------------------------------
 # Load the module under test from its script path
@@ -55,14 +60,10 @@ SENTINEL_PREFIX = cp.COOKIE_EXPIRY_SENTINEL_PREFIX
 # Helper — build a fake HTTPError for a given HTTP status code
 # ---------------------------------------------------------------------------
 
-def _http_error(code: int) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(
-        url="https://claude.ai/api/usage",
-        code=code,
-        msg=f"HTTP {code}",
-        hdrs=None,
-        fp=None,
-    )
+def _http_error(code: int) -> "_RequestsHTTPError":
+    mock_response = MagicMock()
+    mock_response.status_code = code
+    return _RequestsHTTPError(response=mock_response)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`~/.claude/cc-budget/state.json` is only written when Claude Code actively reports quota data via the `statusLine` hook — which only fires during active CC sessions. During idle periods (including weekly quota resets on Saturday at 16:00 UTC), the file retains pre-reset numbers for hours or days. Observed in production: 138h stale (2026-05-04 → 2026-05-10). Any executor dispatch gate or user-facing usage report built on this file reads garbage data after an idle weekend.

The fix requires hitting the server-side endpoint directly, which is the only source that sees quota resets regardless of local session activity (as noted in issue #1101 and by `m13v`'s comment).

## What this PR does

Adds `scheduled-tasks/cc-usage-poller.py` — a Type B cron script (no LLM, no dispatcher involvement) that:

1. Reads a session cookie from `~/lobster-user-config/cc-usage-session-cookie`
2. Makes an authenticated GET to `https://claude.ai/api/usage` (same endpoint ClaudeMeter/eddmann uses)
3. Parses `five_hour.used_percentage` and `seven_day.used_percentage` from the response
4. Merges the new values into `~/.claude/cc-budget/state.json` atomically (temp file + rename), preserving existing `snapshots` and `session_cost_usd` written by the `statusLine` hook
5. Adds `source: "cc-usage-poller"` and `last_updated` ISO timestamp to distinguish poller-written data from hook-written data

The script runs on a `*/30 * * * *` schedule. Error handling is graceful throughout: missing cookie exits 0 (unconfigured, not broken); 401/403 logs "cookie may be expired" instructions; network errors log and return 0 for cron retry.

## Activation

The poller is inert until Dan pastes a `sessionKey` cookie value into `~/lobster-user-config/cc-usage-session-cookie`. Migration 107 creates a comment-only placeholder for this file on `upgrade.sh` runs. Once the cookie is present, the poller activates on the next 30-minute cron tick.

To get the cookie: claude.ai → DevTools → Application → Cookies → `sessionKey` → copy value → paste into the config file.

Session cookies expire; when they do, the script logs an auth error with refresh instructions and exits 0 (does not crash or spam).

## What is out of scope

This PR does not wire `state.json` into the executor dispatch gate (that is the next step from the cc-usage workstream README). It does not add Telegram alerting at quota thresholds. It does not change any existing scripts.

## Functional patterns

Pure functions for all data transforms (`read_session_cookie`, `parse_usage_response`, `merge_into_state`). Side effects isolated at two explicit boundaries: `fetch_usage` (HTTP) and `write_state_atomically` (disk). The atomic write uses temp file + `os.replace` — no partial writes possible. All error branches return 0 so cron continues retrying rather than marking the job failed.

## Tests run

- [x] `uv run pytest tests/unit/test_scheduled_tasks/test_cc_usage_poller.py -v` — 23 passed, 0 failed
- [x] `uv run pytest tests/unit/test_scheduled_tasks/ -q` — 68 passed, 0 failed (no regressions in sibling tests)
- [x] `uv run --with ruff ruff check scheduled-tasks/cc-usage-poller.py tests/unit/test_scheduled_tasks/test_cc_usage_poller.py` — clean

## Manual test

N/A for the script itself — hitting `claude.ai/api/usage` in production requires the real session cookie (which is user-private and should not be used in automated tests). The integration is gated behind the missing-cookie check, so a test environment would require a live claude.ai session. The pure function tests cover all parse/merge logic; the `main()` integration tests cover all error paths with mocked HTTP.

Note: the cron entry and jobs.json update are not in the repo (they live outside the git tree) and were applied directly to the production install.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure logic tested; HTTP boundary mocked; cookie required for live test)
- [x] User-visible outcome: not applicable for this PR — it writes to state.json, not a user-facing surface. The executor dispatch gate and usage reporting that consume state.json are separate PRs.
- [x] Side-effect audit: single file write (atomic), no sends, no loops, bounded HTTP call with 30s timeout
- [x] External service calls: mocked in all tests; production call is explicitly scoped (single GET, authenticated, 30s timeout)

Closes #1101