### PR TITLE
feat(bisque): /wos/uow/<uow_id> dynamic detail page

### DIFF
--- a/src/bisque/relay_server.py
+++ b/src/bisque/relay_server.py
@@ -27,7 +27,9 @@ import logging
 import logging.handlers
 import mimetypes
 import os
+import re
 import signal
+import sys
 import tempfile
 import time
 import uuid
@@ -727,6 +729,79 @@ class BisqueRelayServer:
             },
         )
 
+    # --- HTTP handler: GET /wos/uow/{uow_id} (WOS UoW detail page) ---
+
+    async def _http_wos_uow_detail(self, request: web.Request) -> web.Response:
+        """Serve a live per-UoW detail page queried from the WOS registry DB.
+
+        No auth required — the page contains observability data, not user data.
+        Returns 404 if the UoW is not found, 500 on DB error.
+
+        URL pattern: /wos/uow/{uow_id}
+        Example:     /wos/uow/uow_20260517_4827ef
+        """
+        uow_id = request.match_info.get("uow_id", "")
+        # Basic validation: UoW IDs follow the pattern uow_YYYYMMDD_XXXXXX
+        if not uow_id or not re.fullmatch(r"uow_\d{8}_[0-9a-f]+", uow_id):
+            return web.Response(
+                status=400,
+                text="Invalid UoW ID format. Expected: uow_YYYYMMDD_XXXXXX",
+                content_type="text/plain",
+            )
+
+        try:
+            _install = Path(os.environ.get("LOBSTER_INSTALL_DIR", str(Path.home() / "lobster")))
+            _src = _install / "src"
+            if str(_src) not in sys.path:
+                sys.path.insert(0, str(_src))
+            from orchestration import wos_uow_detail_gen  # type: ignore[import]
+
+            db_path = wos_uow_detail_gen._registry_path()
+            ledger_path = wos_uow_detail_gen._ledger_path()
+
+            conn = wos_uow_detail_gen._connect(db_path)
+            try:
+                uow_data = wos_uow_detail_gen._fetch_uow_data(conn, uow_id)
+                if uow_data is None:
+                    return web.Response(
+                        status=404,
+                        text=f"UoW {uow_id!r} not found in registry",
+                        content_type="text/plain",
+                    )
+                audit_trail = wos_uow_detail_gen._fetch_audit_trail(conn, uow_id)
+                traces = wos_uow_detail_gen._fetch_corrective_traces(conn, uow_id)
+                heartbeats = wos_uow_detail_gen._fetch_heartbeat_log(conn, uow_id)
+            finally:
+                conn.close()
+
+            ledger_entries = wos_uow_detail_gen._read_ledger(ledger_path)
+            token_data = wos_uow_detail_gen._fetch_token_data(ledger_entries, uow_id)
+
+            html = wos_uow_detail_gen.generate_html(
+                uow_data, audit_trail, traces, heartbeats, token_data
+            )
+
+            # Patch the back-link to point at the WOS dashboard stable URL
+            html = html.replace(
+                '<a class="back" href="javascript:history.back()">← Back</a>',
+                '<a class="back" href="/files/wos-dashboard-active.html">← WOS Dashboard</a>',
+            )
+
+            return web.Response(
+                body=html.encode("utf-8"),
+                content_type="text/html",
+                charset="utf-8",
+                headers={"Access-Control-Allow-Origin": "*"},
+            )
+
+        except Exception as exc:
+            log.error("Error rendering WOS UoW detail for %s: %s", uow_id, exc)
+            return web.Response(
+                status=500,
+                text=f"Internal error: {exc}",
+                content_type="text/plain",
+            )
+
     # --- WebSocket handler ---
 
     async def _ws_handler(self, request: web.Request) -> web.WebSocketResponse:
@@ -1339,6 +1414,9 @@ class BisqueRelayServer:
         app.router.add_post("/bisque-relay/upload", self._http_upload)
         app.router.add_route("OPTIONS", "/bisque-relay/upload", self._http_upload_options)
         app.router.add_get("/bisque-relay/files/{filename}", self._http_serve_file)
+        # WOS UoW detail page — dynamic, live-queried from registry DB
+        app.router.add_get("/wos/uow/{uow_id}", self._http_wos_uow_detail)
+        app.router.add_get("/bisque-relay/wos/uow/{uow_id}", self._http_wos_uow_detail)
         app.router.add_get("/", self._ws_handler)
         # Catch-all for WS connections on any path
         app.router.add_get("/{path:.*}", self._ws_handler)

--- a/src/orchestration/wos_dashboard.py
+++ b/src/orchestration/wos_dashboard.py
@@ -638,13 +638,8 @@ def _uow_id_cell(uow_id: str, drilldown_urls: dict[str, str]) -> str:
     """Return an HTML table cell for a UoW ID linked to its detail page.
 
     Always links to the stable /wos/uow/<uow_id> route served by the Bisque relay.
-    Falls back to a legacy drilldown_urls URL if present (e.g. pre-generated static pages).
     """
-    # Prefer the stable dynamic route; fall back to pre-generated static URL if provided.
     url = f"/wos/uow/{uow_id}"
-    legacy_url = drilldown_urls.get(uow_id)
-    if legacy_url and not url:
-        url = legacy_url
     return f'<td class="uid"><a href="{url}" target="_blank">{uow_id} &#x2197;</a></td>'
 
 

--- a/src/orchestration/wos_dashboard.py
+++ b/src/orchestration/wos_dashboard.py
@@ -635,11 +635,17 @@ def render_text(data: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 def _uow_id_cell(uow_id: str, drilldown_urls: dict[str, str]) -> str:
-    """Return an HTML table cell for a UoW ID, optionally linked to its drilldown page."""
-    url = drilldown_urls.get(uow_id)
-    if url:
-        return f'<td class="uid"><a href="{url}" target="_blank">{uow_id} &#x2197;</a></td>'
-    return f'<td class="uid">{uow_id}</td>'
+    """Return an HTML table cell for a UoW ID linked to its detail page.
+
+    Always links to the stable /wos/uow/<uow_id> route served by the Bisque relay.
+    Falls back to a legacy drilldown_urls URL if present (e.g. pre-generated static pages).
+    """
+    # Prefer the stable dynamic route; fall back to pre-generated static URL if provided.
+    url = f"/wos/uow/{uow_id}"
+    legacy_url = drilldown_urls.get(uow_id)
+    if legacy_url and not url:
+        url = legacy_url
+    return f'<td class="uid"><a href="{url}" target="_blank">{uow_id} &#x2197;</a></td>'
 
 
 def _active_uow_row(u: dict, drilldown_urls: dict[str, str]) -> str:

--- a/tests/unit/test_orchestration/test_wos_dashboard.py
+++ b/tests/unit/test_orchestration/test_wos_dashboard.py
@@ -615,20 +615,19 @@ class TestRenderHtml:
         assert "uow_20260101_abc" in html
 
     def test_drilldown_link_rendered_when_url_provided(self):
-        """UoW ID cell becomes a link when a drilldown URL is available."""
+        """UoW ID cell always links to the stable /wos/uow/<uow_id> route."""
         from src.orchestration.wos_dashboard import render_html
         urls = {"uow_20260101_abc": "http://test:9101/files/abc.html"}
         html = render_html(self._base_data(), drilldown_urls=urls)
-        assert 'href="http://test:9101/files/abc.html"' in html
+        assert 'href="/wos/uow/uow_20260101_abc"' in html
         assert "uow_20260101_abc" in html
 
-    def test_no_link_when_no_drilldown_url(self):
-        """When drilldown_urls is empty, UoW ID appears as plain text (no href link for it)."""
+    def test_link_always_present_without_drilldown_urls(self):
+        """UoW ID cell always links to /wos/uow/<uow_id>, even when drilldown_urls is empty."""
         from src.orchestration.wos_dashboard import render_html
         html = render_html(self._base_data(), drilldown_urls={})
-        # The uow id appears but there should be no drilldown href for it
+        assert 'href="/wos/uow/uow_20260101_abc"' in html
         assert "uow_20260101_abc" in html
-        assert "http://test:9101/files/" not in html
 
     def test_dashboard_title_in_html(self):
         from src.orchestration.wos_dashboard import render_html
@@ -653,7 +652,7 @@ class TestRenderHtml:
         assert "uow_stalled" in html
 
     def test_drilldown_links_for_stalled_uow(self):
-        """Stalled UoWs also get drilldown links when URLs are available."""
+        """Stalled UoWs always link to /wos/uow/<uow_id>."""
         from src.orchestration.wos_dashboard import render_html
         data = self._base_data()
         data["stalled_uows"] = [{
@@ -663,7 +662,7 @@ class TestRenderHtml:
         }]
         urls = {"uow_stalled_x": "http://test:9101/files/stalled.html"}
         html = render_html(data, drilldown_urls=urls)
-        assert 'href="http://test:9101/files/stalled.html"' in html
+        assert 'href="/wos/uow/uow_stalled_x"' in html
 
     def test_issue_title_displayed_in_active_row(self):
         """When a UoW row has an issue_title, it appears prominently in the row HTML."""


### PR DESCRIPTION
## Summary

- Adds a live HTTP route `/wos/uow/{uow_id}` to the Bisque relay server that queries the WOS registry DB on each request and renders the full UoW detail page (reusing `wos_uow_detail_gen` functions)
- Updates `wos_dashboard._uow_id_cell` to always link UoW IDs to the stable `/wos/uow/<uow_id>` route — no pre-generation step required
- The back-link on detail pages points to `/files/wos-dashboard-active.html` (the stable dashboard URL)

**URL pattern:** `http://5.78.201.64:9101/wos/uow/{uow_id}`
**Example:** http://5.78.201.64:9101/wos/uow/uow_20260517_4827ef (live)

## Why

Previously, UoW detail pages required running `wos_dashboard.py --with-drilldowns` to pre-generate static HTML files at random UUID paths. The new route makes every UoW detail page linkable with a stable, predictable URL that always reflects current DB state.

## Test plan

- [x] `curl http://5.78.201.64:9101/wos/uow/uow_20260517_4827ef` returns HTTP 200 with valid HTML
- [x] Invalid UoW format returns HTTP 400
- [x] Non-existent UoW ID with valid format returns HTTP 404
- [x] Bisque service restarted and route is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)