### PR TITLE
fix(wos): route dispatch_eligibility_skip to separate skip-log table (#uow_20260509_116aa7)

### DIFF
--- a/src/orchestration/migrations/0024_dispatch_eligibility_skip_table.sql
+++ b/src/orchestration/migrations/0024_dispatch_eligibility_skip_table.sql
@@ -1,0 +1,16 @@
+-- Migration 0024: route dispatch_eligibility_skip to a dedicated table.
+--
+-- The audit_log table accumulates dispatch_eligibility_skip records at ~9:1
+-- noise-to-signal ratio, burying real forensic events. This migration creates
+-- a separate dispatch_skip_log table for these non-decision records, keeping
+-- audit_log clean for actions and transitions.
+
+CREATE TABLE IF NOT EXISTS dispatch_skip_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts             TEXT    NOT NULL,
+    uow_id         TEXT    NOT NULL,
+    eligibility    TEXT    NOT NULL,
+    steward_cycles INTEGER,
+    actor          TEXT,
+    note           TEXT
+);

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1188,6 +1188,36 @@ class Registry:
         finally:
             conn.close()
 
+    def write_dispatch_skip(self, uow_id: str, entry: dict[str, Any]) -> None:
+        """Write a dispatch_eligibility_skip record to dispatch_skip_log.
+
+        Kept out of audit_log to prevent noise from drowning forensic events.
+        The entry dict must contain 'eligibility'; other keys are optional.
+        """
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO dispatch_skip_log (ts, uow_id, eligibility, steward_cycles, actor, note)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    _now_iso(),
+                    uow_id,
+                    entry.get("eligibility", "unknown"),
+                    entry.get("steward_cycles"),
+                    entry.get("actor"),
+                    json.dumps(entry),
+                ),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
     def record_stall_detected(
         self,
         uow_id: str,

--- a/src/orchestration/schema.sql
+++ b/src/orchestration/schema.sql
@@ -162,3 +162,17 @@ CREATE TABLE IF NOT EXISTS audit_log (
     agent       TEXT,
     note        TEXT
 );
+
+-- dispatch_skip_log: non-decision records for dispatch_eligibility_skip events.
+--   Separated from audit_log to preserve forensic signal-to-noise ratio.
+--   These records fire every steward cycle for ineligible UoWs and would
+--   otherwise account for ~88% of audit_log volume.
+CREATE TABLE IF NOT EXISTS dispatch_skip_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts             TEXT    NOT NULL,
+    uow_id         TEXT    NOT NULL,
+    eligibility    TEXT    NOT NULL,
+    steward_cycles INTEGER,
+    actor          TEXT,
+    note           TEXT
+);

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -5408,8 +5408,7 @@ def run_steward_cycle(
                     uow_id, throttle_count, _effective_burst_batch_size,
                 )
                 if not dry_run:
-                    registry.append_audit_log(uow_id, {
-                        "event": "dispatch_eligibility_skip",
+                    registry.write_dispatch_skip(uow_id, {
                         "actor": _ACTOR_STEWARD,
                         "uow_id": uow_id,
                         "steward_cycles": uow.steward_cycles,
@@ -5429,8 +5428,7 @@ def run_steward_cycle(
                 uow_id, _eligibility,
             )
             if not dry_run:
-                registry.append_audit_log(uow_id, {
-                    "event": "dispatch_eligibility_skip",
+                registry.write_dispatch_skip(uow_id, {
                     "actor": _ACTOR_STEWARD,
                     "uow_id": uow_id,
                     "steward_cycles": uow.steward_cycles,

--- a/tests/unit/test_orchestration/test_steward_dispatch_eligibility.py
+++ b/tests/unit/test_orchestration/test_steward_dispatch_eligibility.py
@@ -478,5 +478,135 @@ class TestDispatchEligibilityPrecedence:
         assert result == "pause"
 
 
+# ---------------------------------------------------------------------------
+# Integration: dispatch_eligibility_skip routed to dispatch_skip_log, not audit_log
+# ---------------------------------------------------------------------------
+
+class TestDispatchSkipRoutedToSeparateTable:
+    """dispatch_eligibility_skip events go to dispatch_skip_log, not audit_log.
+
+    Separation ensures the main audit_log retains its forensic signal-to-noise
+    ratio. These records previously constituted ~88% of audit_log volume.
+    """
+
+    @pytest.fixture
+    def registry(self, tmp_path):
+        """Registry backed by a temporary SQLite DB."""
+        from src.orchestration.registry import Registry
+        return Registry(tmp_path / "test_skip_log.db")
+
+    def test_throttle_skip_writes_to_dispatch_skip_log_not_audit_log(self, registry, tmp_path):
+        """A throttle-pattern skip routes to dispatch_skip_log, leaving audit_log clean."""
+        import sqlite3
+
+        uow_id = "uow_test_throttle_skip"
+        registry.write_dispatch_skip(uow_id, {
+            "actor": "steward",
+            "uow_id": uow_id,
+            "steward_cycles": 3,
+            "eligibility": "throttle",
+            "timestamp": "2026-05-16T00:00:00+00:00",
+        })
+
+        conn = sqlite3.connect(str(tmp_path / "test_skip_log.db"))
+
+        # audit_log must have no dispatch_eligibility_skip entries
+        audit_skip_count = conn.execute(
+            "SELECT COUNT(*) FROM audit_log WHERE event = 'dispatch_eligibility_skip'"
+        ).fetchone()[0]
+        assert audit_skip_count == 0, (
+            f"Expected 0 dispatch_eligibility_skip entries in audit_log, got {audit_skip_count}"
+        )
+
+        # dispatch_skip_log must have exactly one entry with eligibility='throttle'
+        skip_rows = conn.execute(
+            "SELECT eligibility FROM dispatch_skip_log WHERE uow_id = ?",
+            (uow_id,),
+        ).fetchall()
+        assert len(skip_rows) == 1, f"Expected 1 row in dispatch_skip_log, got {len(skip_rows)}"
+        assert skip_rows[0][0] == "throttle"
+
+        conn.close()
+
+    def test_pause_skip_writes_to_dispatch_skip_log_not_audit_log(self, registry, tmp_path):
+        """A pause-pattern skip (dead-end) routes to dispatch_skip_log, leaving audit_log clean."""
+        import sqlite3
+
+        uow_id = "uow_test_pause_skip"
+        registry.write_dispatch_skip(uow_id, {
+            "actor": "steward",
+            "uow_id": uow_id,
+            "steward_cycles": 5,
+            "eligibility": "pause",
+            "timestamp": "2026-05-16T00:00:00+00:00",
+        })
+
+        conn = sqlite3.connect(str(tmp_path / "test_skip_log.db"))
+
+        audit_skip_count = conn.execute(
+            "SELECT COUNT(*) FROM audit_log WHERE event = 'dispatch_eligibility_skip'"
+        ).fetchone()[0]
+        assert audit_skip_count == 0
+
+        skip_rows = conn.execute(
+            "SELECT eligibility FROM dispatch_skip_log WHERE uow_id = ?",
+            (uow_id,),
+        ).fetchall()
+        assert len(skip_rows) == 1
+        assert skip_rows[0][0] == "pause"
+
+        conn.close()
+
+    def test_multiple_skips_accumulate_in_dispatch_skip_log(self, registry, tmp_path):
+        """Multiple skip writes all land in dispatch_skip_log; audit_log remains empty of skips."""
+        import sqlite3
+
+        SKIP_COUNT = 5
+        for i in range(SKIP_COUNT):
+            registry.write_dispatch_skip(f"uow_multi_{i}", {
+                "actor": "steward",
+                "uow_id": f"uow_multi_{i}",
+                "steward_cycles": i + 1,
+                "eligibility": "throttle",
+                "timestamp": "2026-05-16T00:00:00+00:00",
+            })
+
+        conn = sqlite3.connect(str(tmp_path / "test_skip_log.db"))
+
+        audit_skip_count = conn.execute(
+            "SELECT COUNT(*) FROM audit_log WHERE event = 'dispatch_eligibility_skip'"
+        ).fetchone()[0]
+        assert audit_skip_count == 0
+
+        skip_total = conn.execute(
+            "SELECT COUNT(*) FROM dispatch_skip_log"
+        ).fetchone()[0]
+        assert skip_total == SKIP_COUNT
+
+        conn.close()
+
+    def test_dispatch_skip_log_stores_eligibility_field(self, registry, tmp_path):
+        """Each dispatch_skip_log row carries the eligibility value for diagnostics."""
+        import sqlite3
+
+        for eligibility in ("throttle", "pause", "escalate"):
+            registry.write_dispatch_skip(f"uow_{eligibility}", {
+                "actor": "steward",
+                "uow_id": f"uow_{eligibility}",
+                "steward_cycles": 1,
+                "eligibility": eligibility,
+                "timestamp": "2026-05-16T00:00:00+00:00",
+            })
+
+        conn = sqlite3.connect(str(tmp_path / "test_skip_log.db"))
+        rows = conn.execute(
+            "SELECT eligibility FROM dispatch_skip_log ORDER BY eligibility"
+        ).fetchall()
+        conn.close()
+
+        stored = {r[0] for r in rows}
+        assert stored == {"throttle", "pause", "escalate"}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What problem this solves

`dispatch_eligibility_skip` events are non-decisions — written every steward cycle for every ineligible UoW — and they constituted ~88% of `audit_log` volume. Real forensic events (state transitions, oracle decisions, escalations) were buried in noise, making post-incident diagnosis slow and unreliable.

## What changed

Skip events now route to a new `dispatch_skip_log` table instead of `audit_log`. The audit log retains only actions and transitions; the skip log holds the high-volume non-decision records.

**Routing flow change:**

```
Before:
  steward dispatch gate skip → registry.append_audit_log(uow_id, {"event": "dispatch_eligibility_skip", ...})
                                                                    ↓
                                                              audit_log (88% noise)

After:
  steward dispatch gate skip → registry.write_dispatch_skip(uow_id, {...})
                                                                    ↓
                                                        dispatch_skip_log (isolated)
  write_gate_fired() calls immediately after: unchanged
```

**Files changed:**

- `src/orchestration/migrations/0024_dispatch_eligibility_skip_table.sql` — new migration, `CREATE TABLE dispatch_skip_log`
- `src/orchestration/schema.sql` — table definition added after `audit_log`
- `src/orchestration/registry.py` — `write_dispatch_skip()` method added immediately after `append_audit_log()`, same atomic `BEGIN IMMEDIATE` pattern, stores `eligibility` as a first-class column
- `src/orchestration/steward.py` — two call sites updated: throttle burst exceeded branch (line ~5411) and non-dispatch non-throttle patterns branch (line ~5432); `write_gate_fired()` calls left untouched in both
- `tests/unit/test_orchestration/test_steward_dispatch_eligibility.py` — `TestDispatchSkipRoutedToSeparateTable` class (4 tests) verifying that `audit_log` receives no `dispatch_eligibility_skip` entries and `dispatch_skip_log` receives them with correct `eligibility` values

**Functional patterns:** pure write function (`write_dispatch_skip`), explicit error boundary with rollback, immutable entry dict passed through without mutation.

**Out of scope:** no changes to `audit_queries.py`, no removal of `write_gate_fired` calls, no changes to how queries read `audit_log`.

## Tests run

- [x] `uv run -m pytest tests/unit/test_orchestration/test_steward_dispatch_eligibility.py -v` — 50 passed, 0 failed (46 pre-existing + 4 new)
- [x] `uv run -m pytest tests/unit/test_orchestration/ --ignore=tests/unit/test_orchestration/test_registry_cli.py --ignore=tests/unit/test_orchestration/test_executor_subprocess.py` — 424 passed, 0 failed (excluding 2 pre-existing broken files: `test_registry_cli.py` has a SyntaxError from a prior commit; `test_executor_subprocess.py` has 4 pre-existing failures confirmed on `main`)
- [x] Migration 0024 applied to live `wos.db`; confirmed `dispatch_skip_log` present in table list

## Manual test

Migration was applied to the live `~/lobster-workspace/data/wos.db` and table presence confirmed:

```python
tables = [r[0] for r in db.execute("SELECT name FROM sqlite_master WHERE type='table'")]
# dispatch_skip_log present: True
```

This change is entirely internal — it reroutes write traffic between two DB tables. No Telegram/UI output is produced by this change. N/A for user-visible outcome verification.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Migration applied to live DB and confirmed
- [x] User-visible outcome: not applicable — internal write routing change only
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume; this change reduces audit_log write volume by ~88%
- [x] External service calls: none

WOS-UoW: uow_20260509_116aa7