### PR TITLE
fix(wos): remove low-signal skipped audit writes from Registry.upsert()

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -627,13 +627,6 @@ class Registry:
 
             if existing:
                 skip_reason = f"existing record {existing['id']} is in '{existing['status']}' status"
-                self._write_audit(
-                    conn,
-                    uow_id=existing["id"],
-                    event="skipped",
-                    note=f"upsert skipped: {skip_reason}",
-                )
-                conn.commit()
                 return UpsertSkipped(id=existing["id"], reason=skip_reason)
 
             # Check for same-date UNIQUE conflict (terminal record from a prior run today).
@@ -654,13 +647,6 @@ class Registry:
                     f"terminal record {same_date_row['id']} (status={same_date_row['status']}) "
                     f"already exists for sweep_date={sweep_date}; will re-propose on next sweep date"
                 )
-                self._write_audit(
-                    conn,
-                    uow_id=same_date_row["id"],
-                    event="skipped",
-                    note=f"upsert skipped: {skip_reason}",
-                )
-                conn.commit()
                 return UpsertSkipped(id=same_date_row["id"], reason=skip_reason)
 
             uow_id = _generate_uow_id()


### PR DESCRIPTION
## Problem

`Registry.upsert()` has two skip paths — one for UoWs already in a non-terminal status, one for same-date terminal records. Each skip path called `_write_audit()` with `event="skipped"` before returning `UpsertSkipped`.

`garden-caretaker` runs every 15 minutes and calls `upsert()` for every active issue. These skip-path audit writes have accumulated 675k+ `skipped` entries in the audit table, all of them zero-signal: they record the fact that a UoW was not re-created, which is expected behavior on every invocation for any in-progress UoW.

The `UpsertSkipped` return value already encodes the outcome to callers — the audit write adds nothing.

## Change

Remove `_write_audit()` (and the now-vacuous `conn.commit()`) from both skip paths in `_upsert_typed()`. The `UpsertSkipped` return is unchanged. All other audit writes — creates, status transitions, errors — are untouched.

This is a pure noise reduction: no logic changes, no interface changes, no state machine transitions affected.

## Functional pattern

Pure deletion of side effects from guard-clause early returns. The guard clauses themselves are unchanged; only the DB write that occurred before the early return is removed.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py -q` — **80 passed, 0 failed**
- [x] `uv run pytest tests/ -q --ignore=tests/unit/test_attunement.py --ignore=tests/unit/test_orchestration/test_registry_cli.py` — 1953 passed, 23 failed (all 23 failures confirmed pre-existing on `main` via identical run against the base branch; no regressions introduced)

## Manual test

N/A — this change is entirely internal (removes DB writes from skip paths; no external service calls, no user-visible output, no file I/O beyond SQLite).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal DB write removal)
- [x] User-visible outcome verified — N/A (no user-visible output)
- [x] Side-effect audit complete: this change removes side effects; it cannot cause floods, unscoped writes, or unintended volume
- [x] External service calls — none