### PR TITLE
fix: sweep throughput pre-check wrong label + add deliberate-pause guard

### DIFF
--- a/memory/canonical-templates/sweep-context.md
+++ b/memory/canonical-templates/sweep-context.md
@@ -69,7 +69,14 @@ Naming a pattern without stating its effect on your analysis is not a citation �
 
 Before reading any domain-specific content, check the WOS throughput steady-state pattern. Given that a throughput stall is a high-signal system-health indicator, it must surface at the top of every sweep, not buried in the pattern-match section.
 
-1. Count open WOS UoWs: `gh issue list --repo dcetlin/Lobster --state open --label "wos-uow" --json number,title,updatedAt --limit 100`
+**Deliberate-pause check (run first):** Read `~/lobster-workspace/data/wos-config.json`. If `execution_enabled` is `false`, WOS has been deliberately paused. In this case:
+- Skip throughput stall classification — low throughput is expected and correct.
+- Record at the top of the Detection Pass: "WOS deliberately paused (execution_enabled=false in wos-config.json) — throughput checks skipped. This is not a stall."
+- Proceed to domain-specific detection without flagging starvation.
+
+If `execution_enabled` is `true` (or wos-config.json is absent), proceed with the throughput checks below:
+
+1. Count open WOS UoWs: `gh issue list --repo dcetlin/Lobster --state open --label "wos:executing" --json number,title,updatedAt --limit 100`
 2. For each open UoW, check the `updatedAt` field. If no UoW has been updated in the past 3 days, flag as a potential stall.
 3. Check the executor heartbeat log for recent dispatch events: `tail -50 ~/lobster-workspace/scheduled-jobs/logs/executor-heartbeat.log` (or the most recent executor-heartbeat log file).
 4. If throughput appears stalled (no UoW updates in >3 days, or no dispatch events in executor log within 3 days), record a **WOS throughput stall** finding immediately — at the top of the Detection Pass section in your sweep output, before any domain-specific findings.


### PR DESCRIPTION
## Summary

Two bugs in the WOS Throughput Pre-Check (Step 1b) of `memory/canonical-templates/sweep-context.md`, both instances of the same-appearance/opposite-structure problem identified in the 2026-05-17 weekly retro.

**Bug 1 — Wrong label (Register 1):**
- Line 72 used `--label "wos-uow"` which does not exist in this repo
- The actual label is `wos:executing`
- Every sweep since this instruction was written silently returned `[]` for open UoW count — a false zero producing confident but wrong throughput narratives
- This is the direct fix for #1184

**Bug 2 — No deliberate-pause awareness (Register 2):**
- When WOS is deliberately paused (`execution_enabled=false` in `wos-config.json`), the sweep had no way to distinguish low throughput from a real stall — same appearance, opposite structure
- Fix: Step 1b now reads `wos-config.json` first. If `execution_enabled=false`, throughput checks are skipped and the sweep output is annotated: "WOS deliberately paused — not a stall."
- This closes the self-detection gap described in the weekly retro

## What changed

In `memory/canonical-templates/sweep-context.md` Step 1b:
- Added deliberate-pause guard block at the top (reads wos-config.json, skips stall checks if execution_enabled=false)
- Changed `--label "wos-uow"` to `--label "wos:executing"` in the count query

## Test plan

- [ ] Verify `gh issue list --repo dcetlin/Lobster --state open --label "wos:executing"` returns non-empty results
- [ ] Confirm `wos-config.json` `execution_enabled=false` path produces "deliberately paused" annotation in next sweep run
- [ ] Run negentropic sweep and confirm throughput pre-check no longer produces false-zero stall diagnosis when WOS is paused

Closes #1184