### PR TITLE
fix: add jobs.json enabled gate to 3 cron-direct scripts

### DIFF
--- a/scheduled-tasks/granola_ingest.py
+++ b/scheduled-tasks/granola_ingest.py
@@ -40,7 +40,7 @@ if str(_THIS_DIR) not in sys.path:
 
 
 # ---------------------------------------------------------------------------
-# jobs.json enabled gate — Type B dispatch path
+# jobs.json enabled gate — Type C dispatch path
 # ---------------------------------------------------------------------------
 
 JOB_NAME = "granola-ingest"

--- a/scheduled-tasks/granola_ingest.py
+++ b/scheduled-tasks/granola_ingest.py
@@ -23,6 +23,7 @@ Logs are written to ~/lobster-workspace/granola-notes/ingest.log
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -36,6 +37,29 @@ from typing import Iterator
 _THIS_DIR = Path(__file__).parent.resolve()
 if str(_THIS_DIR) not in sys.path:
     sys.path.insert(0, str(_THIS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type B dispatch path
+# ---------------------------------------------------------------------------
+
+JOB_NAME = "granola-ingest"
+
+
+def _is_job_enabled(job_name: str) -> bool:
+    """
+    Return True if the job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when jobs.json is absent, the entry is missing, or the
+    file is unreadable or malformed.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+    try:
+        data = json.loads(jobs_file.read_text())
+        return bool(data.get("jobs", {}).get(job_name, {}).get("enabled", True))
+    except Exception:
+        return True
 
 from granola_client import GranolaClient, GranolaAPIError  # noqa: E402
 from granola_state import IncrementalFetcher, StateManager  # noqa: E402
@@ -144,6 +168,9 @@ def _fetch_notes_for_account(
 # ---------------------------------------------------------------------------
 
 def main() -> int:
+    if not _is_job_enabled(JOB_NAME):
+        return 0
+
     log = _setup_logging()
     log.info("=== Granola ingest started ===")
 

--- a/scheduled-tasks/morning-delivery-flush.py
+++ b/scheduled-tasks/morning-delivery-flush.py
@@ -39,6 +39,26 @@ from src.delivery.circadian import flush_morning_queue  # noqa: E402
 JOB_NAME = "morning-delivery-flush"
 
 
+# ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type B dispatch path
+# ---------------------------------------------------------------------------
+
+def _is_job_enabled(job_name: str) -> bool:
+    """
+    Return True if the job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when jobs.json is absent, the entry is missing, or the
+    file is unreadable or malformed.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+    try:
+        data = json.loads(jobs_file.read_text())
+        return bool(data.get("jobs", {}).get(job_name, {}).get("enabled", True))
+    except Exception:
+        return True
+
+
 def _make_send_fn(dry_run: bool):
     """Return a send_fn suitable for flush_morning_queue."""
 
@@ -86,6 +106,9 @@ def _write_task_output(output: str, status: str, timestamp: str) -> None:
 
 
 def run(dry_run: bool = False) -> int:
+    if not _is_job_enabled(JOB_NAME):
+        return 0
+
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     print(f"[{timestamp}] Starting {JOB_NAME}")
 

--- a/scheduled-tasks/morning-delivery-flush.py
+++ b/scheduled-tasks/morning-delivery-flush.py
@@ -40,7 +40,7 @@ JOB_NAME = "morning-delivery-flush"
 
 
 # ---------------------------------------------------------------------------
-# jobs.json enabled gate — Type B dispatch path
+# jobs.json enabled gate — Type C dispatch path
 # ---------------------------------------------------------------------------
 
 def _is_job_enabled(job_name: str) -> bool:

--- a/scheduled-tasks/transcription-monitor.py
+++ b/scheduled-tasks/transcription-monitor.py
@@ -49,7 +49,7 @@ from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
-# jobs.json enabled gate — Type B dispatch path
+# jobs.json enabled gate — Type C dispatch path
 # ---------------------------------------------------------------------------
 
 JOB_NAME = "transcription-monitor"

--- a/scheduled-tasks/transcription-monitor.py
+++ b/scheduled-tasks/transcription-monitor.py
@@ -49,6 +49,29 @@ from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
+# jobs.json enabled gate — Type B dispatch path
+# ---------------------------------------------------------------------------
+
+JOB_NAME = "transcription-monitor"
+
+
+def _is_job_enabled(job_name: str) -> bool:
+    """
+    Return True if the job is enabled in jobs.json, False if explicitly disabled.
+
+    Defaults to True when jobs.json is absent, the entry is missing, or the
+    file is unreadable or malformed.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+    try:
+        data = json.loads(jobs_file.read_text())
+        return bool(data.get("jobs", {}).get(job_name, {}).get("enabled", True))
+    except Exception:
+        return True
+
+
+# ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 _MESSAGES = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
@@ -232,6 +255,8 @@ def atomic_write_json(dest: Path, data: dict) -> None:
 
 def main() -> int:
     """Run the transcription monitor. Returns 0 on success, 1 on error."""
+    if not _is_job_enabled(JOB_NAME):
+        return 0
 
     # Step 1: Check if whisper-cli is running.
     pid = find_whisper_pid()

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3906,6 +3906,87 @@ PYEOF
         migrated=$((migrated + 1))
     fi
 
+    # Migration 110: Register transcription-monitor and morning-delivery-flush in jobs.json
+    # as Type C (cron-direct) jobs, and correct any existing entries that were written with
+    # "type": "B" before the type label was standardized.
+    local _m110_jobs_file="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/scheduled-jobs/jobs.json"
+    if [ -f "$_m110_jobs_file" ]; then
+        local _m110_needs_fix
+        _m110_needs_fix=$(uv run python3 -c "
+import json, sys
+data = json.loads(open('$_m110_jobs_file').read())
+jobs = data.get('jobs', {})
+needs = (
+    jobs.get('transcription-monitor', {}).get('type') != 'C'
+    or jobs.get('morning-delivery-flush', {}).get('type') != 'C'
+)
+print('yes' if needs else 'no')
+" 2>/dev/null || echo "yes")
+        if [ "$_m110_needs_fix" = "yes" ]; then
+            uv run python3 - <<'PYEOF'
+import json, os
+from datetime import datetime, timezone
+from pathlib import Path
+
+workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+jobs_file = workspace / "scheduled-jobs" / "jobs.json"
+try:
+    data = json.loads(jobs_file.read_text())
+except Exception:
+    data = {"jobs": {}}
+
+data.setdefault("jobs", {})
+now = datetime.now(timezone.utc).isoformat()
+
+if "transcription-monitor" not in data["jobs"]:
+    data["jobs"]["transcription-monitor"] = {
+        "name": "transcription-monitor",
+        "type": "C",
+        "dispatch": "cron-direct",
+        "task_file": None,
+        "schedule": "*/5 * * * *",
+        "schedule_human": "Every 5 minutes",
+        "description": "Transcription keep-alive monitor: writes a progress ping to outbox/ while whisper-cli is running",
+        "enabled": True,
+        "created_at": now,
+        "updated_at": now,
+        "last_run": None,
+        "last_status": None,
+    }
+else:
+    data["jobs"]["transcription-monitor"]["type"] = "C"
+    data["jobs"]["transcription-monitor"]["updated_at"] = now
+
+if "morning-delivery-flush" not in data["jobs"]:
+    data["jobs"]["morning-delivery-flush"] = {
+        "name": "morning-delivery-flush",
+        "type": "C",
+        "dispatch": "cron-direct",
+        "task_file": None,
+        "schedule": "0 14 * * *",
+        "schedule_human": "Daily at 14:00 UTC",
+        "description": "Flush messages queued by the circadian delivery gate during off-peak hours",
+        "enabled": True,
+        "created_at": now,
+        "updated_at": now,
+        "last_run": None,
+        "last_status": None,
+    }
+else:
+    data["jobs"]["morning-delivery-flush"]["type"] = "C"
+    data["jobs"]["morning-delivery-flush"]["updated_at"] = now
+
+jobs_file.write_text(json.dumps(data, indent=2))
+print("Migration 110: transcription-monitor and morning-delivery-flush registered/corrected as Type C in jobs.json")
+PYEOF
+            migrated=$((migrated + 1))
+        else
+            substep "Migration 110: transcription-monitor and morning-delivery-flush already Type C in jobs.json — skipping"
+        fi
+    else
+        substep "Migration 110: jobs.json not found — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary
- Adds `_is_job_enabled()` gate at top of `main()` in `granola_ingest.py` and `transcription-monitor.py`, and at top of `run()` in `morning-delivery-flush.py`
- Adds `JOB_NAME` constant to `granola_ingest.py` and `transcription-monitor.py` (matching reference pattern; `morning-delivery-flush.py` already had it)
- Registers `transcription-monitor` and `morning-delivery-flush` in `jobs.json` as Type C (cron-direct) via Migration 110 in upgrade.sh
- Follows reference implementation pattern from `executor-heartbeat.py` / `steward-heartbeat.py`

## Why
Per CLAUDE.md, Type C cron-direct scripts must check `_is_job_enabled()` before any work. Without this gate, toggling `enabled: false` in `jobs.json` has no effect — the script runs unconditionally on every cron tick.

## Test plan
- [ ] Confirm `_is_job_enabled()` is called before any DB/IO in all three scripts
- [ ] Confirm `jobs.json` is valid JSON with new entries matching Type C schema
- [ ] Manually set `enabled: false` for one job and confirm it exits early (no side effects)
- [ ] Run Migration 110 on an install with existing "type": "B" entries and confirm they are corrected to "C"

WOS-UoW: uow_20260512_6d7883

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)