### PR TITLE
fix(wos): exclude infrastructure kills from dead-end gate failure count

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2610,17 +2610,74 @@ def _count_oracle_passes(audit_entries: list[dict]) -> int:
     return sum(1 for e in audit_entries if e.get("event") == "oracle_approved")
 
 
-def _count_failed_or_blocked_transitions(audit_entries: list[dict]) -> int:
-    """Count audit entries where the UoW transitioned to failed or blocked.
+# Infrastructure kill reason codes that must NOT count toward the dead-end
+# threshold.  These represent session kills or platform-level dispatch failures
+# where no execution outcome was produced — the agent never confirmed work.
+#
+# Mapping to audit note["reason"] prefixes written by Registry.fail_uow:
+#   executing_orphan          → steward-detected: dispatched, write_result never received
+#   orphan_kill_before_start  → heartbeat-classified: session killed before work began
+#   orphan_kill_during_execution → heartbeat-classified: session killed mid-execution
+#   ttl_exceeded              → executor-heartbeat: active/executing state exceeded 4h TTL
+#
+# CalledProcessError and all other reasons are genuine execution failures and
+# DO count toward the threshold.
+DEAD_END_INFRA_KILL_REASONS: frozenset[str] = frozenset({
+    "executing_orphan",
+    "orphan_kill_before_start",
+    "orphan_kill_during_execution",
+    "ttl_exceeded",
+})
 
-    Includes both executor-driven failures (to_status='failed') and
-    Steward-driven surface/block transitions (to_status='blocked').
-    Used by the Dead-end pattern detector.
+
+def _is_infra_kill_audit_entry(entry: dict) -> bool:
+    """Return True when an audit entry records an infrastructure kill, not a genuine failure.
+
+    Parses the entry's note JSON and checks whether the ``reason`` field starts
+    with one of the DEAD_END_INFRA_KILL_REASONS codes.  Infrastructure kills are
+    session terminations by the platform (TTL eviction, orphan recovery) where
+    the agent never confirmed an execution outcome.
+
+    The ``reason`` values written by Registry.fail_uow follow the pattern
+    ``"<code>: <human-readable detail>"``, so a ``startswith`` check on each
+    code is the correct discriminant.
+
+    Pure function — no side effects, no I/O.
+    """
+    note = entry.get("note")
+    if not note:
+        return False
+    try:
+        note_data = json.loads(note)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    reason: str | None = note_data.get("reason") if isinstance(note_data, dict) else None
+    if not reason:
+        return False
+    return any(reason.startswith(code) for code in DEAD_END_INFRA_KILL_REASONS)
+
+
+def _count_failed_or_blocked_transitions(audit_entries: list[dict]) -> int:
+    """Count genuine failure/block transitions, excluding infrastructure kills.
+
+    Counts audit entries where the UoW transitioned to failed or blocked,
+    but skips entries where the failure reason is an infrastructure kill
+    (executing_orphan, orphan_kill_before_start, orphan_kill_during_execution,
+    ttl_exceeded).  Infrastructure kills are platform-level session terminations
+    where no execution outcome was produced — they must not consume the dead-end
+    budget.
+
+    Genuine failures (CalledProcessError, agent-reported failure, etc.) still
+    count.  Used by the Dead-end pattern detector.
 
     Pure function — reads only audit_entries; no side effects.
     """
     terminal = {"failed", "blocked"}
-    return sum(1 for e in audit_entries if e.get("to_status") in terminal)
+    return sum(
+        1
+        for e in audit_entries
+        if e.get("to_status") in terminal and not _is_infra_kill_audit_entry(e)
+    )
 
 
 def _check_dispatch_eligibility(

--- a/tests/unit/test_orchestration/test_steward_dispatch_eligibility.py
+++ b/tests/unit/test_orchestration/test_steward_dispatch_eligibility.py
@@ -13,6 +13,7 @@ All threshold values are referenced from named constants, not magic literals.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -31,10 +32,12 @@ from src.orchestration.steward import (
     _check_dispatch_eligibility,
     _count_oracle_passes,
     _count_failed_or_blocked_transitions,
+    _is_infra_kill_audit_entry,
     SPIRAL_ORACLE_PASS_THRESHOLD,
     DEAD_END_FAILURE_THRESHOLD,
     BURST_BATCH_SIZE,
     BURST_BASELINE_QUEUE_DEPTH,
+    DEAD_END_INFRA_KILL_REASONS,
 )
 from src.orchestration.registry import UoW
 
@@ -80,13 +83,35 @@ def _oracle_approved_entries(n: int) -> list[dict[str, Any]]:
 
 
 def _blocked_or_failed_entries(n_failed: int = 0, n_blocked: int = 0) -> list[dict[str, Any]]:
-    """Return audit entries for failed and blocked transitions."""
+    """Return audit entries for genuine failed and blocked transitions (no infra note)."""
     entries = []
     for _ in range(n_failed):
         entries.append(_audit_entry("execution_failed", to_status="failed", from_status="active"))
     for _ in range(n_blocked):
         entries.append(_audit_entry("steward_surface", to_status="blocked", from_status="diagnosing"))
     return entries
+
+
+def _infra_kill_entry(reason_code: str) -> dict[str, Any]:
+    """Build an audit entry that represents an infrastructure kill via Registry.fail_uow.
+
+    The note format mirrors what Registry.fail_uow writes:
+        {"actor": "executor", "reason": "<code>: <detail>", "timestamp": "..."}
+    """
+    note = json.dumps({
+        "actor": "executor",
+        "reason": f"{reason_code}: infrastructure detail",
+        "timestamp": "2026-04-21T00:00:00+00:00",
+    })
+    return {
+        "ts": "2026-04-21T00:00:00+00:00",
+        "uow_id": "uow_20260421_aabbcc",
+        "event": "execution_failed",
+        "from_status": "active",
+        "to_status": "failed",
+        "agent": "executor",
+        "note": note,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +181,137 @@ class TestCountFailedOrBlockedTransitions:
             {"event": "expire", "to_status": "expired", "from_status": "proposed"},
         ]
         assert _count_failed_or_blocked_transitions(entries) == 0
+
+    def test_infra_kills_do_not_count_toward_dead_end(self):
+        """Infrastructure kill entries (to_status=failed, infra reason) are excluded."""
+        entries = [_infra_kill_entry(code) for code in DEAD_END_INFRA_KILL_REASONS]
+        assert _count_failed_or_blocked_transitions(entries) == 0
+
+    def test_genuine_failure_counts_even_when_infra_kills_present(self):
+        """A genuine failure still counts when mixed with infrastructure kills."""
+        entries = (
+            [_infra_kill_entry("executing_orphan"), _infra_kill_entry("ttl_exceeded")]
+            + _blocked_or_failed_entries(n_failed=1)
+        )
+        assert _count_failed_or_blocked_transitions(entries) == 1
+
+    def test_mixed_infra_and_real_only_real_ones_count(self):
+        """Only genuine failures count; infra kills in the same audit log are skipped."""
+        entries = (
+            [_infra_kill_entry("executing_orphan")] * 3
+            + _blocked_or_failed_entries(n_failed=2)
+        )
+        # 3 infra kills + 2 genuine = only 2 should count
+        assert _count_failed_or_blocked_transitions(entries) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_infra_kill_audit_entry (pure function)
+# ---------------------------------------------------------------------------
+
+class TestIsInfraKillAuditEntry:
+    """_is_infra_kill_audit_entry discriminates infrastructure kills from genuine failures."""
+
+    def test_executing_orphan_reason_is_infra_kill(self):
+        entry = _infra_kill_entry("executing_orphan")
+        assert _is_infra_kill_audit_entry(entry) is True
+
+    def test_orphan_kill_before_start_is_infra_kill(self):
+        entry = _infra_kill_entry("orphan_kill_before_start")
+        assert _is_infra_kill_audit_entry(entry) is True
+
+    def test_orphan_kill_during_execution_is_infra_kill(self):
+        entry = _infra_kill_entry("orphan_kill_during_execution")
+        assert _is_infra_kill_audit_entry(entry) is True
+
+    def test_ttl_exceeded_is_infra_kill(self):
+        entry = _infra_kill_entry("ttl_exceeded")
+        assert _is_infra_kill_audit_entry(entry) is True
+
+    def test_called_process_error_is_not_infra_kill(self):
+        """CalledProcessError is a genuine execution failure, not an infrastructure kill."""
+        note = json.dumps({
+            "actor": "executor",
+            "reason": "CalledProcessError: Command returned non-zero exit status 1",
+            "timestamp": "2026-04-21T00:00:00+00:00",
+        })
+        entry = _audit_entry("execution_failed", to_status="failed")
+        entry["note"] = note
+        assert _is_infra_kill_audit_entry(entry) is False
+
+    def test_entry_without_note_is_not_infra_kill(self):
+        entry = _audit_entry("execution_failed", to_status="failed")
+        assert _is_infra_kill_audit_entry(entry) is False
+
+    def test_entry_with_non_json_note_is_not_infra_kill(self):
+        entry = _audit_entry("execution_failed", to_status="failed")
+        entry["note"] = "plain text reason"
+        assert _is_infra_kill_audit_entry(entry) is False
+
+    def test_entry_without_reason_field_is_not_infra_kill(self):
+        note = json.dumps({"actor": "executor", "timestamp": "2026-04-21T00:00:00+00:00"})
+        entry = _audit_entry("execution_failed", to_status="failed")
+        entry["note"] = note
+        assert _is_infra_kill_audit_entry(entry) is False
+
+    def test_dead_end_infra_kill_reasons_constant_covers_all_known_codes(self):
+        """DEAD_END_INFRA_KILL_REASONS covers the four infrastructure kill codes from the data audit."""
+        expected = {
+            "executing_orphan",
+            "orphan_kill_before_start",
+            "orphan_kill_during_execution",
+            "ttl_exceeded",
+        }
+        assert expected.issubset(DEAD_END_INFRA_KILL_REASONS)
+
+
+# ---------------------------------------------------------------------------
+# Integration: dead-end gate with infra-kill discrimination
+# ---------------------------------------------------------------------------
+
+class TestDeadEndGateInfraKillDiscrimination:
+    """Dead-end gate must not fire when all failures are infrastructure kills."""
+
+    def test_all_infra_kills_do_not_trigger_dead_end_gate(self):
+        """DEAD_END_FAILURE_THRESHOLD infra kills → dispatch (gate does not fire)."""
+        uow = _make_uow()
+        entries = [_infra_kill_entry("executing_orphan")] * DEAD_END_FAILURE_THRESHOLD
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "dispatch"
+
+    def test_many_infra_kills_alone_do_not_trigger_dead_end_gate(self):
+        """More infra kills than the threshold → gate still does not fire."""
+        uow = _make_uow()
+        entries = [_infra_kill_entry("ttl_exceeded")] * (DEAD_END_FAILURE_THRESHOLD + 5)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "dispatch"
+
+    def test_real_failures_still_trigger_dead_end_gate(self):
+        """Genuine failures (no infra note) at threshold → gate fires as before."""
+        uow = _make_uow()
+        entries = _blocked_or_failed_entries(n_failed=DEAD_END_FAILURE_THRESHOLD)
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "pause"
+
+    def test_infra_kills_plus_one_real_below_threshold_does_not_pause(self):
+        """Many infra kills + one genuine failure (below threshold) → dispatch, not pause."""
+        uow = _make_uow()
+        entries = (
+            [_infra_kill_entry("orphan_kill_during_execution")] * 5
+            + _blocked_or_failed_entries(n_failed=DEAD_END_FAILURE_THRESHOLD - 1)
+        )
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result != "pause"
+
+    def test_infra_kills_plus_real_failures_at_threshold_triggers_pause(self):
+        """Infra kills do not dilute: DEAD_END_FAILURE_THRESHOLD real failures → pause."""
+        uow = _make_uow()
+        entries = (
+            [_infra_kill_entry("executing_orphan")] * 10
+            + _blocked_or_failed_entries(n_failed=DEAD_END_FAILURE_THRESHOLD)
+        )
+        result = _check_dispatch_eligibility(uow, entries, queue_depth=1)
+        assert result == "pause"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The WOS dead-end gate was counting infrastructure kills — session crashes, TTL evictions, and orphan kills — as genuine execution failures. A UoW killed by the platform before the agent could confirm work was penalized the same as a UoW that ran and failed. This caused the dead-end gate to suppress 136 UoWs permanently, even though those UoWs had never actually produced a failure outcome.

## What changed

`_count_failed_or_blocked_transitions` now skips audit entries that represent infrastructure kills. The discriminant lives in two new additions:

- `DEAD_END_INFRA_KILL_REASONS` — a `frozenset` of the four infrastructure kill reason codes (`executing_orphan`, `orphan_kill_before_start`, `orphan_kill_during_execution`, `ttl_exceeded`). Named constant so tests and implementation share the same source of truth.
- `_is_infra_kill_audit_entry(entry)` — pure function that parses the audit entry's `note` JSON and checks whether the `reason` field starts with one of the infra kill codes. Returns `False` for entries with no note, non-JSON notes, or any reason not in the infra set.

Genuine failures — `CalledProcessError` and any other agent-reported failure reason — are unaffected and still count toward the dead-end threshold.

## Functional patterns used

Pure functions throughout: `_is_infra_kill_audit_entry` has no side effects and no I/O. `_count_failed_or_blocked_transitions` remains a pure transformation over the audit entries list. The `frozenset` for `DEAD_END_INFRA_KILL_REASONS` enforces immutability at the type level.

## Out of scope

- No change to the dead-end threshold value itself (`DEAD_END_FAILURE_THRESHOLD`)
- No change to other pattern detectors (spiral, burst)
- No change to how `Registry.fail_uow` writes audit entries — this fix reads the existing format

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward_dispatch_eligibility.py -v -x` — 46 passed, 0 failed (includes 13 new tests covering `_is_infra_kill_audit_entry` and infra-kill discrimination in `_count_failed_or_blocked_transitions`)

## Manual test

N/A — this change is entirely internal to the dead-end pattern detector. No external services, no file I/O, no Telegram output.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, pure internal logic change
- [x] User-visible outcome verified — N/A, internal gate behavior
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none