### PR TITLE
feat(wos): suppress backlog_starvation alert when wos stop is user-commanded

### DIFF
--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -58,6 +58,7 @@ if str(_REPO_ROOT) not in sys.path:
 from src.orchestration.paths import REGISTRY_DB
 from src.orchestration.steward import is_bootup_candidate_gate_active, run_steward_cycle
 from src.orchestration.github_sync import run_post_completion_sync
+from src.orchestration.dispatcher_handlers import read_wos_config
 from src.utils.jobs import is_job_enabled
 
 # ---------------------------------------------------------------------------
@@ -869,16 +870,37 @@ def check_backlog_alerts(
             _append_observation(msg)
 
     if starvation_alert:
-        msg = (
-            f"backlog_starvation: ready-for-executor queue at zero for "
-            f"{STARVATION_CONSECUTIVE_CYCLES} consecutive cycles "
-            f"(current_depth={depth}) "
-            f"— cultivator not proposing or germinator not germinating; "
-            f"throughput death, not rest"
-        )
-        log.warning("%s", msg)
-        if not dry_run:
-            _append_observation(msg)
+        # Guard: suppress the starvation alert when WOS execution is intentionally
+        # paused by the user. An empty ready-for-executor queue is expected and
+        # benign when execution_enabled=false and pause_reason="user_command".
+        # The alert is still emitted when execution_enabled=false but pause_reason
+        # is absent or not "user_command" — an infrastructure-triggered disable
+        # is not safe to suppress.
+        try:
+            _starvation_wos_config = read_wos_config()
+        except Exception:
+            _starvation_wos_config = {}
+
+        if (
+            not _starvation_wos_config.get("execution_enabled", True)
+            and _starvation_wos_config.get("pause_reason") == "user_command"
+        ):
+            log.info(
+                "backlog_starvation suppressed: wos execution intentionally paused "
+                "(execution_enabled=false, pause_reason=user_command) — "
+                "empty queue is expected"
+            )
+        else:
+            msg = (
+                f"backlog_starvation: ready-for-executor queue at zero for "
+                f"{STARVATION_CONSECUTIVE_CYCLES} consecutive cycles "
+                f"(current_depth={depth}) "
+                f"— cultivator not proposing or germinator not germinating; "
+                f"throughput death, not rest"
+            )
+            log.warning("%s", msg)
+            if not dry_run:
+                _append_observation(msg)
 
     log.debug(
         "Backlog alert check: depth=%d toxicity=%s starvation=%s history=%s",
@@ -1025,7 +1047,7 @@ def main() -> int:
     # run because they are cheap and ensure state consistency even when WOS is
     # paused. Phase 3 (LLM prescription) and Phase 4 (GitHub sync) are skipped
     # when execution_enabled=false to prevent LLM cost drain.
-    from src.orchestration.dispatcher_handlers import is_execution_enabled
+    from src.orchestration.dispatcher_handlers import is_execution_enabled  # noqa: PLC0415
 
     # Alert condition 2: queue depth when execution is disabled (#618).
     # Check before skipping Phase 3 so the alert fires even when WOS is paused.

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -58,7 +58,7 @@ if str(_REPO_ROOT) not in sys.path:
 from src.orchestration.paths import REGISTRY_DB
 from src.orchestration.steward import is_bootup_candidate_gate_active, run_steward_cycle
 from src.orchestration.github_sync import run_post_completion_sync
-from src.orchestration.dispatcher_handlers import read_wos_config
+from src.orchestration.dispatcher_handlers import read_wos_config, _PAUSE_REASON_USER_COMMAND
 from src.utils.jobs import is_job_enabled
 
 # ---------------------------------------------------------------------------
@@ -883,7 +883,7 @@ def check_backlog_alerts(
 
         if (
             not _starvation_wos_config.get("execution_enabled", True)
-            and _starvation_wos_config.get("pause_reason") == "user_command"
+            and _starvation_wos_config.get("pause_reason") == _PAUSE_REASON_USER_COMMAND
         ):
             log.info(
                 "backlog_starvation suppressed: wos execution intentionally paused "

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -178,7 +178,7 @@ def get_disabled_wos_core_jobs() -> list[str]:
     )
 
 
-def toggle_wos_core_jobs(enabled: bool) -> dict:
+def toggle_wos_core_jobs(enabled: bool, pause_reason: str | None = None) -> dict:
     """Enable or disable all WOS-core jobs atomically.
 
     Reads jobs.json, sets the `enabled` field on every job where
@@ -188,6 +188,16 @@ def toggle_wos_core_jobs(enabled: bool) -> dict:
 
     Jobs listed in _WOS_CORE_JOBS but absent from jobs.json are silently
     skipped and reported in the `not_found` list of the return value.
+
+    Args:
+        enabled: True to enable WOS execution; False to disable.
+        pause_reason: Optional reason string written to wos-config.json when
+            disabling (``enabled=False``). Pass ``"user_command"`` when the
+            pause was explicitly requested by the user (via ``/wos stop``).
+            When ``enabled=True``, ``pause_reason`` is removed from the config
+            regardless of this argument. When ``enabled=False`` and
+            ``pause_reason`` is None, the field is left unchanged if already
+            present (preserves any prior reason written by an earlier call).
 
     Returns a summary dict:
         {
@@ -223,7 +233,16 @@ def toggle_wos_core_jobs(enabled: bool) -> dict:
     # (handle_wos_start / handle_wos_stop) catches OSError and reports it.
     _write_jobs_json({**jobs_data, "jobs": updated_jobs})
     config = read_wos_config()
-    _write_wos_config({**config, "execution_enabled": enabled})
+    new_config = {**config, "execution_enabled": enabled}
+    if enabled:
+        # Starting: clear pause_reason so monitoring knows execution is intentionally on.
+        new_config.pop("pause_reason", None)
+    elif pause_reason is not None:
+        # Stopping with an explicit reason: record it so monitors can suppress
+        # starvation alerts when the pause is intentional (user_command).
+        new_config["pause_reason"] = pause_reason
+    # else: stopping without a reason — leave any existing pause_reason unchanged.
+    _write_wos_config(new_config)
 
     return {
         "toggled": toggled,
@@ -748,7 +767,7 @@ def handle_wos_stop(*, registry: "Registry | None" = None) -> str:
         )
 
     try:
-        result = toggle_wos_core_jobs(enabled=False)
+        result = toggle_wos_core_jobs(enabled=False, pause_reason="user_command")
     except OSError as exc:
         return (
             f"Failed to disable WOS-core jobs: {exc}\n"

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -105,6 +105,12 @@ def _write_wos_config(config: dict) -> None:
     tmp.rename(_WOS_CONFIG_PATH)
 
 
+# Canonical pause_reason value written to wos-config.json when the operator
+# explicitly runs `wos stop`. Steward-heartbeat imports this constant to
+# identify intentional pauses and suppress false-positive starvation alerts.
+_PAUSE_REASON_USER_COMMAND: str = "user_command"
+
+
 # ---------------------------------------------------------------------------
 # WOS-core job list — canonical gate list for wos start / wos stop
 # ---------------------------------------------------------------------------
@@ -767,7 +773,7 @@ def handle_wos_stop(*, registry: "Registry | None" = None) -> str:
         )
 
     try:
-        result = toggle_wos_core_jobs(enabled=False, pause_reason="user_command")
+        result = toggle_wos_core_jobs(enabled=False, pause_reason=_PAUSE_REASON_USER_COMMAND)
     except OSError as exc:
         return (
             f"Failed to disable WOS-core jobs: {exc}\n"

--- a/tests/unit/test_orchestration/test_backlog_alerts.py
+++ b/tests/unit/test_orchestration/test_backlog_alerts.py
@@ -288,3 +288,42 @@ class TestCheckBacklogAlerts:
         msg = mock_obs.call_args[0][0]
         assert "current_depth=4" in msg
         assert "growth=+3" in msg
+
+
+# ---------------------------------------------------------------------------
+# Starvation suppression guard — pause_reason-aware behavior
+# ---------------------------------------------------------------------------
+
+class TestStarvationSuppression:
+    """Verify that the starvation alert respects the pause_reason suppression guard."""
+
+    def _run_starvation(self, wos_config: dict):
+        """Seed starvation condition and run check_backlog_alerts with a given wos_config."""
+        registry = _make_registry()
+        state = {"depths": [0, 0], "last_updated": _now_iso()}
+        registry.list.return_value = []  # current depth = 0
+
+        with patch.object(_MODULE, "_load_backlog_state", return_value=state), \
+             patch.object(_MODULE, "_save_backlog_state"), \
+             patch.object(_MODULE, "_append_observation") as mock_obs, \
+             patch.object(_MODULE, "read_wos_config", return_value=wos_config):
+            result = check_backlog_alerts(registry)
+
+        return result, mock_obs
+
+    def test_suppression_fires_when_user_commanded_pause(self) -> None:
+        """Starvation condition met + execution_enabled=False + pause_reason=user_command
+        → _append_observation NOT called; log message contains 'suppressed'."""
+        wos_config = {"execution_enabled": False, "pause_reason": "user_command"}
+        result, mock_obs = self._run_starvation(wos_config)
+        assert result.starvation_alert is True  # detection still fires
+        mock_obs.assert_not_called()  # but observation is suppressed
+
+    def test_no_suppression_when_pause_reason_absent(self) -> None:
+        """Starvation condition met + execution_enabled=False + no pause_reason
+        → _append_observation IS called (infrastructure-triggered pause, not user intent)."""
+        wos_config = {"execution_enabled": False}
+        result, mock_obs = self._run_starvation(wos_config)
+        assert result.starvation_alert is True
+        mock_obs.assert_called_once()
+        assert "backlog_starvation" in mock_obs.call_args[0][0]

--- a/tests/unit/test_orchestration/test_toggle_wos_core_jobs.py
+++ b/tests/unit/test_orchestration/test_toggle_wos_core_jobs.py
@@ -186,6 +186,45 @@ class TestToggleWosCoreJobs:
         assert written_jobs["jobs"]["executor-heartbeat"]["enabled"] is False
         assert "executor-heartbeat" not in result["toggled"]
 
+    def _run_with_pause_reason(self, enabled: bool, pause_reason: str | None,
+                               existing_wos_config: dict | None = None):
+        """Run toggle_wos_core_jobs with a given pause_reason, return the written config."""
+        jobs_data = _make_jobs_json({"executor-heartbeat": _wos_core_entry("executor-heartbeat", not enabled)})
+        wos_config = existing_wos_config or {"execution_enabled": not enabled}
+        written = {}
+
+        toggle = self._import()
+        with (
+            patch("src.orchestration.dispatcher_handlers._read_jobs_json", return_value=jobs_data),
+            patch("src.orchestration.dispatcher_handlers._write_jobs_json"),
+            patch("src.orchestration.dispatcher_handlers.read_wos_config", return_value=wos_config),
+            patch("src.orchestration.dispatcher_handlers._write_wos_config",
+                  side_effect=lambda cfg: written.update({"config": cfg})),
+        ):
+            toggle(enabled=enabled, pause_reason=pause_reason)
+
+        return written.get("config", {})
+
+    def test_disable_with_user_command_writes_pause_reason(self):
+        """toggle_wos_core_jobs(enabled=False, pause_reason='user_command') writes
+        pause_reason to wos-config.json so the starvation guard can read it."""
+        written_config = self._run_with_pause_reason(
+            enabled=False, pause_reason="user_command",
+            existing_wos_config={"execution_enabled": True},
+        )
+        assert written_config.get("pause_reason") == "user_command"
+        assert written_config["execution_enabled"] is False
+
+    def test_enable_clears_pause_reason(self):
+        """toggle_wos_core_jobs(enabled=True) removes pause_reason from wos-config.json
+        regardless of what was previously stored."""
+        written_config = self._run_with_pause_reason(
+            enabled=True, pause_reason=None,
+            existing_wos_config={"execution_enabled": False, "pause_reason": "user_command"},
+        )
+        assert "pause_reason" not in written_config
+        assert written_config["execution_enabled"] is True
+
 
 # ---------------------------------------------------------------------------
 # handle_wos_start — idempotency and delegation
@@ -338,7 +377,7 @@ class TestHandleWosStop:
         assert "paused" in result.lower()
 
     def test_stop_calls_toggle_with_enabled_false(self):
-        """Stopping WOS should call toggle_wos_core_jobs(enabled=False)."""
+        """Stopping WOS should call toggle_wos_core_jobs(enabled=False, pause_reason='user_command')."""
         handle_wos_stop = self._import()
         mock_result = {"toggled": ["executor-heartbeat", "steward-heartbeat"],
                        "not_found": [], "new_state": "disabled"}
@@ -349,7 +388,7 @@ class TestHandleWosStop:
                   return_value=mock_result) as mock_toggle,
         ):
             result = handle_wos_stop()
-        mock_toggle.assert_called_once_with(enabled=False)
+        mock_toggle.assert_called_once_with(enabled=False, pause_reason="user_command")
         assert "2" in result  # toggled count
 
     def test_stop_reports_not_found_jobs(self):


### PR DESCRIPTION
## Summary

- `toggle_wos_core_jobs` now accepts a `pause_reason` param; `handle_wos_stop` passes `"user_command"` so the reason is recorded in `wos-config.json`
- `wos start` clears `pause_reason` from the config
- `check_backlog_alerts` in `steward-heartbeat.py` guards the `backlog_starvation` warning: when `execution_enabled=false` and `pause_reason="user_command"`, emits an info-level suppression log instead of warning+observation
- Alert still fires normally for infrastructure-triggered disables (absent or non-`user_command` reason)
- Module-level import of `read_wos_config` added to steward-heartbeat; redundant local import in `main()` retained with noqa comment

## Test plan

- [ ] Run `wos stop` → confirm `wos-config.json` contains `"pause_reason": "user_command"`
- [ ] Run `wos start` → confirm `pause_reason` is absent from `wos-config.json`
- [ ] Run steward-heartbeat with `execution_enabled=false, pause_reason=user_command` and empty queue → confirm info log only, no `backlog_starvation` in observations.log
- [ ] Run steward-heartbeat with `execution_enabled=false` and no `pause_reason` → confirm `backlog_starvation` warning still fires
- [ ] Run steward-heartbeat with `execution_enabled=true` and empty queue → confirm normal starvation detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)