### PR TITLE
fix(wos): always specify --repo dcetlin/Lobster in gh CLI dispatch

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -449,6 +449,9 @@ Before declaring any integration or manual test PASS:
 
 - **Default repo:** `SiderealPress/lobster` (owner=SiderealPress, repo=lobster) is the Lobster *system* repo — for Lobster maintenance tasks. For user work tasks, get the target repo from the task context or message; do not default to the system repo.
 
+- **Always specify `--repo dcetlin/Lobster` in `gh` CLI commands.**
+  When running `gh pr` or `gh issue` commands in WOS dispatch or any task context, always pass `--repo dcetlin/Lobster` explicitly. Never rely on the working directory's git remote to determine the target repository — the remote may point to `SiderealPress/lobster` (the upstream public fork) and will silently operate on the wrong repo.
+
 - **Linear API:** Access Linear via REST API. The `LINEAR_API_KEY` environment variable is set. GraphQL endpoint: `https://api.linear.app/graphql`. Use `curl -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json"`.
 
 - **Python:** Always use `uv run` not `python` or `python3`.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

WOS dispatch prompts and subagent boot context did not explicitly require `--repo` in `gh` CLI commands. This caused `gh pr` and `gh issue` invocations to default to the working directory's git remote (`SiderealPress/lobster` — the upstream public fork), silently operating on the wrong repository instead of `dcetlin/Lobster`.

## Changes

- **`.claude/sys.subagent.bootup.md`**: Added an explicit-repo reminder in the Tooling conventions section. Subagents now see:

  > **Always specify `--repo dcetlin/Lobster` in `gh` CLI commands.**
  > When running `gh pr` or `gh issue` commands in WOS dispatch or any task context, always pass `--repo dcetlin/Lobster` explicitly. Never rely on the working directory's git remote — it may point to `SiderealPress/lobster` and will silently operate on the wrong repo.

## Audit findings

- `src/orchestration/dispatcher_handlers.py`: zero `gh pr`/`gh issue` invocations → no change needed
- `~/lobster-workspace/scheduled-jobs/tasks/`: all existing commands already include `--repo dcetlin/Lobster` (one prose reference updated locally)

## Verification

```
grep -n "gh pr\|gh issue" src/orchestration/dispatcher_handlers.py | grep -v "\-\-repo"
# → empty (exit 1)

grep -rn "gh pr\|gh issue" ~/lobster-workspace/scheduled-jobs/tasks/ | grep -v "\-\-repo"
# → empty (exit 1)
```

WOS-UoW: uow_20260514_ebc90d