### PR TITLE
fix: upgrade.sh skip lobster-claude restart to avoid self-termination (Issue #1107)

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -877,11 +877,15 @@ restart_services() {
     step "Restarting services"
 
     if $DRY_RUN; then
-        info "[dry-run] Would restart lobster-router and lobster-claude"
+        info "[dry-run] Would restart lobster-router (lobster-claude skipped — restarts itself)"
         return 0
     fi
 
-    local services=("lobster-router" "lobster-claude")
+    # lobster-claude is intentionally excluded from this list.
+    # Restarting it here would kill the active dispatcher session mid-upgrade,
+    # before migrations have run (step 9). The dispatcher restarts itself on the
+    # next message cycle after upgrade.sh completes. See issue #1107.
+    local services=("lobster-router")
 
     for svc in "${services[@]}"; do
         if systemctl is-enabled --quiet "$svc" 2>/dev/null; then
@@ -906,6 +910,8 @@ restart_services() {
         substep "Restarting lobster-slack-router..."
         sudo systemctl restart "lobster-slack-router" 2>/dev/null || warn "Failed to restart slack router"
     fi
+
+    info "Note: lobster-claude restart skipped — the dispatcher restarts itself on the next message cycle."
 
     log_to_file "Services restarted"
 }


### PR DESCRIPTION
## Summary

- Removes `lobster-claude` from `restart_services()` in `upgrade.sh` to prevent the upgrade script from killing the active dispatcher session before migrations run (step 9).
- Other services (`lobster-router`, `lobster-slack-router`) still restart as normal.
- Adds a clear informational message at the end of `restart_services()` so the operator knows the lobster-claude skip is intentional.

## Root cause

`restart_services()` was called at step 7, before `run_migrations()` at step 9. Including `lobster-claude` in the services list killed the active dispatcher session mid-upgrade, orphaning any in-flight work and leaving migrations unrun in the old session's context.

## Fix

```bash
# Before
local services=("lobster-router" "lobster-claude")

# After
local services=("lobster-router")  # lobster-claude excluded — see comment
```

The dispatcher restarts itself on the next message cycle after upgrade completes. No manual restart needed.

## Test plan
- [ ] Run `upgrade.sh --dry-run` and confirm the dry-run message reflects the new behavior
- [ ] Confirm lobster-router restarts normally
- [ ] Confirm active dispatcher session survives the upgrade (is not killed at step 7)
- [ ] Confirm migrations still run at step 9 within the same session

Closes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)