### PR TITLE
fix(wos): handle_wos_start detects and repairs partial-enable state

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -154,6 +154,28 @@ def _write_jobs_json(data: dict) -> None:
     tmp.rename(_JOBS_JSON_PATH)
 
 
+def get_disabled_wos_core_jobs() -> list[str]:
+    """Return a sorted list of wos_core job names that are currently disabled.
+
+    Reads jobs.json and returns the names of all jobs where both:
+    - ``wos_core`` is truthy
+    - ``enabled`` is falsy (False, missing, or None)
+
+    Used by handle_wos_start to detect partially-enabled state: when
+    execution_enabled=True in wos-config.json but one or more wos_core jobs
+    are still disabled (e.g. due to a manual edit that bypassed toggle_wos_core_jobs).
+
+    Returns an empty list when all wos_core jobs are enabled or when jobs.json
+    is absent/unreadable.
+    """
+    jobs = _read_jobs_json().get("jobs", {})
+    return sorted(
+        name
+        for name, entry in jobs.items()
+        if entry.get("wos_core") and not entry.get("enabled", False)
+    )
+
+
 def toggle_wos_core_jobs(enabled: bool) -> dict:
     """Enable or disable all WOS-core jobs atomically.
 
@@ -581,7 +603,15 @@ def handle_wos_start(*, registry: "Registry | None" = None) -> str:
     in wos-config.json so that executor-heartbeat dispatches UoWs on its next
     cycle (within ~90 seconds).
 
-    Idempotent: calling /wos start when already started returns a notice.
+    Partial-recovery path: if execution_enabled is already True but some wos_core
+    jobs are disabled (e.g. due to a manual jobs.json edit that bypassed the toggle),
+    re-enables those jobs and reports the recovered names rather than silently
+    declaring "already running". This prevents a class of stall where a partial
+    enable leaves the steward (or other core jobs) disabled while the system
+    believes the pipeline is running.
+
+    Idempotent: calling /wos start when already fully started (all wos_core jobs
+    enabled) returns a notice without calling toggle_wos_core_jobs.
 
     Args:
         registry: Optional Registry instance. When omitted (the default), a new
@@ -595,10 +625,49 @@ def handle_wos_start(*, registry: "Registry | None" = None) -> str:
 
     config = read_wos_config()
     if config.get("execution_enabled"):
-        return (
-            "WOS pipeline is already running.\n"
-            "executor-heartbeat is dispatching UoWs normally."
+        # Detect partial-enable: execution is on but some wos_core jobs are still disabled.
+        disabled_core_jobs = get_disabled_wos_core_jobs()
+        if not disabled_core_jobs:
+            # Fully started — nothing to do.
+            return (
+                "WOS pipeline is already running.\n"
+                "executor-heartbeat is dispatching UoWs normally."
+            )
+
+        # Partial recovery: re-enable the disabled wos_core jobs via toggle.
+        try:
+            result = toggle_wos_core_jobs(enabled=True)
+        except OSError as exc:
+            return (
+                f"Failed to re-enable disabled WOS-core jobs: {exc}\n"
+                f"Config: `{_WOS_CONFIG_PATH}`"
+            )
+
+        lines = [
+            f"WOS partial recovery: {len(disabled_core_jobs)} wos_core job(s) were "
+            f"disabled while execution_enabled=true — re-enabled: "
+            f"{', '.join(disabled_core_jobs)}.",
+            "executor-heartbeat will dispatch ready-for-executor UoWs on its next "
+            "cycle (within ~90 seconds).",
+        ]
+        if result["not_found"]:
+            lines.append(
+                f"Note: {len(result['not_found'])} WOS-core job(s) not in jobs.json "
+                f"(may be systemd-only): {', '.join(sorted(result['not_found']))}"
+            )
+
+        reg = registry if registry is not None else _Registry()
+        reg.log_control_event(
+            ControlEventType.WOS_START,
+            {
+                "partial_recovery": True,
+                "recovered": sorted(disabled_core_jobs),
+                "toggled": sorted(result["toggled"]),
+                "not_found": sorted(result["not_found"]),
+            },
         )
+
+        return "\n".join(lines)
 
     try:
         result = toggle_wos_core_jobs(enabled=True)

--- a/tests/unit/test_orchestration/test_toggle_wos_core_jobs.py
+++ b/tests/unit/test_orchestration/test_toggle_wos_core_jobs.py
@@ -196,15 +196,84 @@ class TestHandleWosStart:
         from src.orchestration.dispatcher_handlers import handle_wos_start
         return handle_wos_start
 
-    def test_idempotent_when_already_started(self):
-        """When execution_enabled is already True, return a notice without calling toggle."""
+    def _make_jobs_json_all_core_enabled(self) -> dict:
+        """Return a jobs.json with all wos_core jobs enabled."""
+        return {
+            "jobs": {
+                "executor-heartbeat": {"wos_core": True, "enabled": True},
+                "steward-heartbeat": {"wos_core": True, "enabled": True},
+            }
+        }
+
+    def _make_jobs_json_steward_disabled(self) -> dict:
+        """Return a jobs.json where steward-heartbeat is disabled but execution_enabled=True."""
+        return {
+            "jobs": {
+                "executor-heartbeat": {"wos_core": True, "enabled": True},
+                "steward-heartbeat": {"wos_core": True, "enabled": False},
+            }
+        }
+
+    def test_idempotent_when_already_started_and_all_core_jobs_enabled(self):
+        """When execution_enabled is True and all wos_core jobs are enabled, return a notice."""
         handle_wos_start = self._import()
-        with patch("src.orchestration.dispatcher_handlers.read_wos_config",
-                   return_value={"execution_enabled": True}):
+        jobs_data = self._make_jobs_json_all_core_enabled()
+        with (
+            patch("src.orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": True}),
+            patch("src.orchestration.dispatcher_handlers._read_jobs_json",
+                  return_value=jobs_data),
+        ):
             result = handle_wos_start()
         assert "already" in result.lower()
-        # Should mention the pipeline is running
         assert "running" in result.lower()
+
+    def test_partial_recovery_when_execution_enabled_but_core_jobs_disabled(self):
+        """When execution_enabled=True but some wos_core jobs are disabled, re-enable them."""
+        handle_wos_start = self._import()
+        jobs_data = self._make_jobs_json_steward_disabled()
+        written = {}
+
+        def fake_write_jobs(data):
+            written["jobs"] = data
+
+        def fake_write_config(cfg):
+            written["config"] = cfg
+
+        with (
+            patch("src.orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": True}),
+            patch("src.orchestration.dispatcher_handlers._read_jobs_json",
+                  return_value=jobs_data),
+            patch("src.orchestration.dispatcher_handlers._write_jobs_json",
+                  side_effect=fake_write_jobs),
+            patch("src.orchestration.dispatcher_handlers._write_wos_config",
+                  side_effect=fake_write_config),
+        ):
+            result = handle_wos_start()
+
+        # steward-heartbeat must be re-enabled
+        assert written["jobs"]["jobs"]["steward-heartbeat"]["enabled"] is True
+        # executor-heartbeat must remain enabled
+        assert written["jobs"]["jobs"]["executor-heartbeat"]["enabled"] is True
+        # Response must indicate a recovery was performed (not "already running")
+        assert "already" not in result.lower()
+        # Response must mention what was fixed
+        assert "steward-heartbeat" in result
+
+    def test_partial_recovery_does_not_fire_when_all_core_jobs_enabled(self):
+        """No toggle call occurs when execution_enabled=True and all wos_core jobs are enabled."""
+        handle_wos_start = self._import()
+        jobs_data = self._make_jobs_json_all_core_enabled()
+        with (
+            patch("src.orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": True}),
+            patch("src.orchestration.dispatcher_handlers._read_jobs_json",
+                  return_value=jobs_data),
+            patch("src.orchestration.dispatcher_handlers.toggle_wos_core_jobs") as mock_toggle,
+        ):
+            handle_wos_start()
+        mock_toggle.assert_not_called()
 
     def test_start_calls_toggle_with_enabled_true(self):
         """Starting WOS should call toggle_wos_core_jobs(enabled=True)."""


### PR DESCRIPTION
## Summary

`wos start` was silently declaring "already running" without verifying that all wos_core jobs were enabled, allowing a partially-enabled state to persist indefinitely. This caused Issue #1139: steward-heartbeat disabled for 9 days, 179 UoWs stuck.

**The structural bug:** `handle_wos_start`'s idempotency check reads only `execution_enabled` from wos-config.json. On 2026-05-10, a subagent manually set `executor-heartbeat.enabled=true` and `execution_enabled=true` but left `steward-heartbeat.enabled=false`. Every subsequent `wos start` call saw `execution_enabled=true`, returned early, and never called `toggle_wos_core_jobs` — so steward remained disabled for days.

## What changed

Added `get_disabled_wos_core_jobs()` — a pure function that reads jobs.json and returns any wos_core job currently disabled. Modified `handle_wos_start` to check this when `execution_enabled=true`:

- **Before:** `execution_enabled=True` → return "already running" (no further check)
- **After:** `execution_enabled=True` → check disabled wos_core jobs → if any found, re-enable via toggle and report recovery; if none, return "already running"

```
wos start called, execution_enabled=True
        │
        ▼
get_disabled_wos_core_jobs()
        │
   empty? ──yes──► "WOS pipeline is already running" (unchanged)
        │
       no
        │
        ▼
toggle_wos_core_jobs(enabled=True)
        │
        ▼
"WOS partial recovery: N wos_core jobs re-enabled: steward-heartbeat, ..."
```

Nothing else changed: the normal start path (execution_enabled=False), wos stop, and all other handlers are unmodified.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_toggle_wos_core_jobs.py -v` — 24 passed, 0 failed (3 new tests added for the partial-recovery path)
- [x] `uv run pytest tests/unit/test_orchestration/test_control_events.py -v` — 19 passed, 0 failed
- [x] Pre-existing ruff F401 (`_LOBSTER_WORKSPACE` unused import) confirmed pre-existing on main — not introduced by this PR

## Manual test

steward-heartbeat was re-enabled in the live jobs.json before this PR was opened (the dispatcher processed a `wos start` that triggered the new recovery path). Confirmed at 2026-05-12T03:46Z in `/home/lobster/lobster-workspace/scheduled-jobs/logs/steward-heartbeat.log`: steward is actively evaluating ready-for-steward UoWs (throttle/pause patterns firing, not "skipped disabled"). WOS queue was 179 UoWs ready-for-steward at time of fix.

User-visible outcome: steward processing is active. Not a user-facing Telegram change — no Telegram verification required.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test: steward confirmed running in production logs
- [x] User-visible outcome: N/A — this is internal WOS pipeline plumbing, no user-facing output
- [x] Side-effect audit: no floods, no mass sends. Recovery only re-enables jobs that wos_core=true; does not create new UoWs or modify registry data
- [x] External service calls: none in this change

Closes #1139