### PR TITLE
fix(cron): remove CRONTAB_DIR guard from Migration 46, add crontab_write error helper

### DIFF
--- a/scripts/cron-manage.sh
+++ b/scripts/cron-manage.sh
@@ -15,9 +15,42 @@
 #   Both subcommands use the (crontab -l | grep -v MARKER; ...) | crontab -
 #   pattern to avoid overwriting the entire crontab. Raw `echo | crontab -`
 #   usage is prohibited — always use this script instead.
+#
+# Prerequisites:
+#   The calling user must be in the crontab group (or the system must allow
+#   crontab writes via the setgid bit on /usr/bin/crontab). If you see a
+#   "mkstemp: Permission denied" error, run upgrade.sh which applies Migration 46
+#   to add the lobster user to the crontab group, or run manually:
+#     sudo usermod -aG crontab $USER
+#   The change takes effect on the next login (or via: newgrp crontab).
 #===============================================================================
 
 set -euo pipefail
+
+# Write a new crontab from stdin, capturing stderr to provide an actionable
+# error message when crontab writes fail due to group permissions.
+crontab_write() {
+    local tmp_err
+    tmp_err=$(mktemp)
+    if ! crontab - 2>"$tmp_err"; then
+        local err_text
+        err_text=$(cat "$tmp_err")
+        rm -f "$tmp_err"
+        if echo "$err_text" | grep -qi "permission denied\|mkstemp\|cannot create"; then
+            echo "Error: crontab write failed — $err_text" >&2
+            echo "" >&2
+            echo "Fix: the lobster user needs to be in the crontab group." >&2
+            echo "  sudo usermod -aG crontab \$USER" >&2
+            echo "  newgrp crontab  (or log out and back in)" >&2
+            echo "" >&2
+            echo "Alternatively, run upgrade.sh which applies Migration 46 automatically." >&2
+        else
+            echo "$err_text" >&2
+        fi
+        return 1
+    fi
+    rm -f "$tmp_err"
+}
 
 usage() {
     cat >&2 <<EOF
@@ -48,13 +81,13 @@ case "$SUBCOMMAND" in
         ENTRY="$3"
         # Remove any existing entry with the same marker, then append the new one.
         # The `|| true` guards against grep returning exit code 1 when no lines match.
-        (crontab -l 2>/dev/null | grep -vF "$MARKER" || true; echo "$ENTRY") | crontab -
+        (crontab -l 2>/dev/null | grep -vF "$MARKER" || true; echo "$ENTRY") | crontab_write
         echo "Cron entry added: $ENTRY"
         ;;
 
     remove)
         # Strip all lines containing the marker. If none match, crontab is unchanged.
-        (crontab -l 2>/dev/null | grep -vF "$MARKER" || true) | crontab -
+        (crontab -l 2>/dev/null | grep -vF "$MARKER" || true) | crontab_write
         echo "Cron entry removed (marker: $MARKER)"
         ;;
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -222,6 +222,16 @@ preflight_checks() {
         success "Python venv found"
     fi
 
+    # Crontab group membership (needed for reliable cron-manage.sh operation)
+    # The crontab binary is setgid, but direct group membership is more reliable
+    # and prevents mkstemp failures in /var/spool/cron/ when the setgid path fails.
+    if id -nG "$USER" 2>/dev/null | grep -qw crontab; then
+        success "User $USER is in the crontab group"
+    else
+        warn "User $USER is not in the crontab group — cron entry writes may fail."
+        warn "Migration 46 will add $USER to the crontab group if sudo is available."
+    fi
+
     # Record current version/commit
     cd "$LOBSTER_DIR"
     if [ "$INSTALL_MODE" = "git" ]; then
@@ -1937,20 +1947,27 @@ if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
     # The MCP server process runs under PR_SET_NO_NEW_PRIVS (NoNewPrivs=1), which
     # suppresses setgid bits on child processes. The `crontab` binary is setgid-crontab,
     # so `crontab -` fails with "mkstemp: Permission denied" when called from the MCP
-    # server. Fix: add the lobster user to the crontab group so sync-crontab.sh can
+    # server. Fix: add the lobster user to the crontab group so cron-manage.sh can
     # write directly to /var/spool/cron/crontabs/$USER (group-writable directory) without
     # needing the setgid bit. Requires sudo; warns and skips if sudo is unavailable.
-    local CRONTAB_DIR="/var/spool/cron/crontabs"
-    if [ -d "$CRONTAB_DIR" ] && ! id -nG "$USER" | grep -qw "crontab"; then
+    #
+    # Note: we no longer gate this on the crontabs directory existing first. Group
+    # membership is a prerequisite for crontab writes, not a consequence of the directory
+    # state. The original [ -d "$CRONTAB_DIR" ] guard caused a bootstrap failure: if the
+    # crontabs directory did not exist when Migration 46 ran (e.g. fresh install), this
+    # step was skipped. The crontabs directory was then created by the first successful
+    # crontab write — but that write itself could fail without group membership. Now we
+    # ensure group membership unconditionally so any subsequent crontab call succeeds.
+    if ! id -nG "$USER" 2>/dev/null | grep -qw "crontab"; then
         if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             sudo usermod -aG crontab "$USER" 2>/dev/null && {
-                substep "Added $USER to the crontab group (fixes NoNewPrivs crontab permission error)"
+                substep "Added $USER to the crontab group (fixes crontab permission errors)"
                 migrated=$((migrated + 1))
                 warn "Group membership change takes effect at next login. Run 'newgrp crontab' or restart the Lobster service to apply immediately."
             } || warn "Failed to add $USER to crontab group — run: sudo usermod -aG crontab $USER"
         else
             warn "Cannot add $USER to crontab group (sudo unavailable). Run manually: sudo usermod -aG crontab $USER"
-            warn "Until this is done, create_scheduled_job/update_scheduled_job/delete_scheduled_job will fail to sync crontab."
+            warn "Until this is done, cron-manage.sh calls may fail to write crontab entries."
         fi
     fi
 


### PR DESCRIPTION
## What and why

WOS UoW `uow_20260514_efbf2b` blocked when it tried to install the pending-actions-nudge cron entry. The UoW ran `upgrade.sh`, which triggered Migration 46 — but Migration 46 silently skipped because it gated the `usermod` on `/var/spool/cron/crontabs` existing first. On that install the directory didn't exist yet, so Migration 46 saw `[ -d /var/spool/cron/crontabs ] = false` and skipped. The subsequent `crontab -` call then failed with `mkstemp: Permission denied` because it tried to create the `crontabs/` directory inside root-owned `/var/spool/cron/`.

The bootstrap failure was circular: group membership is what you need *before* the first crontab write, not something you acquire *after* the directory gets created.

## Changes

**`scripts/upgrade.sh`**

- Migration 46: remove the `[ -d "$CRONTAB_DIR" ]` guard. The `crontab` group must be assigned unconditionally — it is a prerequisite for crontab writes, not a consequence of the directory state. The extended comment explains the original failure mode so the guard never comes back.
- `preflight_checks()`: add a crontab group membership check that warns early (before any migrations run) if the user is missing from the group and points to Migration 46.

**`scripts/cron-manage.sh`**

- Add `crontab_write()` helper that wraps `crontab -` with stderr capture. When a permission failure occurs, it emits a structured error with the specific `usermod` command and a note to run `upgrade.sh`. All `crontab -` calls in `add` and `remove` now go through this helper.
- Update header comment to document the crontab group prerequisite.

## Before / after

```
Before:
  upgrade.sh → Migration 46 → [ -d /var/spool/cron/crontabs ] = false → SKIP
  cron-manage.sh add → crontab - → mkstemp Permission denied
  WOS UoW → blocked, no actionable error

After:
  upgrade.sh → Migration 46 → id -nG $USER | grep crontab? → usermod -aG crontab lobster
  cron-manage.sh add → crontab_write → crontab - → success
  WOS UoW → proceeds; if crontab fails, actionable error with exact fix command
```

No behavior change for installs where the user is already in the crontab group — the Migration 46 condition short-circuits immediately.

## Immediate unblocking

The pending-actions-nudge cron entry (`LOBSTER-PENDING-ACTIONS-NUDGE`) is already present in the live crontab (verified: it was manually added on 2026-05-14 after the UoW failure). No action needed on that entry.

To get lobster into the crontab group now (so future installs don't hit this), Dan needs to run upgrade.sh once (or run `sudo usermod -aG crontab lobster` directly from the host). After that, no re-login is needed as long as new sessions pick up the group — or `newgrp crontab` in the current session.

## Tests run

- [x] `bash -n scripts/upgrade.sh` — syntax OK
- [x] `bash -n scripts/cron-manage.sh` — syntax OK
- [x] cron-manage.sh add + remove functional test — passes, crontab entry correctly added and removed
- [ ] Full `upgrade.sh` run — skipped: would restart services; the individual changes are narrow and the idempotency guards prevent any double-application

## Manual test

N/A for this PR — no systemd units, external service calls, or DB schema changes. The cron-manage.sh changes were functionally tested directly. Migration 46 changes are gated on `id -nG $USER | grep -qw crontab` which is safe to verify without running the full upgrade.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, shell scripts
- [x] Integration/manual test run — cron-manage.sh add/remove verified functional
- [x] User-visible outcome verified — N/A (infrastructure fix, no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: N/A