### PR TITLE
fix(los): remove ACTIVE TODOS.md write from LOS nightly

### DIFF
--- a/docs/todo-canonical-design.md
+++ b/docs/todo-canonical-design.md
@@ -102,12 +102,25 @@ self_action_items.db  ←── CANONICAL SOURCE OF TRUTH
 
 ### 4a. Lobster → Obsidian (write direction)
 
-Trigger: nightly LOS sweep, or on-demand via Telegram command.
+**Sole writer:** `todo_obsidian_sync.py` (runs every 30 min) is the **exclusive** writer of
+`ACTIVE TODOS.md`. No other job — including any future LOS nightly sweep — should call
+`render_active_todos()` or write this file directly.
 
-Process:
-1. Query `action_items` where `status IN ('open', 'snoozed')` ordered by priority, workstream, extracted_at.
-2. Render `✅ ACTIVE TODOS.md` with the symbol hierarchy (see Section 6).
-3. Commit to `~/obsidian-vault/` and push.
+Rationale: if a second job regenerates the file independently, it creates a race condition
+where Dan's unsynced Obsidian checkmarks are overwritten before `todo_obsidian_sync.py` can
+read and persist them to the DB. See the module docstring in `todo_obsidian_sync.py` for
+the full failure sequence.
+
+Any future LOS nightly sweep should write **only** to the DB (archival, extraction, etc.).
+The file regeneration step is `todo_obsidian_sync.py`'s responsibility.
+
+Process (performed by `todo_obsidian_sync.py` in a single atomic pass):
+1. git pull the vault (get latest Mac edits)
+2. Read Dan's checkmarks from ACTIVE TODOS.md
+3. Persist checkmark changes to DB
+4. Query `action_items` where `status IN ('open', 'snoozed')` ordered by priority, workstream, extracted_at.
+5. Render `✅ ACTIVE TODOS.md` with the symbol hierarchy (see Section 6).
+6. Commit to `~/obsidian-vault/` and push.
 
 ### 4b. Obsidian → Lobster (read direction)
 
@@ -145,7 +158,7 @@ Items are archived (not deleted) when:
 
 Archived items do not appear in `ACTIVE TODOS.md`. They remain in the DB and are queryable via `status = 'archived'`.
 
-The nightly LOS sweep runs archival before rendering ACTIVE TODOS.md. This keeps the view clean without destroying history.
+Any future LOS nightly sweep runs archival before the next `todo_obsidian_sync.py` pass regenerates ACTIVE TODOS.md. The sweep writes only to the DB; `todo_obsidian_sync.py` picks up the archival changes on its next run and omits archived items from the rendered file.
 
 ---
 

--- a/scheduled-tasks/todo_obsidian_sync.py
+++ b/scheduled-tasks/todo_obsidian_sync.py
@@ -6,6 +6,28 @@ Reads ACTIVE TODOS.md from the obsidian vault and syncs human edits back
 into the canonical self_action_items.db, then regenerates the file from DB
 and commits it.
 
+SOLE WRITER OF ACTIVE TODOS.md
+-------------------------------
+This script is the exclusive writer of ACTIVE TODOS.md in the Obsidian vault.
+No other script or job (including any future LOS nightly sweep) should call
+render_active_todos() or write to this file directly.
+
+Rationale: a race condition arises if any other job regenerates ACTIVE TODOS.md
+independently. The sequence that causes data loss:
+  1. Dan checks off items in Obsidian on his Mac.
+  2. Obsidian-git pushes the vault to the VPS.
+  3. A second writer (e.g. LOS nightly at 3am) reads the DB and regenerates
+     ACTIVE TODOS.md before this sync job runs — overwriting Dan's checkmarks.
+  4. This sync job runs, finds no checkmarks in the file, and never marks those
+     items done in the DB.
+
+Keeping this script as the sole writer removes the race: checkmarks are always
+read before the file is overwritten, in a single atomic pass.
+
+# ACTIVE TODOS.md is written exclusively by todo_obsidian_sync.py to prevent
+# the race condition where a second writer overwrites unsynced Obsidian checkmarks
+# before this script can persist them to the DB.
+
 Flow:
   1. git pull the obsidian vault (pull latest edits from Mac)
   2. Parse ACTIVE TODOS.md:


### PR DESCRIPTION
## Summary

Establishes `todo_obsidian_sync.py` as the sole writer of `ACTIVE TODOS.md` to prevent a race condition between any LOS nightly sweep and the 30-minute sync job.

### The race condition

If a second writer (e.g. a LOS nightly sweep at 3am) regenerates `ACTIVE TODOS.md` from the DB independently, the following failure sequence occurs:

1. Dan checks off items in Obsidian on his Mac.
2. Obsidian-git pushes the vault to the VPS.
3. The second writer reads the DB and regenerates `ACTIVE TODOS.md` — overwriting Dan's checkmarks before `todo_obsidian_sync.py` has run.
4. `todo_obsidian_sync.py` runs, finds no checkmarks, and never marks those items done in the DB.

The items appear open again on the next sync, defeating the checkmark.

### The fix

`todo_obsidian_sync.py` is the correct sole writer because it performs the read-checkmarks and regenerate-file steps atomically in a single pass — there is no window for another writer to clobber unsynced edits.

**Research finding:** no separate LOS nightly script currently writes `ACTIVE TODOS.md`. The only writer today is `todo_obsidian_sync.py`. This PR is a pre-emptive architectural guard: a prominent module docstring and updated design doc make the sole-writer contract explicit so any future nightly sweep implementation cannot accidentally introduce the race.

Any future LOS nightly sweep should write **only to the DB** (archival, extraction, etc.). `todo_obsidian_sync.py` picks up those changes on its next 30-minute run and renders them into the file.

### Changes

- `scheduled-tasks/todo_obsidian_sync.py`: added `SOLE WRITER OF ACTIVE TODOS.md` comment block with the full race condition explanation and the architectural invariant
- `docs/todo-canonical-design.md`: updated Section 4a (write direction) to document the sole-writer contract; updated Section 5 (archival) to clarify that archival runs write only to the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)