### PR TITLE
feat(hooks): PreToolUse idempotency guard for gh pr create

### DIFF
--- a/hooks/pre-tool-use-pr-idempotency.py
+++ b/hooks/pre-tool-use-pr-idempotency.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: blocks duplicate `gh pr create` calls for the same branch.
+
+Fires before every Bash tool call. When the command contains `gh pr create`,
+extracts the `--repo` value (or falls back to the current git remote) and the
+`--head` branch (or the current branch), then queries GitHub for existing open
+PRs. If a match is found, the tool call is hard-blocked.
+
+## Why this exists
+
+WOS executor can re-dispatch the same UoW without knowing an open PR already
+exists for its branch. Without this guard, each re-dispatch opens a new PR,
+producing duplicate PR clusters that pollute the review queue.
+
+Advisory enforcement in markdown instruction files was identified by the oracle
+as insufficient (oracle NEEDS_CHANGES on PR #1148). This hook replaces that
+advisory approach with a structural block.
+
+## Block condition
+
+A `gh pr create` call is blocked when:
+  `gh pr list --repo <repo> --head <branch> --state open` returns at least one result.
+
+The hook never blocks when:
+- The tool is not Bash
+- The command does not contain `gh pr create`
+- The branch cannot be determined (allow-on-error, to avoid blocking legitimate PRs)
+- The `gh` subprocess fails (allow-on-error)
+
+## Exit codes
+
+  0 — not applicable, or no existing PR found
+  2 — hard block: open PR already exists for this branch
+
+## settings.json configuration
+
+Add to ~/.claude/settings.json under "hooks" -> "PreToolUse":
+
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 /home/lobster/lobster/hooks/pre-tool-use-pr-idempotency.py",
+          "timeout": 15
+        }
+      ]
+    }
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Parsing helpers (pure — no I/O)
+# ---------------------------------------------------------------------------
+
+_GH_PR_CREATE_RE = re.compile(r'\bgh\s+pr\s+create\b')
+_REPO_RE = re.compile(r'--repo\s+(\S+)')
+_HEAD_RE = re.compile(r'--head\s+(\S+)')
+
+
+def contains_gh_pr_create(command: str) -> bool:
+    """Return True if the command contains a `gh pr create` invocation."""
+    return bool(_GH_PR_CREATE_RE.search(command))
+
+
+def extract_repo(command: str) -> "str | None":
+    """Extract the --repo value from the command string, or None if absent."""
+    match = _REPO_RE.search(command)
+    return match.group(1) if match else None
+
+
+def extract_head_branch(command: str) -> "str | None":
+    """Extract the --head branch from the command string, or None if absent."""
+    match = _HEAD_RE.search(command)
+    return match.group(1) if match else None
+
+
+def _detect_repo_from_remote(cwd: "str | None" = None) -> "str | None":
+    """Infer the GitHub repo (owner/name) from the git remote URL.
+
+    Handles both HTTPS and SSH remotes:
+      https://github.com/owner/repo.git  -> owner/repo
+      git@github.com:owner/repo.git      -> owner/repo
+
+    Returns None if the remote cannot be determined.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+        if result.returncode != 0:
+            return None
+        url = result.stdout.strip()
+        # HTTPS: https://github.com/owner/repo[.git]
+        https_match = re.search(r'github\.com/([^/]+/[^/]+?)(?:\.git)?$', url)
+        if https_match:
+            return https_match.group(1)
+        # SSH: git@github.com:owner/repo[.git]
+        ssh_match = re.search(r'github\.com:([^/]+/[^/]+?)(?:\.git)?$', url)
+        if ssh_match:
+            return ssh_match.group(1)
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _detect_current_branch(cwd: "str | None" = None) -> "str | None":
+    """Return the current git branch name, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+        if result.returncode != 0:
+            return None
+        branch = result.stdout.strip()
+        return branch if branch and branch != "HEAD" else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# GitHub query (has I/O — thin wrapper for testability)
+# ---------------------------------------------------------------------------
+
+
+def find_existing_pr(repo: str, branch: str) -> "dict | None":
+    """Query GitHub for an open PR matching repo + branch.
+
+    Returns the first matching PR dict (with 'number' and 'title' keys),
+    or None if none found or the query fails.
+
+    Failure policy: return None (allow-on-error) so a transient gh failure
+    never blocks a legitimate PR creation.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--repo", repo,
+                "--head", branch,
+                "--state", "open",
+                "--json", "number,title",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        prs = json.loads(result.stdout)
+        return prs[0] if prs else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Decision (pure — no I/O)
+# ---------------------------------------------------------------------------
+
+
+def should_block(
+    existing_pr: "dict | None",
+    branch: str,
+    repo: str,
+) -> "tuple[bool, str]":
+    """Return (block, reason) given the existing PR lookup result.
+
+    Pure function — all I/O is done before calling this.
+    """
+    if existing_pr is None:
+        return False, "no existing open PR found"
+    pr_number = existing_pr.get("number", "?")
+    pr_title = existing_pr.get("title", "")
+    return True, (
+        f"Idempotency check: PR already exists for branch '{branch}' on {repo}: "
+        f"#{pr_number} '{pr_title}'. "
+        f"Close or merge it before creating a new one."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point — executed at module level (matches codebase hook convention)
+# ---------------------------------------------------------------------------
+
+try:
+    _data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+_tool_name = _data.get("tool_name", "")
+if _tool_name != "Bash":
+    sys.exit(0)
+
+_tool_input = _data.get("tool_input", {})
+_command = _tool_input.get("command", "")
+
+if not contains_gh_pr_create(_command):
+    sys.exit(0)
+
+# Extract repo — prefer explicit --repo flag, fall back to git remote
+_repo = extract_repo(_command) or _detect_repo_from_remote()
+if not _repo:
+    # Cannot determine repo — allow-on-error
+    sys.exit(0)
+
+# Extract branch — prefer explicit --head flag, fall back to current branch
+_branch = extract_head_branch(_command) or _detect_current_branch()
+if not _branch:
+    # Cannot determine branch — allow-on-error
+    sys.exit(0)
+
+_existing_pr = find_existing_pr(_repo, _branch)
+_block, _reason = should_block(_existing_pr, _branch, _repo)
+
+if not _block:
+    sys.exit(0)
+
+print(_reason, file=sys.stderr)
+sys.exit(2)

--- a/install.sh
+++ b/install.sh
@@ -2407,6 +2407,26 @@ else
     info "Skipping require-auditor-context-update SubagentStop hook (settings.json not yet created)"
 fi
 
+# Set up PreToolUse hook to block duplicate `gh pr create` calls.
+# Prevents duplicate PR clusters when the WOS executor re-dispatches the same
+# UoW without knowing an open PR already exists for that branch.
+chmod +x "$INSTALL_DIR/hooks/pre-tool-use-pr-idempotency.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("pre-tool-use-pr-idempotency"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq --arg cmd "python3 $INSTALL_DIR/hooks/pre-tool-use-pr-idempotency.py" \
+           '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": $cmd, "timeout": 15}]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "pre-tool-use-pr-idempotency PreToolUse hook installed"
+    else
+        info "pre-tool-use-pr-idempotency hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping pre-tool-use-pr-idempotency hook (settings.json not yet created)"
+fi
+
 #===============================================================================
 # Python Environment
 #===============================================================================

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4008,6 +4008,35 @@ PYEOF
         substep "Migration 111: LOBSTER-PENDING-ACTIONS-NUDGE cron entry already present — skipping"
     fi
 
+    # Migration 112: Register pre-tool-use-pr-idempotency.py PreToolUse hook.
+    # Replaces advisory bash blocks in markdown files with a structural hook that
+    # hard-blocks `gh pr create` when an open PR already exists for the same branch.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local has_pr_idempotency_hook
+        has_pr_idempotency_hook=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+            | map(select(contains("pre-tool-use-pr-idempotency")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_pr_idempotency_hook:-0}" = "0" ] || [ "${has_pr_idempotency_hook:-0}" = "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "python3 $LOBSTER_DIR/hooks/pre-tool-use-pr-idempotency.py" \
+               '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": $cmd,
+                    "timeout": 15
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            chmod +x "$LOBSTER_DIR/hooks/pre-tool-use-pr-idempotency.py" 2>/dev/null || true
+            substep "Registered pre-tool-use-pr-idempotency PreToolUse hook (Migration 112)"
+            migrated=$((migrated + 1))
+        else
+            substep "pre-tool-use-pr-idempotency hook already registered — skipping Migration 112"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_hooks/test_pre_tool_use_pr_idempotency.py
+++ b/tests/unit/test_hooks/test_pre_tool_use_pr_idempotency.py
@@ -1,0 +1,409 @@
+"""
+Unit tests for hooks/pre-tool-use-pr-idempotency.py
+
+Behavior under test:
+- Non-Bash tool calls pass through (exit 0)
+- Bash commands not containing `gh pr create` pass through (exit 0)
+- `gh pr create` with explicit --repo and --head: queried correctly
+- `gh pr create` with no --head: current branch is detected via git
+- `gh pr create` with no --repo: repo is detected via git remote
+- No existing PR found → allow (exit 0)
+- Existing PR found → hard-block (exit 2), error message on stderr
+- `gh` subprocess failure → allow-on-error (exit 0)
+- Undetectable repo → allow-on-error (exit 0)
+- Undetectable branch → allow-on-error (exit 0)
+- Block message includes branch name, repo, PR number, and PR title
+
+Named constants for spec values:
+  EXIT_ALLOW = 0   — create permitted
+  EXIT_BLOCK = 2   — create hard-blocked
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "pre-tool-use-pr-idempotency.py"
+
+EXIT_ALLOW = 0
+EXIT_BLOCK = 2
+
+
+# ---------------------------------------------------------------------------
+# Module loading helper
+# ---------------------------------------------------------------------------
+
+
+def _load_module() -> object:
+    """Load pre-tool-use-pr-idempotency.py as a module.
+
+    Feeds a non-Bash sentinel so the top-level guard exits before reaching
+    the Bash-specific logic, then returns the loaded module for function access.
+    """
+    import io
+    orig_stdin = sys.stdin
+    sys.stdin = io.StringIO(json.dumps({"tool_name": "Write", "tool_input": {}}))
+    spec = importlib.util.spec_from_file_location(
+        "pre_tool_use_pr_idempotency", HOOK_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        with pytest.raises(SystemExit):
+            spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    finally:
+        sys.stdin = orig_stdin
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# contains_gh_pr_create tests
+# ---------------------------------------------------------------------------
+
+
+class TestContainsGhPrCreate:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_bare_command_matches(self):
+        assert self.mod.contains_gh_pr_create("gh pr create --title foo") is True
+
+    def test_embedded_in_longer_command_matches(self):
+        assert self.mod.contains_gh_pr_create(
+            "git push && gh pr create --repo foo/bar"
+        ) is True
+
+    def test_gh_pr_list_does_not_match(self):
+        assert self.mod.contains_gh_pr_create("gh pr list --repo foo/bar") is False
+
+    def test_gh_pr_merge_does_not_match(self):
+        assert self.mod.contains_gh_pr_create("gh pr merge 123") is False
+
+    def test_empty_command_does_not_match(self):
+        assert self.mod.contains_gh_pr_create("") is False
+
+
+# ---------------------------------------------------------------------------
+# extract_repo tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRepo:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_extracts_repo_flag(self):
+        assert self.mod.extract_repo("gh pr create --repo owner/repo") == "owner/repo"
+
+    def test_extracts_repo_with_other_flags(self):
+        result = self.mod.extract_repo(
+            "gh pr create --title foo --repo dcetlin/Lobster --body bar"
+        )
+        assert result == "dcetlin/Lobster"
+
+    def test_no_repo_flag_returns_none(self):
+        assert self.mod.extract_repo("gh pr create --title foo") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_head_branch tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractHeadBranch:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_extracts_head_flag(self):
+        assert self.mod.extract_head_branch(
+            "gh pr create --head feat/my-feature"
+        ) == "feat/my-feature"
+
+    def test_extracts_head_with_other_flags(self):
+        result = self.mod.extract_head_branch(
+            "gh pr create --repo foo/bar --head fix/issue-42 --title baz"
+        )
+        assert result == "fix/issue-42"
+
+    def test_no_head_flag_returns_none(self):
+        assert self.mod.extract_head_branch("gh pr create --repo foo/bar") is None
+
+
+# ---------------------------------------------------------------------------
+# should_block tests (pure function)
+# ---------------------------------------------------------------------------
+
+
+class TestShouldBlock:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_no_existing_pr_does_not_block(self):
+        block, _ = self.mod.should_block(None, "feat/foo", "owner/repo")
+        assert block is False
+
+    def test_existing_pr_blocks(self):
+        existing = {"number": 42, "title": "feat: my feature"}
+        block, reason = self.mod.should_block(existing, "feat/foo", "owner/repo")
+        assert block is True
+
+    def test_block_message_contains_branch(self):
+        existing = {"number": 42, "title": "feat: my feature"}
+        _, reason = self.mod.should_block(existing, "feat/foo", "owner/repo")
+        assert "feat/foo" in reason
+
+    def test_block_message_contains_pr_number(self):
+        existing = {"number": 99, "title": "fix: some fix"}
+        _, reason = self.mod.should_block(existing, "fix/bar", "dcetlin/Lobster")
+        assert "#99" in reason
+
+    def test_block_message_contains_pr_title(self):
+        existing = {"number": 7, "title": "chore: cleanup task"}
+        _, reason = self.mod.should_block(existing, "chore/cleanup", "x/y")
+        assert "chore: cleanup task" in reason
+
+    def test_block_message_contains_repo(self):
+        existing = {"number": 1, "title": "x"}
+        _, reason = self.mod.should_block(existing, "branch", "dcetlin/Lobster")
+        assert "dcetlin/Lobster" in reason
+
+
+# ---------------------------------------------------------------------------
+# find_existing_pr tests (mocked subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestFindExistingPr:
+    @pytest.fixture(autouse=True)
+    def load_mod(self):
+        self.mod = _load_module()
+
+    def test_returns_first_pr_when_found(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps([
+            {"number": 5, "title": "feat: existing PR"},
+        ])
+        with patch("subprocess.run", return_value=mock_result):
+            result = self.mod.find_existing_pr("owner/repo", "feat/branch")
+        assert result == {"number": 5, "title": "feat: existing PR"}
+
+    def test_returns_none_when_no_pr_found(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps([])
+        with patch("subprocess.run", return_value=mock_result):
+            result = self.mod.find_existing_pr("owner/repo", "feat/branch")
+        assert result is None
+
+    def test_returns_none_on_subprocess_failure(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        with patch("subprocess.run", return_value=mock_result):
+            result = self.mod.find_existing_pr("owner/repo", "feat/branch")
+        assert result is None
+
+    def test_returns_none_on_exception(self):
+        with patch("subprocess.run", side_effect=OSError("gh not found")):
+            result = self.mod.find_existing_pr("owner/repo", "feat/branch")
+        assert result is None
+
+    def test_passes_correct_args_to_gh(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps([])
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            self.mod.find_existing_pr("dcetlin/Lobster", "feat/my-branch")
+        args = mock_run.call_args[0][0]
+        assert "--repo" in args
+        assert "dcetlin/Lobster" in args
+        assert "--head" in args
+        assert "feat/my-branch" in args
+        assert "--state" in args
+        assert "open" in args
+
+
+# ---------------------------------------------------------------------------
+# End-to-end exit code contract tests (stdin injection)
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(command: str, find_existing_pr_return=None) -> int:
+    """Run the hook with the given Bash command, capturing the exit code.
+
+    Mocks find_existing_pr to return the given value (None by default).
+    Also mocks _detect_current_branch and _detect_repo_from_remote to return
+    stable test values, so tests don't require a real git repo.
+    """
+    import io
+
+    payload = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    })
+
+    orig_stdin = sys.stdin
+    sys.stdin = io.StringIO(payload)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"pre_tool_use_pr_idempotency_{id(command)}", HOOK_PATH
+        )
+        mod = importlib.util.module_from_spec(spec)
+
+        with (
+            patch.object(
+                mod if False else MagicMock(),  # placeholder; real patch below
+                "find_existing_pr",
+                return_value=find_existing_pr_return,
+            ),
+            patch(
+                "subprocess.run",
+                return_value=_make_subprocess_result(find_existing_pr_return),
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            spec.loader.exec_module(mod)
+            # patch module-level functions after exec for the guard path
+    except SystemExit:
+        pass
+    finally:
+        sys.stdin = orig_stdin
+
+    return exc_info.value.code
+
+
+def _make_subprocess_result(pr_data):
+    """Build a mock subprocess.run result for the given PR data."""
+    mock = MagicMock()
+    mock.returncode = 0
+    if pr_data is None:
+        mock.stdout = json.dumps([])
+    else:
+        mock.stdout = json.dumps([pr_data])
+    return mock
+
+
+class TestExitCodeContract:
+    """Verify exit code semantics by running the hook end-to-end with mocked I/O."""
+
+    def _run(self, command: str, pr_data=None) -> "tuple[int, str]":
+        """Run the hook, capturing exit code and stderr."""
+        import io
+        import importlib.util as ilu
+
+        payload = json.dumps({
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        })
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps([pr_data] if pr_data else [])
+
+        orig_stdin = sys.stdin
+        captured_stderr = io.StringIO()
+        orig_stderr = sys.stderr
+        sys.stdin = io.StringIO(payload)
+        sys.stderr = captured_stderr
+
+        exit_code = EXIT_ALLOW
+        try:
+            spec = ilu.spec_from_file_location(
+                f"hook_{id(command)}", HOOK_PATH
+            )
+            mod = ilu.module_from_spec(spec)
+            with patch("subprocess.run", return_value=mock_result):
+                spec.loader.exec_module(mod)
+        except SystemExit as e:
+            exit_code = e.code
+        finally:
+            sys.stdin = orig_stdin
+            sys.stderr = orig_stderr
+
+        return exit_code, captured_stderr.getvalue()
+
+    def test_non_bash_tool_passes_through(self):
+        import io
+        import importlib.util as ilu
+
+        payload = json.dumps({
+            "tool_name": "Write",
+            "tool_input": {"command": "irrelevant"},
+        })
+        orig_stdin = sys.stdin
+        sys.stdin = io.StringIO(payload)
+        exit_code = EXIT_ALLOW
+        try:
+            spec = ilu.spec_from_file_location("hook_nonbash", HOOK_PATH)
+            mod = ilu.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+        except SystemExit as e:
+            exit_code = e.code
+        finally:
+            sys.stdin = orig_stdin
+        assert exit_code == EXIT_ALLOW
+
+    def test_bash_without_pr_create_passes_through(self):
+        code, _ = self._run("git push origin main")
+        assert code == EXIT_ALLOW
+
+    def test_gh_pr_list_command_passes_through(self):
+        code, _ = self._run("gh pr list --repo foo/bar")
+        assert code == EXIT_ALLOW
+
+    def test_no_existing_pr_allows_create(self):
+        code, _ = self._run(
+            "gh pr create --repo dcetlin/Lobster --head feat/new-thing --title 'test'",
+            pr_data=None,
+        )
+        assert code == EXIT_ALLOW
+
+    def test_existing_pr_blocks_create(self):
+        code, stderr = self._run(
+            "gh pr create --repo dcetlin/Lobster --head feat/existing --title 'test'",
+            pr_data={"number": 42, "title": "feat: already open"},
+        )
+        assert code == EXIT_BLOCK
+
+    def test_block_message_on_stderr_mentions_pr(self):
+        _, stderr = self._run(
+            "gh pr create --repo dcetlin/Lobster --head feat/existing --title 'test'",
+            pr_data={"number": 42, "title": "feat: already open"},
+        )
+        assert "42" in stderr
+        assert "feat: already open" in stderr
+
+    def test_gh_subprocess_failure_allows_create(self):
+        import io
+        import importlib.util as ilu
+
+        payload = json.dumps({
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "gh pr create --repo dcetlin/Lobster --head feat/x"
+            },
+        })
+        orig_stdin = sys.stdin
+        sys.stdin = io.StringIO(payload)
+        exit_code = EXIT_ALLOW
+        try:
+            spec = ilu.spec_from_file_location("hook_failure", HOOK_PATH)
+            mod = ilu.module_from_spec(spec)
+            with patch("subprocess.run", side_effect=OSError("gh not found")):
+                spec.loader.exec_module(mod)
+        except SystemExit as e:
+            exit_code = e.code
+        finally:
+            sys.stdin = orig_stdin
+        assert exit_code == EXIT_ALLOW


### PR DESCRIPTION
## Summary

Duplicate PR clusters occur when the WOS executor re-dispatches a UoW without knowing an open PR already exists for that branch. Previously, the fix was advisory bash code blocks in `.claude/agents/functional-engineer.md` and `lobster-shop/desloppify/behavior/system.md` — enforcement that oracle (PR #1148, round 1) correctly identified as the wrong layer for a structural invariant.

This PR replaces advisory enforcement with a PreToolUse hook that hard-blocks `gh pr create` mechanically: if an open PR already exists for the branch, the tool call is rejected before GitHub is ever contacted for PR creation.

## What changed

`hooks/pre-tool-use-pr-idempotency.py` intercepts every Bash tool call containing `gh pr create`, extracts `--repo` and `--head` (falling back to git remote and current branch), queries GitHub via `gh pr list --state open`, and exits 2 with a descriptive message if a match is found.

Allow-on-error semantics apply throughout: undetectable repo, undetectable branch, and `gh` subprocess failures all exit 0 — the hook never blocks when it cannot determine the context.

Registered in `install.sh` (fresh installs) and `scripts/upgrade.sh` as Migration 112 (existing installs). The settings.json entry must be added by the migration — this hook is not auto-discovered.

The advisory markdown content from PR #1148 was never merged to main (PR #1148 was closed), so no removal is needed.

## Areas to review closely

- The `extract_head_branch` / `extract_repo` regex parsing: do they handle all command forms agents actually use? The hook requires an explicit `--head` or falls back to `git rev-parse --abbrev-ref HEAD`. Agents that rely on GitHub's default branch detection (no `--head`) are covered by the fallback.
- Migration 112 in `upgrade.sh`: uses the same jq pattern as Migration 82 (pr-merge-gate). Check idempotency guard condition.
- Allow-on-error policy: the hook is intentionally permissive on failure. If `gh` is unavailable or git remote is unreachable, the create proceeds. This is the correct tradeoff.

## Functional patterns used

Pure functions handle all parsing and decision logic (`contains_gh_pr_create`, `extract_repo`, `extract_head_branch`, `should_block`). Side-effectful subprocess I/O is isolated in `find_existing_pr`, `_detect_repo_from_remote`, and `_detect_current_branch`. Module-level execution matches the codebase hook convention (same pattern as `pr-merge-gate.py`).

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_pre_tool_use_pr_idempotency.py -v` — 29 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -q` — 661 passed (18 pre-existing failures unrelated to this change, same failures present on main)

## Manual test

Not applicable — this hook intercepts Bash tool calls at the PreToolUse layer. No external service calls, no file system state changes, no database schema changes. The hook is tested via subprocess mocking that covers all decision branches. A live test would require opening a real PR and re-attempting to create a duplicate, which would be a side effect on the production repo.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test: N/A — see Manual test section
- [x] User-visible outcome: not applicable — hook is transparent when no duplicate exists; blocks are surfaced in stderr to the calling agent
- [x] Side-effect audit: hook is read-only (only runs `gh pr list` and `git` read commands); no floods, no unscoped writes, no shared state mutations
- [x] External service calls: mocked in tests; `gh pr list` is the only production call (bounded to one repo + one branch, read-only)

Closes #1148 (split: idempotency enforcement layer)