### PR TITLE
feat(wos): extend StrEnum boundary to UoWType and UoWRegister

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -56,7 +56,7 @@ from orchestration.config import TimeoutConfig
 
 log = logging.getLogger("executor")
 
-from orchestration.registry import Registry, UoW, UoWStatus
+from orchestration.registry import Registry, UoW, UoWRegister, UoWStatus
 from orchestration.result_writer import write_result as _write_subagent_result
 from orchestration.workflow_artifact import WorkflowArtifact, from_json, from_frontmatter
 from orchestration.error_capture import (
@@ -148,7 +148,7 @@ class ClaimSucceeded:
     uow_id: str
     output_ref: str
     artifact: WorkflowArtifact
-    register: str = "operational"
+    register: UoWRegister = UoWRegister.OPERATIONAL
 
 
 @dataclass(frozen=True)
@@ -568,7 +568,7 @@ class Executor:
                 _write_result_json(output_ref, null_result)
                 null_trace = _build_trace(
                     uow_id=uow_id,
-                    register=row["register"] if row["register"] else "operational",
+                    register=UoWRegister(row["register"]) if row["register"] else UoWRegister.OPERATIONAL,
                     outcome=ExecutorOutcome.FAILED,
                     execution_summary=null_reason,
                     surprises=[null_reason],
@@ -602,7 +602,7 @@ class Executor:
                     _write_result_json(output_ref, missing_result)
                     missing_trace = _build_trace(
                         uow_id=uow_id,
-                        register=row["register"] if row["register"] else "operational",
+                        register=UoWRegister(row["register"]) if row["register"] else UoWRegister.OPERATIONAL,
                         outcome=ExecutorOutcome.FAILED,
                         execution_summary=missing_reason,
                         surprises=[missing_reason],
@@ -643,7 +643,7 @@ class Executor:
                 _write_result_json(output_ref, deser_result)
                 deser_trace = _build_trace(
                     uow_id=uow_id,
-                    register=row["register"] if row["register"] else "operational",
+                    register=UoWRegister(row["register"]) if row["register"] else UoWRegister.OPERATIONAL,
                     outcome=ExecutorOutcome.FAILED,
                     execution_summary=deser_reason,
                     surprises=[str(e)],
@@ -657,7 +657,7 @@ class Executor:
                     reason=f"workflow_artifact deserialization failed: {e}",
                 )
 
-            register = row["register"] if row["register"] else "operational"
+            register = UoWRegister(row["register"]) if row["register"] else UoWRegister.OPERATIONAL
             return ClaimSucceeded(uow_id=uow_id, output_ref=output_ref, artifact=artifact, register=register)
 
         except Exception:
@@ -683,7 +683,7 @@ class Executor:
         uow_id: str,
         output_ref: str,
         artifact: WorkflowArtifact,
-        register: str = "operational",
+        register: UoWRegister = UoWRegister.OPERATIONAL,
     ) -> ExecutorResult:
         """
         Execute a claimed UoW through its full step sequence.
@@ -749,7 +749,7 @@ class Executor:
         uow_id: str,
         output_ref: str,
         artifact: WorkflowArtifact,
-        register: str = "operational",
+        register: UoWRegister = UoWRegister.OPERATIONAL,
     ) -> ExecutorResult:
         """
         Inner execution: activate skills, dispatch subagent, write results.

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -95,6 +95,30 @@ class UoWStatus(StrEnum):
 
 
 # ---------------------------------------------------------------------------
+# UoW type enum — classifies execution mode of the unit of work
+# ---------------------------------------------------------------------------
+
+class UoWType(StrEnum):
+    EXECUTABLE = "executable"  # standard agent-dispatched execution
+    INLINE = "inline"          # lightweight, no subagent dispatch
+
+
+# ---------------------------------------------------------------------------
+# UoW register enum — attentional configuration for completion evaluation
+#
+# These four values are canonical across the codebase (germinator, steward,
+# executor, dispatcher_handlers). If a new register is added, add it here
+# and update the executor's dispatch table and steward's register-aware logic.
+# ---------------------------------------------------------------------------
+
+class UoWRegister(StrEnum):
+    OPERATIONAL = "operational"
+    ITERATIVE_CONVERGENT = "iterative-convergent"
+    PHILOSOPHICAL = "philosophical"
+    HUMAN_JUDGMENT = "human-judgment"
+
+
+# ---------------------------------------------------------------------------
 # Named result types — no dict[str, Any] from decision functions
 # ---------------------------------------------------------------------------
 
@@ -169,7 +193,7 @@ class UoW:
     created_at: str
     updated_at: str
     sweep_date: str | None = None
-    type: str = "executable"
+    type: UoWType = UoWType.EXECUTABLE
     posture: str = "solo"
     route_reason: str | None = None
     steward_notes: str = ""
@@ -209,7 +233,7 @@ class UoW:
     #   than reclassifying autonomously.
     # uow_mode: mirrors register; used for execution context selection by Executor.
     #   Kept separate to allow future divergence without a schema change.
-    register: str = "operational"
+    register: UoWRegister = UoWRegister.OPERATIONAL
     uow_mode: str | None = None
     # Delivery≠closure fields (populated after migration 0007)
     # closed_at: ISO timestamp written by Steward when it declares the loop done.
@@ -286,6 +310,25 @@ class UoW:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_enum(raw: str | None, enum_cls: type, default: Any) -> Any:
+    """Convert a raw DB string to a StrEnum value.
+
+    Falls back to ``default`` for NULL or unrecognized values so that legacy
+    rows do not raise at the read boundary.  This is the only place where
+    unknown enum strings are tolerated — new writes always use enum values.
+    """
+    if raw is None:
+        return default
+    try:
+        return enum_cls(raw)
+    except ValueError:
+        log.debug(
+            "_coerce_enum: unknown value %r for %s, using default %r",
+            raw, enum_cls.__name__, default,
+        )
+        return default
 
 
 def _generate_uow_id() -> str:
@@ -449,7 +492,7 @@ class Registry:
             created_at=d.get("created_at") or "",
             updated_at=d.get("updated_at") or "",
             sweep_date=d.get("sweep_date"),
-            type=d.get("type") or "executable",
+            type=_coerce_enum(d.get("type"), UoWType, UoWType.EXECUTABLE),
             posture=d.get("posture") or "solo",
             route_reason=d.get("route_reason"),
             steward_notes=d.get("steward_notes") or "",
@@ -469,7 +512,7 @@ class Registry:
             source_last_seen_at=d.get("source_last_seen_at"),
             source_state=d.get("source_state"),
             issue_url=d.get("issue_url"),
-            register=d.get("register") or "operational",
+            register=_coerce_enum(d.get("register"), UoWRegister, UoWRegister.OPERATIONAL),
             uow_mode=d.get("uow_mode"),
             closed_at=d.get("closed_at"),
             close_reason=d.get("close_reason"),

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
-from src.orchestration.registry import UoW
+from src.orchestration.registry import UoW, UoWStatus, UoWRegister
 from src.orchestration.paths import WOS_GATE_CLEARED_FLAG as _GATE_CLEARED_FLAG
 from src.orchestration.error_capture import (
     run_subprocess_with_error_capture,
@@ -437,29 +437,8 @@ def _build_claude_env() -> dict[str, str]:
     return env
 
 
-# ---------------------------------------------------------------------------
-# Status enum (golden pattern: StrEnum so values serialize as plain strings)
-# ---------------------------------------------------------------------------
-
-class UoWStatus(StrEnum):
-    PROPOSED = "proposed"
-    PENDING = "pending"
-    READY_FOR_STEWARD = "ready-for-steward"
-    DIAGNOSING = "diagnosing"
-    READY_FOR_EXECUTOR = "ready-for-executor"
-    ACTIVE = "active"
-    DONE = "done"
-    BLOCKED = "blocked"
-    FAILED = "failed"
-    EXPIRED = "expired"
-    # NEEDS_HUMAN_REVIEW: retry cap exceeded; UoW awaits human decision.
-    NEEDS_HUMAN_REVIEW = "needs-human-review"
-
-    def is_terminal(self) -> bool:
-        return self in {UoWStatus.DONE, UoWStatus.FAILED, UoWStatus.EXPIRED}
-
-    def is_in_flight(self) -> bool:
-        return self in {UoWStatus.ACTIVE, UoWStatus.READY_FOR_EXECUTOR, UoWStatus.DIAGNOSING}
+# UoWStatus is the canonical source in registry.py; imported above.
+# The duplicate definition has been removed — use UoWStatus from the import.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_strenum_boundary.py
+++ b/tests/unit/test_orchestration/test_strenum_boundary.py
@@ -1,0 +1,241 @@
+"""
+Tests for the StrEnum read-boundary enforcement: UoWType, UoWPosture, UoWRegister.
+
+The read boundary is _row_to_uow in Registry. Every raw DB row must be
+converted through the StrEnum there — raw string comparisons are eliminated.
+
+Tests are named after the behavior being verified, not the mechanism.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.orchestration.registry import (
+    Registry,
+    UoW,
+    UoWRegister,
+    UoWStatus,
+    UoWType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path) -> Registry:
+    import os
+    os.environ["REGISTRY_DB_PATH"] = str(db_path)
+    reg = Registry(db_path=db_path)
+    yield reg
+    del os.environ["REGISTRY_DB_PATH"]
+
+
+def _insert_raw_uow(
+    db_path: Path,
+    uow_id: str,
+    status: str,
+    type_: str,
+    posture: str,
+    register: str,
+) -> None:
+    """Insert a raw UoW row, bypassing Registry to test read-boundary coercion."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _open_db(db_path)
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+          (id, type, source, source_issue_number, sweep_date, status, posture,
+           created_at, updated_at, summary, success_criteria)
+        VALUES (?, ?, 'test', 1, '2026-01-01', ?, ?,
+                ?, ?, 'test summary', 'test done')
+        """,
+        (uow_id, type_, status, posture, now, now),
+    )
+    conn.execute(
+        "UPDATE uow_registry SET register = ? WHERE id = ?",
+        (register, uow_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# UoWType StrEnum
+# ---------------------------------------------------------------------------
+
+class TestUoWTypeEnum:
+    def test_canonical_string_values(self):
+        """UoWType values must match the DB defaults exactly."""
+        assert UoWType.EXECUTABLE == "executable"
+        assert UoWType.INLINE == "inline"
+
+    def test_is_str_subclass(self):
+        """UoWType must be StrEnum so it serializes as a plain string."""
+        assert isinstance(UoWType.EXECUTABLE, str)
+        assert str(UoWType.EXECUTABLE) == "executable"
+
+    def test_row_to_uow_coerces_type_to_enum(self, registry: Registry, db_path: Path):
+        """_row_to_uow must coerce the raw DB 'type' string into UoWType."""
+        _insert_raw_uow(db_path, "uow_type_test_1", "proposed", "executable", "solo", "operational")
+        uow = registry.get("uow_type_test_1")
+        assert uow is not None
+        assert isinstance(uow.type, UoWType)
+        assert uow.type == UoWType.EXECUTABLE
+
+    def test_row_to_uow_coerces_inline_type(self, registry: Registry, db_path: Path):
+        """_row_to_uow must coerce 'inline' type correctly."""
+        _insert_raw_uow(db_path, "uow_type_test_2", "proposed", "inline", "solo", "operational")
+        uow = registry.get("uow_type_test_2")
+        assert uow is not None
+        assert uow.type == UoWType.INLINE
+
+    def test_unknown_type_falls_back_to_executable(self, registry: Registry, db_path: Path):
+        """Legacy rows with unknown type values fall back to EXECUTABLE without raising."""
+        _insert_raw_uow(db_path, "uow_type_test_3", "proposed", "legacy-unknown", "solo", "operational")
+        uow = registry.get("uow_type_test_3")
+        assert uow is not None
+        # Falls back to EXECUTABLE default (same as if NULL)
+        assert uow.type == UoWType.EXECUTABLE
+
+
+# ---------------------------------------------------------------------------
+# UoWRegister StrEnum
+# ---------------------------------------------------------------------------
+
+VALID_REGISTERS = [
+    ("operational", "OPERATIONAL"),
+    ("iterative-convergent", "ITERATIVE_CONVERGENT"),
+    ("philosophical", "PHILOSOPHICAL"),
+    ("human-judgment", "HUMAN_JUDGMENT"),
+]
+
+
+class TestUoWRegisterEnum:
+    def test_canonical_string_values(self):
+        """UoWRegister values must match the strings used throughout the codebase."""
+        assert UoWRegister.OPERATIONAL == "operational"
+        assert UoWRegister.ITERATIVE_CONVERGENT == "iterative-convergent"
+        assert UoWRegister.PHILOSOPHICAL == "philosophical"
+        assert UoWRegister.HUMAN_JUDGMENT == "human-judgment"
+
+    def test_is_str_subclass(self):
+        """UoWRegister must be StrEnum."""
+        assert isinstance(UoWRegister.OPERATIONAL, str)
+        assert str(UoWRegister.HUMAN_JUDGMENT) == "human-judgment"
+
+    @pytest.mark.parametrize("raw_value, attr_name", VALID_REGISTERS)
+    def test_row_to_uow_coerces_register_to_enum(
+        self, registry: Registry, db_path: Path, raw_value: str, attr_name: str
+    ):
+        """_row_to_uow must coerce every valid register string to UoWRegister."""
+        uow_id = f"uow_reg_test_{attr_name.lower()}"
+        _insert_raw_uow(db_path, uow_id, "proposed", "executable", "solo", raw_value)
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert isinstance(uow.register, UoWRegister)
+        expected = getattr(UoWRegister, attr_name)
+        assert uow.register == expected
+
+    def test_unknown_register_falls_back_to_operational(self, registry: Registry, db_path: Path):
+        """Legacy rows with unknown register values fall back to OPERATIONAL without raising."""
+        _insert_raw_uow(db_path, "uow_reg_unknown", "proposed", "executable", "solo", "legacy-unknown")
+        uow = registry.get("uow_reg_unknown")
+        assert uow is not None
+        assert uow.register == UoWRegister.OPERATIONAL
+
+    def test_omitted_register_defaults_to_operational(self, registry: Registry, db_path: Path):
+        """Rows where register is omitted from INSERT use the DB DEFAULT 'operational'.
+
+        The column has NOT NULL + DEFAULT 'operational', so NULL is not a valid
+        stored value. But the _coerce_enum path still defaults to OPERATIONAL for
+        any missing or unrecognised value — verified here via the DB DEFAULT path.
+        """
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        conn = _open_db(db_path)
+        # Insert without specifying register — DB DEFAULT 'operational' applies.
+        conn.execute(
+            """
+            INSERT INTO uow_registry
+              (id, type, source, source_issue_number, sweep_date, status, posture,
+               created_at, updated_at, summary, success_criteria)
+            VALUES (?, 'executable', 'test', 99, '2026-01-01', 'proposed', 'solo',
+                    ?, ?, 'summary', 'done')
+            """,
+            ("uow_reg_omit", now, now),
+        )
+        conn.commit()
+        conn.close()
+        uow = registry.get("uow_reg_omit")
+        assert uow is not None
+        assert uow.register == UoWRegister.OPERATIONAL
+
+
+# ---------------------------------------------------------------------------
+# UoWStatus import from steward matches registry definition
+# ---------------------------------------------------------------------------
+
+class TestStewardImportsRegistryStatus:
+    def test_steward_uses_registry_uow_status(self):
+        """steward.py must import UoWStatus from registry, not define its own."""
+        from src.orchestration import steward
+        from src.orchestration import registry
+
+        # After deduplication, the UoWStatus in steward's module namespace
+        # must be the same object as registry.UoWStatus.
+        steward_status = getattr(steward, "UoWStatus", None)
+        assert steward_status is not None, "UoWStatus not found in steward module"
+        assert steward_status is registry.UoWStatus, (
+            "steward.UoWStatus is not the same object as registry.UoWStatus — "
+            "duplicate definition still present"
+        )
+
+
+# ---------------------------------------------------------------------------
+# UoWType appears on UoW dataclass field
+# ---------------------------------------------------------------------------
+
+class TestUoWDataclassTyping:
+    def test_uow_type_field_is_enum_after_read(self, registry: Registry, db_path: Path):
+        """After a round-trip through Registry.get(), uow.type is UoWType, not str."""
+        _insert_raw_uow(db_path, "uow_dc_type", "proposed", "executable", "solo", "operational")
+        uow = registry.get("uow_dc_type")
+        assert isinstance(uow.type, UoWType)
+
+    def test_uow_register_field_is_enum_after_read(self, registry: Registry, db_path: Path):
+        """After a round-trip through Registry.get(), uow.register is UoWRegister, not str."""
+        _insert_raw_uow(db_path, "uow_dc_reg", "proposed", "executable", "solo", "philosophical")
+        uow = registry.get("uow_dc_reg")
+        assert isinstance(uow.register, UoWRegister)
+        assert uow.register == UoWRegister.PHILOSOPHICAL
+
+    def test_uow_register_equality_with_raw_string(self, registry: Registry, db_path: Path):
+        """UoWRegister is StrEnum, so uow.register == 'operational' still works."""
+        _insert_raw_uow(db_path, "uow_dc_eq", "proposed", "executable", "solo", "operational")
+        uow = registry.get("uow_dc_eq")
+        # StrEnum: the enum value IS a str — backward-compat comparisons continue to work
+        assert uow.register == "operational"
+        assert uow.register == UoWRegister.OPERATIONAL
+
+    def test_uow_type_equality_with_raw_string(self, registry: Registry, db_path: Path):
+        """UoWType is StrEnum, so uow.type == 'executable' still works."""
+        _insert_raw_uow(db_path, "uow_dc_type_eq", "proposed", "executable", "solo", "operational")
+        uow = registry.get("uow_dc_type_eq")
+        assert uow.type == "executable"
+        assert uow.type == UoWType.EXECUTABLE


### PR DESCRIPTION
## What this solves

Raw string comparisons for UoW `type` and `register` fields were scattered across executor.py, steward.py, and registry.py. There was no type-safe way to know whether `"operational"` was spelled correctly at a call site, and steward.py contained a duplicate `UoWStatus` definition that had drifted from the canonical version in registry.py (it was missing `EXECUTING` and `CANCELLED`).

This PR closes that gap by following the same StrEnum pattern already established by `UoWStatus`.

## What changed

**registry.py** — two new StrEnums added:
- `UoWType` (`executable` / `inline`) — classifies execution mode
- `UoWRegister` (`operational` / `iterative-convergent` / `philosophical` / `human-judgment`) — attentional configuration for completion evaluation

Both are enforced at the `_row_to_uow` read boundary via a new `_coerce_enum` helper. Unknown or legacy DB values fall back to the canonical default (`UoWType.EXECUTABLE`, `UoWRegister.OPERATIONAL`) — backward-compatible with all existing rows. The `UoW` dataclass fields `type` and `register` are now typed as `UoWType` and `UoWRegister` respectively.

**steward.py** — duplicate `UoWStatus` removed. The module now imports `UoWStatus` and `UoWRegister` from registry.py. The steward's local copy had diverged: it was missing `EXECUTING` and `CANCELLED` variants, and its `is_terminal` / `is_in_flight` methods were narrower than the canonical versions.

**executor.py** — raw string fallbacks replaced with `UoWRegister` enum values in `ClaimSucceeded`, `_run_step_sequence`, `_run_execution`, and the four `_build_trace` call sites that previously used `row["register"] if row["register"] else "operational"`.

## Functional patterns

- Single authoritative source: all three UoW field enums live in registry.py
- Pure read-boundary coercion: `_coerce_enum` is a pure function, no side effects, called only in `_row_to_uow`
- StrEnum: values serialize as plain strings — all existing string comparisons (`uow.register == "operational"`) remain valid

## What is not changed

- No schema changes; no DB migrations
- No changes to vault-pipeline files or wos-config.json
- `UoWPosture` is not introduced — the `posture` column stores DB-level dispatch state (`solo`, `shard`, `parallel`) but the steward's `reentry_posture` is a separate runtime concept; conflating them would misname both

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_strenum_boundary.py` — 18 passed, 0 failed (new tests, written before implementation)
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py` — 80 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_executor_register_routing.py tests/unit/test_orchestration/test_executor_trace.py tests/unit/test_orchestration/test_select_executor_type_by_register.py` — 78 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_register_aware_diagnosis.py tests/unit/test_orchestration/test_steward_register_mismatch.py tests/unit/test_orchestration/test_steward_dispatch_eligibility.py tests/unit/test_orchestration/test_steward_prescription_confidence.py tests/unit/test_orchestration/test_steward_return_reason_exhaustiveness.py tests/unit/test_orchestration/test_steward_cycle_trace.py` — 78 passed, 0 failed
- [x] Full orchestration suite (excluding pre-existing syntax error in test_registry_cli.py) — 23 pre-existing failures, 2066 passed; zero regressions introduced

**Pre-existing failures (not introduced by this PR, confirmed on main):** test_steward.py::TestSelectExecutorType (4), test_steward_execution_gate.py (3), test_prescriptions_per_cycle.py (8), test_failure_traces_cleanup.py (6), test_executor_subprocess.py::test_instructions_are_passed_to_dispatcher (1), test_registry_cli.py syntax error (excluded from run).

## Manual test

N/A — this change is entirely internal (StrEnum coercion at the read boundary). No external services, no systemd, no file I/O affecting runtime state beyond what the unit tests exercise. StrEnum values serialize identically to their string counterparts, so no observable behavior change at runtime.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, see above
- [x] User-visible outcome — not applicable (internal type enforcement)
- [x] Side-effect audit — no floods, no shared state writes, no volume changes
- [x] External service calls — none in this change