### PR TITLE
fix: implement gh pr create idempotency as PreToolUse hook

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -135,7 +135,7 @@ If yes to any of the first three: run in test scope first, verify bounds, then s
 
 **Before opening the PR, run all applicable tests.** Only then write the PR description.
 
-- When implementation is complete, open a pull request using `gh pr create --repo <owner/repo> --title "..." --body "..."`
+- When implementation is complete, open a pull request using `gh pr create --repo <owner/repo> --title "..." --body "..."`. Duplicate PR prevention is enforced by the PreToolUse hook `check-pr-exists-before-create.py` -- no manual check needed.
 - Reference the issue in the PR description using keywords (Closes #XX, Fixes #XX, or Relates to #XX)
 - **Set "Main Board" project status to "In Review"** after PR is opened
 

--- a/hooks/check-pr-exists-before-create.py
+++ b/hooks/check-pr-exists-before-create.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: blocks 'gh pr create' when an open PR already exists for the
+same branch on the same repo.
+
+WOS executor re-dispatches UoWs, and agents may attempt to create duplicate PRs.
+This hook enforces idempotency structurally: any 'gh pr create' command is
+checked against the GitHub API before execution. If a matching open PR exists,
+the tool call is hard-blocked.
+
+The hook uses branch-name matching only (via --head), not title matching.
+Title-prefix matching was rejected in the oracle review of PR #1148 due to
+false-positive risk across unrelated UoWs with similar titles.
+
+Exit codes:
+  0 -- not a PR create command, or no existing PR found (allow)
+  2 -- hard block: an open PR already exists for this branch/repo
+"""
+import json
+import re
+import subprocess
+import sys
+
+
+def extract_repo(command: str) -> "str | None":
+    """Extract the --repo / -R value from a gh pr create command.
+
+    Handles:
+      --repo owner/repo
+      --repo=owner/repo
+      -R owner/repo
+    """
+    match = re.search(r'(?:--repo(?:=|\s+)|-R\s+)([\w./-]+)', command)
+    return match.group(1) if match else None
+
+
+def extract_head_branch(command: str) -> "str | None":
+    """Extract the --head / -H value from a gh pr create command.
+
+    Handles:
+      --head branch-name
+      --head=branch-name
+      -H branch-name
+    """
+    match = re.search(r'(?:--head(?:=|\s+)|-H\s+)([\w./-]+)', command)
+    return match.group(1) if match else None
+
+
+def get_current_branch() -> "str | None":
+    """Get the current git branch name as a fallback when --head is not specified."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+            return branch if branch and branch != "HEAD" else None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def check_for_existing_pr(repo: str, head_branch: str) -> "dict | None":
+    """Query GitHub for an open PR matching the given repo and head branch.
+
+    Returns the first matching PR as a dict with 'number' and 'title' keys,
+    or None if no match is found. Fails open (returns None) on any error.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--repo", repo,
+                "--head", head_branch,
+                "--state", "open",
+                "--json", "number,title",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    try:
+        prs = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not prs:
+        return None
+
+    return prs[0]
+
+
+# ---------------------------------------------------------------------------
+# Top-level hook execution
+# ---------------------------------------------------------------------------
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+tool_name = data.get("tool_name", "")
+tool_input = data.get("tool_input", {})
+
+if tool_name != "Bash":
+    sys.exit(0)
+
+command = tool_input.get("command", "")
+
+if "gh pr create" not in command:
+    sys.exit(0)
+
+repo = extract_repo(command)
+head = extract_head_branch(command)
+
+# Fallback: if --head is not in the command, detect the current branch
+if head is None:
+    head = get_current_branch()
+
+# If we cannot determine repo or branch, fail open (allow the call)
+if repo is None or head is None:
+    sys.exit(0)
+
+existing = check_for_existing_pr(repo, head)
+
+if existing is None:
+    # No matching PR found -- allow creation
+    sys.exit(0)
+
+pr_number = existing.get("number", "?")
+pr_title = existing.get("title", "(untitled)")
+
+print(
+    f"BLOCKED: PR already exists for branch '{head}' on {repo}: "
+    f"PR #{pr_number} -- {pr_title}.\n"
+    f"To proceed, close the existing PR first or use a different branch.\n"
+    f"Idempotency hook -- see hooks/check-pr-exists-before-create.py.",
+    file=sys.stderr,
+)
+sys.exit(2)

--- a/install.sh
+++ b/install.sh
@@ -428,6 +428,20 @@ HOOKEOF
         info "block-claude-p hook already configured"
     fi
 
+    # Block gh pr create when an open PR already exists for the same branch/repo
+    chmod +x "$INSTALL_DIR/hooks/check-pr-exists-before-create.py" 2>/dev/null || true
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("check-pr-exists-before-create"))' "$_settings" > /dev/null 2>&1; then
+        _tmp=$(mktemp)
+        jq --arg cmd "python3 $INSTALL_DIR/hooks/check-pr-exists-before-create.py" \
+           '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": $cmd, "timeout": 15}]
+        }]' "$_settings" > "$_tmp" && mv "$_tmp" "$_settings"
+        success "check-pr-exists-before-create hook installed"
+    else
+        info "check-pr-exists-before-create hook already configured"
+    fi
+
     # Enforce task_id on register_agent calls
     chmod +x "$INSTALL_DIR/hooks/require-register-agent-task-id.py" 2>/dev/null || true
     if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("require-register-agent-task-id"))' "$_settings" > /dev/null 2>&1; then

--- a/lobster-shop/desloppify/behavior/system.md
+++ b/lobster-shop/desloppify/behavior/system.md
@@ -253,7 +253,7 @@ python -m pytest desloppify/tests/ -q
 python -m desloppify scan --path <project-root>   # the project you were scanning
 ```
 
-Once it looks good, push and open a PR:
+Once it looks good, push and open a PR. Duplicate PR prevention is enforced by the PreToolUse hook `check-pr-exists-before-create.py` -- no manual check needed.
 
 ```bash
 git add <files> && git commit -m "fix: <what and why>"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4008,6 +4008,35 @@ PYEOF
         substep "Migration 111: LOBSTER-PENDING-ACTIONS-NUDGE cron entry already present — skipping"
     fi
 
+    # Migration 112: Register check-pr-exists-before-create.py PreToolUse hook.
+    # Enforces gh pr create idempotency: blocks duplicate PR creation when an
+    # open PR already exists for the same branch/repo. Replaces advisory
+    # markdown instructions with structural enforcement (vision.yaml principle-3).
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local has_pr_create_gate
+        has_pr_create_gate=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+            | map(select(contains("check-pr-exists-before-create")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_pr_create_gate:-0}" = "0" ] || [ "${has_pr_create_gate:-0}" = "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "python3 $LOBSTER_DIR/hooks/check-pr-exists-before-create.py" \
+               '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": $cmd,
+                    "timeout": 15
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered check-pr-exists-before-create PreToolUse hook (Migration 112)"
+            migrated=$((migrated + 1))
+        else
+            substep "check-pr-exists-before-create hook already registered — skipping Migration 112"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_hooks/test_check_pr_exists.py
+++ b/tests/unit/test_hooks/test_check_pr_exists.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for hooks/check-pr-exists-before-create.py
+
+Behavior under test:
+- Non-Bash tool calls pass through (exit 0)
+- Bash commands not containing 'gh pr create' pass through (exit 0)
+- 'gh pr create' where no matching open PR exists allows creation (exit 0)
+- 'gh pr create' where a matching open PR exists hard-blocks (exit 2)
+- Repo and branch are extracted correctly from various command forms
+- When --head is not specified, the hook extracts the current branch via git
+
+Named constants for spec values:
+- EXIT_ALLOW = 0  -- tool call permitted
+- EXIT_BLOCK = 2  -- tool call hard-blocked (duplicate PR exists)
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "check-pr-exists-before-create.py"
+
+EXIT_ALLOW = 0
+EXIT_BLOCK = 2
+
+
+# ---------------------------------------------------------------------------
+# Module loading helper
+# ---------------------------------------------------------------------------
+
+def _load_module():
+    """Load the hook module, catching the SystemExit from the top-level guard."""
+    import io
+    orig_stdin = sys.stdin
+    # Feed a non-Bash payload so the top-level guard exits 0 immediately
+    sys.stdin = io.StringIO(json.dumps({"tool_name": "Write", "tool_input": {}}))
+    spec = importlib.util.spec_from_file_location(
+        "check_pr_exists_before_create", HOOK_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        with pytest.raises(SystemExit):
+            spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    finally:
+        sys.stdin = orig_stdin
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# extract_repo tests
+# ---------------------------------------------------------------------------
+
+class TestExtractRepo:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_long_form_repo_flag(self):
+        assert self.mod.extract_repo("gh pr create --repo owner/repo --title foo") == "owner/repo"
+
+    def test_short_form_repo_flag(self):
+        assert self.mod.extract_repo("gh pr create -R owner/repo --title foo") == "owner/repo"
+
+    def test_no_repo_flag_returns_none(self):
+        assert self.mod.extract_repo("gh pr create --title foo") is None
+
+    def test_repo_with_equals_sign(self):
+        assert self.mod.extract_repo("gh pr create --repo=owner/repo --title foo") == "owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# extract_head_branch tests
+# ---------------------------------------------------------------------------
+
+class TestExtractHeadBranch:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_long_form_head_flag(self):
+        assert self.mod.extract_head_branch("gh pr create --head fix/my-branch --title foo") == "fix/my-branch"
+
+    def test_short_form_head_flag(self):
+        assert self.mod.extract_head_branch("gh pr create -H fix/my-branch --title foo") == "fix/my-branch"
+
+    def test_no_head_flag_returns_none(self):
+        assert self.mod.extract_head_branch("gh pr create --title foo") is None
+
+    def test_head_with_equals_sign(self):
+        assert self.mod.extract_head_branch("gh pr create --head=fix/my-branch --title foo") == "fix/my-branch"
+
+
+# ---------------------------------------------------------------------------
+# check_for_existing_pr tests
+# ---------------------------------------------------------------------------
+
+class TestCheckForExistingPr:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_no_existing_pr_returns_none(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="[]\n", stderr=""
+            )
+            result = self.mod.check_for_existing_pr("owner/repo", "fix/my-branch")
+            assert result is None
+
+    def test_existing_pr_returns_info(self):
+        pr_data = [{"number": 42, "title": "fix: something"}]
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=json.dumps(pr_data) + "\n", stderr=""
+            )
+            result = self.mod.check_for_existing_pr("owner/repo", "fix/my-branch")
+            assert result == {"number": 42, "title": "fix: something"}
+
+    def test_gh_cli_failure_returns_none(self):
+        """When gh CLI fails, allow the PR creation (fail-open)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="error"
+            )
+            result = self.mod.check_for_existing_pr("owner/repo", "fix/my-branch")
+            assert result is None
+
+    def test_passes_correct_args_to_gh(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="[]\n", stderr=""
+            )
+            self.mod.check_for_existing_pr("dcetlin/Lobster", "fix/some-branch")
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert "gh" in args
+            assert "pr" in args
+            assert "list" in args
+            assert "--repo" in args
+            idx = args.index("--repo")
+            assert args[idx + 1] == "dcetlin/Lobster"
+            assert "--head" in args
+            idx = args.index("--head")
+            assert args[idx + 1] == "fix/some-branch"
+
+    def test_multiple_open_prs_returns_first(self):
+        """If multiple PRs match (unlikely but possible), return the first."""
+        pr_data = [
+            {"number": 42, "title": "fix: first"},
+            {"number": 43, "title": "fix: second"},
+        ]
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=json.dumps(pr_data) + "\n", stderr=""
+            )
+            result = self.mod.check_for_existing_pr("owner/repo", "fix/branch")
+            assert result == {"number": 42, "title": "fix: first"}
+
+
+# ---------------------------------------------------------------------------
+# Gate logic integration tests
+# ---------------------------------------------------------------------------
+
+def _run_gate(mod, tool_name: str, command: str, mock_pr_result=None,
+              mock_branch="main"):
+    """
+    Simulate the hook's gate logic using the module's pure functions.
+
+    mock_pr_result: if not None, patch check_for_existing_pr to return this
+    mock_branch: the fallback branch name when --head is not in the command
+    """
+    if tool_name != "Bash":
+        return EXIT_ALLOW
+
+    if "gh pr create" not in command:
+        return EXIT_ALLOW
+
+    repo = mod.extract_repo(command)
+    head = mod.extract_head_branch(command)
+
+    if head is None:
+        head = mock_branch
+
+    if repo is None or head is None:
+        return EXIT_ALLOW
+
+    with patch.object(mod, "check_for_existing_pr", return_value=mock_pr_result):
+        existing = mod.check_for_existing_pr(repo, head)
+
+    if existing is not None:
+        return EXIT_BLOCK
+
+    return EXIT_ALLOW
+
+
+class TestGateLogic:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_non_bash_tool_allows(self):
+        result = _run_gate(self.mod, "Write", "gh pr create --repo o/r")
+        assert result == EXIT_ALLOW
+
+    def test_non_pr_create_command_allows(self):
+        result = _run_gate(self.mod, "Bash", "git status")
+        assert result == EXIT_ALLOW
+
+    def test_no_existing_pr_allows_creation(self):
+        result = _run_gate(
+            self.mod, "Bash",
+            "gh pr create --repo owner/repo --head fix/branch --title foo",
+            mock_pr_result=None,
+        )
+        assert result == EXIT_ALLOW
+
+    def test_existing_pr_blocks_creation(self):
+        result = _run_gate(
+            self.mod, "Bash",
+            "gh pr create --repo owner/repo --head fix/branch --title foo",
+            mock_pr_result={"number": 42, "title": "fix: something"},
+        )
+        assert result == EXIT_BLOCK
+
+    def test_fallback_branch_used_when_no_head_flag(self):
+        """When --head is absent, the hook uses the current git branch."""
+        result = _run_gate(
+            self.mod, "Bash",
+            "gh pr create --repo owner/repo --title foo",
+            mock_pr_result={"number": 99, "title": "fix: thing"},
+            mock_branch="fix/my-current-branch",
+        )
+        assert result == EXIT_BLOCK
+
+    def test_missing_repo_allows_creation(self):
+        """When --repo cannot be extracted, fail-open (allow)."""
+        result = _run_gate(
+            self.mod, "Bash",
+            "gh pr create --title foo",
+            mock_pr_result={"number": 1, "title": "anything"},
+        )
+        assert result == EXIT_ALLOW
+
+    def test_heredoc_command_with_gh_pr_create(self):
+        """gh pr create inside a heredoc or multiline command is still caught."""
+        cmd = (
+            'gh pr create --repo dcetlin/Lobster --head fix/branch '
+            '--title "fix: something" --body "$(cat <<\'EOF\'\nBody text\nEOF\n)"'
+        )
+        result = _run_gate(
+            self.mod, "Bash", cmd,
+            mock_pr_result={"number": 10, "title": "fix: something"},
+        )
+        assert result == EXIT_BLOCK


### PR DESCRIPTION
## Problem

WOS executor re-dispatches UoWs, and agents may attempt to create duplicate PRs for the same branch. PR #1148 addressed this by embedding idempotency check bash snippets in agent definition markdown files (`functional-engineer.md`, `lobster-shop/desloppify/behavior/system.md`). The oracle review (Round 1) returned NEEDS_CHANGES for two blocking reasons:

1. **Feature bundling** -- PR #1148 bundled four unrelated workstreams (oracle verdict archive, analytics feature, the idempotency check, and desloppify behavior update).
2. **Wrong enforcement layer** -- Advisory markdown instructions violate vision.yaml principle-3: "If-then logic and field checks are code, not LLM instructions." An idempotency check is definitionally if-then logic with no interpretive component.

## Solution

This PR replaces the advisory approach with a **structural PreToolUse hook** (`hooks/check-pr-exists-before-create.py`) that intercepts every `Bash` tool call containing `gh pr create`. Before the command executes, the hook:

1. Extracts `--repo` and `--head` (or falls back to the current git branch)
2. Queries `gh pr list --repo <repo> --head <branch> --state open` to check for existing open PRs
3. Hard-blocks (exit 2) with a descriptive error if a matching PR exists
4. Allows the call (exit 0) if no match is found

This covers all agents by construction -- any tool call through Claude Code that runs `gh pr create` is checked, regardless of which agent definition is active or how much context pressure the agent is under.

**Design decisions:**
- **Branch-name matching only** -- title-prefix matching was explicitly rejected per oracle feedback due to false-positive risk across unrelated UoWs with similar titles.
- **Fail-open** -- if `gh pr list` fails or repo/branch cannot be extracted, the hook allows the call (exit 0). This prevents the hook from becoming a blocker when GitHub is unreachable.
- **15-second timeout** -- higher than the standard 5s for hooks because this hook makes a network call to the GitHub API.

**Functional patterns:** Pure functions for extraction (`extract_repo`, `extract_head_branch`, `check_for_existing_pr`) with side effects isolated at the module boundary (stdin parsing, subprocess calls, exit codes). All functions are independently testable.

**Before/after flow:**

```
Before (advisory):
  Agent reads markdown instructions -> may or may not run bash check -> gh pr create
  (skipped under context pressure = duplicate PR)

After (structural):
  Any Bash call -> PreToolUse hook fires -> extracts repo/branch -> queries GH API
  -> blocks if PR exists (exit 2) / allows if no PR (exit 0)
  (cannot be skipped regardless of context state)
```

## Out of scope

- Analytics `outcome_cost_correlation` feature (172 additions to analytics.py) -- separate PR
- Oracle verdict archive for PR #1146 -- separate commit to main
- Any changes to executor.py, registry.py, or WOS source files

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/test_check_pr_exists.py -v` -- 20 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/test_pr_merge_gate.py -v` -- 19 passed, 0 failed (regression check against analogous hook)
- [ ] Live integration test -- skipped: would require creating a real PR on GitHub to verify the hook blocks a duplicate. The hook delegates to `gh pr list` which is covered by mocked subprocess tests. The gh CLI itself is a trusted dependency.

**Blocked items needing attention before merge:** none

## Manual test
N/A -- this change does not touch systemd, cron, external services at runtime, file I/O, or DB schema. The hook is a PreToolUse interceptor that runs `gh pr list` (read-only GitHub API call). The subprocess call is mocked in unit tests.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) -- N/A, see above
- [x] User-visible outcome verified OR not applicable -- this is a structural guard, not user-visible output
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume. The hook only reads from GitHub (gh pr list), never writes.
- [x] External service calls: mocked in tests, read-only in production

WOS-UoW: uow_20260514_715dd1