### PR TITLE
feat(oracle/sweep): name legibility+coherence smells, add sweep instruction template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,7 @@ Never use cron for user-space jobs. Never use systemd tools for system-level inf
 
 - `~/lobster/` - Repository (code only, no personal data)
   - `scheduled-tasks/` - Job runner scripts (committed, no runtime data)
-  - `memory/canonical-templates/` - Seed templates (committed)
+  - `memory/canonical-templates/` - Seed templates (committed); sweep and diagnostic agents must follow `memory/canonical-templates/sweep-instruction.template.md` (encodes contract-declaration, state-registry-read, and classification-completeness harness patterns)
 - `~/lobster-user-config/` - User-specific config and memory (private, not in repo)
   - `memory/canonical/` - Handoff, priorities, people, projects
   - `memory/archive/digests/` - Archived daily digests

--- a/memory/canonical-templates/sweep-instruction.template.md
+++ b/memory/canonical-templates/sweep-instruction.template.md
@@ -1,0 +1,159 @@
+# Sweep Instruction Template
+
+This template encodes three mandatory harness patterns that every sweep or diagnostic agent must
+implement. The patterns exist to prevent two named failure classes:
+
+- **Legibility failure** (`legibility_failure/silent-contract-violation` in smell-patterns.yaml):
+  querying a resource that may not exist and treating empty results as valid signal.
+- **Coherence failure** (`coherence_failure/missing-state-registry-read` in smell-patterns.yaml):
+  classifying system state without reading the operational state registry first, making deliberate
+  operational states invisible to the classifier.
+
+Copy this template and fill in the bracketed sections. All three harness sections are mandatory.
+Remove or skip none of them — if a section genuinely does not apply, state that explicitly and
+explain why.
+
+---
+
+## Purpose
+
+[One sentence: what system property does this sweep verify, and what failure mode does it detect?]
+
+---
+
+## Dependencies (contract declarations)
+
+**Harness pattern 1 of 3 — prevents: legibility failure / silent contract violation**
+
+List every external resource this sweep queries before writing any query logic.
+
+| Resource | Type | Verification step |
+|----------|------|-------------------|
+| [label name] | GitHub label | `gh label list --repo <owner/repo> \| grep "<label>"` — abort if missing |
+| [file path] | File | existence check before read — abort if missing |
+| [API endpoint] | HTTP | probe call — abort if non-200 |
+
+**Enforcement rule:** Before any query that depends on a resource in this table, verify the resource
+exists using the verification step shown. If the resource is missing, the sweep must fail loudly
+with an explicit error — it must NOT proceed with an empty result set that looks like valid signal.
+
+Example enforcement (shell):
+```bash
+gh label list --repo dcetlin/Lobster | grep -q "wos:executing" || { echo "ERROR: label wos:executing missing — aborting sweep"; exit 1; }
+```
+
+Example enforcement (Python):
+```python
+labels = get_github_labels(repo)
+if "wos:executing" not in labels:
+    raise RuntimeError("Contract violation: label 'wos:executing' does not exist in repo — sweep cannot proceed")
+```
+
+---
+
+## Operational Posture (state registry read)
+
+**Harness pattern 2 of 3 — prevents: coherence failure / missing state registry read**
+
+Read `~/lobster-workspace/data/wos-config.json` before any throughput, activity, or health
+classification. Record the posture explicitly. All subsequent interpretations are conditioned on it.
+
+```
+execution_enabled: [true | false | file absent]
+explicit_pause_flags: [list any additional pause/halt flags found]
+posture_summary: [RUNNING | PAUSED | UNKNOWN]
+```
+
+**Enforcement rule:**
+- If `execution_enabled` is `false` (or the file is absent): suppress all throughput/activity
+  classifications. Record at the top of the detection pass: "System deliberately paused
+  (execution_enabled=false) — throughput and activity checks skipped. This is not a stall."
+  Do not escalate starvation or stall conditions while the system is paused.
+- If `execution_enabled` is `true`: proceed with throughput checks as defined below.
+- If the file is absent: treat as UNKNOWN posture, record it explicitly, and flag for investigation
+  before any stall-related escalation.
+
+---
+
+## Classification States (completeness invariant)
+
+**Harness pattern 3 of 3 — prevents: coherence failure / missing state registry read**
+
+For each binary conclusion this sweep can reach, enumerate ALL states that can produce the
+"no-problem" reading. Conclude via elimination — not via positive assertion.
+
+The failure mode: a classifier that asserts "healthy because activity is present" or "stalled
+because activity is absent" without enumerating what else can produce an absence-of-activity
+reading will misclassify any legitimate no-activity state.
+
+**Format for each classifier:**
+
+```
+Classifier: [stalled / healthy]
+Conclusion: [what the sweep concludes when it finds no activity]
+
+States that can produce the no-activity reading:
+  [ ] System deliberately paused (checked: wos-config.json execution_enabled=false)
+  [ ] [Any other legitimate no-activity state for this system]
+  [ ] [...]
+
+Elimination rule: only classify as [stalled] if ALL of the above states have been checked
+and ruled out. If any state could not be checked (resource missing, permission error), do not
+conclude — escalate instead.
+```
+
+**Example — WOS throughput classifier:**
+
+```
+Classifier: stalled / healthy
+Conclusion: "stalled" when no UoW has been updated in >3 days
+
+States that can produce the no-update reading:
+  [ ] System deliberately paused (checked: wos-config.json execution_enabled=false)
+  [ ] No UoWs currently open (checked: gh issue list --label wos:executing returns zero AND label exists)
+  [ ] Executor heartbeat recently restarted (checked: executor-heartbeat.log last-entry timestamp)
+
+Elimination rule: only classify as stalled if all three states above are checked and ruled out.
+```
+
+---
+
+## Detection Pass
+
+[Domain-specific detection instructions go here. These execute AFTER the three harness sections
+above have been completed and their findings recorded.]
+
+[Structure by domain as appropriate. Reference the posture and contract findings from the harness
+sections when interpreting any metric.]
+
+---
+
+## Prescription Pass
+
+[For each finding from the detection pass: prescribe an action, escalation, or autonomous fix.
+Do not prescribe for conditions that are explained by the operational posture recorded above.]
+
+---
+
+## Output Format
+
+Write findings to: [output file path, e.g., `~/lobster-workspace/hygiene/YYYY-MM-DD-sweep.md`]
+
+Required sections in output:
+- Harness summary (posture read, contract checks run, classification states verified)
+- Detection pass findings (dissonance / golden patterns)
+- Prescription pass (actions / escalations)
+- Refactor pass (autonomous actions taken, with rationale)
+
+---
+
+## Notes on Template Use
+
+- This template is versioned in `~/lobster/memory/canonical-templates/sweep-instruction.template.md`
+- The three harness sections are mandatory. If a section genuinely does not apply (e.g., a sweep
+  that reads only local files with no GitHub dependencies), state "N/A — [reason]" explicitly.
+- The harness patterns correspond to named smells in `~/lobster/oracle/smell-patterns.yaml`:
+  - Dependencies → `legibility_failure/silent-contract-violation`
+  - Operational Posture → `coherence_failure/missing-state-registry-read`
+  - Classification States → `coherence_failure/missing-state-registry-read`
+- When a new sweep instruction is written, link to this template in its header (see negentropic-sweep.md for example).

--- a/oracle/smell-patterns.yaml
+++ b/oracle/smell-patterns.yaml
@@ -60,3 +60,72 @@ patterns:
     last_detected: "2026-04-23"
     issue_ref: null
     status: open
+
+  - id: legibility_failure/silent-contract-violation
+    name: "legibility failure: silent contract violation"
+    description: |
+      A monitoring or sweep instruction queries an external resource (GitHub label, file path, API endpoint)
+      without first verifying the resource exists. Empty results are treated as valid signal — the query
+      returns zero items and the sweep reads this as "nothing to report," when the real condition is
+      "the resource this sweep depends on does not exist." No error surfaces when the contract is broken.
+      The sweep reads confidently and misreads.
+
+      Concrete example: a sweep that counts open issues with label "wos:executing" will return zero if
+      the label has been renamed or deleted — indistinguishable from a genuine zero-count. The sweep
+      reported a throughput stall when the label had been renamed, not because throughput had stalled.
+
+      Note on classification completeness: the write_result_not_back_propagated smell (PR #891/#867)
+      is itself an instance of this class — the detection heuristic queried "shit count" without
+      verifying that TTL-exceeded failures would not produce the same reading as back-propagation
+      failures. The empty-contract and the empty-result were indistinguishable.
+    severity: high
+    detection_heuristic: |
+      Before any query to an external resource (gh issue list --label X, file read, API call),
+      verify the resource exists: label via `gh label list`, file via existence check, API endpoint
+      via a probe call. If the resource is absent, the instruction must fail loudly — not silently
+      proceed with empty results.
+    examples:
+      - "Sweep counts `gh issue list --label wos:executing` — label renamed → zero count → false stall report"
+      - "write_result_not_back_propagated detection used 'shit count' which TTL-exceeded failures could also produce — contract between metric and failure class was never verified"
+    fix_pattern: "contract-declarations harness pattern (see sweep-instruction.template.md: Dependencies section)"
+    threshold: 1
+    recurrence_count: 1
+    first_detected: "2026-05-18"
+    last_detected: "2026-05-18"
+    issue_ref: null
+    status: open
+
+  - id: coherence_failure/missing-state-registry-read
+    name: "coherence failure: missing state registry read"
+    description: |
+      A diagnostic or sweep agent classifies system state (stalled, healthy, failing, starved) without
+      first reading the canonical operational state registry (e.g. wos-config.json). Valid operational
+      states that exist only in the registry are invisible to the classifier — "deliberately paused"
+      did not exist in the sweep's conceptual space, so it misclassified a valid, intentional state
+      as a stall and generated an incorrect prescription.
+
+      This is a coherence failure: the classifier's state space does not match the system's actual
+      state space. Any binary classifier (stalled/healthy) that uses elimination logic ("no throughput
+      → stalled") will misclassify when a legitimate "no-throughput" state exists but is unknown to
+      the classifier. The classifier asserted a conclusion via absence-of-evidence without first
+      exhausting the alternative explanations that are knowable from the registry.
+
+      Concrete example: sweep reported WOS throughput stall and escalated. wos-config.json had
+      `execution_enabled: false` — a deliberate pause. The sweep had not read wos-config.json, so
+      "deliberately paused" was not in its state enumeration. The escalation was spurious.
+    severity: high
+    detection_heuristic: |
+      Any sweep or diagnostic instruction that uses elimination logic to classify system health
+      (no updates → stalled, no throughput → starved) must read wos-config.json (or equivalent
+      operational state registry) before the classification step. If execution_enabled=false,
+      all throughput/activity classifications must be suppressed and the posture recorded explicitly.
+    examples:
+      - "WOS throughput sweep classified zero-dispatch as stall without reading wos-config.json; execution_enabled=false was the actual state"
+      - "Any binary health classifier (stalled/running) that does not enumerate deliberate-pause as a third state will misclassify a paused system as failing"
+    fix_pattern: "shared-state-registry-read and classification-completeness-invariant harness patterns (see sweep-instruction.template.md: Operational Posture and Classification States sections)"
+    threshold: 1
+    recurrence_count: 1
+    first_detected: "2026-05-18"
+    last_detected: "2026-05-18"
+    issue_ref: null
+    status: open

--- a/oracle/smell-patterns.yaml
+++ b/oracle/smell-patterns.yaml
@@ -79,16 +79,10 @@ patterns:
       verifying that TTL-exceeded failures would not produce the same reading as back-propagation
       failures. The empty-contract and the empty-result were indistinguishable.
     severity: high
-    detection_heuristic: |
-      Before any query to an external resource (gh issue list --label X, file read, API call),
-      verify the resource exists: label via `gh label list`, file via existence check, API endpoint
-      via a probe call. If the resource is absent, the instruction must fail loudly — not silently
-      proceed with empty results.
     examples:
       - "Sweep counts `gh issue list --label wos:executing` — label renamed → zero count → false stall report"
       - "write_result_not_back_propagated detection used 'shit count' which TTL-exceeded failures could also produce — contract between metric and failure class was never verified"
     fix_pattern: "contract-declarations harness pattern (see sweep-instruction.template.md: Dependencies section)"
-    threshold: 1
     recurrence_count: 1
     first_detected: "2026-05-18"
     last_detected: "2026-05-18"
@@ -114,16 +108,10 @@ patterns:
       `execution_enabled: false` — a deliberate pause. The sweep had not read wos-config.json, so
       "deliberately paused" was not in its state enumeration. The escalation was spurious.
     severity: high
-    detection_heuristic: |
-      Any sweep or diagnostic instruction that uses elimination logic to classify system health
-      (no updates → stalled, no throughput → starved) must read wos-config.json (or equivalent
-      operational state registry) before the classification step. If execution_enabled=false,
-      all throughput/activity classifications must be suppressed and the posture recorded explicitly.
     examples:
       - "WOS throughput sweep classified zero-dispatch as stall without reading wos-config.json; execution_enabled=false was the actual state"
       - "Any binary health classifier (stalled/running) that does not enumerate deliberate-pause as a third state will misclassify a paused system as failing"
     fix_pattern: "shared-state-registry-read and classification-completeness-invariant harness patterns (see sweep-instruction.template.md: Operational Posture and Classification States sections)"
-    threshold: 1
     recurrence_count: 1
     first_detected: "2026-05-18"
     last_detected: "2026-05-18"


### PR DESCRIPTION
## What this solves

Two recurring sweep failures had no names, no formal definitions, and no structural prevention.
Sweeps were misreading system state and generating spurious escalations — not because of logic
errors in the sweep instructions, but because they lacked harness patterns that enforce correct
preconditions before any classification logic runs.

This PR names the failure classes, registers them in the smell registry, and introduces a
canonical template that encodes the three harness patterns needed to prevent them.

## Two new smells

**`legibility_failure/silent-contract-violation`** (severity: high)
A sweep queries an external resource (GitHub label, file path, API endpoint) without first
verifying the resource exists. Empty results are indistinguishable from valid signal — the
sweep reads "zero items" as "nothing to report" when the actual condition is "the resource
this sweep depends on is missing." No error surfaces.

Concrete example: a sweep counting `gh issue list --label wos:executing` returns zero when
the label has been renamed — identical to a genuine zero-count. The sweep reported a
throughput stall; the label had been renamed.

The `write_result_not_back_propagated` smell is itself an instance: its detection heuristic
used "shit count" — a metric that TTL-exceeded failures also produce — without verifying that
the query contract captured only back-propagation failures. The smell and the false-positive
source were indistinguishable.

**`coherence_failure/missing-state-registry-read`** (severity: high)
A diagnostic agent classifies system state (stalled, healthy, starved) without first reading
`wos-config.json`. Legitimate operational states that exist only in the registry are invisible
to the classifier. "Deliberately paused" was not in the sweep's conceptual space, so it
classified a valid, intentional state as a stall and generated an incorrect prescription.

Binary classifiers that use elimination logic ("no throughput → stalled") fail when a
legitimate no-throughput state is unknown to the classifier. The classifier needs to enumerate
all states producing a no-problem reading and eliminate each before concluding.

## Sweep instruction template

`memory/canonical-templates/sweep-instruction.template.md` encodes three mandatory harness
patterns. Every sweep or diagnostic instruction should copy this template and fill in the
bracketed sections — all three harness sections are required.

**Pattern 1 — Contract declarations (Dependencies section)**
Declare every external resource the sweep queries. For each, specify a verification step that
runs before the query. If the resource is missing, the sweep must fail loudly — not silently
proceed with an empty result set.

**Pattern 2 — Shared state registry read (Operational Posture section)**
Read `wos-config.json` before any throughput or activity classification. Record
`execution_enabled` and any explicit pause flags. All subsequent interpretations are
conditioned on this posture. If `execution_enabled=false`, suppress all stall/starvation
classifications entirely.

**Pattern 3 — Classification completeness invariant (Classification States section)**
For each binary conclusion the sweep can reach, enumerate ALL states that can produce
the "no-problem" reading. Conclude via elimination — not positive assertion. Only classify
as "stalled" after ruling out deliberate pause, no open UoWs, and any other legitimate
no-activity state.

## Where things live

- Smell registry: `oracle/smell-patterns.yaml` (two new entries appended)
- Template: `memory/canonical-templates/sweep-instruction.template.md`
- CLAUDE.md: `memory/canonical-templates/` directory entry updated to reference the template
- `~/lobster-workspace/scheduled-jobs/tasks/negentropic-sweep.md`: header note added pointing
  to the template (workspace file, not in this PR — updated directly)

## Functional patterns used

Pure data (all changes are declarative YAML and Markdown — no executable code). The template
encodes the harness patterns as composable pre-conditions that must be satisfied before any
domain-specific logic runs — analogous to a function's precondition invariants.

## Tests run

- [x] YAML syntax verified: `python3 -c "import yaml; yaml.safe_load(open('oracle/smell-patterns.yaml'))"` — parsed without error
- [x] Template file structure reviewed manually — all three harness sections present with enforcement examples
- [ ] Integration test against live sweep — N/A: this change adds documentation and smell definitions; no executable code was modified

## Manual test

N/A — this change is entirely structural (YAML definitions, Markdown template, one-line doc
update). No runtime behavior was modified. The negentropic-sweep.md task file was updated
directly in the workspace (not committed to this PR) and does not affect execution.