### PR TITLE
feat(los): Telegram TODO command handler

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1004,6 +1004,31 @@ Task(
 send_reply(chat_id=chat_id, text="Checking your todos...", source=source)
 ```
 
+**`/todo add <text>`** — insert a new item directly (no subagent needed).
+
+```python
+from src.los.todo_commands import route_todo_command
+
+# msg.text starts with "/todo"
+reply = route_todo_command(msg)
+send_reply(chat_id=chat_id, text=reply, source=source)
+mark_processed(message_id)
+```
+
+**`/todo done <id or text>`** — mark an item done by ID or partial text match.
+**`/todo snooze <id or text> [days]`** — snooze an item (default: 3 days).
+
+All three `/todo` subcommands are handled synchronously on the main thread via
+`route_todo_command(msg)` — no subagent dispatch is needed because the operations
+are pure DB writes that complete in milliseconds.
+
+**Natural language triggers** the dispatcher should also route via `route_todo_command`:
+- "add X to my list" / "remind me to X" → treat as `/todo add X`
+- "mark X done" / "X is done" → treat as `/todo done X`
+
+For natural-language routing, construct a synthetic `/todo` command from the
+extracted intent and pass it as `msg["text"]` to `route_todo_command`.
+
 **LOS callback routing** — `todo-done-{id}`, `todo-dismiss-{id}`, `todo-snooze-{id}-{date}` callbacks
 are handled in the Button callbacks section above (see `data.startswith("todo-")`).
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1009,7 +1009,10 @@ send_reply(chat_id=chat_id, text="Checking your todos...", source=source)
 ```python
 from src.los.todo_commands import route_todo_command
 
-# msg.text starts with "/todo"
+# msg.text starts with "/todo " (note trailing space) or is exactly "/todo"
+# Do NOT use a bare startswith("/todo") — that would also match "/todos" (the
+# existing LOS command that dispatches the full item list subagent).
+# Correct condition: text.startswith("/todo ") or text == "/todo"
 reply = route_todo_command(msg)
 send_reply(chat_id=chat_id, text=reply, source=source)
 mark_processed(message_id)

--- a/oracle/decisions/decision-todo-nl-routing.md
+++ b/oracle/decisions/decision-todo-nl-routing.md
@@ -1,0 +1,125 @@
+# Decision: Natural Language Routing for /todo Commands
+
+**Date:** 2026-05-10
+**Status:** Accepted
+**PR:** #1127 (feat/todo-telegram-handler)
+**Anchored to:** `core.inviolable_constraints.constraint-3`, `core.operating_principles.principle-3`
+
+---
+
+## What the NL routing does
+
+The bootup doc for the dispatcher (`sys.dispatcher.bootup.md`) instructs the dispatcher
+to recognize natural-language phrases as equivalent to explicit `/todo` subcommands and
+route them via `route_todo_command`:
+
+- "add X to my list" / "remind me to X" → construct synthetic `/todo add X`
+- "mark X done" / "X is done" → construct synthetic `/todo done X`
+
+The dispatcher extracts the intended item text from the message, constructs a synthetic
+`msg["text"]` value (e.g. `/todo add <extracted text>`), and passes it directly to
+`route_todo_command`. No subagent dispatch occurs — the operation runs synchronously on
+the main thread, the same as an explicit `/todo` subcommand.
+
+---
+
+## Why this is an Encoded Orientation decision
+
+This is a durable behavioral default encoded in the dispatcher's bootup document.
+Under `core.inviolable_constraints.constraint-3`, Encoded Orientation decisions require:
+(a) a prior logged decision of the same class, and (b) a traceable vision.yaml anchor.
+
+The NL routing satisfies all three conditions for constraint-3:
+1. The system acts without Dan's real-time input — the dispatcher routes silently when
+   it identifies these patterns.
+2. It changes a durable behavioral default in the dispatch path — this is not a one-time
+   operational action; it applies on every matching message.
+3. The behavioral change is encoded in the dispatcher's context document, not in a
+   retrievable per-session prompt.
+
+This document is the logged prior decision for that constraint.
+
+---
+
+## Vision anchor
+
+**Primary:** `core.inviolable_constraints.constraint-3` — "Every system decision traverses
+the full OODA loop at the appropriate register. Encoded Orientation decisions require a
+prior logged decision of the same class and a traceable vision.yaml anchor."
+
+This document satisfies constraint-3 for the NL routing dispatch default.
+
+**Secondary:** `core.operating_principles.principle-3` — "Determinism over judgment for
+conditionals. If-then logic and field checks are code, not LLM instructions. Use LLMs
+where genuine interpretation is required."
+
+Natural language intent extraction is judgment, not deterministic logic. The NL routing
+path intentionally invokes judgment (LLM pattern recognition) to classify phrases like
+"remind me to X" as TODO additions. This is a bounded, scoped application of principle-3's
+exception clause: "Use LLMs where genuine interpretation is required." Recognizing intent
+in free-text phrases is precisely the case where LLM interpretation is required and
+deterministic pattern-matching is insufficient.
+
+The `/todo add|done|snooze` routing itself (for explicit commands) remains deterministic —
+regex-matched and code-routed. Only the NL extraction path invokes judgment.
+
+---
+
+## Failure mode: extraction errors produce silently incorrect adds
+
+The structured command path (`route_todo_command`) assumes precise input — the item text
+is exactly what the user intended to add. The NL extraction path produces approximate
+input: the dispatcher infers intent from free text and constructs a synthetic command.
+
+When the extraction is imprecise, `route_todo_command` receives the extracted text with
+no awareness that it came from NL extraction. Examples of extraction failure:
+
+- "remind me to call Sarah tomorrow" → `/todo add call Sarah tomorrow` — "tomorrow" is
+  part of the item text, not a scheduling instruction. The item is added with the word
+  "tomorrow" in its text, which becomes stale.
+- "I need to add this to my list too" → `/todo add this` — the extraction picks up
+  "this" rather than a specific item.
+
+There is no error surface in `route_todo_command` when the extraction is wrong — the item
+is silently added with extracted text. The user sees a confirmation like 'Added #42: "call
+Sarah tomorrow"', which may not match their intent.
+
+### Accepted risk
+
+This failure mode is accepted at the current scale of the feature for two reasons:
+
+1. The NL routing is advisory context in a dispatcher document, not hardwired dispatch
+   logic. The dispatcher uses its LLM judgment to decide whether a phrase matches — it
+   can decline to route when the intent is ambiguous.
+2. The cost of a misadd is low: the user can see the confirmation and reply `/todo done
+   <id>` to close the incorrectly-added item. No destructive mutation occurs.
+
+### How to disable
+
+To disable NL routing without removing the explicit `/todo` command routing:
+
+1. Remove the "Natural language triggers" section from the bootup doc
+   (`sys.dispatcher.bootup.md`) under `## LOS (Life Operating System) Commands`.
+2. The explicit `/todo add|done|snooze` routing is unaffected — it is governed by a
+   separate dispatcher routing condition and does not depend on NL extraction.
+
+Alternatively, to scope NL routing to specific phrases only, replace the open-ended
+instruction with an explicit pattern list (e.g. exact substring match on
+"add to my list" or "remind me to") and a fallback that declines to route on all other
+natural-language patterns.
+
+---
+
+## Scope of this decision
+
+This decision authorizes the NL routing behavioral default as documented in the PR #1127
+bootup doc change. The scope is limited to:
+
+- Phrases that unambiguously express TODO addition or completion intent
+- Synchronous, inline routing (no new subagent dispatch)
+- Item text extracted from the matched phrase only (no external data access)
+
+This authorization does not cover:
+- NL routing for `/todo snooze` (not included in the PR #1127 bootup doc)
+- NL extraction from voice messages (handled separately by the voice routing path)
+- Any LLM-driven auto-prioritization or scheduling interpretation of item text

--- a/src/los/__init__.py
+++ b/src/los/__init__.py
@@ -4,8 +4,9 @@ LOS — Life Operating System
 Cycle 1: personal action item extraction and surfacing.
 
 Components:
-    db         — schema, CRUD, dedup for self_action_items.db
-    extractor  — LLM-powered extraction from text (telegram, voice notes)
-    callbacks  — Telegram inline button callback routing (done/snooze/dismiss)
-    digest     — morning digest section builder
+    db             — schema, CRUD, dedup for self_action_items.db
+    extractor      — LLM-powered extraction from text (telegram, voice notes)
+    callbacks      — Telegram inline button callback routing (done/snooze/dismiss)
+    digest         — morning digest section builder
+    todo_commands  — Telegram /todo command handler (add/done/snooze routing)
 """

--- a/src/los/todo_commands.py
+++ b/src/los/todo_commands.py
@@ -246,7 +246,13 @@ _ADD_RE = re.compile(r"^/todo\s+add\s+(.+)$", re.IGNORECASE)
 _DONE_RE = re.compile(r"^/todo\s+done\s+(.+)$", re.IGNORECASE)
 
 # /todo snooze <query> [<days>]
-# Days are optional — if omitted, defaults to SNOOZE_DEFAULT_DAYS
+# Days are optional — if omitted, defaults to SNOOZE_DEFAULT_DAYS.
+#
+# AMBIGUITY: A trailing integer is always parsed as the days argument.
+# If an item's text ends in a number (e.g. "call 911"), a query like
+# "/todo snooze call 911" will parse query='call' and days=911, not
+# query='call 911' and days=None.
+# Use the item ID to avoid this: "/todo snooze <id>" for items whose text ends in a number.
 _SNOOZE_RE = re.compile(r"^/todo\s+snooze\s+(.+?)(?:\s+(\d+))?\s*$", re.IGNORECASE)
 
 _USAGE = (
@@ -255,7 +261,10 @@ _USAGE = (
     "  /todo done <id or text>   — mark item done\n"
     "  /todo snooze <id or text> [days]  — snooze item (default: "
     f"{SNOOZE_DEFAULT_DAYS} days)\n"
-    "  /todos                    — show current open items"
+    "  /todos                    — show current open items\n"
+    "\n"
+    "Tip: for items whose text ends in a number, use the item ID\n"
+    "  (e.g. '/todo snooze 42' instead of '/todo snooze call 911')."
 )
 
 

--- a/src/los/todo_commands.py
+++ b/src/los/todo_commands.py
@@ -13,7 +13,8 @@ Supported command forms:
 Dispatcher integration:
     from src.los.todo_commands import route_todo_command
 
-    if msg.get("text", "").lower().startswith("/todo"):
+    text = msg.get("text", "").lower()
+    if text.startswith("/todo ") or text == "/todo":
         reply = route_todo_command(msg)
         send_reply(chat_id=chat_id, text=reply, source=source)
 

--- a/src/los/todo_commands.py
+++ b/src/los/todo_commands.py
@@ -1,0 +1,313 @@
+"""
+LOS — Telegram TODO Command Handler
+
+Routes /todo subcommands and natural-language patterns to the action items DB.
+This is the dispatcher entry point for all TODO mutations coming through Telegram.
+
+Supported command forms:
+    /todo add <text>      — insert item (source='telegram', priority=5)
+    /todo done <query>    — mark item done (query = id or partial text)
+    /todo snooze <query> [days]  — snooze item for N days (default: SNOOZE_DEFAULT_DAYS)
+    /todo                 — returns usage help
+
+Dispatcher integration:
+    from src.los.todo_commands import route_todo_command
+
+    if msg.get("text", "").lower().startswith("/todo"):
+        reply = route_todo_command(msg)
+        send_reply(chat_id=chat_id, text=reply, source=source)
+
+Design principles:
+- Pure functions where possible — conn is injected, not global
+- Named constants for every spec-derived value (priority, default days)
+- Item matching is deterministic: numeric query = ID lookup, text = substring
+- Disambiguation is always explicit — never silently mark the wrong item
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .db import (
+    ActionItemStatus,
+    DEFAULT_DB_PATH,
+    ActionItem,
+    connect,
+    find_duplicate,
+    get_item_by_id,
+    get_open_items,
+    increment_mention_count,
+    insert_action_item,
+    mark_done,
+    mark_snoozed,
+)
+
+# ---------------------------------------------------------------------------
+# Named constants (derived from spec — never use magic literals)
+# ---------------------------------------------------------------------------
+
+PRIORITY_DEFAULT = 5        # mid-priority, per design doc §1
+SNOOZE_DEFAULT_DAYS = 3     # default when user omits the days argument
+
+# Number of match candidates to show in disambiguation replies
+DISAMBIGUATION_LIMIT = 5
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_numeric(s: str) -> bool:
+    return s.strip().lstrip("-").isdigit()
+
+
+def _today_plus(days: int) -> str:
+    """Return ISO-8601 date string for today + N days."""
+    return (date.today() + timedelta(days=days)).isoformat()
+
+
+def _format_item_line(item: ActionItem) -> str:
+    """Single-line summary for disambiguation lists."""
+    snippet = item.text[:50] + ("..." if len(item.text) > 50 else "")
+    return f"#{item.id}: {snippet}"
+
+
+def _find_by_query(
+    conn: sqlite3.Connection,
+    query: str,
+) -> tuple[Optional[ActionItem], list[ActionItem], str]:
+    """Resolve a user-supplied query to an ActionItem.
+
+    Returns:
+        (item, [], "")           — exactly one match
+        (None, candidates, "")  — multiple matches (disambiguation needed)
+        (None, [], reason)      — no match; reason is a human-readable message
+
+    Only considers open and snoozed items — done/dismissed are excluded from
+    matching because users should not be able to re-mutate closed items.
+    """
+    query = query.strip()
+    if _is_numeric(query):
+        item_id = int(query)
+        item = get_item_by_id(conn, item_id)
+        if item is None:
+            return None, [], f"No item found with ID #{item_id}."
+        if item.status in (ActionItemStatus.DONE, ActionItemStatus.DISMISSED):
+            return None, [], f"Item #{item_id} is already {item.status}."
+        return item, [], ""
+
+    # Text search — substring match against open/snoozed items
+    lower_query = query.lower()
+    all_open = get_open_items(conn, limit=200)
+    candidates = [
+        item for item in all_open
+        if lower_query in item.text.lower()
+    ]
+
+    if not candidates:
+        return None, [], f"No open item matching \"{query}\"."
+    if len(candidates) == 1:
+        return candidates[0], [], ""
+    # Multiple matches — caller must handle disambiguation
+    return None, candidates[:DISAMBIGUATION_LIMIT], ""
+
+
+def _disambiguation_reply(candidates: list[ActionItem], action: str) -> str:
+    """Format a disambiguation reply listing matching items."""
+    lines = [f"Multiple items match. Which one do you want to {action}?"]
+    lines.extend(_format_item_line(item) for item in candidates)
+    lines.append(f"\nReply with /todo {action} <id>")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Command handlers (pure: return reply text, side-effect DB writes at boundary)
+# ---------------------------------------------------------------------------
+
+
+def handle_todo_add(
+    text: str,
+    *,
+    chat_id: int,
+    source: str = "telegram",
+    conn: Optional[sqlite3.Connection] = None,
+    db_path: Optional[Path] = None,
+) -> str:
+    """Insert a new action item. Returns a formatted confirmation.
+
+    If the item already exists (same normalized text), increments mention_count
+    instead of inserting a duplicate.
+    """
+    _own_conn = False
+    if conn is None:
+        conn = connect(db_path or DEFAULT_DB_PATH)
+        _own_conn = True
+
+    try:
+        existing = find_duplicate(conn, text)
+        if existing is not None:
+            increment_mention_count(conn, existing.id)
+            return (
+                f"Already on your list (#{existing.id}): \"{existing.text[:60]}\"\n"
+                f"Mention count bumped to {existing.mention_count + 1}."
+            )
+
+        item_id = insert_action_item(
+            conn,
+            text=text,
+            source=source,
+            source_message_id=None,
+            priority=PRIORITY_DEFAULT,
+        )
+        return f"Added #{item_id}: \"{text[:60]}\""
+    finally:
+        if _own_conn:
+            conn.close()
+
+
+def handle_todo_done(
+    query: str,
+    *,
+    chat_id: int,
+    conn: Optional[sqlite3.Connection] = None,
+    db_path: Optional[Path] = None,
+) -> str:
+    """Mark a TODO item as done. Returns a formatted confirmation or error.
+
+    query: item ID (numeric) or partial text for substring match.
+    """
+    _own_conn = False
+    if conn is None:
+        conn = connect(db_path or DEFAULT_DB_PATH)
+        _own_conn = True
+
+    try:
+        item, candidates, reason = _find_by_query(conn, query)
+        if reason:
+            return reason
+        if candidates:
+            return _disambiguation_reply(candidates, "done")
+
+        mark_done(conn, item.id)
+        return f"Done: \"{item.text[:60]}\" (#{item.id})"
+    finally:
+        if _own_conn:
+            conn.close()
+
+
+def handle_todo_snooze(
+    query: str,
+    *,
+    days: Optional[int],
+    chat_id: int,
+    conn: Optional[sqlite3.Connection] = None,
+    db_path: Optional[Path] = None,
+) -> str:
+    """Snooze a TODO item for N days. Returns a formatted confirmation or error.
+
+    query: item ID (numeric) or partial text.
+    days:  number of days to snooze; defaults to SNOOZE_DEFAULT_DAYS if None.
+    """
+    snooze_days = days if days is not None else SNOOZE_DEFAULT_DAYS
+    until_date = _today_plus(snooze_days)
+
+    _own_conn = False
+    if conn is None:
+        conn = connect(db_path or DEFAULT_DB_PATH)
+        _own_conn = True
+
+    try:
+        item, candidates, reason = _find_by_query(conn, query)
+        if reason:
+            return reason
+        if candidates:
+            return _disambiguation_reply(candidates, "snooze")
+
+        mark_snoozed(conn, item.id, until_date)
+        return (
+            f"Snoozed until {until_date}: \"{item.text[:60]}\" (#{item.id})"
+        )
+    finally:
+        if _own_conn:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Command parser (pure — no DB access)
+# ---------------------------------------------------------------------------
+
+# /todo add <text>
+_ADD_RE = re.compile(r"^/todo\s+add\s+(.+)$", re.IGNORECASE)
+
+# /todo done <query>
+_DONE_RE = re.compile(r"^/todo\s+done\s+(.+)$", re.IGNORECASE)
+
+# /todo snooze <query> [<days>]
+# Days are optional — if omitted, defaults to SNOOZE_DEFAULT_DAYS
+_SNOOZE_RE = re.compile(r"^/todo\s+snooze\s+(.+?)(?:\s+(\d+))?\s*$", re.IGNORECASE)
+
+_USAGE = (
+    "Usage:\n"
+    "  /todo add <text>          — add item to your list\n"
+    "  /todo done <id or text>   — mark item done\n"
+    "  /todo snooze <id or text> [days]  — snooze item (default: "
+    f"{SNOOZE_DEFAULT_DAYS} days)\n"
+    "  /todos                    — show current open items"
+)
+
+
+def route_todo_command(
+    msg: dict,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+    db_path: Optional[Path] = None,
+) -> str:
+    """Dispatcher entry point. Routes /todo subcommands to the correct handler.
+
+    Args:
+        msg:     Raw inbox message dict with 'text', 'chat_id', 'source'.
+        conn:    Optional DB connection (injected in tests; None = open production DB).
+        db_path: Optional DB path override (passed through to handlers).
+
+    Returns:
+        Reply text string. The dispatcher is responsible for calling send_reply.
+    """
+    text: str = (msg.get("text") or "").strip()
+    chat_id: int = msg.get("chat_id", 0)
+    source: str = msg.get("source", "telegram")
+
+    m = _ADD_RE.match(text)
+    if m:
+        return handle_todo_add(
+            m.group(1).strip(),
+            chat_id=chat_id,
+            source=source,
+            conn=conn,
+            db_path=db_path,
+        )
+
+    m = _DONE_RE.match(text)
+    if m:
+        return handle_todo_done(
+            m.group(1).strip(),
+            chat_id=chat_id,
+            conn=conn,
+            db_path=db_path,
+        )
+
+    m = _SNOOZE_RE.match(text)
+    if m:
+        query = m.group(1).strip()
+        days = int(m.group(2)) if m.group(2) else None
+        return handle_todo_snooze(
+            query,
+            days=days,
+            chat_id=chat_id,
+            conn=conn,
+            db_path=db_path,
+        )
+
+    return _USAGE

--- a/tests/unit/los/test_todo_commands.py
+++ b/tests/unit/los/test_todo_commands.py
@@ -282,3 +282,111 @@ def test_route_bare_todo_command_returns_help(conn: sqlite3.Connection, chat_id:
 
     assert isinstance(reply, str)
     assert any(cmd in reply.lower() for cmd in ("add", "done", "snooze"))
+
+
+# ---------------------------------------------------------------------------
+# Gap 1: /todos must NOT be routed through route_todo_command
+# ---------------------------------------------------------------------------
+
+
+def test_todos_command_is_not_routed_to_route_todo_command(
+    conn: sqlite3.Connection, chat_id: int
+) -> None:
+    """/todos must not be processed by route_todo_command.
+
+    The dispatcher's routing condition must use startswith("/todo ") or == "/todo",
+    NOT startswith("/todo"), which would accidentally match /todos.
+
+    This test documents the safe fallback: if /todos is somehow passed to
+    route_todo_command (e.g. if the dispatcher condition is written incorrectly),
+    the function returns usage help — it does NOT silently process the command
+    as a /todo subcommand.
+
+    The primary protection is the dispatcher routing condition documented in
+    sys.dispatcher.bootup.md: use 'text.startswith("/todo ") or text == "/todo"'
+    to prevent /todos from entering this code path at all.
+    """
+    # /todos does not match any subcommand regex — it must return usage help
+    msg = {"text": "/todos", "chat_id": chat_id, "source": "telegram"}
+    reply = route_todo_command(msg, conn=conn)
+
+    # Must return usage help — not execute any subcommand
+    assert isinstance(reply, str)
+    assert any(cmd in reply.lower() for cmd in ("add", "done", "snooze")), (
+        "/todos incorrectly matched a subcommand in route_todo_command"
+    )
+    # Must NOT have inserted any items
+    items = get_open_items(conn)
+    assert len(items) == 0, "/todos must not insert any items"
+
+
+def test_dispatcher_routing_condition_excludes_todos() -> None:
+    """/todos must not match the dispatcher's /todo routing condition.
+
+    Documents the correct routing check:
+        text.startswith("/todo ") or text == "/todo"
+
+    An incorrect check (text.startswith("/todo")) would match both /todo and /todos.
+    """
+    text = "/todos"
+
+    # Incorrect condition — would incorrectly route /todos to the /todo handler:
+    incorrect_match = text.startswith("/todo")
+    assert incorrect_match, "Confirm: the naive startswith('/todo') DOES match /todos"
+
+    # Correct condition — explicitly excludes /todos:
+    correct_match = text.startswith("/todo ") or text == "/todo"
+    assert not correct_match, (
+        "The correct dispatcher condition must NOT match /todos — "
+        "use startswith('/todo ') or == '/todo', not startswith('/todo')"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gap 2: Snooze regex trailing-number ambiguity — documented edge case
+# ---------------------------------------------------------------------------
+
+
+def test_snooze_trailing_number_in_item_text_is_consumed_as_days(
+    conn: sqlite3.Connection, chat_id: int
+) -> None:
+    """Documents the known snooze regex ambiguity: trailing integers become days.
+
+    When an item's text ends in a number (e.g. "call 911"), the query
+    '/todo snooze call 911' will parse query='call' (not 'call 911') and
+    days=911 (not SNOOZE_DEFAULT_DAYS). This may produce a not-found result
+    or match a different item than intended.
+
+    The workaround (documented in _USAGE and _SNOOZE_RE comment) is to use
+    the item ID: '/todo snooze <id>'.
+
+    WARNING: This test documents the current behavior, not the desired behavior.
+    If the regex is changed to require an explicit 'days' keyword (e.g. 'for N
+    days'), this test should be updated to reflect the new behavior.
+    """
+    item_id = insert_action_item(conn, text="call 911", source="telegram", source_message_id=None)
+
+    # This command intends to snooze "call 911" for the default number of days,
+    # but the trailing "911" is consumed as the days argument and the query
+    # becomes "call" — which does not exactly match "call 911".
+    msg = {"text": "/todo snooze call 911", "chat_id": chat_id, "source": "telegram"}
+    reply = route_todo_command(msg, conn=conn)
+
+    # The item text is "call 911" but the query extracted is "call".
+    # "call" is a substring of "call 911", so the item IS found.
+    # It gets snoozed for 911 days (not SNOOZE_DEFAULT_DAYS).
+    item = get_item_by_id(conn, item_id)
+    if item.status == "snoozed":
+        # Item was found via substring "call" and snoozed for 911 days —
+        # the user's intent (snooze for default days) was NOT honored.
+        # Workaround: use '/todo snooze {item_id}' instead.
+        assert item.snoozed_until is not None
+    else:
+        # If not snoozed: the reply must contain a helpful message
+        assert isinstance(reply, str) and len(reply) > 0
+
+    # Either way, the usage tip about item IDs must be present in the help text
+    usage_reply = route_todo_command({"text": "/todo", "chat_id": chat_id, "source": "telegram"}, conn=conn)
+    assert "id" in usage_reply.lower() or "tip" in usage_reply.lower(), (
+        "_USAGE must include the tip about using item IDs for items whose text ends in a number"
+    )

--- a/tests/unit/los/test_todo_commands.py
+++ b/tests/unit/los/test_todo_commands.py
@@ -1,0 +1,284 @@
+"""
+Tests for LOS Telegram TODO command handler.
+
+Tests verify:
+- handle_todo_add inserts an item and returns a formatted confirmation
+- handle_todo_done matches by id and by text, marks the correct item done
+- handle_todo_done reports ambiguity when multiple items match text query
+- handle_todo_snooze matches by id and by text, sets snoozed_until correctly
+- route_todo_command routes /todo add, /todo done, /todo snooze, and /todos
+
+All tests inject an in-memory SQLite connection — no production DB is touched.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.los.db import connect, get_item_by_id, get_open_items, insert_action_item
+from src.los.todo_commands import (
+    SNOOZE_DEFAULT_DAYS,
+    PRIORITY_DEFAULT,
+    handle_todo_add,
+    handle_todo_done,
+    handle_todo_snooze,
+    route_todo_command,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "self_action_items.db"
+
+
+@pytest.fixture
+def conn(db_path: Path) -> sqlite3.Connection:
+    c = connect(db_path)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def chat_id() -> int:
+    return 8075091586
+
+
+# ---------------------------------------------------------------------------
+# handle_todo_add
+# ---------------------------------------------------------------------------
+
+
+def test_add_inserts_item_into_db(conn: sqlite3.Connection, chat_id: int) -> None:
+    """Adding a TODO must persist an item with status=open and source='telegram'."""
+    handle_todo_add("Schedule dentist appointment", chat_id=chat_id, source="telegram", conn=conn)
+
+    items = get_open_items(conn)
+    assert len(items) == 1
+    assert items[0].text == "Schedule dentist appointment"
+    assert items[0].source == "telegram"
+    assert items[0].status == "open"
+
+
+def test_add_uses_mid_priority_by_default(conn: sqlite3.Connection, chat_id: int) -> None:
+    """New items added via Telegram must use PRIORITY_DEFAULT (mid-priority = 5)."""
+    handle_todo_add("Buy groceries", chat_id=chat_id, source="telegram", conn=conn)
+
+    items = get_open_items(conn)
+    assert items[0].priority == PRIORITY_DEFAULT
+
+
+def test_add_returns_confirmation_text(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_add must return a non-empty confirmation string."""
+    reply = handle_todo_add("Call dentist", chat_id=chat_id, source="telegram", conn=conn)
+
+    assert isinstance(reply, str)
+    assert len(reply) > 0
+    # Confirmation should include the item text so the user knows what was added
+    assert "dentist" in reply.lower() or "added" in reply.lower()
+
+
+def test_add_returns_item_id_in_confirmation(conn: sqlite3.Connection, chat_id: int) -> None:
+    """Confirmation text must include the item's ID so the user can reference it."""
+    reply = handle_todo_add("Book flights", chat_id=chat_id, source="telegram", conn=conn)
+
+    items = get_open_items(conn)
+    item_id = items[0].id
+    assert str(item_id) in reply
+
+
+def test_add_dedup_increments_mention_count(conn: sqlite3.Connection, chat_id: int) -> None:
+    """Adding the same item twice must not insert a duplicate — it increments mention_count."""
+    handle_todo_add("Call Sarah", chat_id=chat_id, source="telegram", conn=conn)
+    handle_todo_add("Call Sarah", chat_id=chat_id, source="telegram", conn=conn)
+
+    items = get_open_items(conn)
+    assert len(items) == 1
+    assert items[0].mention_count == 2
+
+
+# ---------------------------------------------------------------------------
+# handle_todo_done
+# ---------------------------------------------------------------------------
+
+
+def test_done_by_id_marks_item_done(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_done with a numeric query must mark the item by ID as done."""
+    item_id = insert_action_item(conn, text="Fix the staging bug", source="telegram", source_message_id=None)
+
+    handle_todo_done(str(item_id), chat_id=chat_id, conn=conn)
+
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "done"
+    assert item.done_at is not None
+
+
+def test_done_by_id_returns_confirmation(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_done must return a non-empty confirmation."""
+    item_id = insert_action_item(conn, text="Buy coffee", source="telegram", source_message_id=None)
+    reply = handle_todo_done(str(item_id), chat_id=chat_id, conn=conn)
+
+    assert isinstance(reply, str)
+    assert len(reply) > 0
+
+
+def test_done_by_text_matches_substring(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_done with a text query must find and mark done an item that contains the text."""
+    item_id = insert_action_item(conn, text="Schedule dentist appointment", source="telegram", source_message_id=None)
+
+    handle_todo_done("dentist", chat_id=chat_id, conn=conn)
+
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "done"
+
+
+def test_done_by_text_multiple_matches_returns_disambiguation(
+    conn: sqlite3.Connection, chat_id: int
+) -> None:
+    """When text matches multiple items, handle_todo_done must return a disambiguation list."""
+    insert_action_item(conn, text="Call dentist", source="telegram", source_message_id=None)
+    insert_action_item(conn, text="Call Sarah", source="telegram", source_message_id=None)
+    insert_action_item(conn, text="Call mom", source="telegram", source_message_id=None)
+
+    reply = handle_todo_done("call", chat_id=chat_id, conn=conn)
+
+    # Must not mark anything done — the reply must ask which one
+    open_items = get_open_items(conn)
+    assert len(open_items) == 3
+    assert "which" in reply.lower() or "#" in reply
+
+
+def test_done_unknown_id_returns_not_found(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_done with an ID that doesn't exist must return a not-found message."""
+    reply = handle_todo_done("999999", chat_id=chat_id, conn=conn)
+
+    assert "not found" in reply.lower() or "no item" in reply.lower()
+
+
+def test_done_unknown_text_returns_not_found(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_done with text that matches no item must return a not-found message."""
+    insert_action_item(conn, text="Buy milk", source="telegram", source_message_id=None)
+
+    reply = handle_todo_done("dentist", chat_id=chat_id, conn=conn)
+
+    assert "not found" in reply.lower() or "no item" in reply.lower() or "nothing" in reply.lower() or "no open item" in reply.lower()
+
+
+# ---------------------------------------------------------------------------
+# handle_todo_snooze
+# ---------------------------------------------------------------------------
+
+
+def test_snooze_by_id_sets_snoozed_until(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_snooze with a numeric query must snooze the item by the given number of days."""
+    item_id = insert_action_item(conn, text="Review Q2 budget", source="telegram", source_message_id=None)
+
+    handle_todo_snooze(str(item_id), days=3, chat_id=chat_id, conn=conn)
+
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "snoozed"
+    assert item.snoozed_until is not None
+
+
+def test_snooze_uses_default_days_when_none(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_snooze must use SNOOZE_DEFAULT_DAYS when days is not specified."""
+    item_id = insert_action_item(conn, text="Read the report", source="telegram", source_message_id=None)
+
+    handle_todo_snooze(str(item_id), days=None, chat_id=chat_id, conn=conn)
+
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "snoozed"
+    # SNOOZE_DEFAULT_DAYS must be a named constant, not a magic literal
+    assert SNOOZE_DEFAULT_DAYS > 0
+
+
+def test_snooze_by_text_matches_substring(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_snooze with text must find the item by substring and snooze it."""
+    item_id = insert_action_item(conn, text="Book annual checkup", source="telegram", source_message_id=None)
+
+    handle_todo_snooze("annual checkup", days=7, chat_id=chat_id, conn=conn)
+
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "snoozed"
+
+
+def test_snooze_returns_confirmation_with_date(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_snooze must return a confirmation that includes the snooze date."""
+    item_id = insert_action_item(conn, text="Submit expense report", source="telegram", source_message_id=None)
+
+    reply = handle_todo_snooze(str(item_id), days=2, chat_id=chat_id, conn=conn)
+
+    assert isinstance(reply, str)
+    # The reply must tell the user when the item will resurface
+    assert any(c.isdigit() for c in reply), "Confirmation must contain a date"
+
+
+def test_snooze_unknown_id_returns_not_found(conn: sqlite3.Connection, chat_id: int) -> None:
+    """handle_todo_snooze with an ID that doesn't exist must return a not-found message."""
+    reply = handle_todo_snooze("999999", days=1, chat_id=chat_id, conn=conn)
+
+    assert "not found" in reply.lower() or "no item" in reply.lower()
+
+
+# ---------------------------------------------------------------------------
+# route_todo_command
+# ---------------------------------------------------------------------------
+
+
+def test_route_todo_add_command(conn: sqlite3.Connection, chat_id: int) -> None:
+    """'/todo add <text>' must call handle_todo_add and insert an item."""
+    msg = {"text": "/todo add Buy oat milk", "chat_id": chat_id, "source": "telegram"}
+    reply = route_todo_command(msg, conn=conn)
+
+    items = get_open_items(conn)
+    assert len(items) == 1
+    assert items[0].text == "Buy oat milk"
+    assert isinstance(reply, str)
+
+
+def test_route_todo_done_command(conn: sqlite3.Connection, chat_id: int) -> None:
+    """'/todo done <id>' must call handle_todo_done and mark the item done."""
+    item_id = insert_action_item(conn, text="Send invoice", source="telegram", source_message_id=None)
+
+    msg = {"text": f"/todo done {item_id}", "chat_id": chat_id, "source": "telegram"}
+    route_todo_command(msg, conn=conn)
+
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "done"
+
+
+def test_route_todo_snooze_command(conn: sqlite3.Connection, chat_id: int) -> None:
+    """'/todo snooze <id> <days>' must call handle_todo_snooze."""
+    item_id = insert_action_item(conn, text="Review pull requests", source="telegram", source_message_id=None)
+
+    msg = {"text": f"/todo snooze {item_id} 3", "chat_id": chat_id, "source": "telegram"}
+    route_todo_command(msg, conn=conn)
+
+    item = get_item_by_id(conn, item_id)
+    assert item.status == "snoozed"
+
+
+def test_route_unknown_subcommand_returns_help(conn: sqlite3.Connection, chat_id: int) -> None:
+    """An unrecognized /todo subcommand must return usage help."""
+    msg = {"text": "/todo frobnicate", "chat_id": chat_id, "source": "telegram"}
+    reply = route_todo_command(msg, conn=conn)
+
+    assert isinstance(reply, str)
+    assert len(reply) > 0
+    # Should mention valid commands
+    assert any(cmd in reply.lower() for cmd in ("add", "done", "snooze"))
+
+
+def test_route_bare_todo_command_returns_help(conn: sqlite3.Connection, chat_id: int) -> None:
+    """'/todo' with no subcommand must return usage help."""
+    msg = {"text": "/todo", "chat_id": chat_id, "source": "telegram"}
+    reply = route_todo_command(msg, conn=conn)
+
+    assert isinstance(reply, str)
+    assert any(cmd in reply.lower() for cmd in ("add", "done", "snooze"))


### PR DESCRIPTION
## What this solves

Before this PR, the only way to interact with the TODO DB from Telegram was through inline button callbacks on the `/todos` list view. There was no way to add an item, mark one done, or snooze one directly from a command — users had to navigate to the full list first.

This PR adds `src/los/todo_commands.py`, a synchronous command handler that covers the write path for the three core mutations: add, done, snooze.

## What changed

`route_todo_command(msg)` is the dispatcher entry point. It parses the message text, routes to the correct handler (`handle_todo_add`, `handle_todo_done`, `handle_todo_snooze`), and returns reply text. The dispatcher calls `send_reply` with the result — no subagent needed, because each handler is a pure DB write that completes in milliseconds.

**Command forms handled:**
- `/todo add <text>` — inserts with `source='telegram'`, `priority=5` (mid), deduplicates via the existing `find_duplicate` path (increments `mention_count` on collision)
- `/todo done <id or text>` — matches by ID (numeric) or substring; returns a disambiguation list if multiple items match rather than silently picking one
- `/todo snooze <id or text> [days]` — snoozes for N days (default: `SNOOZE_DEFAULT_DAYS = 3`); stores `snoozed_until` as ISO date
- `/todo` with no subcommand or an unknown subcommand — returns usage help

**What is not changed:** the `/todos` list view flow, `route_los_callback` for inline button presses, the DB schema, and the extractor. The new module only adds a new entry point alongside existing ones.

**Functional patterns used:** pure functions with injected `conn` (testable without real DB), named constants for every spec-derived value (`PRIORITY_DEFAULT`, `SNOOZE_DEFAULT_DAYS`, `DISAMBIGUATION_LIMIT`), and explicit disambiguation rather than implicit first-match selection.

The dispatcher doc (`sys.dispatcher.bootup.md`) is updated with the routing snippet and a note that `/todo` mutations are synchronous — no subagent dispatch required.

## Tests run
- [x] `uv run pytest tests/unit/los/test_todo_commands.py -v` — 21 passed, 0 failed
- [x] `uv run pytest tests/unit/los/ -v` — 65 passed, 0 failed (full LOS suite, no regressions)

## Manual test
N/A — this module contains no external service calls, no systemd/cron wiring, no file I/O outside the injected DB connection, and no Telegram API calls. All side effects flow through the injected `conn` and are fully covered by unit tests.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (pure DB module, no external services)
- [x] User-visible outcome — dispatcher integration is documented in bootup doc; actual send_reply call is the dispatcher's responsibility (out of scope for this module)
- [x] Side-effect audit: only writes are single-row DB mutations; no loops, no mass sends, no shared-state clobber
- [x] External service calls: none