### PR TITLE
feat(wos): surface UoW title + category from labels in dashboard; canonical URL

### DIFF
--- a/src/orchestration/wos_dashboard.py
+++ b/src/orchestration/wos_dashboard.py
@@ -32,8 +32,10 @@ Design:
   it maps over UoW IDs and isolates per-UoW errors without aborting the whole batch.
 - upload_html() is the single bisque upload point for the dashboard; it writes to a
   canonical filename so the URL is stable across regenerations.
-- _fetch_issue_title() and _derive_category_from_labels() are pure/near-pure enrichment
-  helpers that surface GitHub metadata without mutating the registry.
+- _fetch_issue_metadata() and _derive_category_from_labels() are pure/near-pure enrichment
+  helpers that surface GitHub metadata without mutating the registry. A single gh CLI call
+  fetches both title and labels in one round-trip, eliminating the semantic inconsistency
+  window that two sequential calls would create.
 """
 
 from __future__ import annotations
@@ -139,21 +141,23 @@ def upload_html(html: str) -> str:
 # GitHub metadata enrichment — near-pure helpers
 # ---------------------------------------------------------------------------
 
-def _fetch_issue_title(issue_url: str | None) -> str | None:
-    """Fetch the GitHub issue title from its URL using the gh CLI.
+def _fetch_issue_metadata(issue_url: str | None) -> dict | None:
+    """Fetch title and labels for a GitHub issue in a single gh CLI call.
 
-    Returns the title string on success, None if the URL is absent, the CLI
-    call fails, or the JSON response is malformed. Never raises.
+    Returns {"title": str | None, "labels": list[dict]} on success, or None
+    if the URL is absent, the CLI call fails, or the JSON response is malformed.
+    Never raises.
 
-    Parses the issue number and repo from the URL rather than calling the
-    GitHub REST API directly — gh CLI handles auth automatically.
+    A single combined call (--json title,labels) eliminates the semantic
+    inconsistency window that two sequential calls would create, and halves
+    the subprocess overhead per UoW.
     """
     if not issue_url:
         return None
 
     try:
         result = subprocess.run(
-            ["gh", "issue", "view", issue_url, "--json", "title"],
+            ["gh", "issue", "view", issue_url, "--json", "title,labels"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -161,31 +165,10 @@ def _fetch_issue_title(issue_url: str | None) -> str | None:
         if result.returncode != 0:
             return None
         data = json.loads(result.stdout)
-        return data.get("title") or None
-    except Exception:
-        return None
-
-
-def _fetch_issue_labels(issue_url: str | None) -> list[dict] | None:
-    """Fetch labels for a GitHub issue via its URL using the gh CLI.
-
-    Returns a list of label dicts (each with at least a 'name' key), or None
-    on failure. Never raises.
-    """
-    if not issue_url:
-        return None
-
-    try:
-        result = subprocess.run(
-            ["gh", "issue", "view", issue_url, "--json", "labels"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode != 0:
-            return None
-        data = json.loads(result.stdout)
-        return data.get("labels") or []
+        return {
+            "title": data.get("title") or None,
+            "labels": data.get("labels") or [],
+        }
     except Exception:
         return None
 
@@ -230,19 +213,19 @@ def _enrich_uow_with_github_metadata(uow_row: dict) -> dict:
     Adds 'issue_title' and 'category' keys. Either may be None/default if the
     GitHub call fails (non-fatal — the row renders without enrichment).
 
-    Called per-UoW at render time. Side effect: subprocess call to gh CLI.
+    Called per-UoW at render time. Side effect: one subprocess call to gh CLI,
+    which fetches title and labels in a single round-trip via _fetch_issue_metadata.
     """
     issue_url = uow_row.get("issue_url")
     if not issue_url:
         return {**uow_row, "issue_title": None, "category": "general"}
 
-    # Fetch title and labels in two separate calls to reuse existing helpers.
-    # A combined call (--json title,labels) would be slightly faster but the
-    # helpers are independently testable and the latency difference is negligible
-    # for a dashboard with typically <20 active UoWs.
-    title = _fetch_issue_title(issue_url)
-    labels = _fetch_issue_labels(issue_url)
-    category = _derive_category_from_labels(labels)
+    metadata = _fetch_issue_metadata(issue_url)
+    if metadata is None:
+        return {**uow_row, "issue_title": None, "category": "general"}
+
+    title = metadata["title"]
+    category = _derive_category_from_labels(metadata["labels"])
 
     return {**uow_row, "issue_title": title, "category": category}
 

--- a/src/orchestration/wos_dashboard.py
+++ b/src/orchestration/wos_dashboard.py
@@ -16,6 +16,11 @@ drilldown HTML page for each active and stalled UoW via wos_uow_detail_gen.gener
 then links each UoW row to its detail page. Generating drilldowns for all UoWs can be
 slow if the queue is large; it is off by default.
 
+With --format html, the dashboard is written to a canonical stable filename
+(wos-dashboard-active.html) in the bisque-uploads directory and the public URL is
+printed to stdout. This makes the URL stable across regenerations:
+  http://<PUBLIC_IP>:9101/files/wos-dashboard-active.html
+
 Exits 0 on success.
 
 Design:
@@ -25,6 +30,10 @@ Design:
 - Composable: build_dashboard_data() returns a plain dict usable by all renderers.
 - generate_drilldown_urls() is the single composition point for drilldown side effects;
   it maps over UoW IDs and isolates per-UoW errors without aborting the whole batch.
+- upload_html() is the single bisque upload point for the dashboard; it writes to a
+  canonical filename so the URL is stable across regenerations.
+- _fetch_issue_title() and _derive_category_from_labels() are pure/near-pure enrichment
+  helpers that surface GitHub metadata without mutating the registry.
 """
 
 from __future__ import annotations
@@ -32,6 +41,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -51,13 +61,201 @@ def _default_registry_path() -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Bisque upload helpers — side-effectful, isolated
+# ---------------------------------------------------------------------------
+
+# Canonical filename for the dashboard HTML file in bisque-uploads.
+# Using a stable name (not a UUID) makes the URL cross-linkable and bookmarkable.
+DASHBOARD_CANONICAL_FILENAME = "wos-dashboard-active.html"
+
+
+def _uploads_dir() -> Path:
+    """Return the bisque-uploads directory path."""
+    messages_dir = Path(
+        os.environ.get("LOBSTER_INBOX_DIR", str(Path.home() / "messages" / "inbox"))
+    ).parent
+    return messages_dir / "bisque-uploads"
+
+
+def _bisque_base_url() -> str:
+    """Return the HTTP base URL of the bisque relay server.
+
+    Priority:
+    1. BISQUE_RELAY_HTTP_URL env var
+    2. LOBSTER_PUBLIC_IP env var with default port 9101
+    3. Parse ~/lobster-config/config.env
+    4. curl ifconfig.me fallback
+    5. localhost last resort
+    """
+    env_url = os.environ.get("BISQUE_RELAY_HTTP_URL", "").strip()
+    if env_url:
+        return env_url.rstrip("/")
+
+    public_ip = os.environ.get("LOBSTER_PUBLIC_IP", "").strip()
+    if not public_ip:
+        config_file = Path.home() / "lobster-config" / "config.env"
+        if config_file.exists():
+            for line in config_file.read_text().splitlines():
+                stripped = line.strip()
+                if stripped.startswith("LOBSTER_PUBLIC_IP="):
+                    public_ip = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
+                if stripped.startswith("BISQUE_RELAY_HTTP_URL="):
+                    return stripped.split("=", 1)[1].strip().strip('"').strip("'").rstrip("/")
+
+    if not public_ip:
+        try:
+            result = subprocess.run(
+                ["curl", "-s", "--max-time", "5", "-4", "ifconfig.me"],
+                capture_output=True, text=True, timeout=6,
+            )
+            public_ip = result.stdout.strip()
+        except Exception:
+            pass
+
+    port = os.environ.get("BISQUE_RELAY_PORT", "9101")
+    if public_ip:
+        return f"http://{public_ip}:{port}"
+    return f"http://localhost:{port}"
+
+
+def upload_html(html: str) -> str:
+    """Write the dashboard HTML to the canonical filename and return its public URL.
+
+    Writes to wos-dashboard-active.html (stable across regenerations).
+    Returns the full public URL: {base_url}/files/wos-dashboard-active.html
+
+    Side effects: writes to ~/messages/bisque-uploads/wos-dashboard-active.html
+    """
+    uploads = _uploads_dir()
+    uploads.mkdir(parents=True, exist_ok=True)
+    dest = uploads / DASHBOARD_CANONICAL_FILENAME
+    dest.write_text(html, encoding="utf-8")
+    base_url = _bisque_base_url()
+    return f"{base_url}/files/{DASHBOARD_CANONICAL_FILENAME}"
+
+
+# ---------------------------------------------------------------------------
+# GitHub metadata enrichment — near-pure helpers
+# ---------------------------------------------------------------------------
+
+def _fetch_issue_title(issue_url: str | None) -> str | None:
+    """Fetch the GitHub issue title from its URL using the gh CLI.
+
+    Returns the title string on success, None if the URL is absent, the CLI
+    call fails, or the JSON response is malformed. Never raises.
+
+    Parses the issue number and repo from the URL rather than calling the
+    GitHub REST API directly — gh CLI handles auth automatically.
+    """
+    if not issue_url:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", issue_url, "--json", "title"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        return data.get("title") or None
+    except Exception:
+        return None
+
+
+def _fetch_issue_labels(issue_url: str | None) -> list[dict] | None:
+    """Fetch labels for a GitHub issue via its URL using the gh CLI.
+
+    Returns a list of label dicts (each with at least a 'name' key), or None
+    on failure. Never raises.
+    """
+    if not issue_url:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", issue_url, "--json", "labels"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        return data.get("labels") or []
+    except Exception:
+        return None
+
+
+def _derive_category_from_labels(labels: list[dict] | None) -> str:
+    """Derive a display category from GitHub labels.
+
+    Taxonomy:
+    - type:* → use the value after the colon (e.g. type:bug → "bug",
+      type:feat → "feature")
+    - workstream:* → use the value after the colon as category (fallback
+      when no type: label is present)
+    - no matching label → "general"
+
+    type: labels take priority over workstream: labels when both are present.
+    """
+    if not labels:
+        return "general"
+
+    type_label: str | None = None
+    workstream_label: str | None = None
+
+    for label in labels:
+        name = label.get("name", "")
+        if name.startswith("type:") and type_label is None:
+            value = name[len("type:"):]
+            # Normalize common aliases
+            type_label = "feature" if value == "feat" else value
+        elif name.startswith("workstream:") and workstream_label is None:
+            workstream_label = name[len("workstream:"):]
+
+    if type_label:
+        return type_label
+    if workstream_label:
+        return workstream_label
+    return "general"
+
+
+def _enrich_uow_with_github_metadata(uow_row: dict) -> dict:
+    """Fetch issue title and category from GitHub and return an enriched UoW dict.
+
+    Adds 'issue_title' and 'category' keys. Either may be None/default if the
+    GitHub call fails (non-fatal — the row renders without enrichment).
+
+    Called per-UoW at render time. Side effect: subprocess call to gh CLI.
+    """
+    issue_url = uow_row.get("issue_url")
+    if not issue_url:
+        return {**uow_row, "issue_title": None, "category": "general"}
+
+    # Fetch title and labels in two separate calls to reuse existing helpers.
+    # A combined call (--json title,labels) would be slightly faster but the
+    # helpers are independently testable and the latency difference is negligible
+    # for a dashboard with typically <20 active UoWs.
+    title = _fetch_issue_title(issue_url)
+    labels = _fetch_issue_labels(issue_url)
+    category = _derive_category_from_labels(labels)
+
+    return {**uow_row, "issue_title": title, "category": category}
+
+
+# ---------------------------------------------------------------------------
 # Pure data-gathering functions
 # ---------------------------------------------------------------------------
 
 def _active_uows(registry: Any) -> list[dict]:
     """Return UoWs in active, ready-for-executor, or executing state.
 
-    Each dict has: id, status, steward_cycles, time_in_state_seconds.
+    Each dict has: id, status, steward_cycles, time_in_state_seconds,
+    issue_url (raw, for downstream enrichment).
     """
     from src.orchestration.registry import UoWStatus
     active_statuses = {
@@ -86,6 +284,7 @@ def _active_uows(registry: Any) -> list[dict]:
             "status": str(uow.status),
             "steward_cycles": uow.steward_cycles,
             "time_in_state_seconds": time_in_state,
+            "issue_url": getattr(uow, "issue_url", None),
         })
 
     return result
@@ -341,8 +540,31 @@ def _uow_id_cell(uow_id: str, drilldown_urls: dict[str, str]) -> str:
     """Return an HTML table cell for a UoW ID, optionally linked to its drilldown page."""
     url = drilldown_urls.get(uow_id)
     if url:
-        return f'<td class="uid"><a href="{url}" target="_blank">{uow_id} ↗</a></td>'
+        return f'<td class="uid"><a href="{url}" target="_blank">{uow_id} &#x2197;</a></td>'
     return f'<td class="uid">{uow_id}</td>'
+
+
+def _active_uow_row(u: dict, drilldown_urls: dict[str, str]) -> str:
+    """Render a single active-UoW table row, including title and category badge.
+
+    Columns: UoW ID (linked if drilldown available), issue title (or em-dash),
+    status badge + category badge, steward cycle count, time in state.
+    """
+    title_display = u.get("issue_title") or "—"
+    category = u.get("category") or "general"
+    id_cell = _uow_id_cell(u["id"], drilldown_urls)
+    category_badge = f"<span class='badge bc' style='margin-left:4px'>{category}</span>"
+
+    return (
+        f"<tr>"
+        f"{id_cell}"
+        f"<td style='font-size:.78rem;color:var(--text2)'>{title_display}</td>"
+        f"<td><span class='badge {_status_badge_class(u['status'])}'>{u['status']}</span>"
+        f"{category_badge}</td>"
+        f"<td>{u['steward_cycles']}</td>"
+        f"<td>{_fmt_duration(u['time_in_state_seconds'])}</td>"
+        f"</tr>"
+    )
 
 
 def render_html(data: dict[str, Any], drilldown_urls: dict[str, str]) -> str:
@@ -351,6 +573,13 @@ def render_html(data: dict[str, Any], drilldown_urls: dict[str, str]) -> str:
     Pure function: no IO. drilldown_urls maps uow_id → public URL for any UoWs
     that have a pre-generated drilldown page. Rows with no entry in drilldown_urls
     show the UoW ID as plain text.
+
+    Each active UoW row now shows:
+    - UoW ID (linked if drilldown URL available)
+    - Issue title (fetched from GitHub; "—" if absent)
+    - Status badge + category badge (derived from GitHub labels)
+    - Steward cycle count
+    - Time in current state
     """
     generated_at = data.get("generated_at", "")
     active = data.get("active_uows", [])
@@ -362,18 +591,13 @@ def render_html(data: dict[str, Any], drilldown_urls: dict[str, str]) -> str:
     # --- Active UoWs table ---
     if active:
         active_rows = "\n".join(
-            f"<tr>"
-            f"{_uow_id_cell(u['id'], drilldown_urls)}"
-            f"<td><span class='badge {_status_badge_class(u['status'])}'>{u['status']}</span></td>"
-            f"<td>{u['steward_cycles']}</td>"
-            f"<td>{_fmt_duration(u['time_in_state_seconds'])}</td>"
-            f"</tr>"
+            _active_uow_row(u, drilldown_urls)
             for u in active
         )
         active_section = f"""
         <table class="tbl">
           <thead><tr>
-            <th>UoW ID</th><th>Status</th><th>Cycles</th><th>In State</th>
+            <th>UoW ID</th><th>Title</th><th>Status / Category</th><th>Cycles</th><th>In State</th>
           </tr></thead>
           <tbody>{active_rows}</tbody>
         </table>"""
@@ -577,7 +801,16 @@ def main(argv: list[str] | None = None) -> int:
                 db_path=registry_path,
                 ledger_path=ledger_path,
             )
-        print(render_html(data, drilldown_urls=drilldown_urls), end="")
+        # Enrich each active UoW with title and category from GitHub.
+        # Errors per-UoW are non-fatal: _enrich_uow_with_github_metadata never raises.
+        data["active_uows"] = [
+            _enrich_uow_with_github_metadata(u)
+            for u in data["active_uows"]
+        ]
+        html = render_html(data, drilldown_urls=drilldown_urls)
+        # Write to canonical filename in bisque-uploads and print the stable URL.
+        url = upload_html(html)
+        print(url)
     else:
         print(render_text(data), end="")
 

--- a/tests/unit/test_orchestration/test_wos_dashboard.py
+++ b/tests/unit/test_orchestration/test_wos_dashboard.py
@@ -20,9 +20,13 @@ Tests cover:
 - main(): --format json outputs valid JSON
 - main(): --format html writes to canonical filename and outputs URL
 - main(): --with-drilldowns flag calls generate_drilldown_urls
-- _fetch_issue_title: returns title for valid issue URL
-- _fetch_issue_title: returns None when issue URL is missing
-- _fetch_issue_title: returns None on subprocess failure
+- _fetch_issue_metadata: returns {title, labels} dict for valid issue URL
+- _fetch_issue_metadata: returns None when issue URL is missing or empty
+- _fetch_issue_metadata: returns None on subprocess failure
+- _fetch_issue_metadata: returns None on malformed JSON
+- _enrich_uow_with_github_metadata: injects title and category when issue_url present
+- _enrich_uow_with_github_metadata: passthrough with defaults when no issue_url
+- _enrich_uow_with_github_metadata: graceful fallback when metadata fetch returns None
 - _derive_category_from_labels: type:bug → "bug"
 - _derive_category_from_labels: type:feat → "feature"
 - _derive_category_from_labels: workstream:wos → "wos"
@@ -702,59 +706,152 @@ class TestRenderHtml:
 
 
 # ---------------------------------------------------------------------------
-# _fetch_issue_title
+# _fetch_issue_metadata
 # ---------------------------------------------------------------------------
 
-class TestFetchIssueTitle:
-    def test_returns_title_for_valid_issue_url(self):
-        """Returns issue title string when gh CLI succeeds."""
-        from src.orchestration.wos_dashboard import _fetch_issue_title
-        import subprocess
+class TestFetchIssueMetadata:
+    _URL = "https://github.com/SiderealPress/lobster/issues/42"
+
+    def test_returns_title_and_labels_for_valid_issue_url(self):
+        """Returns {title, labels} dict when gh CLI returns both fields."""
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
         fake_result = MagicMock()
         fake_result.returncode = 0
-        fake_result.stdout = '{"title": "Fix flaky CI pipeline"}'
+        fake_result.stdout = '{"title": "Fix flaky CI pipeline", "labels": [{"name": "type:bug"}]}'
         with patch("subprocess.run", return_value=fake_result):
-            title = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
-        assert title == "Fix flaky CI pipeline"
+            result = _fetch_issue_metadata(self._URL)
+        assert result is not None
+        assert result["title"] == "Fix flaky CI pipeline"
+        assert result["labels"] == [{"name": "type:bug"}]
+
+    def test_uses_single_combined_gh_call(self):
+        """Verifies only one subprocess.run call is made (combined --json title,labels)."""
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = '{"title": "My Issue", "labels": []}'
+        with patch("subprocess.run", return_value=fake_result) as mock_run:
+            _fetch_issue_metadata(self._URL)
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args[0][0]
+        assert "--json" in cmd
+        # The json fields argument must contain both title and labels in a single call
+        json_arg = cmd[cmd.index("--json") + 1]
+        assert "title" in json_arg
+        assert "labels" in json_arg
 
     def test_returns_none_when_issue_url_is_none(self):
         """Returns None when no issue URL is provided."""
-        from src.orchestration.wos_dashboard import _fetch_issue_title
-        result = _fetch_issue_title(None)
-        assert result is None
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
+        assert _fetch_issue_metadata(None) is None
 
     def test_returns_none_when_issue_url_is_empty(self):
         """Returns None when issue URL is an empty string."""
-        from src.orchestration.wos_dashboard import _fetch_issue_title
-        result = _fetch_issue_title("")
-        assert result is None
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
+        assert _fetch_issue_metadata("") is None
 
     def test_returns_none_on_subprocess_failure(self):
         """Returns None when gh CLI returns non-zero exit code."""
-        from src.orchestration.wos_dashboard import _fetch_issue_title
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
         fake_result = MagicMock()
         fake_result.returncode = 1
         fake_result.stdout = ""
         with patch("subprocess.run", return_value=fake_result):
-            result = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
-        assert result is None
+            assert _fetch_issue_metadata(self._URL) is None
 
     def test_returns_none_on_subprocess_exception(self):
         """Returns None when subprocess.run raises an exception."""
-        from src.orchestration.wos_dashboard import _fetch_issue_title
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
         with patch("subprocess.run", side_effect=Exception("gh not found")):
-            result = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
-        assert result is None
+            assert _fetch_issue_metadata(self._URL) is None
 
     def test_returns_none_on_malformed_json(self):
         """Returns None when gh CLI returns unparseable JSON."""
-        from src.orchestration.wos_dashboard import _fetch_issue_title
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
         fake_result = MagicMock()
         fake_result.returncode = 0
         fake_result.stdout = "not valid json"
         with patch("subprocess.run", return_value=fake_result):
-            result = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
-        assert result is None
+            assert _fetch_issue_metadata(self._URL) is None
+
+    def test_empty_labels_normalised_to_list(self):
+        """Returns labels as empty list when gh returns null or absent labels field."""
+        from src.orchestration.wos_dashboard import _fetch_issue_metadata
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = '{"title": "My Issue"}'
+        with patch("subprocess.run", return_value=fake_result):
+            result = _fetch_issue_metadata(self._URL)
+        assert result is not None
+        assert result["labels"] == []
+
+
+# ---------------------------------------------------------------------------
+# _enrich_uow_with_github_metadata
+# ---------------------------------------------------------------------------
+
+class TestEnrichUowWithGithubMetadata:
+    _URL = "https://github.com/SiderealPress/lobster/issues/42"
+
+    def _uow_with_url(self) -> dict:
+        return {
+            "id": "uow_20260101_abc",
+            "status": "active",
+            "steward_cycles": 2,
+            "time_in_state_seconds": 300,
+            "issue_url": self._URL,
+        }
+
+    def _uow_without_url(self) -> dict:
+        return {
+            "id": "uow_20260101_xyz",
+            "status": "active",
+            "steward_cycles": 1,
+            "time_in_state_seconds": 60,
+            "issue_url": None,
+        }
+
+    def test_injects_title_and_category_when_issue_url_present(self):
+        """When issue_url is present and metadata fetch succeeds, title and category are injected."""
+        from src.orchestration.wos_dashboard import _enrich_uow_with_github_metadata
+        metadata = {"title": "Fix flaky CI pipeline", "labels": [{"name": "type:bug"}]}
+        with patch("src.orchestration.wos_dashboard._fetch_issue_metadata", return_value=metadata):
+            result = _enrich_uow_with_github_metadata(self._uow_with_url())
+        assert result["issue_title"] == "Fix flaky CI pipeline"
+        assert result["category"] == "bug"
+        # Original fields are preserved
+        assert result["id"] == "uow_20260101_abc"
+        assert result["steward_cycles"] == 2
+
+    def test_passthrough_with_defaults_when_no_issue_url(self):
+        """UoW without issue_url gets issue_title=None and category='general' without any gh call."""
+        from src.orchestration.wos_dashboard import _enrich_uow_with_github_metadata
+        with patch("src.orchestration.wos_dashboard._fetch_issue_metadata") as mock_fetch:
+            result = _enrich_uow_with_github_metadata(self._uow_without_url())
+        mock_fetch.assert_not_called()
+        assert result["issue_title"] is None
+        assert result["category"] == "general"
+        assert result["id"] == "uow_20260101_xyz"
+
+    def test_graceful_fallback_when_metadata_fetch_returns_none(self):
+        """When _fetch_issue_metadata returns None, defaults are used and no exception raised."""
+        from src.orchestration.wos_dashboard import _enrich_uow_with_github_metadata
+        with patch("src.orchestration.wos_dashboard._fetch_issue_metadata", return_value=None):
+            result = _enrich_uow_with_github_metadata(self._uow_with_url())
+        assert result["issue_title"] is None
+        assert result["category"] == "general"
+        # Original fields are still preserved
+        assert result["id"] == "uow_20260101_abc"
+
+    def test_original_uow_dict_is_not_mutated(self):
+        """_enrich_uow_with_github_metadata returns a new dict; the original is unchanged."""
+        from src.orchestration.wos_dashboard import _enrich_uow_with_github_metadata
+        original = self._uow_with_url()
+        original_copy = dict(original)
+        metadata = {"title": "A title", "labels": []}
+        with patch("src.orchestration.wos_dashboard._fetch_issue_metadata", return_value=metadata):
+            _enrich_uow_with_github_metadata(original)
+        assert original == original_copy  # unchanged
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_wos_dashboard.py
+++ b/tests/unit/test_orchestration/test_wos_dashboard.py
@@ -14,10 +14,22 @@ Tests cover:
 - generate_drilldown_urls: generates URL map for given UoW IDs, skips on error
 - render_html: produces valid HTML with UoW table and drilldown links when urls provided
 - render_html: renders UoW IDs as plain text when no drilldown URLs provided
+- render_html: displays issue title when provided
+- render_html: displays category badge when provided
 - main(): exits 0, text format default
 - main(): --format json outputs valid JSON
-- main(): --format html outputs valid HTML
+- main(): --format html writes to canonical filename and outputs URL
 - main(): --with-drilldowns flag calls generate_drilldown_urls
+- _fetch_issue_title: returns title for valid issue URL
+- _fetch_issue_title: returns None when issue URL is missing
+- _fetch_issue_title: returns None on subprocess failure
+- _derive_category_from_labels: type:bug → "bug"
+- _derive_category_from_labels: type:feat → "feature"
+- _derive_category_from_labels: workstream:wos → "wos"
+- _derive_category_from_labels: type: preferred over workstream: when both present
+- _derive_category_from_labels: no matching labels → "general"
+- _derive_category_from_labels: empty labels → "general"
+- upload_html: writes to canonical filename, returns stable URL
 """
 
 from __future__ import annotations
@@ -465,22 +477,28 @@ class TestMain:
         # Text output has section headers, not JSON
         assert "[1]" in out
 
-    def test_format_html_outputs_html(self, tmp_path, capsys):
+    def test_format_html_outputs_canonical_url(self, tmp_path, capsys):
+        """--format html outputs the stable canonical URL (not raw HTML) to stdout."""
         from src.orchestration.wos_dashboard import main
         db = tmp_path / "registry.db"
-        with self._patch_all(tmp_path):
+        uploads_dir = tmp_path / "bisque-uploads"
+        with self._patch_all(tmp_path), \
+             patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
             rc = main(["--db", str(db), "--format", "html"])
         assert rc == 0
-        out = capsys.readouterr().out
-        assert "<!DOCTYPE html>" in out
-        assert "WOS Dashboard" in out
+        out = capsys.readouterr().out.strip()
+        assert out == "http://test:9101/files/wos-dashboard-active.html"
 
     def test_with_drilldowns_calls_generate_drilldown_urls(self, tmp_path, capsys):
         """--with-drilldowns causes generate_drilldown_urls to be called for each active UoW."""
         from src.orchestration.wos_dashboard import main
         db = tmp_path / "registry.db"
+        uploads_dir = tmp_path / "bisque-uploads"
         with self._patch_all(tmp_path), \
-             patch("src.orchestration.wos_dashboard.generate_drilldown_urls", return_value={}) as mock_gen:
+             patch("src.orchestration.wos_dashboard.generate_drilldown_urls", return_value={}) as mock_gen, \
+             patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
             rc = main(["--db", str(db), "--format", "html", "--with-drilldowns"])
         assert rc == 0
         mock_gen.assert_called_once()
@@ -489,8 +507,11 @@ class TestMain:
         """Without --with-drilldowns, generate_drilldown_urls is NOT called."""
         from src.orchestration.wos_dashboard import main
         db = tmp_path / "registry.db"
+        uploads_dir = tmp_path / "bisque-uploads"
         with self._patch_all(tmp_path), \
-             patch("src.orchestration.wos_dashboard.generate_drilldown_urls", return_value={}) as mock_gen:
+             patch("src.orchestration.wos_dashboard.generate_drilldown_urls", return_value={}) as mock_gen, \
+             patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
             rc = main(["--db", str(db), "--format", "html"])
         assert rc == 0
         mock_gen.assert_not_called()
@@ -639,3 +660,239 @@ class TestRenderHtml:
         urls = {"uow_stalled_x": "http://test:9101/files/stalled.html"}
         html = render_html(data, drilldown_urls=urls)
         assert 'href="http://test:9101/files/stalled.html"' in html
+
+    def test_issue_title_displayed_in_active_row(self):
+        """When a UoW row has an issue_title, it appears prominently in the row HTML."""
+        from src.orchestration.wos_dashboard import render_html
+        data = self._base_data()
+        data["active_uows"] = [{
+            "id": "uow_20260101_abc",
+            "status": "active",
+            "steward_cycles": 3,
+            "time_in_state_seconds": 600,
+            "issue_title": "Fix flaky CI pipeline",
+            "category": "bug",
+        }]
+        html = render_html(data, drilldown_urls={})
+        assert "Fix flaky CI pipeline" in html
+
+    def test_category_badge_displayed_in_active_row(self):
+        """When a UoW row has a category, a badge appears in the row HTML."""
+        from src.orchestration.wos_dashboard import render_html
+        data = self._base_data()
+        data["active_uows"] = [{
+            "id": "uow_20260101_abc",
+            "status": "active",
+            "steward_cycles": 3,
+            "time_in_state_seconds": 600,
+            "issue_title": "Some feature",
+            "category": "feature",
+        }]
+        html = render_html(data, drilldown_urls={})
+        assert "feature" in html
+
+    def test_missing_title_renders_empty_dash(self):
+        """When issue_title is absent from a UoW row, render falls back gracefully."""
+        from src.orchestration.wos_dashboard import render_html
+        data = self._base_data()
+        # base_data has a UoW without issue_title/category keys
+        html = render_html(data, drilldown_urls={})
+        # Should render without error and include the UoW id
+        assert "uow_20260101_abc" in html
+
+
+# ---------------------------------------------------------------------------
+# _fetch_issue_title
+# ---------------------------------------------------------------------------
+
+class TestFetchIssueTitle:
+    def test_returns_title_for_valid_issue_url(self):
+        """Returns issue title string when gh CLI succeeds."""
+        from src.orchestration.wos_dashboard import _fetch_issue_title
+        import subprocess
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = '{"title": "Fix flaky CI pipeline"}'
+        with patch("subprocess.run", return_value=fake_result):
+            title = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
+        assert title == "Fix flaky CI pipeline"
+
+    def test_returns_none_when_issue_url_is_none(self):
+        """Returns None when no issue URL is provided."""
+        from src.orchestration.wos_dashboard import _fetch_issue_title
+        result = _fetch_issue_title(None)
+        assert result is None
+
+    def test_returns_none_when_issue_url_is_empty(self):
+        """Returns None when issue URL is an empty string."""
+        from src.orchestration.wos_dashboard import _fetch_issue_title
+        result = _fetch_issue_title("")
+        assert result is None
+
+    def test_returns_none_on_subprocess_failure(self):
+        """Returns None when gh CLI returns non-zero exit code."""
+        from src.orchestration.wos_dashboard import _fetch_issue_title
+        fake_result = MagicMock()
+        fake_result.returncode = 1
+        fake_result.stdout = ""
+        with patch("subprocess.run", return_value=fake_result):
+            result = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
+        assert result is None
+
+    def test_returns_none_on_subprocess_exception(self):
+        """Returns None when subprocess.run raises an exception."""
+        from src.orchestration.wos_dashboard import _fetch_issue_title
+        with patch("subprocess.run", side_effect=Exception("gh not found")):
+            result = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
+        assert result is None
+
+    def test_returns_none_on_malformed_json(self):
+        """Returns None when gh CLI returns unparseable JSON."""
+        from src.orchestration.wos_dashboard import _fetch_issue_title
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "not valid json"
+        with patch("subprocess.run", return_value=fake_result):
+            result = _fetch_issue_title("https://github.com/SiderealPress/lobster/issues/42")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _derive_category_from_labels
+# ---------------------------------------------------------------------------
+
+class TestDeriveCategoryFromLabels:
+    def test_type_bug_returns_bug(self):
+        """type:bug label → category 'bug'."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        labels = [{"name": "type:bug"}, {"name": "priority:high"}]
+        assert _derive_category_from_labels(labels) == "bug"
+
+    def test_type_feat_returns_feature(self):
+        """type:feat label → category 'feature'."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        labels = [{"name": "type:feat"}]
+        assert _derive_category_from_labels(labels) == "feature"
+
+    def test_type_label_preferred_over_workstream(self):
+        """When both type: and workstream: labels present, type: wins."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        labels = [{"name": "workstream:wos"}, {"name": "type:bug"}]
+        assert _derive_category_from_labels(labels) == "bug"
+
+    def test_workstream_label_used_when_no_type(self):
+        """workstream:wos → category 'wos' when no type: label present."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        labels = [{"name": "workstream:wos"}, {"name": "priority:high"}]
+        assert _derive_category_from_labels(labels) == "wos"
+
+    def test_no_matching_labels_returns_general(self):
+        """No type: or workstream: labels → 'general'."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        labels = [{"name": "priority:high"}, {"name": "status:blocked"}]
+        assert _derive_category_from_labels(labels) == "general"
+
+    def test_empty_labels_returns_general(self):
+        """Empty labels list → 'general'."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        assert _derive_category_from_labels([]) == "general"
+
+    def test_none_labels_returns_general(self):
+        """None labels → 'general'."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        assert _derive_category_from_labels(None) == "general"
+
+    def test_type_enhancement_returns_enhancement(self):
+        """type:enhancement label → category 'enhancement' (value after colon)."""
+        from src.orchestration.wos_dashboard import _derive_category_from_labels
+        labels = [{"name": "type:enhancement"}]
+        assert _derive_category_from_labels(labels) == "enhancement"
+
+
+# ---------------------------------------------------------------------------
+# upload_html
+# ---------------------------------------------------------------------------
+
+class TestUploadHtml:
+    def test_writes_to_canonical_filename(self, tmp_path):
+        """upload_html writes the HTML to wos-dashboard-active.html in bisque-uploads."""
+        from src.orchestration.wos_dashboard import upload_html
+
+        uploads_dir = tmp_path / "bisque-uploads"
+        with patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
+            url = upload_html("<html>test</html>")
+
+        assert url == "http://test:9101/files/wos-dashboard-active.html"
+        dest = uploads_dir / "wos-dashboard-active.html"
+        assert dest.exists()
+        assert dest.read_text() == "<html>test</html>"
+
+    def test_returns_stable_canonical_url(self, tmp_path):
+        """Calling upload_html twice returns the same URL (stable filename)."""
+        from src.orchestration.wos_dashboard import upload_html
+
+        uploads_dir = tmp_path / "bisque-uploads"
+        with patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
+            url1 = upload_html("<html>v1</html>")
+            url2 = upload_html("<html>v2</html>")
+
+        assert url1 == url2
+        assert url1 == "http://test:9101/files/wos-dashboard-active.html"
+
+    def test_creates_uploads_dir_if_missing(self, tmp_path):
+        """upload_html creates the bisque-uploads directory when it doesn't exist."""
+        from src.orchestration.wos_dashboard import upload_html
+
+        uploads_dir = tmp_path / "nested" / "bisque-uploads"
+        assert not uploads_dir.exists()
+        with patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
+            upload_html("<html>test</html>")
+
+        assert uploads_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# main() — html format writes canonical file and outputs URL
+# ---------------------------------------------------------------------------
+
+class TestMainHtmlCanonical:
+    def _patch_all(self, tmp_path: Path):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        registry = _make_registry([])
+        registry.list.return_value = []
+
+        stack.enter_context(patch("src.orchestration.registry.Registry", return_value=registry))
+        stack.enter_context(patch("src.orchestration.audit_queries.execution_outcomes", return_value={}))
+        stack.enter_context(patch("src.orchestration.wos_dashboard._fetch_completed_uow_ids_since", return_value=[]))
+        stack.enter_context(patch("src.orchestration.steward.BOOTUP_CANDIDATE_GATE", False))
+        return stack
+
+    def test_html_format_outputs_canonical_url(self, tmp_path, capsys):
+        """--format html outputs the canonical URL to stdout, not raw HTML."""
+        from src.orchestration.wos_dashboard import main
+        db = tmp_path / "registry.db"
+        uploads_dir = tmp_path / "bisque-uploads"
+        with self._patch_all(tmp_path), \
+             patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
+            rc = main(["--db", str(db), "--format", "html"])
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        assert out == "http://test:9101/files/wos-dashboard-active.html"
+
+    def test_html_format_writes_file_to_bisque_uploads(self, tmp_path):
+        """--format html writes wos-dashboard-active.html to the bisque-uploads dir."""
+        from src.orchestration.wos_dashboard import main
+        db = tmp_path / "registry.db"
+        uploads_dir = tmp_path / "bisque-uploads"
+        with self._patch_all(tmp_path), \
+             patch("src.orchestration.wos_dashboard._uploads_dir", return_value=uploads_dir), \
+             patch("src.orchestration.wos_dashboard._bisque_base_url", return_value="http://test:9101"):
+            main(["--db", str(db), "--format", "html"])
+        dest = uploads_dir / "wos-dashboard-active.html"
+        assert dest.exists()
+        assert "<!DOCTYPE html>" in dest.read_text()


### PR DESCRIPTION
## What this changes

The WOS dashboard `--format html` path had three gaps: rows showed only the opaque `uow_id` with no human context, labels were ignored, and every regeneration produced a new UUID URL making the dashboard hard to link to. This PR closes all three.

**Before:** each active-UoW row shows `uow_20260510_9e2629 | active | 3 | 10m`

**After:** each active-UoW row shows `uow_20260510_9e2629 | Fix flaky CI pipeline | active [bug] | 3 | 10m`

And the stable URL `http://5.78.201.64:9101/files/wos-dashboard-active.html` works on every regeneration.

## Three changes in detail

### 1. UoW title column
Each active-UoW row now includes a "Title" column showing the GitHub issue title. Fetched via `gh issue view {url} --json title` at render time per UoW. Falls back gracefully to "—" when the UoW has no `issue_url`, the gh CLI call fails, or any exception is raised.

`render_html()` remains a pure function. The enrichment (`_enrich_uow_with_github_metadata`) runs in `main()` before the render call, keeping side effects at the boundary.

### 2. Category badge from GitHub labels
Each active-UoW row now includes a `.badge.bc` category chip next to the status badge. Category is derived by `_derive_category_from_labels()` (pure function):
- `type:*` → value after colon (`type:bug` → "bug", `type:feat` → "feature")
- `workstream:*` → value after colon (fallback when no `type:` label)
- no match or empty → "general"
- `type:` takes priority over `workstream:` when both present

### 3. Canonical URL for `--format html`
`--format html` now writes to `wos-dashboard-active.html` (stable filename, not a UUID) and prints the URL to stdout. The URL `http://5.78.201.64:9101/files/wos-dashboard-active.html` is stable across all regenerations. Text and JSON formats are unchanged.

`upload_html()` mirrors the pattern from `wos_uow_detail_gen.py`. The stable filename is a deliberate exception to the patterns.md UUID-per-file rule; that rule prevents collisions between multiple callers, which does not apply to a singleton dashboard. The filename is declared as a module constant (`DASHBOARD_CANONICAL_FILENAME`).

## Flow change

Before: `--format html` → `render_html()` → print raw HTML to stdout (caller writes to bisque)

After: `--format html` → enrich UoWs with GitHub metadata → `render_html()` → `upload_html()` → print canonical URL to stdout

Text and JSON paths are completely unchanged.

## Functional patterns used
- Pure function composition: `render_html()`, `_derive_category_from_labels()`, `_active_uow_row()` — no IO
- Side effects isolated at boundary: `upload_html()`, `_enrich_uow_with_github_metadata()` — only called from `main()`
- Immutability: enrichment creates new dicts (`{**uow_row, ...}`) rather than mutating rows
- Error isolation: per-UoW GitHub fetch failures never raise; worst case is "—" title + "general" category

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_dashboard.py -q` — 65 passed, 0 failed (28 new tests covering all new functions)
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_audit_queries.py -q` — 116 passed, no regressions
- [x] `python3 -m py_compile src/orchestration/wos_dashboard.py` — syntax clean
- [ ] `uv run ruff check` — ruff not installed in this env (pre-existing gap)
- [ ] Live regeneration — blocked: requires production environment with registry DB + gh CLI auth; no change to text/JSON paths

## Manual test
N/A — change is internal to HTML generation logic. Bisque upload tested via unit tests with mocked `_uploads_dir` and `_bisque_base_url`. GitHub fetch tested via mocked `subprocess.run`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Graceful degradation: title absent → "—", labels unavailable → "general"
- [x] Side-effect audit: enrichment calls bounded by active UoW count; no floods, no unscoped writes
- [x] Canonical filename deviation from patterns.md documented in module docstring and PR description