### PR TITLE
feat(dashboard): CC quota widget in WOS dashboard

### DIFF
--- a/src/orchestration/wos_dashboard.py
+++ b/src/orchestration/wos_dashboard.py
@@ -231,6 +231,112 @@ def _enrich_uow_with_github_metadata(uow_row: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# CC quota widget — pure functions reading ~/.claude/cc-budget/state.json
+# ---------------------------------------------------------------------------
+
+# Stale threshold: state older than this is treated as unavailable.
+CC_QUOTA_STALE_THRESHOLD_MINUTES = 60
+
+# Color thresholds: <70% green, 70–89% yellow/orange, ≥90% red.
+CC_QUOTA_COLOR_GREEN_MAX = 70
+CC_QUOTA_COLOR_RED_MIN = 90
+
+
+def _read_cc_budget_state(state_path: str | None = None) -> dict | None:
+    """Read CC budget state from state.json and return the parsed dict, or None.
+
+    Pure read: no side effects beyond file I/O. Returns None when:
+    - File is absent or unreadable
+    - JSON is malformed
+    - Required keys (five_hour_pct, seven_day_pct, fetched_at) are missing
+
+    Path resolution order:
+    1. state_path argument (if provided)
+    2. LOBSTER_CC_BUDGET_STATE env var
+    3. ~/.claude/cc-budget/state.json (default)
+    """
+    if state_path is None:
+        state_path = os.environ.get(
+            "LOBSTER_CC_BUDGET_STATE",
+            str(Path.home() / ".claude" / "cc-budget" / "state.json"),
+        )
+    try:
+        text = Path(state_path).read_text(encoding="utf-8")
+        data = json.loads(text)
+        # Validate required keys are present
+        if not all(k in data for k in ("five_hour_pct", "seven_day_pct", "fetched_at")):
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def _cc_quota_color(pct: float) -> str:
+    """Return a CSS color string for the given usage percentage.
+
+    <70%  → green (#1a7a3c)
+    70–89% → orange (#a06000)
+    ≥90%  → red (#c0392b)
+    """
+    if pct >= CC_QUOTA_COLOR_RED_MIN:
+        return "#c0392b"
+    if pct >= CC_QUOTA_COLOR_GREEN_MAX:
+        return "#a06000"
+    return "#1a7a3c"
+
+
+def _format_cc_quota_widget(state: dict | None, now: datetime) -> str:
+    """Return an HTML string for the CC quota widget.
+
+    Handles two cases:
+    - state is None or stale (>60 min): shows "CC quota: unavailable"
+    - state is fresh: shows 5h%, 7d%, and relative data age
+
+    Pure function: no side effects. All inputs are arguments.
+    """
+    # Determine if state is usable (present and fresh).
+    if state is not None:
+        try:
+            fetched_at_str = state["fetched_at"].replace("Z", "+00:00")
+            fetched_at = datetime.fromisoformat(fetched_at_str)
+            age_minutes = (now - fetched_at).total_seconds() / 60
+            if age_minutes > CC_QUOTA_STALE_THRESHOLD_MINUTES:
+                state = None  # treat as unavailable
+        except Exception:
+            state = None
+
+    if state is None:
+        return (
+            "<div style='display:inline-flex;align-items:center;gap:8px;"
+            "font-size:.8rem;color:var(--text3)'>"
+            "<strong>CC quota:</strong> <span>unavailable</span></div>"
+        )
+
+    five_pct = state["five_hour_pct"]
+    seven_pct = state["seven_day_pct"]
+
+    # Relative age string (e.g. "8m ago")
+    age_seconds = int((now - fetched_at).total_seconds())
+    if age_seconds < 60:
+        age_str = f"{age_seconds}s ago"
+    else:
+        age_str = f"{age_seconds // 60}m ago"
+
+    five_color = _cc_quota_color(five_pct)
+    seven_color = _cc_quota_color(seven_pct)
+
+    return (
+        "<div style='display:inline-flex;align-items:center;gap:10px;"
+        "font-size:.8rem;flex-wrap:wrap'>"
+        f"<strong>CC quota:</strong>"
+        f"<span style='color:{five_color};font-weight:600'>5h: {five_pct:.0f}%</span>"
+        f"<span style='color:{seven_color};font-weight:600'>7d: {seven_pct:.0f}%</span>"
+        f"<span style='color:var(--text3);font-size:.72rem'>as of {age_str}</span>"
+        "</div>"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Pure data-gathering functions
 # ---------------------------------------------------------------------------
 
@@ -397,14 +503,20 @@ def build_dashboard_data(
 
     This function is the composition point: each sub-query is pure and
     independently testable; build_dashboard_data just calls them in sequence.
+
+    cc_quota is included as a pre-rendered HTML string so render_html stays
+    a pure function — all state reads and formatting happen here.
     """
+    now = datetime.now(timezone.utc)
+    cc_state = _read_cc_budget_state()
     return {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": now.isoformat(),
         "active_uows": _active_uows(registry),
         "throughput_24h": _throughput_24h(registry_path),
         "cycle_histogram_7d": _cycle_histogram_last_7d(registry, registry_path),
         "stalled_uows": _stalled_uows(registry),
         "bootup_candidate_gate": _bootup_gate_status(registry),
+        "cc_quota": _format_cc_quota_widget(cc_state, now),
     }
 
 
@@ -563,6 +675,9 @@ def render_html(data: dict[str, Any], drilldown_urls: dict[str, str]) -> str:
     - Status badge + category badge (derived from GitHub labels)
     - Steward cycle count
     - Time in current state
+
+    The CC quota widget (data["cc_quota"]) is injected near the top of the page,
+    alongside the status summary, as a pre-rendered HTML string.
     """
     generated_at = data.get("generated_at", "")
     active = data.get("active_uows", [])
@@ -570,6 +685,7 @@ def render_html(data: dict[str, Any], drilldown_urls: dict[str, str]) -> str:
     hist = data.get("cycle_histogram_7d", {})
     stalls = data.get("stalled_uows", [])
     gate = data.get("bootup_candidate_gate", {})
+    cc_quota_html = data.get("cc_quota") or ""
 
     # --- Active UoWs table ---
     if active:
@@ -671,6 +787,7 @@ h2{{font-size:.8rem;font-weight:600;margin-bottom:10px;color:var(--text2);text-t
 <h1>WOS Dashboard</h1>
 <p class="meta">Generated {generated_at}</p>
 {drilldown_note}
+{f'<div class="sec" style="padding:10px 14px;margin-bottom:8px">{cc_quota_html}</div>' if cc_quota_html else ''}
 
 <div class="sec">
   <h2>Active UoWs ({len(active)})</h2>

--- a/tests/unit/test_orchestration/test_wos_dashboard.py
+++ b/tests/unit/test_orchestration/test_wos_dashboard.py
@@ -993,3 +993,238 @@ class TestMainHtmlCanonical:
         dest = uploads_dir / "wos-dashboard-active.html"
         assert dest.exists()
         assert "<!DOCTYPE html>" in dest.read_text()
+
+
+# ---------------------------------------------------------------------------
+# _read_cc_budget_state
+# ---------------------------------------------------------------------------
+
+class TestReadCcBudgetState:
+    def test_returns_dict_for_valid_state_file(self, tmp_path):
+        """Returns parsed dict when state.json contains valid CC quota data."""
+        from src.orchestration.wos_dashboard import _read_cc_budget_state
+        state_file = tmp_path / "state.json"
+        state_file.write_text(
+            '{"five_hour_pct": 52.0, "seven_day_pct": 28.0, "fetched_at": "2026-05-10T18:42:00Z"}'
+        )
+        result = _read_cc_budget_state(str(state_file))
+        assert result is not None
+        assert result["five_hour_pct"] == 52.0
+        assert result["seven_day_pct"] == 28.0
+        assert result["fetched_at"] == "2026-05-10T18:42:00Z"
+
+    def test_returns_none_when_file_missing(self, tmp_path):
+        """Returns None when the state file does not exist."""
+        from src.orchestration.wos_dashboard import _read_cc_budget_state
+        result = _read_cc_budget_state(str(tmp_path / "nonexistent.json"))
+        assert result is None
+
+    def test_returns_none_on_malformed_json(self, tmp_path):
+        """Returns None when the state file contains invalid JSON."""
+        from src.orchestration.wos_dashboard import _read_cc_budget_state
+        state_file = tmp_path / "state.json"
+        state_file.write_text("not valid json")
+        result = _read_cc_budget_state(str(state_file))
+        assert result is None
+
+    def test_returns_none_when_required_key_missing(self, tmp_path):
+        """Returns None when the state file is missing required keys."""
+        from src.orchestration.wos_dashboard import _read_cc_budget_state
+        state_file = tmp_path / "state.json"
+        state_file.write_text('{"five_hour_pct": 52.0}')  # missing seven_day_pct and fetched_at
+        result = _read_cc_budget_state(str(state_file))
+        assert result is None
+
+    def test_reads_from_env_var_path_when_state_path_is_none(self, tmp_path, monkeypatch):
+        """When state_path=None, reads from LOBSTER_CC_BUDGET_STATE env var."""
+        from src.orchestration.wos_dashboard import _read_cc_budget_state
+        state_file = tmp_path / "state.json"
+        state_file.write_text(
+            '{"five_hour_pct": 75.0, "seven_day_pct": 40.0, "fetched_at": "2026-05-10T10:00:00Z"}'
+        )
+        monkeypatch.setenv("LOBSTER_CC_BUDGET_STATE", str(state_file))
+        result = _read_cc_budget_state(None)
+        assert result is not None
+        assert result["five_hour_pct"] == 75.0
+
+    def test_uses_default_path_when_no_env_var_and_state_path_is_none(self, monkeypatch):
+        """Falls back to ~/.claude/cc-budget/state.json when no env var and no explicit path."""
+        from src.orchestration.wos_dashboard import _read_cc_budget_state
+        monkeypatch.delenv("LOBSTER_CC_BUDGET_STATE", raising=False)
+        # Default path does not exist in test environment — should return None, not raise.
+        result = _read_cc_budget_state(None)
+        assert result is None  # file absent at default location
+
+
+# ---------------------------------------------------------------------------
+# _format_cc_quota_widget
+# ---------------------------------------------------------------------------
+
+# Named constants matching spec requirements
+CC_QUOTA_STALE_THRESHOLD_MINUTES = 60
+CC_QUOTA_COLOR_GREEN_MAX = 70       # <70% is green
+CC_QUOTA_COLOR_YELLOW_MAX = 90      # 70-89% is yellow/orange; >=90% is red
+
+
+class TestFormatCcQuotaWidget:
+    def _now(self) -> datetime:
+        return datetime(2026, 5, 10, 18, 50, 0, tzinfo=timezone.utc)
+
+    def _fresh_state(self) -> dict:
+        """State fetched 8 minutes before _now()."""
+        return {
+            "five_hour_pct": 52.0,
+            "seven_day_pct": 28.0,
+            "fetched_at": "2026-05-10T18:42:00Z",
+        }
+
+    def _stale_state(self) -> dict:
+        """State fetched 70 minutes before _now() — exceeds 60-min threshold."""
+        return {
+            "five_hour_pct": 30.0,
+            "seven_day_pct": 15.0,
+            "fetched_at": "2026-05-10T17:40:00Z",
+        }
+
+    def test_unavailable_widget_when_state_is_none(self):
+        """None state → unavailable widget."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        html = _format_cc_quota_widget(None, self._now())
+        assert "unavailable" in html.lower()
+
+    def test_unavailable_widget_when_state_is_stale(self):
+        """Stale state (>60 min) → unavailable widget."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        html = _format_cc_quota_widget(self._stale_state(), self._now())
+        assert "unavailable" in html.lower()
+
+    def test_fresh_state_shows_five_hour_percentage(self):
+        """Fresh state shows 5h quota percentage."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        html = _format_cc_quota_widget(self._fresh_state(), self._now())
+        assert "52" in html
+        assert "5h" in html
+
+    def test_fresh_state_shows_seven_day_percentage(self):
+        """Fresh state shows 7d quota percentage."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        html = _format_cc_quota_widget(self._fresh_state(), self._now())
+        assert "28" in html
+        assert "7d" in html
+
+    def test_fresh_state_shows_relative_data_age(self):
+        """Fresh state shows data age as relative time ('as of Nm ago')."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        html = _format_cc_quota_widget(self._fresh_state(), self._now())
+        # 8 minutes ago
+        assert "8m" in html
+
+    def test_green_color_below_threshold(self):
+        """Percentages below 70% are colored green (low usage)."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        state = {"five_hour_pct": 40.0, "seven_day_pct": 20.0, "fetched_at": "2026-05-10T18:42:00Z"}
+        html = _format_cc_quota_widget(state, self._now())
+        # Green CSS color or class should appear
+        assert "green" in html.lower() or "#" in html  # color indicator present
+
+    def test_red_color_at_or_above_90_percent(self):
+        """Percentages at or above 90% are colored red (high usage)."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        state = {"five_hour_pct": 92.0, "seven_day_pct": 95.0, "fetched_at": "2026-05-10T18:42:00Z"}
+        html = _format_cc_quota_widget(state, self._now())
+        assert "red" in html.lower() or "#c0392b" in html or "#f87171" in html
+
+    def test_widget_is_html_string(self):
+        """Returns an HTML string (contains angle brackets)."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        html = _format_cc_quota_widget(self._fresh_state(), self._now())
+        assert "<" in html and ">" in html
+
+    def test_cc_quota_label_present(self):
+        """Widget contains a recognizable 'CC quota' or 'CC Quota' label."""
+        from src.orchestration.wos_dashboard import _format_cc_quota_widget
+        html = _format_cc_quota_widget(self._fresh_state(), self._now())
+        assert "CC" in html
+
+
+# ---------------------------------------------------------------------------
+# render_html — CC quota widget injection
+# ---------------------------------------------------------------------------
+
+class TestRenderHtmlCcQuota:
+    def _base_data(self, cc_quota: dict | None = None) -> dict:
+        data = {
+            "generated_at": "2026-05-10T18:50:00+00:00",
+            "active_uows": [],
+            "throughput_24h": {"completed": 3, "failed": 0},
+            "cycle_histogram_7d": {},
+            "stalled_uows": [],
+            "bootup_candidate_gate": {
+                "gate_open": False,
+                "blocked_count": 0,
+                "description": "gate is CLOSED — all UoWs are processed normally",
+            },
+        }
+        if cc_quota is not None:
+            data["cc_quota"] = cc_quota
+        return data
+
+    def test_cc_quota_section_present_when_data_provided(self):
+        """When cc_quota key is present in data, the widget appears in the rendered HTML."""
+        from src.orchestration.wos_dashboard import render_html
+        cc_quota_html = "<span>CC quota: 5h: 52%</span>"
+        data = self._base_data(cc_quota=cc_quota_html)
+        html = render_html(data, drilldown_urls={})
+        assert "52" in html
+        assert "CC" in html
+
+    def test_cc_quota_absent_when_key_missing(self):
+        """When cc_quota key is absent, the widget area is omitted gracefully."""
+        from src.orchestration.wos_dashboard import render_html
+        data = self._base_data(cc_quota=None)  # no cc_quota key
+        html = render_html(data, drilldown_urls={})
+        # Should still be valid HTML without errors
+        assert "<!DOCTYPE html>" in html
+
+    def test_cc_quota_unavailable_string_renders(self):
+        """When cc_quota contains 'unavailable', that text appears in the HTML."""
+        from src.orchestration.wos_dashboard import render_html
+        data = self._base_data(cc_quota="<span>CC quota: unavailable</span>")
+        html = render_html(data, drilldown_urls={})
+        assert "unavailable" in html
+
+
+# ---------------------------------------------------------------------------
+# build_dashboard_data — CC quota included
+# ---------------------------------------------------------------------------
+
+class TestBuildDashboardDataCcQuota:
+    def test_cc_quota_key_present_in_data(self, tmp_path):
+        """build_dashboard_data includes cc_quota key when called."""
+        from src.orchestration.wos_dashboard import build_dashboard_data
+        registry = _make_registry([])
+        db_path = tmp_path / "registry.db"
+
+        with patch("src.orchestration.audit_queries.execution_outcomes", return_value={}), \
+             patch("src.orchestration.wos_dashboard._fetch_completed_uow_ids_since", return_value=[]), \
+             patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=False), \
+             patch("src.orchestration.wos_dashboard._read_cc_budget_state", return_value=None):
+            data = build_dashboard_data(registry, db_path)
+
+        assert "cc_quota" in data
+
+    def test_cc_quota_is_html_string_when_state_available(self, tmp_path):
+        """When state is available, cc_quota value is an HTML string."""
+        from src.orchestration.wos_dashboard import build_dashboard_data
+        registry = _make_registry([])
+        db_path = tmp_path / "registry.db"
+        state = {"five_hour_pct": 52.0, "seven_day_pct": 28.0, "fetched_at": "2026-05-10T18:42:00Z"}
+
+        with patch("src.orchestration.audit_queries.execution_outcomes", return_value={}), \
+             patch("src.orchestration.wos_dashboard._fetch_completed_uow_ids_since", return_value=[]), \
+             patch("src.orchestration.steward.is_bootup_candidate_gate_active", return_value=False), \
+             patch("src.orchestration.wos_dashboard._read_cc_budget_state", return_value=state):
+            data = build_dashboard_data(registry, db_path)
+
+        assert isinstance(data["cc_quota"], str)
+        assert "<" in data["cc_quota"]

--- a/tests/unit/test_orchestration/test_wos_dashboard.py
+++ b/tests/unit/test_orchestration/test_wos_dashboard.py
@@ -1060,12 +1060,6 @@ class TestReadCcBudgetState:
 # _format_cc_quota_widget
 # ---------------------------------------------------------------------------
 
-# Named constants matching spec requirements
-CC_QUOTA_STALE_THRESHOLD_MINUTES = 60
-CC_QUOTA_COLOR_GREEN_MAX = 70       # <70% is green
-CC_QUOTA_COLOR_YELLOW_MAX = 90      # 70-89% is yellow/orange; >=90% is red
-
-
 class TestFormatCcQuotaWidget:
     def _now(self) -> datetime:
         return datetime(2026, 5, 10, 18, 50, 0, tzinfo=timezone.utc)
@@ -1124,8 +1118,8 @@ class TestFormatCcQuotaWidget:
         from src.orchestration.wos_dashboard import _format_cc_quota_widget
         state = {"five_hour_pct": 40.0, "seven_day_pct": 20.0, "fetched_at": "2026-05-10T18:42:00Z"}
         html = _format_cc_quota_widget(state, self._now())
-        # Green CSS color or class should appear
-        assert "green" in html.lower() or "#" in html  # color indicator present
+        # Green CSS hex color should appear
+        assert "#1a7a3c" in html
 
     def test_red_color_at_or_above_90_percent(self):
         """Percentages at or above 90% are colored red (high usage)."""


### PR DESCRIPTION
## What this solves

The WOS HTML dashboard previously had no visibility into Claude Code quota consumption. When the 5-hour or 7-day quota was running high, there was no in-dashboard signal — you had to check separately. This PR adds a CC quota widget to the dashboard header area, surfacing both quota levels at a glance alongside the WOS status summary.

## What changed

The widget reads `~/.claude/cc-budget/state.json` (written by the cc-usage-poller, merged in #1122) and injects a pre-rendered HTML string into the dashboard. Two pure functions do the work:

- **`_read_cc_budget_state(state_path)`** — reads the JSON file, validates required keys (`five_hour_pct`, `seven_day_pct`, `fetched_at`), returns `None` on any failure (absent file, malformed JSON, missing keys). Path resolution: explicit argument → `LOBSTER_CC_BUDGET_STATE` env var → `~/.claude/cc-budget/state.json` default.

- **`_format_cc_quota_widget(state, now)`** — returns an HTML string. Handles two cases: state is None or older than 60 minutes → "CC quota: unavailable"; otherwise shows `5h: N%`, `7d: N%`, and "as of Xm ago". Color-codes by severity using named constants (`CC_QUOTA_STALE_THRESHOLD_MINUTES = 60`, `CC_QUOTA_COLOR_GREEN_MAX = 70`, `CC_QUOTA_COLOR_RED_MIN = 90`).

`build_dashboard_data()` now calls both functions and stores the result as `data["cc_quota"]` — a pre-rendered HTML string. This keeps `render_html()` a pure function: it receives the widget HTML and injects it, without touching the file system.

The widget appears in a compact section between the page header and the Active UoWs table.

### Functional patterns

- Pure functions with no side effects except at the boundary (`_read_cc_budget_state` reads a file; everything else is pure transformation)
- Immutable data flow: `build_dashboard_data` produces a new dict including `cc_quota`; `render_html` consumes it without mutation
- Named constants for all spec-derived thresholds — no magic literals

## Before / after (HTML layout)

```
Before:
  <h1>WOS Dashboard</h1>
  <p class="meta">Generated ...</p>
  [active UoWs section]

After:
  <h1>WOS Dashboard</h1>
  <p class="meta">Generated ...</p>
  [CC quota widget: "CC quota: 5h: 52%  7d: 28%  as of 8m ago"]   ← new
  [active UoWs section]
```

When state is absent or stale: "CC quota: unavailable" (same placement, no layout disruption).

## Out of scope

- No changes to executor-heartbeat, cc-usage-poller, or any other dashboard files
- The widget does not write anything; it is read-only at the state file boundary

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_dashboard.py -v` — 91 passed, 0 failed (21 new tests covering _read_cc_budget_state, _format_cc_quota_widget, render_html CC quota injection, and build_dashboard_data cc_quota key)
- [ ] Live dashboard render — skipped: requires running system with cc-budget state file present; no behavior change to existing sections

## Manual test

N/A — this change is entirely internal HTML generation. The widget reads a local file and renders HTML; no external service calls, no DB writes, no systemd/cron changes. The cc-usage-poller (which writes state.json) was separately tested and merged in #1122.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] User-visible outcome: widget renders correct percentages and colors in HTML output — verified via unit tests asserting HTML string content
- [x] Side-effect audit: reads one file at dashboard generation time; no writes, no floods, no shared state mutations
- [x] External service calls: none (file read only, mocked in tests)