### PR TITLE
fix(tests): import pricing constants from wos_uow_detail_gen instead of redeclaring

### DIFF
--- a/tests/unit/test_orchestration/test_wos_uow_detail_gen.py
+++ b/tests/unit/test_orchestration/test_wos_uow_detail_gen.py
@@ -26,14 +26,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-# ---------------------------------------------------------------------------
-# Constants matching the spec (Sonnet 4.6 pricing)
-# ---------------------------------------------------------------------------
-
-SONNET_4_6_INPUT_PER_MTK = 3.0     # $3 per 1M input tokens
-SONNET_4_6_OUTPUT_PER_MTK = 15.0   # $15 per 1M output tokens
-SONNET_4_6_CACHE_READ_PER_MTK = 0.30  # $0.30 per 1M cache_read tokens
+from src.orchestration.wos_uow_detail_gen import (
+    SONNET_4_6_CACHE_READ_PER_MTK,
+    SONNET_4_6_INPUT_PER_MTK,
+    SONNET_4_6_OUTPUT_PER_MTK,
+)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Before this change, `test_wos_uow_detail_gen.py` declared `SONNET_4_6_INPUT_PER_MTK`, `SONNET_4_6_OUTPUT_PER_MTK`, and `SONNET_4_6_CACHE_READ_PER_MTK` as local copies of the values defined in `src/orchestration/wos_uow_detail_gen.py`. This mirror-constant pattern means a pricing change in the source module silently leaves tests verifying stale values — the tests continue to pass while the behavior they claim to cover diverges.

This PR removes the local declarations and replaces them with a direct import from the source module, so the test and implementation share a single source of truth. If the constants are ever updated, the tests automatically test the new values.

Closes oracle advisory from [PR #1116](https://github.com/dcetlin/Lobster/pull/1116) round 2.

UoW: `uow_20260510_c5a153`

## What changed

- Removed 3 locally-declared constant definitions (lines 34-36 of the original test file)
- Added `from src.orchestration.wos_uow_detail_gen import SONNET_4_6_CACHE_READ_PER_MTK, SONNET_4_6_INPUT_PER_MTK, SONNET_4_6_OUTPUT_PER_MTK`
- No source files touched — the constants were already module-level in `wos_uow_detail_gen.py`

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_uow_detail_gen.py -v` — 41 passed, 0 failed

## Manual test

N/A — this change is entirely internal to the test file. No external services, file I/O, or DB schema affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (test-only change)
- [x] User-visible outcome verified — N/A (no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none