### PR TITLE
fix(wos): correct import path for timezone util in dispatcher_handlers

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 from .registry import ApproveConfirmed, ApproveExpired, ApproveNotFound, ApproveSkipped
 from .paths import LOBSTER_WORKSPACE as _LOBSTER_WORKSPACE, WOS_CONFIG as _WOS_CONFIG_PATH_FROM_PATHS, WOS_GATE_CLEARED_FLAG as _GATE_CLEARED_FLAG, JOBS_JSON as _JOBS_JSON_PATH
 from .steward import ReturnReasonClassification, MAX_RETRIES as _STEWARD_MAX_RETRIES, _HARD_CAP_CYCLES
-from utils.timezone import format_iso_for_user as _format_iso_for_user, get_owner_tz_name as _get_owner_tz_name
+from src.utils.timezone import format_iso_for_user as _format_iso_for_user, get_owner_tz_name as _get_owner_tz_name
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

`steward-heartbeat.py` was crashing every 3 minutes at the point where it imports `is_execution_enabled` from `src.orchestration.dispatcher_handlers`. The crash happened because `dispatcher_handlers.py` contained a bare import `from utils.timezone import ...` which resolves to nothing when the script runs from the repo root (where `utils` is not a top-level package — the module lives at `src/utils/timezone.py`).

Root cause: the import path was `utils.timezone` but should be `src.utils.timezone`. This left 183 WOS UoWs stuck at `ready-for-steward` since the steward loop never completed a run.

## Change

Single-line fix in `src/orchestration/dispatcher_handlers.py` line 43:

```
- from utils.timezone import format_iso_for_user as _format_iso_for_user, get_owner_tz_name as _get_owner_tz_name
+ from src.utils.timezone import format_iso_for_user as _format_iso_for_user, get_owner_tz_name as _get_owner_tz_name
```

No other changes. No refactoring. Purely the import path correction.

Functional pattern: pure import — no side effects, no behavior change. The fix corrects the module resolution path so the existing pure functions `format_iso_for_user` and `get_owner_tz_name` are reachable at module load time.

## Out of scope

Other files with bare `from utils.` imports (e.g., `src/channels/outbox.py`, `src/mcp/inbox_server.py`) were not touched — those are separate concerns and may have their own sys.path setup. This PR is scoped to the one import causing the steward crash.

## Tests run

- [x] `python3 -c "from src.orchestration.dispatcher_handlers import is_execution_enabled; print('Import OK')"` — Import OK
- [x] `uv run pytest tests/unit/test_orchestration/test_dispatcher_commands.py --no-header -q` — 28 passed, 0 failed
- [x] Manual verification: confirmed `from utils.timezone import ...` line is the exact line appearing in the steward-heartbeat.log traceback

## Manual test

The crash is reproduced in live logs at `~/lobster-workspace/scheduled-jobs/logs/steward-heartbeat.log` — the traceback shows `ModuleNotFoundError: No module named 'utils'` at line 43 of `dispatcher_handlers.py` on every 3-minute invocation. The import test passes cleanly with the fix applied. This is entirely internal — no Telegram output, no user-visible side effects to verify.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — import verified; live crash traceback confirms root cause matches
- [x] User-visible outcome: N/A — this is an internal module import fix; the user-visible outcome is that steward-heartbeat stops crashing (observable in the cron log)
- [x] Side-effect audit: no floods, no shared state writes, no volume concerns — import path fix only
- [x] External service calls: none