### PR TITLE
feat(dispatcher): add 8 inline command handlers for snag-time operation

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1103,6 +1103,115 @@ send_reply(chat_id=chat_id, text=handle_help(), source=source, message_id=messag
 
 ---
 
+## Inline Command Index (snag-reachable, no subagent)
+
+These prose commands execute directly on the main thread. Normalize before matching:
+```python
+cmd = msg["text"].strip().lstrip("/").lower()
+```
+
+**`status` / `health`** — inline system snapshot. `get_active_sessions()` is a fast MCP call allowed on the main thread.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_status
+
+active_sessions = get_active_sessions()  # inline — fast read
+text = handle_status(active_sessions)
+send_reply(chat_id=chat_id, text=text, source=source, message_id=message_id)
+```
+
+**`usage`** — inline CC quota read. Pure file read, no MCP calls needed.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_usage
+
+send_reply(chat_id=chat_id, text=handle_usage(), source=source, message_id=message_id)
+```
+
+**`usage full`** — spawns subagent for full usage report.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_usage_full
+
+send_reply(chat_id=chat_id, text=handle_usage_full(), source=source, message_id=message_id)
+Task(
+    subagent_type="lobster-generalist",
+    run_in_background=True,
+    prompt=(
+        f"---\ntask_id: usage-full-report\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+        f"Run: ~/lobster/scripts/usage-report.sh --format full\n\n"
+        f"Send output to user via send_reply, then write_result(task_id=\"usage-full-report\", sent_reply_to_user=True).\n"
+        f"If usage-report.sh does not exist, reply with the raw contents of ~/.claude/cc-budget/state.json formatted readably."
+    ),
+)
+```
+
+**`agents`** — inline active agent list. `get_active_sessions()` is a fast MCP call allowed on the main thread.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_agents
+
+active_sessions = get_active_sessions()  # inline — fast read
+text = handle_agents(active_sessions)
+send_reply(chat_id=chat_id, text=text, source=source, message_id=message_id)
+```
+
+**`inbox`** — inline queue depth. `check_inbox()` and `get_stats()` are allowed on the main thread.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_inbox
+
+msgs = check_inbox(limit=5)
+stats = get_stats()
+total_count = stats.get("inbox_count") or stats.get("total") or len(msgs or [])
+text = handle_inbox(msgs or [], total_count)
+send_reply(chat_id=chat_id, text=text, source=source, message_id=message_id)
+```
+
+**`restart mcp`** — inline ack then subagent restart. The inline half writes the ack; the subagent handles the slow systemctl call.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_restart_mcp
+
+send_reply(
+    chat_id=chat_id,
+    text=handle_restart_mcp(),
+    source=source,
+    message_id=message_id,
+)
+Task(
+    subagent_type="lobster-generalist",
+    run_in_background=True,
+    prompt=(
+        f"---\ntask_id: restart-mcp-exec\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+        f"Run: ~/lobster/scripts/restart-mcp.sh --no-wait\n\n"
+        f"Then call: write_result(task_id=\"restart-mcp-exec\", sent_reply_to_user=True)"
+    ),
+)
+```
+
+Note: `message_id` is passed to `send_reply` to atomically mark the message as processed.
+
+**`restart dispatcher`** — inline instructions. No code operation; returns a static message.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_restart_dispatcher
+
+send_reply(chat_id=chat_id, text=handle_restart_dispatcher(), source=source, message_id=message_id)
+```
+
+**`debug on` / `debug off`** — inline flag file toggle.
+
+```python
+from src.orchestration.dispatcher_handlers import handle_debug
+
+on = cmd == "debug on"
+text = handle_debug(on=on)
+send_reply(chat_id=chat_id, text=text, source=source, message_id=message_id)
+```
+
+---
+
 ## Skill System
 
 At message processing start (when skills are enabled), call `get_skill_context` to load assembled context from all active skills. Apply returned instructions alongside base context.

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -2395,3 +2395,147 @@ def format_status_message(
     quota_line = "◉ " + format_quota_message(quota_state)
 
     return "\n".join([wos_line, agents_line, quota_line])
+
+
+# ---------------------------------------------------------------------------
+# Inline dispatcher command handlers (Phase 1 + 2)
+#
+# These handlers implement snag-reachable commands that execute directly on
+# the dispatcher main thread without spawning a subagent.  Each function is
+# pure with respect to MCP calls — any MCP data (active_sessions, inbox msgs)
+# must be gathered by the dispatcher before calling these functions.
+# ---------------------------------------------------------------------------
+
+# Path to the debug-enabled flag file.  Touch to enable; unlink to disable.
+_DEBUG_FLAG_PATH: Path = Path.home() / "lobster-workspace" / "data" / "debug-enabled"
+
+
+def handle_usage() -> str:
+    """Handle prose 'usage' command — inline CC quota read from state.json.
+
+    Pure file read: reads cc-budget/state.json via read_quota_state() and
+    formats the result using format_quota_message().  Adds session cost when
+    available.  Returns the unavailable message when the file is absent or stale.
+    """
+    state = read_quota_state()
+    quota_msg = format_quota_message(state)
+    if state:
+        cost = state.get("session_cost_usd")
+        if cost is not None:
+            quota_msg += f"\nSession cost: ${cost:.2f}"
+    return quota_msg
+
+
+def handle_status(active_sessions: list[dict]) -> str:
+    """Handle prose 'status' / 'health' command — inline system snapshot.
+
+    Reads wos-config.json and cc-budget/state.json directly (fast file reads).
+    active_sessions must be gathered by the dispatcher via get_active_sessions()
+    before calling this function.
+
+    Returns a 3-line status string covering WOS state, agent count, and CC usage.
+    """
+    wos_config = read_wos_config()
+    quota_state = read_quota_state()
+
+    execution_enabled = bool(wos_config.get("execution_enabled", False))
+    wos_label = "enabled" if execution_enabled else "stopped"
+
+    agent_count = len(active_sessions)
+    quota_msg = format_quota_message(quota_state)
+
+    return "\n".join([
+        f"WOS: {wos_label}",
+        f"Active agents: {agent_count}",
+        quota_msg,
+    ])
+
+
+def handle_agents(active_sessions: list[dict]) -> str:
+    """Handle prose 'agents' command — format active session list.
+
+    active_sessions must be gathered by the dispatcher via get_active_sessions()
+    before calling this function.
+    """
+    if not active_sessions:
+        return "No active agents."
+    lines = [f"Active agents ({len(active_sessions)}):"]
+    for s in active_sessions:
+        agent_id = s.get("task_id") or s.get("agent_id") or s.get("id") or "?"
+        desc = s.get("description", "")
+        lines.append(f"  • {agent_id}: {desc}")
+    return "\n".join(lines)
+
+
+def handle_inbox(msgs: list[dict], total_count: int) -> str:
+    """Handle prose 'inbox' command — format queue depth and recent messages.
+
+    msgs and total_count must be gathered by the dispatcher via check_inbox()
+    and get_stats() before calling this function.
+    """
+    lines = [f"Inbox: {total_count} pending"]
+    for m in (msgs or [])[:5]:
+        preview = (m.get("text") or "")[:60].replace("\n", " ")
+        if preview:
+            lines.append(f"  • {preview}")
+    return "\n".join(lines)
+
+
+def handle_debug(on: bool) -> str:
+    """Handle 'debug on' / 'debug off' — toggle the debug-enabled flag file.
+
+    Touches ~/lobster-workspace/data/debug-enabled to enable debug mode;
+    unlinks it to disable.  Returns a confirmation string.
+    """
+    try:
+        if on:
+            _DEBUG_FLAG_PATH.parent.mkdir(parents=True, exist_ok=True)
+            _DEBUG_FLAG_PATH.touch()
+            return f"Debug mode enabled. Flag: `{_DEBUG_FLAG_PATH}`"
+        else:
+            if _DEBUG_FLAG_PATH.exists():
+                _DEBUG_FLAG_PATH.unlink()
+            return "Debug mode disabled. Flag file removed."
+    except OSError as exc:
+        return f"Debug toggle failed: {exc}"
+
+
+def handle_restart_mcp() -> str:
+    """Handle 'restart mcp' — return the inline ACK message.
+
+    The dispatcher sends this text as an immediate reply, then spawns a subagent
+    to run ~/lobster/scripts/restart-mcp.sh --no-wait.  The subagent performs
+    the actual restart; the dispatcher reconnects automatically.
+
+    Returns the ACK text to send before the subagent is spawned.
+    """
+    return (
+        "MCP restart initiated. The service will restart in ~5 seconds. "
+        "Reconnection is automatic — you may see a brief gap in responsiveness."
+    )
+
+
+def handle_restart_dispatcher() -> str:
+    """Handle 'restart dispatcher' — return manual restart instructions.
+
+    The Claude Code process cannot restart itself.  This function returns
+    the instructions Dan must follow to restart the dispatcher manually.
+    """
+    return (
+        "The dispatcher (Claude Code process) cannot restart itself.\n\n"
+        "To restart:\n"
+        "1. Open a new terminal on the Lobster host\n"
+        "2. Run: ~/lobster/scripts/claude-persistent.sh\n"
+        "3. The new session will pick up from the inbox queue automatically."
+    )
+
+
+def handle_usage_full() -> str:
+    """Handle 'usage full' — return the spawning acknowledgement.
+
+    This command is NOT snag-reachable by design: it requires a subagent.
+    Returns the ack text to send before spawning the usage-report subagent.
+    The dispatcher is responsible for the actual Task spawn with the appropriate
+    prompt (run usage-report.sh --format full, or fall back to state.json).
+    """
+    return "Spawning usage report agent..."


### PR DESCRIPTION
## Summary

- Adds 9 handler functions to `dispatcher_handlers.py` for snag-reachable inline commands: `handle_status`, `handle_usage`, `handle_usage_full`, `handle_agents`, `handle_inbox`, `handle_debug`, `handle_restart_mcp`, `handle_restart_dispatcher`, plus the already-existing `handle_help`
- Adds an **Inline Command Index** section to `sys.dispatcher.bootup.md` documenting routing for 8 new prose commands: `status/health`, `usage`, `usage full`, `agents`, `inbox`, `restart mcp`, `restart dispatcher`, `debug on/off`
- Inline commands are snag-reachable by design — they do at most a file read and one MCP call (`get_active_sessions`, `check_inbox`, `get_stats`), all explicitly permitted on the main thread

## What's inline vs subagent

| Command | Inline? | Notes |
|---------|---------|-------|
| `status` / `health` | ✅ | Reads wos-config.json + cc-budget; calls get_active_sessions inline |
| `usage` | ✅ | Reads cc-budget/state.json directly |
| `usage full` | ❌ | Spawns subagent for full report |
| `agents` | ✅ | Calls get_active_sessions inline |
| `inbox` | ✅ | Calls check_inbox + get_stats inline |
| `restart mcp` | Hybrid | Inline ACK + subagent restart |
| `restart dispatcher` | ✅ | Static instructions only |
| `debug on/off` | ✅ | Touch/unlink flag file |

## Test plan

- [ ] `from src.orchestration.dispatcher_handlers import handle_status, handle_usage, handle_agents, handle_inbox, handle_debug, handle_restart_mcp, handle_restart_dispatcher, handle_usage_full` — all imports succeed
- [ ] `handle_usage()` returns a formatted CC quota string
- [ ] `handle_status([])` returns WOS state + 0 agents + quota
- [ ] `handle_agents([])` returns "No active agents."
- [ ] `handle_inbox([], 0)` returns "Inbox: 0 pending"
- [ ] `handle_debug(True)` creates the flag file; `handle_debug(False)` removes it
- [ ] `handle_restart_mcp()` returns the ACK string
- [ ] `handle_restart_dispatcher()` returns the restart instructions
- [ ] `handle_usage_full()` returns the spawning ack string
- [ ] Existing tests still pass (424 passing tests confirmed; 2 pre-existing failures unrelated to this change)

WOS-UoW: uow_20260504_1dfb70