### PR TITLE
fix(executor-heartbeat): demote 0-UoW legacy registry log to DEBUG

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -121,7 +121,7 @@ def _warn_if_legacy_registry_exists() -> None:
     except Exception:
         uow_count = -1
     if uow_count == 0:
-        log.info(
+        log.debug(
             "Legacy registry DB at %s exists (%d bytes) but has 0 UoWs — "
             "run upgrade.sh to apply Migration 86 and remove it.",
             legacy_path, size,


### PR DESCRIPTION
## Summary

- `_warn_if_legacy_registry_exists()` logged at `log.info` when `wos-registry.db` existed with 0 UoWs — a harmless condition. At the 3-minute cron cadence this produced ~480 log lines/day.
- Demote the 0-UoW branch to `log.debug`; the non-empty-UoW branch stays at `log.warning` (that case still warrants attention).
- The legacy `wos-registry.db` (`~/lobster-workspace/data/`) is already absent on the current install (confirmed via `ls`). upgrade.sh Migration 86 would show "not present — skipping" if run; the migration hit a cron permission error before reaching step 86, but the file was already gone.

## Test plan

- [ ] Confirm `executor-heartbeat.py` line ~124 uses `log.debug` (not `log.info`) for the 0-UoW case
- [ ] Confirm `~/lobster-workspace/data/wos-registry.db` does not exist
- [ ] Run `executor-heartbeat.py` with `--dry-run` and confirm no INFO noise from legacy registry detection

Closes #1071

WOS-UoW: uow_20260513_484e94