### PR TITLE
feat(los): Phase 1 — attribution sub-bullets in Active Todos

### DIFF
--- a/scheduled-tasks/obsidian_sync_core.py
+++ b/scheduled-tasks/obsidian_sync_core.py
@@ -21,13 +21,14 @@ from __future__ import annotations
 import fcntl
 import logging
 import os
+import re
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Optional
-import re
-import sys
+from zoneinfo import ZoneInfo
 
 # ---------------------------------------------------------------------------
 # Path setup (allow import from scheduled-tasks/ without installing)
@@ -139,6 +140,85 @@ ID_COMMENT_RE = re.compile(r"<!--\s*id:(?P<id>\d+)(?:\s+parent:(?P<parent>\d+))?
 
 # Strip HTML comment from text
 HTML_COMMENT_RE = re.compile(r"\s*<!--[^>]*-->")
+
+# Attribution sub-bullet pattern — used to detect existing attribution lines
+# so idempotent renders can skip re-rendering them.
+# Matches:  "  - [[...]]" or "  - [telegram msg · ...]" etc.
+ATTRIBUTION_LINE_RE = re.compile(r"^  - (?:\[\[.+\]\]|\[(?:telegram msg|voicenote|direct|obsidian) ·)")
+
+# ---------------------------------------------------------------------------
+# Attribution (pure functions — no I/O or DB access)
+# ---------------------------------------------------------------------------
+
+_LA_TZ = ZoneInfo("America/Los_Angeles")
+
+# Source type labels used in archaeology-register attributions
+_SOURCE_LABEL: dict[str, str] = {
+    "telegram": "telegram msg",
+    "voice": "voicenote",
+    "direct": "direct",
+}
+
+
+def format_attribution(
+    source: str,
+    source_ref: Optional[str],
+    source_section: Optional[str],
+    created_at_iso: Optional[str],
+) -> Optional[str]:
+    """Return the attribution string for a todo item, or None if attribution is not applicable.
+
+    Rules (Phase 1 — display pass from existing data):
+    - source='obsidian': wiki-link form.
+        - source_ref present: [[source_ref#source_section]] or [[source_ref]]
+        - source_ref absent: omit attribution (no doc name to link)
+    - source='telegram', 'voice', 'direct': archaeology register.
+        - created_at_iso present: "[<label> · Mon May 11 · 10:35 AM PDT]"
+        - created_at_iso absent: "[<label> · Mon May 11]" (date only)
+    - source not in known set: None (skip attribution)
+
+    This is a pure function — no I/O, no DB access.
+    """
+    if not source:
+        return None
+
+    if source.startswith("obsidian"):
+        if not source_ref:
+            return None
+        # Strip the legacy "obsidian:ACTIVE TODOS.md" prefix if source is the obsidian source
+        # constant — use source_ref as the actual doc name
+        ref = source_ref
+        # Remove common file extensions that Obsidian doesn't show in wiki-links
+        if ref.endswith(".md"):
+            ref = ref[:-3]
+        if source_section:
+            return f"[[{ref}#{source_section}]]"
+        return f"[[{ref}]]"
+
+    label = _SOURCE_LABEL.get(source)
+    if label is None:
+        return None
+
+    if not created_at_iso:
+        return None
+
+    try:
+        dt_utc = datetime.fromisoformat(created_at_iso.replace("Z", "+00:00"))
+        dt_la = dt_utc.astimezone(_LA_TZ)
+    except (ValueError, AttributeError):
+        return None
+
+    # Determine timezone abbreviation: PDT (DST) or PST (standard)
+    tz_abbr = "PDT" if dt_la.dst() and dt_la.dst().total_seconds() != 0 else "PST"
+
+    date_str = dt_la.strftime("%a %b %-d")
+    time_str = dt_la.strftime("%-I:%M %p")
+    return f"[{label} · {date_str} · {time_str} {tz_abbr}]"
+
+
+def _render_attribution_line(attribution: str) -> str:
+    """Wrap an attribution string as a 2-space-indented sub-bullet."""
+    return f"  - {attribution}"
 
 
 # ---------------------------------------------------------------------------
@@ -545,12 +625,20 @@ def apply_status_delta(file_content: str, conn) -> str:
     # --- Pass 3: find open/snoozed items that are NOT yet in the file ---
     # These are items added via Telegram (source != obsidian) that need to
     # appear in the file so Dan can see and manage them.
-    items_to_append: list[tuple[int, str, int]] = []  # (id, text, priority)
+
+    # Detect optional Phase 2+ columns for attribution
+    _delta_cols = {row[1] for row in conn.execute("PRAGMA table_info(action_items)").fetchall()}
+    _delta_source_ref = "source_ref" if "source_ref" in _delta_cols else "NULL AS source_ref"
+    _delta_source_section = "source_section" if "source_section" in _delta_cols else "NULL AS source_section"
+
+    # items_to_append: (id, text, priority, source, extracted_at, source_ref, source_section)
+    items_to_append: list[tuple] = []
     if file_dedup_keys:
         placeholders = ",".join("?" * len(file_dedup_keys))
         cur2 = conn.execute(
             f"""
-            SELECT id, text, priority
+            SELECT id, text, priority, source, extracted_at,
+                   {_delta_source_ref}, {_delta_source_section}
             FROM action_items
             WHERE status IN ('open', 'snoozed')
               AND parent_id IS NULL
@@ -562,15 +650,16 @@ def apply_status_delta(file_content: str, conn) -> str:
     else:
         # No items in file at all — append everything open/snoozed
         cur2 = conn.execute(
-            """
-            SELECT id, text, priority
+            f"""
+            SELECT id, text, priority, source, extracted_at,
+                   {_delta_source_ref}, {_delta_source_section}
             FROM action_items
             WHERE status IN ('open', 'snoozed')
               AND parent_id IS NULL
             ORDER BY priority ASC, extracted_at ASC
             """,
         )
-    items_to_append = [(row[0], row[1], row[2]) for row in cur2.fetchall()]
+    items_to_append = list(cur2.fetchall())
 
     if not items_to_append:
         return "".join(out_lines)
@@ -596,8 +685,19 @@ def apply_status_delta(file_content: str, conn) -> str:
     out_lines.append(_LOBSTER_ADDITIONS_MARKER + "\n")
     out_lines.append("*Items added via Telegram — move or edit freely:*\n")
     out_lines.append("\n")
-    for item_id, item_text, _priority in items_to_append:
+    for row in items_to_append:
+        item_id, item_text = row[0], row[1]
+        item_source = row[3] if len(row) > 3 else None
+        item_extracted_at = row[4] if len(row) > 4 else None
+        item_source_ref = row[5] if len(row) > 5 else None
+        item_source_section = row[6] if len(row) > 6 else None
+
         out_lines.append(f"- [ ] {item_text} <!-- id:{item_id} -->\n")
+        attribution = format_attribution(
+            item_source or "", item_source_ref, item_source_section, item_extracted_at
+        )
+        if attribution:
+            out_lines.append(_render_attribution_line(attribution) + "\n")
         log.info("Delta: appended new item from DB: %r (id=%d)", item_text[:60], item_id)
     out_lines.append(_LOBSTER_ADDITIONS_END + "\n")
 
@@ -679,9 +779,17 @@ def render_active_todos(
     change.  The guard line does not affect todo_obsidian_sync.py's own logic
     (it does not read or check the guard).
     """
+    # Detect optional Phase 2+ columns (source_ref, source_section).
+    # In Phase 1 these don't exist; falling back to NULL keeps attribution
+    # working without schema changes.
+    _cols = {row[1] for row in conn.execute("PRAGMA table_info(action_items)").fetchall()}
+    _source_ref_expr = "source_ref" if "source_ref" in _cols else "NULL AS source_ref"
+    _source_section_expr = "source_section" if "source_section" in _cols else "NULL AS source_section"
+
     cur = conn.execute(
-        """
-        SELECT id, text, priority, workstream
+        f"""
+        SELECT id, text, priority, workstream, source, extracted_at,
+               {_source_ref_expr}, {_source_section_expr}
         FROM action_items
         WHERE parent_id IS NULL
           AND (status = 'open'
@@ -746,7 +854,20 @@ def render_active_todos(
     def _append_item_with_subtasks(row) -> None:
         row_id = row[0]
         text = row[1]
+        # row indices: 0=id, 1=text, 2=priority, 3=workstream,
+        #              4=source, 5=extracted_at, 6=source_ref, 7=source_section
+        source = row[4] if len(row) > 4 else None
+        extracted_at = row[5] if len(row) > 5 else None
+        source_ref = row[6] if len(row) > 6 else None
+        source_section = row[7] if len(row) > 7 else None
+
         lines.append(_render_item_line(row_id, text))
+
+        # Attribution sub-bullet: only for top-level items with a source set
+        attribution = format_attribution(source or "", source_ref, source_section, extracted_at)
+        if attribution:
+            lines.append(_render_attribution_line(attribution))
+
         subtasks = get_subtasks(conn, row_id)
         for sub in subtasks:
             lines.append(_render_subtask_line(sub.id, sub.text, row_id))

--- a/scheduled-tasks/obsidian_sync_core.py
+++ b/scheduled-tasks/obsidian_sync_core.py
@@ -141,10 +141,11 @@ ID_COMMENT_RE = re.compile(r"<!--\s*id:(?P<id>\d+)(?:\s+parent:(?P<parent>\d+))?
 # Strip HTML comment from text
 HTML_COMMENT_RE = re.compile(r"\s*<!--[^>]*-->")
 
-# Attribution sub-bullet pattern — used to detect existing attribution lines
-# so idempotent renders can skip re-rendering them.
-# Matches:  "  - [[...]]" or "  - [telegram msg · ...]" etc.
-ATTRIBUTION_LINE_RE = re.compile(r"^  - (?:\[\[.+\]\]|\[(?:telegram msg|voicenote|direct|obsidian) ·)")
+# Attribution sub-bullet pattern — exported for use by callers and future phases.
+# Matches:  "  - [[...]]" (obsidian wiki-link) or "  - [telegram msg · ...]" etc.
+# Note: the label-only form "[telegram msg]" (no middot, produced when created_at_iso
+# is absent) is not matched here but is idempotent: re-rendering produces the same string.
+ATTRIBUTION_LINE_RE = re.compile(r"^  - (?:\[\[.+\]\]|\[(?:telegram msg|voicenote|direct) ·)")
 
 # ---------------------------------------------------------------------------
 # Attribution (pure functions — no I/O or DB access)
@@ -174,7 +175,7 @@ def format_attribution(
         - source_ref absent: omit attribution (no doc name to link)
     - source='telegram', 'voice', 'direct': archaeology register.
         - created_at_iso present: "[<label> · Mon May 11 · 10:35 AM PDT]"
-        - created_at_iso absent: "[<label> · Mon May 11]" (date only)
+        - created_at_iso absent or unparseable: "[<label>]" (label only, no timestamp)
     - source not in known set: None (skip attribution)
 
     This is a pure function — no I/O, no DB access.
@@ -200,13 +201,13 @@ def format_attribution(
         return None
 
     if not created_at_iso:
-        return None
+        return f"[{label}]"
 
     try:
         dt_utc = datetime.fromisoformat(created_at_iso.replace("Z", "+00:00"))
         dt_la = dt_utc.astimezone(_LA_TZ)
     except (ValueError, AttributeError):
-        return None
+        return f"[{label}]"
 
     # Determine timezone abbreviation: PDT (DST) or PST (standard)
     tz_abbr = "PDT" if dt_la.dst() and dt_la.dst().total_seconds() != 0 else "PST"

--- a/tests/unit/los/test_obsidian_sync.py
+++ b/tests/unit/los/test_obsidian_sync.py
@@ -569,13 +569,16 @@ def test_attribution_obsidian_source_constant_without_ref_returns_none() -> None
     assert result is None
 
 
-def test_attribution_missing_created_at_returns_none_for_non_obsidian() -> None:
-    """If created_at is None for telegram/voice/direct, return None (spec: omit time,
-    but with no date either we cannot render anything useful)."""
-    # The spec says "if created_at is missing or null: omit time, render just [telegram msg · Mon May 11]"
-    # However, with no created_at at all we have no date — return None.
-    result = format_attribution("telegram", None, None, None)
-    assert result is None
+def test_attribution_missing_created_at_returns_label_only_for_non_obsidian() -> None:
+    """If created_at is None for telegram/voice/direct, return the label-only form.
+
+    When no timestamp is available the function cannot render a date or time,
+    so it falls back to '[<label>]' rather than returning None. This preserves
+    attribution provenance (the source medium) without fabricating a timestamp.
+    """
+    assert format_attribution("telegram", None, None, None) == "[telegram msg]"
+    assert format_attribution("voice", None, None, None) == "[voicenote]"
+    assert format_attribution("direct", None, None, None) == "[direct]"
 
 
 def test_attribution_unknown_source_returns_none() -> None:

--- a/tests/unit/los/test_obsidian_sync.py
+++ b/tests/unit/los/test_obsidian_sync.py
@@ -7,6 +7,7 @@ Tests derive from spec requirements:
 - sync_obsidian_to_db() is idempotent — running twice produces the same result
 - Priority is updated when an item moves to a different section
 - Items already done in DB are not re-opened by sync
+- Attribution sub-bullets are rendered for all four source types
 
 No file system writes occur in unit tests — all vault and DB operations use
 in-memory or tmp-path fixtures.
@@ -38,6 +39,11 @@ from src.los.db import (
     mark_snoozed,
     get_item_by_id,
     ActionItemStatus,
+)
+from obsidian_sync_core import (  # noqa: E402
+    format_attribution,
+    _render_attribution_line,
+    ATTRIBUTION_LINE_RE,
 )
 from todo_obsidian_sync import (  # noqa: E402
     ParsedTodos,
@@ -491,3 +497,310 @@ def test_render_includes_past_snoozed_items(conn: sqlite3.Connection) -> None:
     assert "Expired snooze task" in output, (
         "Past-expired snoozed item must appear in render output — snooze expiry is not working"
     )
+
+
+# ---------------------------------------------------------------------------
+# format_attribution — pure function, all four source types
+# ---------------------------------------------------------------------------
+
+# Spec: "2026-05-11T22:37:00Z" (UTC) → PDT (UTC-7 in May) → 3:37 PM PDT on Mon May 11
+_SAMPLE_UTC_ISO = "2026-05-11T22:37:00Z"
+# January date → PST (UTC-8)
+_SAMPLE_UTC_ISO_PST = "2026-01-15T18:12:00Z"
+
+
+def test_attribution_telegram_produces_archaeology_anchor() -> None:
+    """source='telegram' must produce '[telegram msg · Mon May 11 · 3:37 PM PDT]'."""
+    result = format_attribution("telegram", None, None, _SAMPLE_UTC_ISO)
+    assert result == "[telegram msg · Mon May 11 · 3:37 PM PDT]"
+
+
+def test_attribution_voice_produces_voicenote_anchor() -> None:
+    """source='voice' must produce '[voicenote · Mon May 11 · 3:37 PM PDT]'."""
+    result = format_attribution("voice", None, None, _SAMPLE_UTC_ISO)
+    assert result == "[voicenote · Mon May 11 · 3:37 PM PDT]"
+
+
+def test_attribution_direct_produces_direct_anchor() -> None:
+    """source='direct' must produce '[direct · Mon May 11 · 3:37 PM PDT]'."""
+    result = format_attribution("direct", None, None, _SAMPLE_UTC_ISO)
+    assert result == "[direct · Mon May 11 · 3:37 PM PDT]"
+
+
+def test_attribution_uses_pst_in_winter() -> None:
+    """Timezone label must be PST (not PDT) when DST is not active."""
+    # January 15, 2026 18:12 UTC → 10:12 AM PST
+    result = format_attribution("telegram", None, None, _SAMPLE_UTC_ISO_PST)
+    assert result is not None
+    assert "PST" in result
+    assert "PDT" not in result
+
+
+def test_attribution_uses_pdt_in_summer() -> None:
+    """Timezone label must be PDT when DST is active (May)."""
+    result = format_attribution("telegram", None, None, _SAMPLE_UTC_ISO)
+    assert result is not None
+    assert "PDT" in result
+    assert "PST" not in result
+
+
+def test_attribution_obsidian_with_source_ref_produces_wiki_link() -> None:
+    """source='obsidian' with source_ref must produce '[[doc-name]]'."""
+    result = format_attribution("obsidian", "meetings/meeting-tania-2026-05-10.md", None, None)
+    assert result == "[[meetings/meeting-tania-2026-05-10]]"
+
+
+def test_attribution_obsidian_with_source_ref_and_section() -> None:
+    """source='obsidian' with source_ref and source_section must produce '[[doc#section]]'."""
+    result = format_attribution("obsidian", "meeting-tania-2026-05-10.md", "Next steps", None)
+    assert result == "[[meeting-tania-2026-05-10#Next steps]]"
+
+
+def test_attribution_obsidian_without_source_ref_returns_none() -> None:
+    """source='obsidian' without source_ref must return None — no doc to link."""
+    result = format_attribution("obsidian", None, None, None)
+    assert result is None
+
+
+def test_attribution_obsidian_source_constant_without_ref_returns_none() -> None:
+    """source='obsidian:ACTIVE TODOS.md' (the legacy OBSIDIAN_SOURCE constant) without
+    source_ref must return None — there is no meaningful link target."""
+    result = format_attribution(OBSIDIAN_SOURCE, None, None, None)
+    assert result is None
+
+
+def test_attribution_missing_created_at_returns_none_for_non_obsidian() -> None:
+    """If created_at is None for telegram/voice/direct, return None (spec: omit time,
+    but with no date either we cannot render anything useful)."""
+    # The spec says "if created_at is missing or null: omit time, render just [telegram msg · Mon May 11]"
+    # However, with no created_at at all we have no date — return None.
+    result = format_attribution("telegram", None, None, None)
+    assert result is None
+
+
+def test_attribution_unknown_source_returns_none() -> None:
+    """Unknown source values must return None (skip attribution)."""
+    result = format_attribution("unknown_source", None, None, _SAMPLE_UTC_ISO)
+    assert result is None
+
+
+def test_attribution_empty_source_returns_none() -> None:
+    """Empty source string must return None."""
+    result = format_attribution("", None, None, _SAMPLE_UTC_ISO)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _render_attribution_line — indented sub-bullet
+# ---------------------------------------------------------------------------
+
+
+def test_render_attribution_line_uses_2space_indent() -> None:
+    """Attribution sub-bullet must be indented with exactly 2 spaces."""
+    line = _render_attribution_line("[telegram msg · Mon May 11 · 3:37 PM PDT]")
+    assert line.startswith("  - ")
+
+
+def test_render_attribution_line_matches_attribution_re() -> None:
+    """Attribution line output must match ATTRIBUTION_LINE_RE for idempotency detection."""
+    tg_line = _render_attribution_line("[telegram msg · Mon May 11 · 3:37 PM PDT]")
+    voice_line = _render_attribution_line("[voicenote · Mon May 11 · 9:45 AM PDT]")
+    direct_line = _render_attribution_line("[direct · Mon May 11 · 9:12 AM PDT]")
+    wiki_line = _render_attribution_line("[[meeting-tania-2026-05-10#Next steps]]")
+    assert ATTRIBUTION_LINE_RE.match(tg_line), f"telegram line did not match: {tg_line!r}"
+    assert ATTRIBUTION_LINE_RE.match(voice_line), f"voice line did not match: {voice_line!r}"
+    assert ATTRIBUTION_LINE_RE.match(direct_line), f"direct line did not match: {direct_line!r}"
+    assert ATTRIBUTION_LINE_RE.match(wiki_line), f"wiki-link line did not match: {wiki_line!r}"
+
+
+# ---------------------------------------------------------------------------
+# render_active_todos — attribution sub-bullets in rendered output
+# ---------------------------------------------------------------------------
+
+
+def test_render_includes_attribution_for_telegram_item(conn: sqlite3.Connection) -> None:
+    """render_active_todos must append an attribution sub-bullet for a telegram-sourced item."""
+    # Insert with a known UTC timestamp
+    conn.execute(
+        """
+        INSERT INTO action_items
+            (text, source, source_message_id, extracted_at, priority, status, mention_count, dedup_key)
+        VALUES (?, 'telegram', NULL, ?, 5, 'open', 1, ?)
+        """,
+        (
+            "Follow up on law hosting decision",
+            "2026-05-11T22:37:00+00:00",
+            compute_dedup_key("Follow up on law hosting decision"),
+        ),
+    )
+    conn.commit()
+
+    output = render_active_todos(conn)
+
+    assert "- [ ] Follow up on law hosting decision" in output
+    assert "  - [telegram msg · Mon May 11 · 3:37 PM PDT]" in output
+
+
+def test_render_includes_attribution_for_voice_item(conn: sqlite3.Connection) -> None:
+    """render_active_todos must append a voicenote attribution sub-bullet."""
+    conn.execute(
+        """
+        INSERT INTO action_items
+            (text, source, source_message_id, extracted_at, priority, status, mention_count, dedup_key)
+        VALUES (?, 'voice', NULL, ?, 8, 'open', 1, ?)
+        """,
+        (
+            "Think through vault-watcher Tier 2",
+            "2026-05-10T16:45:00+00:00",
+            compute_dedup_key("Think through vault-watcher Tier 2"),
+        ),
+    )
+    conn.commit()
+
+    output = render_active_todos(conn)
+
+    assert "  - [voicenote ·" in output
+
+
+def test_render_includes_attribution_for_direct_item(conn: sqlite3.Connection) -> None:
+    """render_active_todos must append a direct attribution sub-bullet."""
+    conn.execute(
+        """
+        INSERT INTO action_items
+            (text, source, source_message_id, extracted_at, priority, status, mention_count, dedup_key)
+        VALUES (?, 'direct', NULL, ?, 5, 'open', 1, ?)
+        """,
+        (
+            "Review this doc",
+            "2026-05-11T16:12:00+00:00",
+            compute_dedup_key("Review this doc"),
+        ),
+    )
+    conn.commit()
+
+    output = render_active_todos(conn)
+
+    assert "  - [direct ·" in output
+
+
+def test_render_omits_attribution_for_obsidian_item_without_source_ref(conn: sqlite3.Connection) -> None:
+    """Items sourced from obsidian without a source_ref must not get an attribution sub-bullet."""
+    # Legacy obsidian-sourced items (source = 'obsidian:ACTIVE TODOS.md') have no source_ref
+    conn.execute(
+        """
+        INSERT INTO action_items
+            (text, source, source_message_id, extracted_at, priority, status, mention_count, dedup_key)
+        VALUES (?, ?, NULL, ?, 5, 'open', 1, ?)
+        """,
+        (
+            "Plan the Tania ads campaign",
+            OBSIDIAN_SOURCE,
+            "2026-05-10T14:00:00+00:00",
+            compute_dedup_key("Plan the Tania ads campaign"),
+        ),
+    )
+    conn.commit()
+
+    output = render_active_todos(conn)
+
+    # The item itself must be present
+    assert "Plan the Tania ads campaign" in output
+    # But no attribution sub-bullet should follow it — no source_ref to link
+    lines = output.splitlines()
+    item_idx = next(
+        (i for i, line in enumerate(lines) if "Plan the Tania ads campaign" in line), None
+    )
+    assert item_idx is not None
+    # The line after the item (if it exists) must not be an attribution sub-bullet
+    if item_idx + 1 < len(lines):
+        next_line = lines[item_idx + 1]
+        assert not ATTRIBUTION_LINE_RE.match(next_line), (
+            f"Unexpected attribution sub-bullet after obsidian item: {next_line!r}"
+        )
+
+
+def test_render_attribution_appears_before_subtasks(conn: sqlite3.Connection) -> None:
+    """Attribution sub-bullet must appear directly after the item line, before any subtasks."""
+    # Insert parent item with telegram source
+    parent_id = conn.execute(
+        """
+        INSERT INTO action_items
+            (text, source, source_message_id, extracted_at, priority, status, mention_count, dedup_key)
+        VALUES (?, 'telegram', NULL, ?, 5, 'open', 1, ?)
+        """,
+        (
+            "Parent item with subtask",
+            "2026-05-11T22:37:00+00:00",
+            compute_dedup_key("Parent item with subtask"),
+        ),
+    ).lastrowid
+    conn.commit()
+
+    # Insert subtask
+    insert_action_item(
+        conn, text="Sub item under parent", source="telegram", source_message_id=None,
+        parent_id=parent_id,
+    )
+
+    output = render_active_todos(conn)
+    lines = output.splitlines()
+
+    # Find the parent item line
+    parent_idx = next(
+        (i for i, line in enumerate(lines) if "Parent item with subtask" in line and "  " not in line[:3]),
+        None,
+    )
+    assert parent_idx is not None, "Parent item not found in output"
+
+    # The line immediately after the parent must be the attribution sub-bullet
+    assert parent_idx + 1 < len(lines), "No lines after parent item"
+    attr_line = lines[parent_idx + 1]
+    assert ATTRIBUTION_LINE_RE.match(attr_line), (
+        f"Expected attribution sub-bullet at line {parent_idx + 1}, got: {attr_line!r}"
+    )
+
+    # Subtask must follow the attribution line
+    assert parent_idx + 2 < len(lines), "No lines after attribution"
+    subtask_line = lines[parent_idx + 2]
+    assert "Sub item under parent" in subtask_line
+
+
+def test_render_subtasks_do_not_get_attribution(conn: sqlite3.Connection) -> None:
+    """Subtasks (items with parent_id) must not receive their own attribution sub-bullet."""
+    parent_id = conn.execute(
+        """
+        INSERT INTO action_items
+            (text, source, source_message_id, extracted_at, priority, status, mention_count, dedup_key)
+        VALUES (?, 'telegram', NULL, ?, 5, 'open', 1, ?)
+        """,
+        (
+            "Top-level item",
+            "2026-05-11T22:37:00+00:00",
+            compute_dedup_key("Top-level item"),
+        ),
+    ).lastrowid
+    conn.commit()
+
+    insert_action_item(
+        conn, text="Subtask item", source="telegram", source_message_id=None,
+        parent_id=parent_id,
+    )
+
+    output = render_active_todos(conn)
+    lines = output.splitlines()
+
+    # Find the subtask line (2-space indent)
+    subtask_idx = next(
+        (i for i, line in enumerate(lines) if "Subtask item" in line), None
+    )
+    assert subtask_idx is not None
+
+    # The subtask line itself starts with "  - [ ]" — that's the subtask, not an attribution
+    # The line AFTER the subtask must not be an attribution sub-bullet for the subtask
+    if subtask_idx + 1 < len(lines):
+        next_line = lines[subtask_idx + 1]
+        # An attribution line would also start with "  - " but would match ATTRIBUTION_LINE_RE
+        # A subtask's content is not its own item, so no attribution should follow
+        assert not (
+            ATTRIBUTION_LINE_RE.match(next_line) and "Subtask item" not in next_line
+        ), f"Unexpected attribution after subtask: {next_line!r}"


### PR DESCRIPTION
## What this solves

Active Todos is a convergence surface — items arrive from Telegram, voice notes, vault documents, and direct additions. Once an item lands in the list, its origin is invisible. This PR adds Phase 1 of the approved attribution system: a display pass that renders the provenance of each item as an indented sub-bullet in Obsidian.

Before:
```
- [ ] Follow up on law hosting decision <!-- id:42 -->
- [ ] Think through vault-watcher Tier 2 <!-- id:18 -->
```

After:
```
- [ ] Follow up on law hosting decision <!-- id:42 -->
  - [telegram msg · Mon May 11 · 3:37 PM PDT]
- [ ] Think through vault-watcher Tier 2 <!-- id:18 -->
  - [voicenote · Sun May 10 · 9:45 AM PDT]
```

Four source types are covered:
| Source | Renders as |
|--------|-----------|
| `telegram` | `[telegram msg · Mon May 11 · 3:37 PM PDT]` |
| `voice` | `[voicenote · Mon May 11 · 3:37 PM PDT]` |
| `direct` | `[direct · Mon May 11 · 3:37 PM PDT]` |
| `obsidian` with `source_ref` | `[[doc-name]]` or `[[doc-name#section]]` |
| `obsidian` without `source_ref` | no attribution (nothing to link to) |

Time format: 12-hour with minute, PDT/PST depending on DST — implemented via `zoneinfo` (America/Los_Angeles).

## What changed

`scheduled-tasks/obsidian_sync_core.py`:
- Added `format_attribution(source, source_ref, source_section, created_at_iso)` — a pure function mapping DB fields to the approved attribution grammar
- Added `_render_attribution_line(label)` — wraps the label as a 2-space-indented sub-bullet
- Added `ATTRIBUTION_LINE_RE` — regex for detecting existing attribution lines (idempotency guard)
- `render_active_todos()`: updated DB query to fetch `source, extracted_at` (plus `source_ref`/`source_section` via PRAGMA-detected column presence); `_append_item_with_subtasks()` now appends the attribution sub-bullet after the item line and before subtasks
- `apply_status_delta()`: updated items-to-append query and render loop to include attribution sub-bullets in the `<!-- lobster-additions -->` block

Phase 2+ forward-compatibility: `source_ref` and `source_section` columns are detected at render time via `PRAGMA table_info`. Missing columns fall back to NULL — no code change needed when those columns are added.

## What is out of scope (Phase 1 boundary)

- No DB schema changes (`source_ref`, `source_section`, `source_date` columns are Phase 2)
- No write path changes — this is a display pass only
- No changes to `parse_active_todos()` — the parser does not need to understand attribution lines
- Subtasks do not receive attribution sub-bullets (spec: top-level items only)

## Functional patterns used

- `format_attribution` is a pure function: same inputs → same output, no side effects
- DB column detection via PRAGMA keeps the render function compatible with both Phase 1 and Phase 2 schemas without branching on a feature flag
- Attribution is composable: `format_attribution` + `_render_attribution_line` are independently testable and independently usable

## Tests run

- [x] `uv run pytest tests/unit/los/test_obsidian_sync.py -v` — 54 passed, 1 failed, 0 errors
  - The 1 failure (`test_render_excludes_done_items`) is pre-existing on `main` — verified by running the same test on main before any changes. It fails because the render function intentionally shows recently-completed items in the "done since last reset" section; the test incorrectly asserts done items never appear.
  - 20 new tests added, all pass: `test_attribution_*`, `test_render_attribution_*`, `test_render_includes_attribution_*`

## Manual test

N/A — this change is entirely internal to the render path. The output is markdown written to a file in the Obsidian vault; no external services, no Telegram output, no DB writes.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure markdown generation, no external services)
- [x] User-visible outcome — attribution sub-bullets will appear in ACTIVE TODOS.md after next sync run; not applicable to verify here (no live vault in CI)
- [x] Side-effect audit: no DB writes, no external calls, no shared state modified
- [x] External service calls: none