### PR TITLE
feat(executor): skip dispatch cycle when CC quota >=90%

### DIFF
--- a/oracle/verdicts/decision-cc-quota-gate.md
+++ b/oracle/verdicts/decision-cc-quota-gate.md
@@ -1,0 +1,32 @@
+# Design Decision: CC Quota Dispatch Suppression Gate
+
+**Date:** 2026-05-10
+**Status:** ACCEPTED
+**Vision anchor:** principle-1 (structural prevention is preferred over reactive recovery), vision.yaml core.inviolable_constraints.constraint-3 (Encoded Orientation requires prior logged decision of same class and a traceable vision.yaml anchor)
+**Linked PR:** dcetlin/Lobster#1125
+
+## Decision
+
+Authorize the `CC_QUOTA_SKIP_THRESHOLD = 90.0` gate in `executor-heartbeat.py`:
+
+- **Pre-dispatch quota check:** Once per dispatch cycle (after the GitHub rate limit check, before `run_executor_cycle`), the heartbeat calls `_read_cc_quota()`. If the returned value is >= 90.0%, the cycle is skipped and main() returns 0.
+- **Threshold value:** `CC_QUOTA_SKIP_THRESHOLD = 90.0` (five-hour utilization percentage). Named constant, not a magic number.
+- **Fail-open design:** If state.json is absent, stale (last_updated > 60 minutes ago), malformed, or the cc-usage-poller is not configured, `_read_cc_quota()` returns None and dispatch proceeds normally. Lack of quota data never suppresses work.
+- **Staleness window:** 60 minutes (`_CC_QUOTA_FRESHNESS_SECONDS = 3600`). The cc-usage-poller runs every 30 minutes, so a 60-minute staleness window tolerates one missed poll cycle before failing open.
+- **State file shape:** Reads `rate_limits.five_hour.pct` and `last_updated` from `~/.claude/cc-budget/state.json`, which is written by `scheduled-tasks/cc-usage-poller.py`.
+
+## Rationale
+
+At the 20X Claude Max plan, token economy is a first-class operational constraint. When the 5-hour quota is near exhaustion, dispatching new subagents is counterproductive: each subagent burns tokens before producing output, and if the quota is exhausted mid-task the work is lost anyway. Suppressing dispatch at 90% prevents this waste without blocking TTL recovery (orphan cleanup runs independently of the dispatch gate).
+
+This is an Encoded Orientation decision: the system autonomously suppresses dispatch cycles without explicit per-invocation user input. It is authorized here with a traceable vision.yaml anchor (principle-1) and satisfies constraint-3 via this logged decision.
+
+The structural class matches `decision-github-rate-limit-gate.md` (same executor-heartbeat.py gate pattern, same fail-open invariant, same pre-dispatch position in the cycle). The two gates compose cleanly: GitHub rate limit is checked first; CC quota is checked second; only if both pass does `run_executor_cycle()` execute.
+
+## Constraints
+
+- The check is per-cycle, not per-UoW — one file read per dispatch loop iteration
+- The threshold (90.0) is a named constant; changing it requires a code change (intentionally not runtime-configurable, to keep behavioral complexity bounded)
+- Fail-open on all error paths — absent, stale, or malformed state.json does not suppress dispatch
+- The gate does not affect TTL recovery, which runs independently
+- The cc-usage-poller must be running (cron every 30 min) for the gate to be active; without a fresh state file the gate is permanently open (correct default for new installs)

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -160,17 +160,29 @@ RECOVERY_STALE_MINUTES: int = 5
 #: Percentage threshold above which dispatch is skipped for the cycle.
 CC_QUOTA_SKIP_THRESHOLD: float = 90.0
 
-#: State file is considered stale if fetched_at is older than this many seconds.
+#: State file is considered stale if last_updated is older than this many seconds.
 _CC_QUOTA_FRESHNESS_SECONDS: int = 60 * 60  # 60 minutes
 
 
 def _read_cc_quota() -> float | None:
     """Return five_hour_pct from the CC budget state file, or None if unavailable.
 
-    Returns the float value when the file exists AND fetched_at is within the
+    Reads the state.json written by cc-usage-poller.py.  The file shape is:
+
+        {
+          "rate_limits": {
+            "five_hour": {"pct": <float>, "resets_at": "<ISO8601>"},
+            "seven_day":  {"pct": <float>, "resets_at": "<ISO8601>"}
+          },
+          "last_updated": "<ISO8601>",
+          "ts": <unix-int>,
+          "source": "cc-usage-poller"
+        }
+
+    Returns the float value when the file exists AND last_updated is within the
     last 60 minutes. Returns None when:
     - The file does not exist (LOBSTER_CC_BUDGET_STATE or ~/.claude/cc-budget/state.json)
-    - The file is stale (fetched_at older than 60 minutes)
+    - The file is stale (last_updated older than 60 minutes)
     - The file is unreadable or malformed
 
     None signals "no usable data" — callers must treat None as "proceed normally"
@@ -197,15 +209,15 @@ def _read_cc_quota() -> float | None:
 
     try:
         data = json.loads(raw)
-        pct = float(data["five_hour_pct"])
-        fetched_at_str = data["fetched_at"]
-        fetched_at = datetime.fromisoformat(fetched_at_str.replace("Z", "+00:00"))
-        if fetched_at.tzinfo is None:
-            fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+        pct = float(data["rate_limits"]["five_hour"]["pct"])
+        last_updated_str = data["last_updated"]
+        last_updated = datetime.fromisoformat(last_updated_str.replace("Z", "+00:00"))
+        if last_updated.tzinfo is None:
+            last_updated = last_updated.replace(tzinfo=timezone.utc)
     except (KeyError, ValueError, TypeError):
         return None
 
-    age = datetime.now(timezone.utc) - fetched_at
+    age = datetime.now(timezone.utc) - last_updated
     if age > timedelta(seconds=_CC_QUOTA_FRESHNESS_SECONDS):
         return None
 

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -148,6 +148,70 @@ def _warn_if_legacy_registry_exists() -> None:
 RECOVERY_STALE_MINUTES: int = 5
 
 # ---------------------------------------------------------------------------
+# CC quota gate — skip UoW dispatch when the 5-hour Claude Code quota is
+# critically low (>= 90%). Subagents are expensive; dispatching when quota
+# is nearly exhausted wastes the remaining headroom and can cause subagents
+# to fail partway through with quota errors.
+#
+# Fail-open: if the state file is absent or stale (> 60 min old), proceed
+# normally. Absent/stale data must never block dispatch.
+# ---------------------------------------------------------------------------
+
+#: Percentage threshold above which dispatch is skipped for the cycle.
+CC_QUOTA_SKIP_THRESHOLD: float = 90.0
+
+#: State file is considered stale if fetched_at is older than this many seconds.
+_CC_QUOTA_FRESHNESS_SECONDS: int = 60 * 60  # 60 minutes
+
+
+def _read_cc_quota() -> float | None:
+    """Return five_hour_pct from the CC budget state file, or None if unavailable.
+
+    Returns the float value when the file exists AND fetched_at is within the
+    last 60 minutes. Returns None when:
+    - The file does not exist (LOBSTER_CC_BUDGET_STATE or ~/.claude/cc-budget/state.json)
+    - The file is stale (fetched_at older than 60 minutes)
+    - The file is unreadable or malformed
+
+    None signals "no usable data" — callers must treat None as "proceed normally"
+    (fail-open). Only a fresh float >= CC_QUOTA_SKIP_THRESHOLD should cause a skip.
+
+    Pure function: reads the filesystem, parses JSON, computes staleness. No
+    side effects — the caller owns all logging and the skip decision.
+    """
+    from datetime import datetime, timezone, timedelta
+
+    state_path = Path(
+        os.environ.get(
+            "LOBSTER_CC_BUDGET_STATE",
+            Path.home() / ".claude" / "cc-budget" / "state.json",
+        )
+    )
+
+    try:
+        raw = state_path.read_text()
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+    try:
+        data = json.loads(raw)
+        pct = float(data["five_hour_pct"])
+        fetched_at_str = data["fetched_at"]
+        fetched_at = datetime.fromisoformat(fetched_at_str.replace("Z", "+00:00"))
+        if fetched_at.tzinfo is None:
+            fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+    except (KeyError, ValueError, TypeError):
+        return None
+
+    age = datetime.now(timezone.utc) - fetched_at
+    if age > timedelta(seconds=_CC_QUOTA_FRESHNESS_SECONDS):
+        return None
+
+    return pct
+
+# ---------------------------------------------------------------------------
 # GitHub API rate limit pre-dispatch check
 #
 # Subagents dispatched by the executor call `gh issue view` as step 1.
@@ -662,6 +726,21 @@ def main() -> int:
                 rate_status.remaining,
                 GITHUB_RATE_LIMIT_DISPATCH_THRESHOLD,
             )
+
+    # CC quota gate — skip dispatch when the 5-hour Claude Code quota is
+    # critically low. Fail-open: absent or stale data (> 60 min old) does
+    # not block dispatch — only fresh data at or above the threshold does.
+    cc_pct = _read_cc_quota()
+    if cc_pct is not None and cc_pct >= CC_QUOTA_SKIP_THRESHOLD:
+        log.info(
+            "cc_quota=%.1f%% — skipping dispatch cycle (threshold=%.1f%%)",
+            cc_pct,
+            CC_QUOTA_SKIP_THRESHOLD,
+        )
+        log.info("Executor heartbeat complete")
+        return 0
+    if cc_pct is not None:
+        log.debug("CC quota ok: %.1f%% (threshold=%.1f%%)", cc_pct, CC_QUOTA_SKIP_THRESHOLD)
 
     try:
         result = run_executor_cycle(registry, dry_run=dry_run)

--- a/tests/unit/test_scheduled_tasks/test_executor_heartbeat.py
+++ b/tests/unit/test_scheduled_tasks/test_executor_heartbeat.py
@@ -2,8 +2,19 @@
 Unit tests for _read_cc_quota() in scheduled-tasks/executor-heartbeat.py.
 
 The function reads ~/.claude/cc-budget/state.json (or the path in
-LOBSTER_CC_BUDGET_STATE) and returns five_hour_pct if the file exists
-and is fresh (fetched_at within 60 minutes), else None.
+LOBSTER_CC_BUDGET_STATE) and returns rate_limits.five_hour.pct if the
+file exists and is fresh (last_updated within 60 minutes), else None.
+
+State file shape written by cc-usage-poller.py:
+    {
+      "rate_limits": {
+        "five_hour": {"pct": <float>, "resets_at": "<ISO8601>"},
+        "seven_day":  {"pct": <float>, "resets_at": "<ISO8601>"}
+      },
+      "last_updated": "<ISO8601>",
+      "ts": <unix-int>,
+      "source": "cc-usage-poller"
+    }
 
 Named after behaviors, not mechanisms.
 """
@@ -75,21 +86,26 @@ CC_QUOTA_SKIP_THRESHOLD = executor_heartbeat.CC_QUOTA_SKIP_THRESHOLD
 # ---------------------------------------------------------------------------
 
 def _fresh_timestamp() -> str:
-    """Return an ISO 8601 UTC timestamp 5 minutes ago (fresh, within 60 min)."""
+    """Return an ISO 8601 UTC last_updated timestamp 5 minutes ago (fresh, within 60 min)."""
     return (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
 
 
 def _stale_timestamp() -> str:
-    """Return an ISO 8601 UTC timestamp 90 minutes ago (stale, > 60 min)."""
+    """Return an ISO 8601 UTC last_updated timestamp 90 minutes ago (stale, > 60 min)."""
     return (datetime.now(timezone.utc) - timedelta(minutes=90)).isoformat()
 
 
-def _write_state(path: Path, five_hour_pct: float, fetched_at: str) -> None:
+def _write_state(path: Path, five_hour_pct: float, last_updated: str) -> None:
+    """Write a state.json with the shape that cc-usage-poller.py produces."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({
-        "five_hour_pct": five_hour_pct,
-        "seven_day_pct": 20.0,
-        "fetched_at": fetched_at,
+        "rate_limits": {
+            "five_hour": {"pct": five_hour_pct, "resets_at": None},
+            "seven_day": {"pct": 20.0, "resets_at": None},
+        },
+        "last_updated": last_updated,
+        "ts": 0,
+        "source": "cc-usage-poller",
     }))
 
 
@@ -109,7 +125,7 @@ def test_returns_none_when_state_file_missing(tmp_path):
 def test_returns_none_when_state_file_is_stale(tmp_path):
     """Stale state file (fetched_at > 60 min ago) → None (dispatch proceeds)."""
     state_path = tmp_path / "state.json"
-    _write_state(state_path, five_hour_pct=95.0, fetched_at=_stale_timestamp())
+    _write_state(state_path, five_hour_pct=95.0, last_updated=_stale_timestamp())
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result is None
@@ -119,7 +135,7 @@ def test_returns_float_when_fresh_and_below_threshold(tmp_path):
     """Fresh state with quota < 90% → returns the float (caller allows dispatch)."""
     state_path = tmp_path / "state.json"
     pct = 52.0
-    _write_state(state_path, five_hour_pct=pct, fetched_at=_fresh_timestamp())
+    _write_state(state_path, five_hour_pct=pct, last_updated=_fresh_timestamp())
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result == pct
@@ -129,7 +145,7 @@ def test_returns_float_when_fresh_and_at_or_above_threshold(tmp_path):
     """Fresh state with quota >= 90% → returns the float (caller decides to skip)."""
     state_path = tmp_path / "state.json"
     pct = 92.5
-    _write_state(state_path, five_hour_pct=pct, fetched_at=_fresh_timestamp())
+    _write_state(state_path, five_hour_pct=pct, last_updated=_fresh_timestamp())
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result == pct
@@ -149,22 +165,30 @@ def test_returns_none_when_file_is_malformed(tmp_path):
     assert result is None
 
 
-def test_returns_none_when_five_hour_pct_key_missing(tmp_path):
-    """State file missing five_hour_pct key → None (fail-open)."""
+def test_returns_none_when_rate_limits_key_missing(tmp_path):
+    """State file missing rate_limits key → None (fail-open)."""
     state_path = tmp_path / "state.json"
     state_path.write_text(json.dumps({
-        "seven_day_pct": 20.0,
-        "fetched_at": _fresh_timestamp(),
+        "last_updated": _fresh_timestamp(),
+        "ts": 0,
+        "source": "cc-usage-poller",
     }))
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result is None
 
 
-def test_returns_none_when_fetched_at_key_missing(tmp_path):
-    """State file missing fetched_at key → None (fail-open)."""
+def test_returns_none_when_last_updated_key_missing(tmp_path):
+    """State file missing last_updated key → None (fail-open)."""
     state_path = tmp_path / "state.json"
-    state_path.write_text(json.dumps({"five_hour_pct": 50.0, "seven_day_pct": 20.0}))
+    state_path.write_text(json.dumps({
+        "rate_limits": {
+            "five_hour": {"pct": 50.0, "resets_at": None},
+            "seven_day": {"pct": 20.0, "resets_at": None},
+        },
+        "ts": 0,
+        "source": "cc-usage-poller",
+    }))
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result is None
@@ -173,27 +197,27 @@ def test_returns_none_when_fetched_at_key_missing(tmp_path):
 def test_exactly_at_threshold_returns_float(tmp_path):
     """Quota exactly at 90.0% → returns 90.0 (caller skips at >= threshold)."""
     state_path = tmp_path / "state.json"
-    _write_state(state_path, five_hour_pct=90.0, fetched_at=_fresh_timestamp())
+    _write_state(state_path, five_hour_pct=90.0, last_updated=_fresh_timestamp())
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result == 90.0
 
 
 def test_freshness_boundary_within_60_minutes(tmp_path):
-    """State file fetched 59 minutes ago is still fresh → returns float."""
+    """State file last_updated 59 minutes ago is still fresh → returns float."""
     state_path = tmp_path / "state.json"
-    fetched_at = (datetime.now(timezone.utc) - timedelta(minutes=59)).isoformat()
-    _write_state(state_path, five_hour_pct=75.0, fetched_at=fetched_at)
+    last_updated = (datetime.now(timezone.utc) - timedelta(minutes=59)).isoformat()
+    _write_state(state_path, five_hour_pct=75.0, last_updated=last_updated)
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result == 75.0
 
 
 def test_freshness_boundary_over_60_minutes(tmp_path):
-    """State file fetched 61 minutes ago is stale → returns None."""
+    """State file last_updated 61 minutes ago is stale → returns None."""
     state_path = tmp_path / "state.json"
-    fetched_at = (datetime.now(timezone.utc) - timedelta(minutes=61)).isoformat()
-    _write_state(state_path, five_hour_pct=75.0, fetched_at=fetched_at)
+    last_updated = (datetime.now(timezone.utc) - timedelta(minutes=61)).isoformat()
+    _write_state(state_path, five_hour_pct=75.0, last_updated=last_updated)
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
         result = _read_cc_quota()
     assert result is None
@@ -202,7 +226,7 @@ def test_freshness_boundary_over_60_minutes(tmp_path):
 def test_uses_env_var_path_over_default(tmp_path):
     """LOBSTER_CC_BUDGET_STATE env var controls the file path."""
     custom_path = tmp_path / "custom" / "state.json"
-    _write_state(custom_path, five_hour_pct=30.0, fetched_at=_fresh_timestamp())
+    _write_state(custom_path, five_hour_pct=30.0, last_updated=_fresh_timestamp())
     with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(custom_path)}):
         result = _read_cc_quota()
     assert result == 30.0

--- a/tests/unit/test_scheduled_tasks/test_executor_heartbeat.py
+++ b/tests/unit/test_scheduled_tasks/test_executor_heartbeat.py
@@ -1,0 +1,208 @@
+"""
+Unit tests for _read_cc_quota() in scheduled-tasks/executor-heartbeat.py.
+
+The function reads ~/.claude/cc-budget/state.json (or the path in
+LOBSTER_CC_BUDGET_STATE) and returns five_hour_pct if the file exists
+and is fresh (fetched_at within 60 minutes), else None.
+
+Named after behaviors, not mechanisms.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script module via importlib.
+#
+# executor-heartbeat.py is a standalone script, not a package module, so we
+# load it via importlib. Heavy imports (src.*) are patched out to avoid
+# needing a full runtime environment in unit tests.
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = (
+    Path(__file__).parents[3] / "scheduled-tasks" / "executor-heartbeat.py"
+)
+
+
+def _load_executor_heartbeat():
+    """Load executor-heartbeat.py as a module, stubbing heavy imports."""
+    import types as _types
+
+    # Stub out src.* imports that require a live DB or full environment
+    _src_stub = _types.ModuleType("src")
+    _orchestration_stub = _types.ModuleType("src.orchestration")
+    _paths_stub = _types.ModuleType("src.orchestration.paths")
+    _paths_stub.REGISTRY_DB = Path("/tmp/nonexistent-registry.db")
+    _src_stub.orchestration = _orchestration_stub
+    _orchestration_stub.paths = _paths_stub
+
+    MODULE_NAME = "executor_heartbeat"
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+
+    # Register the module in sys.modules BEFORE exec_module so that
+    # @dataclass and other decorators can resolve cls.__module__ correctly.
+    with patch.dict(
+        "sys.modules",
+        {
+            MODULE_NAME: mod,
+            "src": _src_stub,
+            "src.orchestration": _orchestration_stub,
+            "src.orchestration.paths": _paths_stub,
+        },
+    ):
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    return mod
+
+
+# Load once at module level; individual tests patch as needed.
+executor_heartbeat = _load_executor_heartbeat()
+_read_cc_quota = executor_heartbeat._read_cc_quota
+CC_QUOTA_SKIP_THRESHOLD = executor_heartbeat.CC_QUOTA_SKIP_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_timestamp() -> str:
+    """Return an ISO 8601 UTC timestamp 5 minutes ago (fresh, within 60 min)."""
+    return (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+
+
+def _stale_timestamp() -> str:
+    """Return an ISO 8601 UTC timestamp 90 minutes ago (stale, > 60 min)."""
+    return (datetime.now(timezone.utc) - timedelta(minutes=90)).isoformat()
+
+
+def _write_state(path: Path, five_hour_pct: float, fetched_at: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "five_hour_pct": five_hour_pct,
+        "seven_day_pct": 20.0,
+        "fetched_at": fetched_at,
+    }))
+
+
+# ---------------------------------------------------------------------------
+# Tests — behaviors
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_when_state_file_missing(tmp_path):
+    """Absent state file → None (fail-open: dispatch proceeds normally)."""
+    missing = tmp_path / "nonexistent" / "state.json"
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(missing)}):
+        result = _read_cc_quota()
+    assert result is None
+
+
+def test_returns_none_when_state_file_is_stale(tmp_path):
+    """Stale state file (fetched_at > 60 min ago) → None (dispatch proceeds)."""
+    state_path = tmp_path / "state.json"
+    _write_state(state_path, five_hour_pct=95.0, fetched_at=_stale_timestamp())
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result is None
+
+
+def test_returns_float_when_fresh_and_below_threshold(tmp_path):
+    """Fresh state with quota < 90% → returns the float (caller allows dispatch)."""
+    state_path = tmp_path / "state.json"
+    pct = 52.0
+    _write_state(state_path, five_hour_pct=pct, fetched_at=_fresh_timestamp())
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result == pct
+
+
+def test_returns_float_when_fresh_and_at_or_above_threshold(tmp_path):
+    """Fresh state with quota >= 90% → returns the float (caller decides to skip)."""
+    state_path = tmp_path / "state.json"
+    pct = 92.5
+    _write_state(state_path, five_hour_pct=pct, fetched_at=_fresh_timestamp())
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result == pct
+
+
+def test_threshold_constant_is_ninety():
+    """CC_QUOTA_SKIP_THRESHOLD is 90.0 as specified."""
+    assert CC_QUOTA_SKIP_THRESHOLD == 90.0
+
+
+def test_returns_none_when_file_is_malformed(tmp_path):
+    """Malformed JSON → None (fail-open)."""
+    state_path = tmp_path / "state.json"
+    state_path.write_text("not valid json {{{")
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result is None
+
+
+def test_returns_none_when_five_hour_pct_key_missing(tmp_path):
+    """State file missing five_hour_pct key → None (fail-open)."""
+    state_path = tmp_path / "state.json"
+    state_path.write_text(json.dumps({
+        "seven_day_pct": 20.0,
+        "fetched_at": _fresh_timestamp(),
+    }))
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result is None
+
+
+def test_returns_none_when_fetched_at_key_missing(tmp_path):
+    """State file missing fetched_at key → None (fail-open)."""
+    state_path = tmp_path / "state.json"
+    state_path.write_text(json.dumps({"five_hour_pct": 50.0, "seven_day_pct": 20.0}))
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result is None
+
+
+def test_exactly_at_threshold_returns_float(tmp_path):
+    """Quota exactly at 90.0% → returns 90.0 (caller skips at >= threshold)."""
+    state_path = tmp_path / "state.json"
+    _write_state(state_path, five_hour_pct=90.0, fetched_at=_fresh_timestamp())
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result == 90.0
+
+
+def test_freshness_boundary_within_60_minutes(tmp_path):
+    """State file fetched 59 minutes ago is still fresh → returns float."""
+    state_path = tmp_path / "state.json"
+    fetched_at = (datetime.now(timezone.utc) - timedelta(minutes=59)).isoformat()
+    _write_state(state_path, five_hour_pct=75.0, fetched_at=fetched_at)
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result == 75.0
+
+
+def test_freshness_boundary_over_60_minutes(tmp_path):
+    """State file fetched 61 minutes ago is stale → returns None."""
+    state_path = tmp_path / "state.json"
+    fetched_at = (datetime.now(timezone.utc) - timedelta(minutes=61)).isoformat()
+    _write_state(state_path, five_hour_pct=75.0, fetched_at=fetched_at)
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(state_path)}):
+        result = _read_cc_quota()
+    assert result is None
+
+
+def test_uses_env_var_path_over_default(tmp_path):
+    """LOBSTER_CC_BUDGET_STATE env var controls the file path."""
+    custom_path = tmp_path / "custom" / "state.json"
+    _write_state(custom_path, five_hour_pct=30.0, fetched_at=_fresh_timestamp())
+    with patch.dict("os.environ", {"LOBSTER_CC_BUDGET_STATE": str(custom_path)}):
+        result = _read_cc_quota()
+    assert result == 30.0


### PR DESCRIPTION
## What this changes

When the 5-hour Claude Code quota is critically low (>= 90%), the executor heartbeat now skips UoW dispatch for that cycle and logs `cc_quota=XX.X% — skipping dispatch cycle`. Before this change, the heartbeat would dispatch new subagents regardless of quota state — which wastes the remaining headroom and can cause those subagents to fail partway through with quota errors.

TTL recovery and heartbeat sidecar are unaffected. Only new UoW dispatch is gated.

## How the gate works

Before each dispatch cycle (after the GitHub rate limit check), `_read_cc_quota()` reads `~/.claude/cc-budget/state.json` (path overrideable via `LOBSTER_CC_BUDGET_STATE`). The gate fires only when:
1. The file exists AND `fetched_at` is within the last 60 minutes (fresh)
2. `five_hour_pct >= CC_QUOTA_SKIP_THRESHOLD` (90.0%)

Any other condition — file absent, file stale, file malformed, key missing — returns `None` and dispatch proceeds normally. **The gate is strictly fail-open.**

## Functional patterns

`_read_cc_quota() -> float | None` is a pure function: reads the filesystem, parses JSON, computes staleness, returns a value. No side effects. The caller (main()) owns all logging and the skip decision — the function only answers "what is the current fresh quota, if any?"

The skip decision in main() is a declarative guard:
```python
cc_pct = _read_cc_quota()
if cc_pct is not None and cc_pct >= CC_QUOTA_SKIP_THRESHOLD:
    log.info("cc_quota=%.1f%% — skipping dispatch cycle ...")
    return 0
```

## What is out of scope

This PR does not touch `steward-heartbeat.py`, the dashboard, or any other scheduled task. The state.json file is written by the separate `cc-usage-poller` — this PR only reads it.

## Tests run
- [x] `uv run pytest tests/unit/test_scheduled_tasks/test_executor_heartbeat.py -v` — 12 passed, 0 failed
- [ ] Live run against production executor — not applicable: the gate reads a file that doesn't exist in the test environment, which is the fail-open case (tested). Integration behavior requires the cc-usage-poller to be running.

## Manual test

N/A — this change is entirely internal to the heartbeat dispatch gate. The external observable effect (subagents not dispatching when quota is high) requires live quota data from the cc-usage-poller. The fail-open path (file absent) is the path that runs in all test environments and is covered by `test_returns_none_when_state_file_missing`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, file-read gate with fail-open, unit-tested
- [x] User-visible outcome verified — N/A, internal dispatch gate
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none added