### PR TITLE
fix(dispatcher): dispatch session-note-appender as haiku agent to reduce cost

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -706,7 +706,7 @@ Injected by the MCP server after every 20 real user messages. Spawn session-note
    Build in_flight list: [{task_id, type, description, elapsed_minutes}, ...]
 3. Check ~/messages/processing/ — any message file present has been claimed (mark_processing called)
    but not yet answered. Build pending_responses list from those files (use sender and text fields).
-4. Spawn session-note-appender (run_in_background=True, subagent_type: "lobster-generalist"):
+4. Spawn session-note-appender (run_in_background=True, subagent_type: "session-note-appender"):
    - Pass: task_id: "session-note-appender", chat_id: 0, source: "system",
            session_file: <current_session_file>, activity: <recent activity>,
            in_flight: <in_flight list from step 2>,


### PR DESCRIPTION
## Summary

- Changes `subagent_type` for the `session_note_reminder` dispatch from `lobster-generalist` (Sonnet, 0.6x cost) to `session-note-appender` (Haiku, 0.2x cost)
- One-line change in `.claude/sys.dispatcher.bootup.md` at line 709
- `session-note-polish` dispatch (line 287) is intentionally untouched per scope

## Test plan
- [ ] Verify `.claude/sys.dispatcher.bootup.md` line 709 references `subagent_type: "session-note-appender"`
- [ ] Verify `session-note-polish` at line 287 still references `lobster-generalist` (out of scope)

WOS-UoW: uow_20260507_ecd5ca