### PR TITLE
feat: add /quota, /status, and /help dispatcher commands

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1043,6 +1043,50 @@ are handled in the Button callbacks section above (see `data.startswith("todo-")
 
 ---
 
+## System Status Commands
+
+**`/quota`** — show current CC (Claude Code) usage.
+
+Dispatch to a quota-query subagent (reads `~/.claude/cc-budget/state.json` — 7-second rule applies):
+
+```python
+Task(
+    subagent_type="lobster-generalist",
+    run_in_background=True,
+    prompt=(
+        f"---\ntask_id: quota-query-{chat_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+        + open(Path.home() / "lobster-workspace/scheduled-jobs/tasks/dispatcher-quota-query.md").read()
+    ),
+)
+send_reply(chat_id=chat_id, text="Checking quota...", source=source)
+```
+
+**`/status`** — show system status snapshot (agents, WOS state, CC usage).
+
+Dispatch to a status-query subagent (reads files and DB — 7-second rule applies):
+
+```python
+Task(
+    subagent_type="lobster-generalist",
+    run_in_background=True,
+    prompt=(
+        f"---\ntask_id: status-query-{chat_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+        + open(Path.home() / "lobster-workspace/scheduled-jobs/tasks/dispatcher-status-query.md").read()
+    ),
+)
+send_reply(chat_id=chat_id, text="Gathering status...", source=source)
+```
+
+**`/help`** — show command index. Handled inline, no subagent needed:
+
+```python
+from src.orchestration.dispatcher_handlers import handle_help
+
+send_reply(chat_id=chat_id, text=handle_help(), source=source, message_id=message_id)
+```
+
+---
+
 ## Skill System
 
 At message processing start (when skills are enabled), call `get_skill_context` to load assembled context from all active skills. Apply returned instructions alongside base context.

--- a/scheduled-tasks/tasks/dispatcher-quota-query.md
+++ b/scheduled-tasks/tasks/dispatcher-quota-query.md
@@ -1,0 +1,44 @@
+# CC Quota Query
+
+**Triggered by**: `/quota` command from Dan
+**Type**: On-demand subagent (not a scheduled job)
+
+**Minimum viable output:** A formatted CC usage message sent to Dan via Telegram.
+**Boundary:** Read-only. Do not modify any files or send multiple messages.
+
+## Context
+
+Dan sent the `/quota` command. Your job is to read the CC budget state file and
+send a single formatted usage message.
+
+## Instructions
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.home() / "lobster"))
+
+from src.orchestration.dispatcher_handlers import read_quota_state, format_quota_message
+
+state = read_quota_state()
+msg = format_quota_message(state)
+```
+
+Send a single Telegram message with the formatted quota text:
+
+```python
+send_reply(chat_id=chat_id, text=msg, source=source, task_id=task_id)
+```
+
+Then call write_result:
+
+```python
+write_result(
+    task_id=task_id,
+    chat_id=chat_id,
+    text=msg,
+    sent_reply_to_user=True,
+    status="success",
+    source=source,
+)
+```

--- a/scheduled-tasks/tasks/dispatcher-status-query.md
+++ b/scheduled-tasks/tasks/dispatcher-status-query.md
@@ -1,0 +1,67 @@
+# System Status Query
+
+**Triggered by**: `/status` command from Dan
+**Type**: On-demand subagent (not a scheduled job)
+
+**Minimum viable output:** A formatted system status snapshot sent to Dan via Telegram.
+**Boundary:** Read-only. Do not modify any files. Do not send multiple messages.
+
+## Context
+
+Dan sent the `/status` command. Your job is to collect three data sources and
+send a single formatted status snapshot.
+
+## Instructions
+
+### Step 1: Gather data
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.home() / "lobster"))
+
+from src.orchestration.dispatcher_handlers import read_quota_state, read_wos_config
+from src.orchestration.registry import Registry
+from src.agents.session_store import get_active_sessions
+
+# CC quota state
+quota_state = read_quota_state()
+
+# WOS config (execution_enabled, etc.)
+wos_config = read_wos_config()
+
+# WOS queue depth by status
+registry = Registry()
+status_counts = registry.get_status_counts()
+
+# Active background agents
+active_sessions = get_active_sessions()
+```
+
+### Step 2: Format and send
+
+```python
+from src.orchestration.dispatcher_handlers import format_status_message
+
+msg = format_status_message(
+    active_sessions=active_sessions,
+    wos_config=wos_config,
+    status_counts=status_counts,
+    quota_state=quota_state,
+)
+
+send_reply(chat_id=chat_id, text=msg, source=source, task_id=task_id)
+```
+
+### Step 3: Write result
+
+```python
+write_result(
+    task_id=task_id,
+    chat_id=chat_id,
+    text=msg,
+    sent_reply_to_user=True,
+    status="success",
+    source=source,
+)
+```

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4037,6 +4037,21 @@ PYEOF
         fi
     fi
 
+    # Migration 113: Copy dispatcher-quota-query.md and dispatcher-status-query.md task
+    # files to the workspace tasks directory. These task files are used by the /quota
+    # and /status dispatcher commands (issue #1165).
+    local tasks_dir="$WORKSPACE_DIR/scheduled-jobs/tasks"
+    for _task_file in "dispatcher-quota-query.md" "dispatcher-status-query.md"; do
+        local _src="$LOBSTER_DIR/scheduled-tasks/tasks/$_task_file"
+        local _dst="$tasks_dir/$_task_file"
+        if [ -f "$_src" ] && [ ! -f "$_dst" ]; then
+            mkdir -p "$tasks_dir"
+            cp "$_src" "$_dst"
+            substep "Installed dispatcher task file: $_task_file (Migration 113)"
+            migrated=$((migrated + 1))
+        fi
+    done
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -2346,7 +2346,7 @@ def format_status_message(
         agents_line = "◉ Agents: 0 running"
     else:
         agent_ids = [
-            s.get("agent_id") or s.get("task_id") or "?"
+            s.get("task_id") or s.get("id") or "?"
             for s in active_sessions
         ]
         agents_line = f"◉ Agents: {agent_count} running ({', '.join(agent_ids)})"

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -2145,11 +2145,19 @@ def route_callback_message(msg: dict[str, Any], *, registry: "Registry | None" =
 COMMAND_HELP: str = """Lobster command index
 
 System status:
-  status / health     — usage %, WOS state, active agents
-  usage               — Claude quota windows and reset times
+  /status             — running agents, WOS state, CC usage snapshot
+  /quota              — CC quota windows and reset times (5h and 7d)
+  status / health     — usage %, WOS state, active agents (prose command)
+  usage               — Claude quota windows and reset times (prose command)
   usage full          — full usage report (spawns subagent)
   agents              — list active subagent sessions
   inbox               — queue depth and processing state
+
+LOS (action items):
+  /todos              — show open action items with Done/Snooze buttons
+  /todo add <text>    — add a new action item
+  /todo done <text>   — mark an item done by partial text or ID
+  /todo snooze <text> [days] — snooze an item (default: 3 days)
 
 WOS control:
   wos start  — enable WOS pipeline (all 14 WOS-core jobs + execution_enabled)
@@ -2162,6 +2170,14 @@ Decision:
   /approve <uow-id>   — approve a proposed UoW
   /decide <uow-id> <action> — resolve a blocked UoW
 
+Skills:
+  /shop               — list available skills
+  /shop install <name> — install and activate a skill
+  /skill activate/deactivate <name> — toggle a skill
+
+Review:
+  /re-review <PR URL or number> — re-run oracle review on a PR
+
 Restart:
   restart mcp         — restart MCP server (auto-reconnects)
   restart dispatcher  — instructions to restart dispatcher process
@@ -2170,10 +2186,172 @@ Debug:
   debug on / debug off — toggle debug flag file
 
 Help:
-  help / /help        — this index
+  /help / help        — this index
 """
 
 
 def handle_help() -> str:
     """Handle 'help' / '/help' command — return command index."""
     return COMMAND_HELP
+
+
+# ---------------------------------------------------------------------------
+# CC quota state — path and stale threshold
+# ---------------------------------------------------------------------------
+
+# Default path for the cc-budget state file written by cc-usage-poller.py.
+# Overridable via LOBSTER_CC_BUDGET_STATE env var or the state_path argument.
+_CC_BUDGET_STATE_PATH: Path = Path.home() / ".claude" / "cc-budget" / "state.json"
+
+# Data older than this many hours is treated as unavailable (poller may be down).
+QUOTA_STALE_THRESHOLD_HOURS: int = 2
+
+
+def read_quota_state(state_path: Path | None = None) -> dict | None:
+    """Read the CC budget state written by cc-usage-poller.
+
+    Pure read: no side effects beyond file I/O. Returns the parsed dict, or None
+    when the file is absent, unreadable, malformed, or missing ``rate_limits``.
+
+    Path resolution order:
+    1. ``state_path`` argument (if provided)
+    2. ``LOBSTER_CC_BUDGET_STATE`` env var
+    3. ``~/.claude/cc-budget/state.json`` (default)
+    """
+    resolved: Path
+    if state_path is not None:
+        resolved = state_path
+    else:
+        env_override = os.environ.get("LOBSTER_CC_BUDGET_STATE")
+        resolved = Path(env_override) if env_override else _CC_BUDGET_STATE_PATH
+
+    try:
+        text = resolved.read_text(encoding="utf-8")
+        data = json.loads(text)
+        # Require the rate_limits key written by cc-usage-poller (v2 schema).
+        if "rate_limits" not in data:
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def _is_quota_state_stale(state: dict) -> bool:
+    """Return True if the state's last_updated timestamp exceeds QUOTA_STALE_THRESHOLD_HOURS.
+
+    Falls back to False (fresh) when last_updated is absent or unparseable so that
+    partial state data is still surfaced rather than silently suppressed.
+    """
+    from datetime import datetime as _datetime, timezone as _timezone, timedelta as _timedelta
+
+    last_updated = state.get("last_updated")
+    if not last_updated:
+        return False  # no timestamp — assume fresh rather than suppress
+    try:
+        ts_str = last_updated.replace("Z", "+00:00")
+        ts = _datetime.fromisoformat(ts_str)
+        age = _datetime.now(_timezone.utc) - ts
+        return age > _timedelta(hours=QUOTA_STALE_THRESHOLD_HOURS)
+    except Exception:
+        return False
+
+
+def format_quota_message(state: dict | None) -> str:
+    """Format a CC usage string from the cc-budget state dict.
+
+    Returns the unavailable message when:
+    - ``state`` is None (file missing/unreadable)
+    - ``state`` is stale (older than QUOTA_STALE_THRESHOLD_HOURS)
+    - ``rate_limits`` keys are missing or malformed
+
+    Format when data is available:
+        CC usage: 5h 42% | 7d 15%. Resets 5h: May 15 4:10 PM ET / 7d: May 22 11:00 AM ET.
+
+    Pure function: no side effects. All inputs are arguments.
+    """
+    _UNAVAILABLE = "CC usage data unavailable — poller may not have run yet."
+
+    if state is None:
+        return _UNAVAILABLE
+
+    if _is_quota_state_stale(state):
+        return _UNAVAILABLE
+
+    try:
+        rl = state["rate_limits"]
+        five_pct = rl["five_hour"]["pct"]
+        seven_pct = rl["seven_day"]["pct"]
+        five_resets_at = rl["five_hour"]["resets_at"]
+        seven_resets_at = rl["seven_day"]["resets_at"]
+    except (KeyError, TypeError):
+        return _UNAVAILABLE
+
+    def _fmt_reset(iso: str) -> str:
+        """Format an ISO reset timestamp as a short human-readable string (ET)."""
+        try:
+            from datetime import datetime as _datetime
+            from zoneinfo import ZoneInfo
+
+            ts_str = iso.replace("Z", "+00:00")
+            ts = _datetime.fromisoformat(ts_str)
+            et = ts.astimezone(ZoneInfo("America/New_York"))
+            return et.strftime("%b %-d %-I:%M %p ET")
+        except Exception:
+            return iso[:16]  # fallback: truncated ISO
+
+    five_reset_str = _fmt_reset(five_resets_at)
+    seven_reset_str = _fmt_reset(seven_resets_at)
+
+    return (
+        f"CC usage: 5h {five_pct:.0f}% | 7d {seven_pct:.0f}%. "
+        f"Resets — 5h: {five_reset_str} / 7d: {seven_reset_str}."
+    )
+
+
+def format_status_message(
+    active_sessions: list[dict],
+    wos_config: dict,
+    status_counts: dict,
+    quota_state: dict | None,
+) -> str:
+    """Format a system status snapshot for Telegram display.
+
+    Assembles three lines from independently-sourced data:
+    - WOS execution state and queue depth from wos_config + status_counts
+    - Active agent count and IDs from active_sessions
+    - CC usage percentage from quota_state (or unavailable)
+
+    Pure function: all inputs are arguments; no file reads or MCP calls.
+
+    Example output:
+        ◉ WOS: enabled | 179 ready-for-steward | 1 executing
+        ◉ Agents: 2 running (task-a, task-b)
+        ◉ CC usage: 5h 42% | 7d 15%. Resets — 5h: May 15 4:10 PM ET / 7d: May 22 11:00 AM ET.
+    """
+    execution_enabled = bool(wos_config.get("execution_enabled", False))
+    wos_label = "enabled" if execution_enabled else "stopped"
+
+    # Build queue-depth string from status_counts
+    queue_parts: list[str] = []
+    for status, count in sorted(status_counts.items()):
+        if count > 0:
+            queue_parts.append(f"{count} {status}")
+    queue_str = " | ".join(queue_parts) if queue_parts else "0 UoWs"
+
+    wos_line = f"◉ WOS: {wos_label} | {queue_str}"
+
+    # Active agents line
+    agent_count = len(active_sessions)
+    if agent_count == 0:
+        agents_line = "◉ Agents: 0 running"
+    else:
+        agent_ids = [
+            s.get("agent_id") or s.get("task_id") or "?"
+            for s in active_sessions
+        ]
+        agents_line = f"◉ Agents: {agent_count} running ({', '.join(agent_ids)})"
+
+    # CC usage line
+    quota_line = "◉ " + format_quota_message(quota_state)
+
+    return "\n".join([wos_line, agents_line, quota_line])

--- a/tests/unit/test_orchestration/test_dispatcher_commands.py
+++ b/tests/unit/test_orchestration/test_dispatcher_commands.py
@@ -15,20 +15,12 @@ import pytest
 
 from src.orchestration.dispatcher_handlers import (
     COMMAND_HELP,
+    QUOTA_STALE_THRESHOLD_HOURS,
     handle_help,
     read_quota_state,
     format_quota_message,
     format_status_message,
 )
-
-
-# ---------------------------------------------------------------------------
-# Constants matching the spec requirements
-# ---------------------------------------------------------------------------
-
-# Stale threshold in hours: data older than this is treated as unavailable.
-# Matches the poller's 30-minute schedule — 2 hours gives headroom for gaps.
-QUOTA_STALE_THRESHOLD_HOURS = 2
 
 
 # ---------------------------------------------------------------------------
@@ -220,8 +212,8 @@ class TestFormatStatusMessage:
     def test_includes_agent_count_when_agents_present(self) -> None:
         """Active agent count (2) must appear when agents are running."""
         sessions = [
-            {"agent_id": "task-a", "description": "First task"},
-            {"agent_id": "task-b", "description": "Second task"},
+            {"task_id": "task-a", "description": "First task"},
+            {"task_id": "task-b", "description": "Second task"},
         ]
         result = format_status_message(
             active_sessions=sessions,

--- a/tests/unit/test_orchestration/test_dispatcher_commands.py
+++ b/tests/unit/test_orchestration/test_dispatcher_commands.py
@@ -1,0 +1,306 @@
+"""
+Tests for the /quota, /status, and /help dispatcher commands.
+
+These test pure handler functions — no Telegram, MCP, or network calls required.
+All handlers return formatted strings derived from file reads or in-memory data.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.orchestration.dispatcher_handlers import (
+    COMMAND_HELP,
+    handle_help,
+    read_quota_state,
+    format_quota_message,
+    format_status_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants matching the spec requirements
+# ---------------------------------------------------------------------------
+
+# Stale threshold in hours: data older than this is treated as unavailable.
+# Matches the poller's 30-minute schedule — 2 hours gives headroom for gaps.
+QUOTA_STALE_THRESHOLD_HOURS = 2
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fresh_state(tmp_path: Path) -> Path:
+    """Write a fresh cc-budget state.json and return the path."""
+    state = {
+        "v": 1,
+        "ts": int(datetime.now(timezone.utc).timestamp()),
+        "rate_limits": {
+            "five_hour": {
+                "pct": 42.0,
+                "resets_at": "2026-05-15T21:10:00.000000+00:00",
+            },
+            "seven_day": {
+                "pct": 15.0,
+                "resets_at": "2026-05-22T16:00:00.000000+00:00",
+            },
+        },
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "source": "cc-usage-poller",
+    }
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps(state))
+    return p
+
+
+@pytest.fixture
+def stale_state(tmp_path: Path) -> Path:
+    """Write a state.json with a last_updated timestamp 3 hours ago."""
+    from datetime import timedelta
+
+    old_ts = datetime.now(timezone.utc) - timedelta(hours=3)
+    state = {
+        "v": 1,
+        "ts": int(old_ts.timestamp()),
+        "rate_limits": {
+            "five_hour": {"pct": 55.0, "resets_at": "2026-05-15T21:10:00+00:00"},
+            "seven_day": {"pct": 20.0, "resets_at": "2026-05-22T16:00:00+00:00"},
+        },
+        "last_updated": old_ts.isoformat(),
+        "source": "cc-usage-poller",
+    }
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps(state))
+    return p
+
+
+@pytest.fixture
+def missing_state(tmp_path: Path) -> Path:
+    """Return a path where no state.json file exists."""
+    return tmp_path / "state.json"
+
+
+# ---------------------------------------------------------------------------
+# read_quota_state — pure reader, returns dict or None
+# ---------------------------------------------------------------------------
+
+
+class TestReadQuotaState:
+    """read_quota_state reads ~/.claude/cc-budget/state.json (or override path)."""
+
+    def test_returns_dict_for_valid_file(self, fresh_state: Path) -> None:
+        """Valid state.json with rate_limits returns a parsed dict."""
+        result = read_quota_state(state_path=fresh_state)
+        assert result is not None
+        assert isinstance(result, dict)
+
+    def test_extracts_five_hour_pct(self, fresh_state: Path) -> None:
+        """five_hour.pct must be accessible in the returned dict."""
+        result = read_quota_state(state_path=fresh_state)
+        assert result["rate_limits"]["five_hour"]["pct"] == 42.0
+
+    def test_extracts_seven_day_pct(self, fresh_state: Path) -> None:
+        """seven_day.pct must be accessible in the returned dict."""
+        result = read_quota_state(state_path=fresh_state)
+        assert result["rate_limits"]["seven_day"]["pct"] == 15.0
+
+    def test_returns_none_for_missing_file(self, missing_state: Path) -> None:
+        """Returns None (not an exception) when the file is absent."""
+        result = read_quota_state(state_path=missing_state)
+        assert result is None
+
+    def test_returns_none_for_malformed_json(self, tmp_path: Path) -> None:
+        """Returns None when state.json contains invalid JSON."""
+        p = tmp_path / "state.json"
+        p.write_text("{ not valid json }")
+        result = read_quota_state(state_path=p)
+        assert result is None
+
+    def test_returns_none_for_missing_rate_limits_key(self, tmp_path: Path) -> None:
+        """Returns None when 'rate_limits' key is absent from state.json."""
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps({"v": 1, "ts": 1234567890}))
+        result = read_quota_state(state_path=p)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# format_quota_message — pure formatter, returns human-readable string
+# ---------------------------------------------------------------------------
+
+
+class TestFormatQuotaMessage:
+    """format_quota_message formats the quota state dict into a Telegram message."""
+
+    def test_returns_string(self, fresh_state: Path) -> None:
+        state = read_quota_state(state_path=fresh_state)
+        assert isinstance(format_quota_message(state), str)
+
+    def test_includes_five_hour_percentage(self, fresh_state: Path) -> None:
+        """Five-hour utilization percentage must appear in the output."""
+        state = read_quota_state(state_path=fresh_state)
+        msg = format_quota_message(state)
+        assert "42" in msg
+
+    def test_includes_seven_day_percentage(self, fresh_state: Path) -> None:
+        """Seven-day utilization percentage must appear in the output."""
+        state = read_quota_state(state_path=fresh_state)
+        msg = format_quota_message(state)
+        assert "15" in msg
+
+    def test_includes_resets_label(self, fresh_state: Path) -> None:
+        """Output must mention when the quota resets."""
+        state = read_quota_state(state_path=fresh_state)
+        msg = format_quota_message(state)
+        assert "reset" in msg.lower()
+
+    def test_unavailable_message_for_none_state(self) -> None:
+        """None state (missing/unreadable file) produces the unavailable message."""
+        msg = format_quota_message(None)
+        assert "unavailable" in msg.lower()
+
+    def test_unavailable_message_for_stale_state(self, stale_state: Path) -> None:
+        """State older than QUOTA_STALE_THRESHOLD_HOURS triggers unavailable message."""
+        state = read_quota_state(state_path=stale_state)
+        msg = format_quota_message(state)
+        assert "unavailable" in msg.lower()
+
+    def test_quota_prefix_present(self, fresh_state: Path) -> None:
+        """Output should begin with a 'CC usage' label for clarity on mobile."""
+        state = read_quota_state(state_path=fresh_state)
+        msg = format_quota_message(state)
+        assert "CC usage" in msg or "cc usage" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# format_status_message — pure formatter, returns system snapshot string
+# ---------------------------------------------------------------------------
+
+
+class TestFormatStatusMessage:
+    """format_status_message assembles a snapshot from agents, WOS config, and quota."""
+
+    def test_returns_string(self, fresh_state: Path) -> None:
+        state = read_quota_state(state_path=fresh_state)
+        result = format_status_message(
+            active_sessions=[],
+            wos_config={"execution_enabled": True},
+            status_counts={},
+            quota_state=state,
+        )
+        assert isinstance(result, str)
+
+    def test_includes_wos_execution_state_true(self, fresh_state: Path) -> None:
+        """WOS execution_enabled=True must appear in the output."""
+        state = read_quota_state(state_path=fresh_state)
+        result = format_status_message(
+            active_sessions=[],
+            wos_config={"execution_enabled": True},
+            status_counts={},
+            quota_state=state,
+        )
+        assert "true" in result.lower() or "enabled" in result.lower()
+
+    def test_includes_wos_execution_state_false(self) -> None:
+        """WOS execution_enabled=False must appear in the output."""
+        result = format_status_message(
+            active_sessions=[],
+            wos_config={"execution_enabled": False},
+            status_counts={},
+            quota_state=None,
+        )
+        assert "false" in result.lower() or "disabled" in result.lower() or "stopped" in result.lower()
+
+    def test_includes_agent_count_when_agents_present(self) -> None:
+        """Active agent count (2) must appear when agents are running."""
+        sessions = [
+            {"agent_id": "task-a", "description": "First task"},
+            {"agent_id": "task-b", "description": "Second task"},
+        ]
+        result = format_status_message(
+            active_sessions=sessions,
+            wos_config={"execution_enabled": True},
+            status_counts={},
+            quota_state=None,
+        )
+        assert "2" in result or "task-a" in result
+
+    def test_includes_quota_percentage_from_state(self, fresh_state: Path) -> None:
+        """CC usage percentage must appear when quota state is fresh."""
+        state = read_quota_state(state_path=fresh_state)
+        result = format_status_message(
+            active_sessions=[],
+            wos_config={"execution_enabled": True},
+            status_counts={"ready-for-steward": 179, "executing": 1},
+            quota_state=state,
+        )
+        assert "42" in result  # five_hour_pct from fresh_state fixture
+
+    def test_includes_wos_queue_depth_from_status_counts(self) -> None:
+        """WOS queue depth from status_counts must appear in the output."""
+        result = format_status_message(
+            active_sessions=[],
+            wos_config={"execution_enabled": True},
+            status_counts={"ready-for-steward": 179, "executing": 1},
+            quota_state=None,
+        )
+        assert "179" in result
+
+    def test_no_agents_message_when_empty(self) -> None:
+        """When no agents are running, output should reflect that clearly."""
+        result = format_status_message(
+            active_sessions=[],
+            wos_config={"execution_enabled": True},
+            status_counts={},
+            quota_state=None,
+        )
+        # Either "0" or "none" or "no agents" — any clear indicator is acceptable
+        assert "0" in result or "none" in result.lower() or "no agent" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# handle_help — static text, no file reads
+# ---------------------------------------------------------------------------
+
+
+class TestHandleHelp:
+    """handle_help returns a static command index."""
+
+    def test_returns_string(self) -> None:
+        assert isinstance(handle_help(), str)
+
+    def test_returns_command_help_constant(self) -> None:
+        """handle_help must return the COMMAND_HELP constant."""
+        assert handle_help() == COMMAND_HELP
+
+    def test_includes_todos_command(self) -> None:
+        text = handle_help()
+        assert "/todos" in text
+
+    def test_includes_quota_command(self) -> None:
+        """/quota must be listed in the help text after this PR."""
+        text = handle_help()
+        assert "/quota" in text
+
+    def test_includes_status_command(self) -> None:
+        """/status must be listed in the help text after this PR."""
+        text = handle_help()
+        assert "/status" in text
+
+    def test_includes_help_command(self) -> None:
+        text = handle_help()
+        assert "/help" in text or "help" in text.lower()
+
+    def test_includes_shop_command(self) -> None:
+        text = handle_help()
+        assert "/shop" in text
+
+    def test_includes_re_review_command(self) -> None:
+        text = handle_help()
+        assert "/re-review" in text


### PR DESCRIPTION
## What problem this solves

Dan had no quick way from Telegram to see CC quota usage, system state (agents running, WOS enabled, queue depth), or the full command list. The existing prose commands (`status`, `usage`) work but require the dispatcher to recognize natural language — they are not predictably routable. Three slash commands fill this gap.

## What changed

**`/quota`** reads `~/.claude/cc-budget/state.json` (written by `cc-usage-poller`) and formats a one-line usage message:
```
CC usage: 5h 42% | 7d 15%. Resets — 5h: May 15 4:10 PM ET / 7d: May 22 11:00 AM ET.
```
Data older than 2 hours is treated as unavailable. The reset time is converted to ET.

**`/status`** assembles three bullet lines from independently sourced data:
```
◉ WOS: enabled | 179 ready-for-steward | 1 executing
◉ Agents: 2 running (task-a, task-b)
◉ CC usage: 5h 42% | 7d 15%. Resets — 5h: May 15 4:10 PM ET / ...
```

**`/help`** returns an updated static command index that now includes `/todos`, `/shop`, `/re-review`, `/quota`, and `/status`.

## Design approach

The formatting logic (`read_quota_state`, `format_quota_message`, `format_status_message`) lives as pure functions in `dispatcher_handlers.py` — all inputs are arguments, no side effects. The subagents for `/quota` and `/status` import and call these functions rather than embedding logic in markdown. `/help` is handled inline on the dispatcher main thread since it reads no files (7-second rule: only file reads go to subagents).

Functional patterns used: pure functions, immutable inputs (no mutation of state dicts), explicit error returns (None instead of exceptions for missing/malformed files).

## Dispatcher routing

`sys.dispatcher.bootup.md` now contains explicit routing blocks for all three commands, following the same `Task(...)` + `send_reply(...)` pattern used by `/todos`.

## Migration

Migration 113 in `upgrade.sh` copies `dispatcher-quota-query.md` and `dispatcher-status-query.md` to `~/lobster-workspace/scheduled-jobs/tasks/` on next upgrade. Idempotent: skips if destination files already exist.

## What is NOT changed

No WOS orchestration, LOS, skill system, or existing command handlers were modified. The existing prose `status`, `usage`, and `agents` commands continue to work as before.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_dispatcher_commands.py -v` — 28 passed, 0 failed (new tests for all three commands)
- [x] `uv run pytest tests/unit/test_orchestration/test_dispatcher_commands.py tests/unit/test_orchestration/test_dispatcher_integration.py tests/unit/test_orchestration/test_toggle_wos_core_jobs.py -q` — 154 passed, 0 failed (no regression in dispatcher handler tests)
- [x] `uv run python3 -m py_compile src/orchestration/dispatcher_handlers.py` — syntax OK

## Manual test

N/A — this change adds pure formatter functions and dispatcher routing instructions. The formatter functions are verified by unit tests with real state.json fixture data. The routing changes in `sys.dispatcher.bootup.md` take effect on the next dispatcher session start and are structural-prose (no code to execute at rest). Live Telegram verification requires a production run; the dispatcher will pick up the new routes from the updated bootup file on its next context load.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure formatter functions, no external service calls in the handlers themselves)
- [x] User-visible outcome: verified by unit tests; live Telegram delivery deferred to post-merge (routing is bootup-doc-driven, takes effect on next dispatcher context load)
- [x] Side-effect audit: read-only functions; no floods, no unscoped writes; `/quota` and `/status` each send exactly one Telegram message
- [x] External service calls: none in the handlers (poller is a separate process)

Closes #1165