### PR TITLE
fix(vault-pipeline): stop self-trigger loop and ACTIVE TODOS.md oscillation

### DIFF
--- a/scheduled-tasks/obsidian_sync_core.py
+++ b/scheduled-tasks/obsidian_sync_core.py
@@ -532,10 +532,31 @@ def apply_status_delta(file_content: str, conn) -> str:
     """
     lines = file_content.splitlines(keepends=True)
 
-    # --- Pass 1: collect all dedup_keys already present in the file ---
+    # --- Pass 1: collect dedup_keys present in the *main body* of the file ---
+    # We deliberately exclude items inside the <!-- lobster-additions --> block.
+    #
+    # Why: Pass 3 rebuilds the additions block from scratch whenever new DB items
+    # arrive.  If additions-block items were included in file_dedup_keys they would
+    # be excluded from items_to_append, then disappear when the block is stripped
+    # and rewritten — causing the oscillation bug where items alternate between
+    # "present" and "absent" on consecutive runs.
+    #
+    # Using only the main-body keys means additions-block items are always eligible
+    # for re-inclusion in the rebuilt block, making the output stable across runs.
     file_dedup_keys: set[str] = set()
+    _in_additions = False
     for raw_line in lines:
-        line = raw_line.rstrip("\n")
+        stripped_line = raw_line.rstrip("\n")
+        if stripped_line.strip() == _LOBSTER_ADDITIONS_MARKER:
+            _in_additions = True
+            continue
+        if stripped_line.strip() == _LOBSTER_ADDITIONS_END:
+            _in_additions = False
+            continue
+        if _in_additions:
+            continue  # Skip lines inside the additions block
+
+        line = stripped_line
         m = _ANY_CHECKBOX_RE.match(line)
         if not m:
             continue

--- a/scheduled-tasks/vault-processor.py
+++ b/scheduled-tasks/vault-processor.py
@@ -104,6 +104,10 @@ DISPATCHED_AT_RE = re.compile(r"\s*<!--\s*dispatched_at:[^>]*-->")
 # Files to exclude from annotation scan
 ANNOTATION_SCAN_EXCLUDES = {".git", ".obsidian"}
 
+# Commit message sentinel — vault-watcher.py skips commits bearing this tag
+# to prevent vault-processor output from triggering a re-run (self-trigger loop).
+LOBSTER_SYNC_SENTINEL = "[lobster-sync]"
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -581,7 +585,9 @@ def run_processor(config: dict, db_path: Path = DB_PATH_DEFAULT) -> bool:
     # Step 10: git commit + push
     log.info("Step 10: git commit + push")
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    commit_message = f"vault-watcher: sync [{timestamp}]"
+    # Include the sentinel so vault-watcher.py can skip this commit and avoid a
+    # self-trigger loop.  See LOBSTER_SYNC_SENTINEL.
+    commit_message = f"vault-watcher: sync [{timestamp}] {LOBSTER_SYNC_SENTINEL}"
 
     # Stage all modified files (annotation cleanups + todos render)
     all_staged = list({todos_path} | set(staging_files))

--- a/scheduled-tasks/vault-watcher.py
+++ b/scheduled-tasks/vault-watcher.py
@@ -96,6 +96,12 @@ DEFAULT_ANNOTATION_SCOPE = "all"
 MIN_DEBOUNCE_SECONDS = 10
 MAX_DEBOUNCE_SECONDS_CAP = 3600
 
+# Commit message sentinel used by vault-processor.py.
+# Commits bearing this tag were produced by the processor itself — vault-watcher
+# must advance last_processed_head without re-firing the processor, breaking the
+# self-trigger loop.
+LOBSTER_SYNC_SENTINEL = "[lobster-sync]"
+
 # ---------------------------------------------------------------------------
 # Jobs.json enabled gate (Type B compliance)
 # ---------------------------------------------------------------------------
@@ -301,6 +307,36 @@ def _get_remote_head(vault_path: Path, timeout: int = 30) -> Optional[str]:
     return sha
 
 
+def _get_commit_message(vault_path: Path, sha: str) -> Optional[str]:
+    """Return the one-line commit message for sha, or None on failure.
+
+    Pure read — does not modify the repo.
+    """
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%s", sha],
+        cwd=str(vault_path),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        log.warning("git log for %s failed: %s", sha[:12], result.stderr.strip())
+        return None
+    return result.stdout.strip() or None
+
+
+def _commit_is_lobster_sync(vault_path: Path, sha: str) -> bool:
+    """Return True if sha was produced by vault-processor.py (sentinel present).
+
+    vault-processor.py appends LOBSTER_SYNC_SENTINEL to every commit it makes.
+    When vault-watcher detects such a commit as a new HEAD, it must NOT re-fire
+    the processor — the change was the processor's own output, not user edits.
+    """
+    message = _get_commit_message(vault_path, sha)
+    if message is None:
+        return False
+    return LOBSTER_SYNC_SENTINEL in message
+
+
 # ---------------------------------------------------------------------------
 # Processor invocation
 # ---------------------------------------------------------------------------
@@ -392,6 +428,22 @@ def main() -> None:
             changed = (remote_head != state["last_known_head"])
 
             if changed:
+                # Check whether this commit was produced by vault-processor.py itself.
+                # If so, advancing last_processed_head without firing the processor
+                # breaks the self-trigger loop: processor commits → watcher detects
+                # → watcher sees sentinel → marks caught up → no re-fire.
+                if _commit_is_lobster_sync(vault_path, remote_head):
+                    log.info(
+                        "Skipping processor re-fire: HEAD %s bears %s (processor's own commit)",
+                        remote_head[:12],
+                        LOBSTER_SYNC_SENTINEL,
+                    )
+                    state["last_known_head"] = remote_head
+                    state["last_processed_head"] = remote_head
+                    state["first_push_at_in_burst"] = None
+                    _write_json_atomic(STATE_PATH, state)
+                    return
+
                 state["last_known_head"] = remote_head
                 state["last_push_at"] = now
                 if state.get("first_push_at_in_burst") is None:

--- a/tests/unit/los/test_vault_watcher.py
+++ b/tests/unit/los/test_vault_watcher.py
@@ -1151,3 +1151,415 @@ def test_render_guard_line_is_unchecked(conn):
     rendered = render_active_todos(conn)
     assert "- [ ] 🔒 DISABLE PROCESSING" in rendered
     assert "- [x] 🔒 DISABLE PROCESSING" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 fix: [lobster-sync] sentinel prevents self-trigger loop
+# ---------------------------------------------------------------------------
+
+# Named constants matching spec requirements (Bug 1 sentinel behavior)
+_LOBSTER_SYNC_SENTINEL = _vault_processor.LOBSTER_SYNC_SENTINEL
+_WATCHER_SENTINEL = _vault_watcher.LOBSTER_SYNC_SENTINEL
+
+
+def test_processor_commit_message_includes_lobster_sync_sentinel(tmp_path):
+    """vault-processor.py must include [lobster-sync] in commit messages it generates.
+
+    Spec: vault-processor commits must bear LOBSTER_SYNC_SENTINEL so vault-watcher
+    can distinguish them from user-generated commits and skip re-firing.
+    """
+    from unittest.mock import MagicMock, patch
+    import sqlite3
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / ".git").mkdir()
+
+    db_path = tmp_path / "test.db"
+    conn_real = connect(db_path)
+    conn_real.close()
+
+    commit_messages_seen: list[str] = []
+
+    def mock_git_commit_and_push(vault_path, files, message):
+        commit_messages_seen.append(message)
+        return True
+
+    config = {
+        "vault_path": str(vault),
+        "lobster_chat_id": None,
+        "watched_files": [],
+        "annotation_scope": "watched_only",
+    }
+
+    todos_path = vault / "✅ ACTIVE TODOS.md"
+    todos_path.write_text(
+        "# ✅ ACTIVE TODOS\n\n- [ ] 🔒 DISABLE PROCESSING\n\n## Urgent / This Week (P1–P3)\n*(none)*\n",
+        encoding="utf-8",
+    )
+
+    with (
+        patch("vault_processor.git_pull", return_value=True),
+        patch("vault_processor.git_commit_and_push", side_effect=mock_git_commit_and_push),
+        patch("vault_processor.connect", return_value=connect(db_path)),
+        patch("vault_processor.sync_obsidian_to_db"),
+        patch("vault_processor.apply_status_delta", return_value=todos_path.read_text()),
+    ):
+        run_processor(config, db_path)
+
+    assert len(commit_messages_seen) >= 1, "run_processor must attempt a commit"
+    for msg in commit_messages_seen:
+        assert _LOBSTER_SYNC_SENTINEL in msg, (
+            f"Commit message must contain {_LOBSTER_SYNC_SENTINEL!r} — got {msg!r}"
+        )
+
+
+def test_commit_is_lobster_sync_returns_true_for_sentinel_commit(tmp_path):
+    """_commit_is_lobster_sync returns True when the commit message contains the sentinel.
+
+    Spec: vault-watcher must detect processor-generated commits by the sentinel in
+    their commit messages, so it can skip re-firing the processor.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    sentinel_message = f"vault-watcher: sync [2026-05-14T00:00:00Z] {_WATCHER_SENTINEL}"
+    non_sentinel_message = "vault-watcher: sync [2026-05-14T00:00:00Z]"
+
+    def mock_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        if "log" in cmd:
+            r.stdout = sentinel_message + "\n"
+        else:
+            r.stdout = ""
+        return r
+
+    with patch.object(_vault_watcher, "subprocess") as mock_subp:
+        mock_subp.run.side_effect = mock_run
+        result = _vault_watcher._commit_is_lobster_sync(vault, "abc123def456")
+
+    assert result is True, "_commit_is_lobster_sync must return True for sentinel commit"
+
+
+def test_commit_is_lobster_sync_returns_false_for_user_commit(tmp_path):
+    """_commit_is_lobster_sync returns False when the commit lacks the sentinel.
+
+    Spec: user commits (from Obsidian app pushing changes) do NOT have the sentinel.
+    The watcher must treat them as real changes and fire the processor.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    def mock_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        if "log" in cmd:
+            r.stdout = "obsidian: auto-commit\n"  # No sentinel
+        else:
+            r.stdout = ""
+        return r
+
+    with patch.object(_vault_watcher, "subprocess") as mock_subp:
+        mock_subp.run.side_effect = mock_run
+        result = _vault_watcher._commit_is_lobster_sync(vault, "abc123def456")
+
+    assert result is False, "_commit_is_lobster_sync must return False for user commit"
+
+
+def test_commit_is_lobster_sync_returns_false_on_git_failure(tmp_path):
+    """_commit_is_lobster_sync returns False gracefully when git log fails.
+
+    Spec: network/git failures must not crash the watcher — treat as non-sentinel
+    (fire the processor, which is the safe direction: at worst an extra run).
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    def mock_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 1
+        r.stdout = ""
+        r.stderr = "fatal: bad object abc123"
+        return r
+
+    with patch.object(_vault_watcher, "subprocess") as mock_subp:
+        mock_subp.run.side_effect = mock_run
+        result = _vault_watcher._commit_is_lobster_sync(vault, "abc123def456")
+
+    assert result is False, "_commit_is_lobster_sync must return False on git failure"
+
+
+def test_watcher_skips_processor_for_lobster_sync_commit(tmp_path):
+    """vault-watcher main() must NOT invoke the processor when new HEAD is a [lobster-sync] commit.
+
+    Scenario: processor committed, HEAD advanced, watcher detects new HEAD.
+    Expected: watcher advances last_processed_head to match and returns without
+    calling _invoke_processor — breaking the self-trigger loop.
+
+    Spec: "vault-processor commits → watcher detects → watcher sees sentinel →
+    marks caught up → no re-fire"
+    """
+    import time
+
+    config_path = tmp_path / "vault-watch-config.json"
+    state_path = tmp_path / "vault-watch-state.json"
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / ".git").mkdir()
+
+    _write_json_atomic(config_path, {
+        "enabled": True,
+        "vault_path": str(vault),
+        "debounce_seconds": 10,
+        "max_debounce_seconds": 60,
+        "watched_files": [],
+        "annotation_scope": "all",
+        "lobster_chat_id": None,
+        "webhook_mode": False,
+    })
+
+    OLD_HEAD = "aaa000"
+    NEW_HEAD = "bbb111"  # processor's commit
+
+    _write_json_atomic(state_path, {
+        "last_known_head": OLD_HEAD,
+        "last_push_at": time.time() - 120,
+        "last_processed_head": OLD_HEAD,
+        "first_push_at_in_burst": None,
+    })
+
+    invoke_calls: list[str] = []
+
+    def mock_invoke_processor(config, **kwargs):
+        invoke_calls.append("called")
+
+    with (
+        patch.object(_vault_watcher, "CONFIG_PATH", config_path),
+        patch.object(_vault_watcher, "STATE_PATH", state_path),
+        patch.object(_vault_watcher, "_is_job_enabled", return_value=True),
+        patch.object(_vault_watcher, "_get_remote_head", return_value=NEW_HEAD),
+        patch.object(_vault_watcher, "_commit_is_lobster_sync", return_value=True),
+        patch.object(_vault_watcher, "_invoke_processor", side_effect=mock_invoke_processor),
+        patch("vault_watcher.acquire_lock_or_skip", return_value=object()),
+        patch("vault_watcher.release_lock"),
+    ):
+        _vault_watcher.main()
+
+    assert len(invoke_calls) == 0, (
+        "vault-watcher must NOT invoke the processor when new HEAD is a [lobster-sync] commit"
+    )
+
+    # Verify state was advanced to mark the commit as processed
+    import json
+    new_state = json.loads(state_path.read_text())
+    assert new_state["last_processed_head"] == NEW_HEAD, (
+        "vault-watcher must advance last_processed_head to the lobster-sync commit SHA"
+    )
+
+
+def test_watcher_fires_processor_for_user_commit(tmp_path):
+    """vault-watcher main() MUST invoke the processor when new HEAD is a user commit.
+
+    Spec: only [lobster-sync] commits are skipped. User commits from Obsidian
+    must still fire the processor after the debounce expires.
+
+    To trigger debounce expiry without changing HEAD: the state shows that
+    last_known_head has been known (but unprocessed) for longer than debounce_seconds.
+    The remote_head matches last_known_head (no new change), so the watcher
+    falls through to the debounce check with an already-expired timer.
+
+    Note: _load_state() uses a default-arg bound to the original STATE_PATH constant,
+    so we patch _load_state directly to control what state main() sees.
+    """
+    import time
+
+    config_path = tmp_path / "vault-watch-config.json"
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / ".git").mkdir()
+
+    DEBOUNCE_SECONDS = 10
+    _write_json_atomic(config_path, {
+        "enabled": True,
+        "vault_path": str(vault),
+        "debounce_seconds": DEBOUNCE_SECONDS,
+        "max_debounce_seconds": 60,
+        "watched_files": [],
+        "annotation_scope": "all",
+        "lobster_chat_id": None,
+        "webhook_mode": False,
+    })
+
+    USER_HEAD = "ccc222"  # user's commit (no sentinel), detected on a previous tick
+    OLD_PROCESSED = "aaa000"  # previously processed
+
+    # HEAD was already seen (last_known_head = USER_HEAD) but not yet processed.
+    # last_push_at is old enough for debounce to expire.
+    mock_state = {
+        "last_known_head": USER_HEAD,
+        "last_push_at": time.time() - (DEBOUNCE_SECONDS + 30),
+        "last_processed_head": OLD_PROCESSED,
+        "first_push_at_in_burst": time.time() - (DEBOUNCE_SECONDS + 30),
+    }
+
+    invoke_calls: list[str] = []
+
+    def mock_invoke_processor(config, **kwargs):
+        invoke_calls.append("called")
+
+    mock_config = {
+        "enabled": True,
+        "vault_path": str(vault),
+        "debounce_seconds": DEBOUNCE_SECONDS,
+        "max_debounce_seconds": 60,
+        "watched_files": [],
+        "annotation_scope": "all",
+        "lobster_chat_id": None,
+        "webhook_mode": False,
+    }
+
+    with (
+        patch.object(_vault_watcher, "_is_job_enabled", return_value=True),
+        # Patch both loaders directly: their default args are bound at definition time
+        # to module-level path constants, so patching the constants alone is insufficient.
+        patch.object(_vault_watcher, "_load_config", return_value=mock_config),
+        patch.object(_vault_watcher, "_load_state", return_value=mock_state),
+        patch.object(_vault_watcher, "_write_json_atomic"),
+        # Return the SAME head as last_known_head — HEAD is already known, debounce fires
+        patch.object(_vault_watcher, "_get_remote_head", return_value=USER_HEAD),
+        patch.object(_vault_watcher, "_commit_is_lobster_sync", return_value=False),
+        patch.object(_vault_watcher, "_invoke_processor", side_effect=mock_invoke_processor),
+        patch.object(_vault_watcher, "acquire_lock_or_skip", return_value=object()),
+        patch.object(_vault_watcher, "release_lock"),
+    ):
+        _vault_watcher.main()
+
+    assert len(invoke_calls) == 1, (
+        "vault-watcher must invoke the processor when debounce expires for an unprocessed user commit"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 fix: apply_status_delta additions-block oscillation
+# ---------------------------------------------------------------------------
+
+
+def test_apply_status_delta_additions_block_stable_on_second_run(conn):
+    """Items in the lobster-additions block must survive a second apply_status_delta run.
+
+    Scenario (oscillation bug):
+    - Run 1: Telegram item T not in file → appended to additions block; file committed
+    - Run 2: file now contains T in additions block; new telegram item U arrives
+      Without fix: T disappears (was in file_dedup_keys → excluded from items_to_append,
+      then stripped when block is rewritten for U)
+      With fix: T stays in the rebuilt additions block (not counted as "in main file")
+
+    Spec: "Items in DB → always present in ACTIVE TODOS.md; the reconciliation
+    output is stable across identical inputs"
+    """
+    from obsidian_sync_core import apply_status_delta, _LOBSTER_ADDITIONS_MARKER, _LOBSTER_ADDITIONS_END
+    from src.los.db import insert_action_item
+
+    # Insert telegram item T into DB
+    t_id = insert_action_item(conn, text="Telegram item T", source="telegram", source_message_id=None)
+    # Insert telegram item U into DB (will be "new" on run 2)
+    u_id = insert_action_item(conn, text="Telegram item U", source="telegram", source_message_id=None)
+
+    # Run 1: file has no additions block; T and U should both appear
+    file_content_run1 = (
+        "# ✅ ACTIVE TODOS\n\n"
+        "- [ ] 🔒 DISABLE PROCESSING\n\n"
+        "## Active (P4–P6)\n\n"
+        "*(none)*\n"
+    )
+    result_run1 = apply_status_delta(file_content_run1, conn)
+
+    # Both T and U must be in the additions block after run 1
+    assert "Telegram item T" in result_run1, "T must be appended after run 1"
+    assert "Telegram item U" in result_run1, "U must be appended after run 1"
+    assert _LOBSTER_ADDITIONS_MARKER in result_run1
+
+    # Run 2: simulate the file now containing both T and U in the additions block
+    # (as if the processor committed run 1's output and vault-watcher sees no new user commit)
+    # Run apply_status_delta again on the same content — output must be stable
+    result_run2 = apply_status_delta(result_run1, conn)
+
+    assert "Telegram item T" in result_run2, (
+        "T must still be present after run 2 — oscillation bug would remove it"
+    )
+    assert "Telegram item U" in result_run2, (
+        "U must still be present after run 2"
+    )
+    assert _LOBSTER_ADDITIONS_MARKER in result_run2
+
+
+def test_apply_status_delta_additions_block_stable_when_new_item_arrives(conn):
+    """When a new DB item arrives, existing additions-block items must be preserved.
+
+    Oscillation scenario:
+    - File contains additions block with item T (from previous run)
+    - New DB item V is inserted
+    - apply_status_delta is called: must include BOTH T (existing) and V (new)
+      Without fix: T disappears because it was in file_dedup_keys (whole file) →
+      excluded from items_to_append → stripped when block rebuilt for V
+    """
+    from obsidian_sync_core import apply_status_delta, _LOBSTER_ADDITIONS_MARKER, _LOBSTER_ADDITIONS_END
+    from src.los.db import insert_action_item
+
+    t_id = insert_action_item(conn, text="Existing item T", source="telegram", source_message_id=None)
+
+    # File already has T in the additions block (simulates committed state after run 1)
+    file_with_t = (
+        "# ✅ ACTIVE TODOS\n\n"
+        "- [ ] 🔒 DISABLE PROCESSING\n\n"
+        "## Active (P4–P6)\n\n"
+        "*(none)*\n\n"
+        f"{_LOBSTER_ADDITIONS_MARKER}\n"
+        "*Items added via Telegram — move or edit freely:*\n\n"
+        f"- [ ] Existing item T <!-- id:{t_id} -->\n"
+        f"{_LOBSTER_ADDITIONS_END}\n"
+    )
+
+    # Now insert new item V into DB
+    v_id = insert_action_item(conn, text="New item V", source="telegram", source_message_id=None)
+
+    result = apply_status_delta(file_with_t, conn)
+
+    assert "Existing item T" in result, (
+        "Existing additions-block item T must be preserved when new item V arrives"
+    )
+    assert "New item V" in result, (
+        "New item V must be appended to the additions block"
+    )
+    assert _LOBSTER_ADDITIONS_MARKER in result
+
+
+def test_apply_status_delta_main_body_items_excluded_from_additions_block(conn):
+    """Items in the main file body must NOT be re-added to the additions block.
+
+    Spec: once a user moves a Telegram item into the main body of ACTIVE TODOS.md,
+    it must not reappear in the additions block.
+    """
+    from obsidian_sync_core import apply_status_delta, _LOBSTER_ADDITIONS_MARKER
+    from src.los.db import insert_action_item
+
+    # Insert a telegram item into DB
+    t_id = insert_action_item(conn, text="Moved to main body", source="telegram", source_message_id=None)
+
+    # File has the item in its main body (user moved it out of the additions block)
+    file_with_main_body_item = (
+        "# ✅ ACTIVE TODOS\n\n"
+        "- [ ] 🔒 DISABLE PROCESSING\n\n"
+        "## Active (P4–P6)\n\n"
+        f"- [ ] Moved to main body <!-- id:{t_id} -->\n"
+    )
+
+    result = apply_status_delta(file_with_main_body_item, conn)
+
+    # The item appears in the main body — count occurrences to ensure no duplication
+    occurrences = result.count("Moved to main body")
+    assert occurrences == 1, (
+        f"Item in main body must appear exactly once, not be duplicated in additions block — "
+        f"found {occurrences} occurrences"
+    )


### PR DESCRIPTION
## Summary

The Obsidian vault pipeline had two bugs causing continuous background churn even when the user hadn't written anything new.

**Bug 1 — Self-trigger loop (~90s cycle):** vault-processor.py commits its output back to the vault repo. vault-watcher.py detects that new commit as a change and fires the processor again. Repeat forever.

Root cause: vault-watcher had no way to distinguish "user pushed new notes" from "processor committed its own output."

Fix (Option C — commit message sentinel): vault-processor.py now appends `[lobster-sync]` to every commit message it generates. vault-watcher.py reads the commit message of any newly-detected remote HEAD via `_commit_is_lobster_sync()`. When the sentinel is present, it advances `last_processed_head` without firing the processor — breaking the loop in one hop.

Before:
```
user pushes → watcher detects → processor runs → processor commits
                                                       ↓
                              watcher detects new HEAD ←
                              (loop forever, ~90s cycle)
```

After:
```
user pushes → watcher detects → processor runs → processor commits [lobster-sync]
                                                       ↓
                              watcher detects new HEAD, sees [lobster-sync]
                              → advances last_processed_head, returns (no re-fire)
```

**Bug 2 — ACTIVE TODOS.md oscillation:** Items added via Telegram (source != obsidian) would appear in the `<!-- lobster-additions -->` block on one run, vanish on the next, reappear, and so on.

Root cause: `apply_status_delta()` collected `file_dedup_keys` from the entire file — including items already in the additions block. When new DB items arrived, the additions block was stripped and rebuilt using only items NOT in `file_dedup_keys`. Items previously in the additions block (which WERE in `file_dedup_keys`) were excluded from `items_to_append` and silently dropped. Next run, they reappeared. Repeat.

Fix: Pass 1 now excludes additions-block lines from `file_dedup_keys`. Only main-body items are counted as "already in file." The additions block is rebuilt from all DB open items not in the main body — which naturally includes items that were in the old additions block.

## Functional patterns used

- Pure functions: `_commit_is_lobster_sync()` has no side effects — reads git log, returns bool
- Immutability: `file_dedup_keys` computation is now a clean single-pass scan with explicit exclusion logic
- Sentinel pattern: commit message tag creates a machine-readable signal without requiring shared state between watcher and processor

## Tests run

- [x] `uv run pytest tests/unit/los/test_vault_watcher.py -v` — 63 passed, 1 pre-existing failure (`test_parse_renders_done_items_excluded` was already failing on `main` before this PR)
- [x] `uv run pytest tests/unit/los/ tests/los/ -v` — 226 passed, 3 pre-existing failures (2 in `test_subtasks.py`, 1 in `test_vault_watcher.py` — all confirmed pre-existing on `main`)
- [x] `uv run ruff check scheduled-tasks/vault-watcher.py scheduled-tasks/vault-processor.py scheduled-tasks/obsidian_sync_core.py` — clean

## Manual test

N/A for unit tests. Integration verification would require a live vault push — both bugs require the live cron scheduler and a real Obsidian vault git repo with the processor actively committing. Blocked: no production vault available in this environment. The unit tests cover the two fix paths (sentinel detection and additions-block stability) with explicit before/after scenarios derived from the oscillation description in the audit.

User-visible outcome: not self-verifiable from this environment. The fix prevents background commits from appearing in the vault repo every ~90s when the user hasn't written anything. Dan should observe that vault-watcher stops generating commits when no new notes are written.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test run — blocked: requires live vault + cron environment
- [ ] User-visible outcome verified — needs Dan to observe no spurious vault commits after deploy
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume. Fix reduces commit volume, does not increase it.
- [x] External service calls: none in tests (all git calls mocked)