### PR TITLE
fix: session-note-polish flags superseded findings (Issue #1112)

### DIFF
--- a/.claude/agents/session-note-polish.md
+++ b/.claude/agents/session-note-polish.md
@@ -30,7 +30,7 @@ When summarizing recent activity, cover the last **30 minutes OR 25 messages, wh
    - Avoid: "Merged PR #N, commented on issue #M, ran tests."
    - Synthesize from ALL snapshot blocks, not just the most recent context window.
 
-   **Open Threads** — Remove in-progress noise; keep only what is genuinely unresolved. Check snapshot entries for threads that have since resolved.
+   **Open Threads** — Remove in-progress noise; keep only what is genuinely unresolved. Check snapshot entries for threads that have since resolved. When a finding references work that was completed earlier in the same session, mark it as superseded: prefix the entry with `[superseded]` and append a brief note identifying the completing action (e.g., `[superseded — closed by task-id X]`).
 
    **Open Tasks** — Consolidate into two sub-lists:
    - **Just completed** (finished in the last 30 min): task_id + one-line outcome


### PR DESCRIPTION
Adds superseded-findings instruction to session-note-polish agent: when surfacing Open Threads findings, check if the finding references work completed earlier in the session and if so, prefix with [superseded — closed by task-id X].

This prevents stale findings from appearing as active in polished session notes.