### PR TITLE
Add /wos uow <id> Telegram subcommand

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1093,6 +1093,45 @@ Task(
 send_reply(chat_id=chat_id, text="Querying WOS pipeline...", source=source)
 ```
 
+**`/wos uow <uow-id>`** — show detail for a specific Unit of Work.
+
+Accepts a full ID (`uow_20260501_abc123`) or just the trailing hex suffix (`abc123`).
+
+Dispatch to a wos-uow-detail subagent (reads wos.db — 7-second rule applies):
+
+```python
+from src.orchestration.dispatcher_handlers import handle_wos_uow
+from src.orchestration.registry import Registry
+
+registry = Registry()
+parts = msg["text"].strip().split(None, 2)
+# parts: ["wos", "uow", "<id>"]
+uow_id = parts[2].strip() if len(parts) >= 3 else ""
+
+if not uow_id:
+    send_reply(chat_id=chat_id, text="Usage: /wos uow <uow-id>", source=source)
+    mark_processed(message_id)
+else:
+    result = handle_wos_uow(uow_id, registry=registry)
+    if result != "found":
+        # Not found or ambiguous — send the error message inline, no subagent needed
+        send_reply(chat_id=chat_id, text=result, source=source, message_id=message_id)
+    else:
+        task_id = f"wos-uow-detail-{uow_id}"
+        task_file = open(Path.home() / "lobster-workspace/scheduled-jobs/tasks/dispatcher-wos-uow-detail.md").read()
+        Task(
+            subagent_type="lobster-generalist",
+            run_in_background=True,
+            prompt=(
+                f"---\ntask_id: {task_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+                f"uow_id = {uow_id!r}\n\n"
+                + task_file
+            ),
+        )
+        send_reply(chat_id=chat_id, text=f"Looking up UoW `{uow_id}`...", source=source)
+        mark_processed(message_id)
+```
+
 **`/help`** — show command index. Handled inline, no subagent needed:
 
 ```python

--- a/scheduled-tasks/tasks/dispatcher-wos-uow-detail.md
+++ b/scheduled-tasks/tasks/dispatcher-wos-uow-detail.md
@@ -89,15 +89,19 @@ completed_at = extra_row["completed_at"] if extra_row else None
 ### Step 4: Format the detail message
 
 ```python
+import os
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 def fmt_ts(ts):
-    """Format ISO timestamp to concise UTC display."""
+    """Format ISO timestamp to concise local-time display using LOBSTER_USER_TZ."""
     if not ts:
         return "—"
     try:
         dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        return dt.strftime("%Y-%m-%d %H:%M UTC")
+        tz_name = os.environ.get("LOBSTER_USER_TZ", "America/New_York")
+        local_dt = dt.astimezone(ZoneInfo(tz_name))
+        return local_dt.strftime("%Y-%m-%d %H:%M %Z")
     except Exception:
         return ts[:16]
 

--- a/scheduled-tasks/tasks/dispatcher-wos-uow-detail.md
+++ b/scheduled-tasks/tasks/dispatcher-wos-uow-detail.md
@@ -1,0 +1,194 @@
+# WOS UoW Detail Query
+
+**Triggered by**: `/wos uow <id>` command from Dan
+**Type**: On-demand subagent (not a scheduled job)
+
+**Minimum viable output:** A formatted UoW detail message sent to Dan via Telegram.
+**Boundary:** Read-only. Do not modify wos.db or any other files. Do not send multiple messages.
+
+## Context
+
+Dan sent `/wos uow <uow_id>`. Your job is to look up that UoW in the registry, format a
+detail summary, and send it. The `uow_id` variable is injected into this prompt by the
+dispatcher — it will be the raw ID string Dan typed (e.g. `uow_20260501_abc123` or a
+short suffix like `abc123`).
+
+## Instructions
+
+### Step 1: Look up the UoW
+
+```python
+import sys, sqlite3
+from pathlib import Path
+sys.path.insert(0, str(Path.home() / "lobster"))
+
+from src.orchestration.registry import Registry
+from src.orchestration.paths import REGISTRY_DB
+
+registry = Registry()
+
+# Try exact match first
+uow = registry.get(uow_id)
+
+# If not found, try suffix match (user may have typed just the trailing hex, e.g. "abc123")
+if uow is None:
+    conn = sqlite3.connect(str(REGISTRY_DB), timeout=10.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT id FROM uow_registry WHERE id LIKE ? ORDER BY created_at DESC",
+            (f"%{uow_id}",),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if len(rows) == 1:
+        uow = registry.get(rows[0]["id"])
+    elif len(rows) > 1:
+        ids = ", ".join(f"`{r['id']}`" for r in rows[:5])
+        reply = f"Ambiguous ID — {len(rows)} UoWs end with `{uow_id}`: {ids}"
+        send_reply(chat_id=chat_id, text=reply, source=source, task_id=task_id)
+        write_result(task_id=task_id, chat_id=chat_id, text=reply, sent_reply_to_user=True, status="success", source=source)
+        raise SystemExit(0)
+```
+
+### Step 2: Handle not-found
+
+```python
+if uow is None:
+    reply = f"UoW `{uow_id}` not found in registry."
+    send_reply(chat_id=chat_id, text=reply, source=source, task_id=task_id)
+    write_result(task_id=task_id, chat_id=chat_id, text=reply, sent_reply_to_user=True, status="success", source=source)
+    raise SystemExit(0)
+```
+
+### Step 3: Fetch extra fields not in the UoW dataclass
+
+```python
+# outcome_category and gate_fired are DB columns not mapped to the UoW dataclass.
+# Fetch them via direct SQL.
+conn2 = sqlite3.connect(str(REGISTRY_DB), timeout=10.0)
+conn2.execute("PRAGMA journal_mode=WAL")
+conn2.execute("PRAGMA busy_timeout=5000")
+conn2.row_factory = sqlite3.Row
+try:
+    extra_row = conn2.execute(
+        "SELECT outcome_category, gate_fired, completed_at FROM uow_registry WHERE id = ?",
+        (uow.id,),
+    ).fetchone()
+finally:
+    conn2.close()
+
+outcome_category = extra_row["outcome_category"] if extra_row else None
+gate_fired = extra_row["gate_fired"] if extra_row else None
+completed_at = extra_row["completed_at"] if extra_row else None
+```
+
+### Step 4: Format the detail message
+
+```python
+from datetime import datetime, timezone
+
+def fmt_ts(ts):
+    """Format ISO timestamp to concise UTC display."""
+    if not ts:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return ts[:16]
+
+def fmt_duration(start, end):
+    """Compute and format elapsed time between two ISO timestamps."""
+    if not start or not end:
+        return None
+    try:
+        t0 = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        t1 = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        secs = int((t1 - t0).total_seconds())
+        if secs < 60:
+            return f"{secs}s"
+        if secs < 3600:
+            return f"{secs // 60}m {secs % 60}s"
+        h, rem = divmod(secs, 3600)
+        return f"{h}h {rem // 60}m"
+    except Exception:
+        return None
+
+# The completed_at from the extra row; fall back to closed_at if present
+end_ts = completed_at or uow.closed_at
+
+# Status line: append outcome category if present
+status_str = str(uow.status)
+if outcome_category:
+    status_str += f" / {outcome_category}"
+
+# Elapsed time
+elapsed = fmt_duration(uow.started_at, end_ts)
+
+# Cycle counts
+cycles_parts = [f"steward: {uow.steward_cycles}"]
+if uow.lifetime_cycles and uow.lifetime_cycles != uow.steward_cycles:
+    cycles_parts.append(f"lifetime: {uow.lifetime_cycles}")
+if uow.execution_attempts:
+    cycles_parts.append(f"exec attempts: {uow.execution_attempts}")
+if uow.retry_count:
+    cycles_parts.append(f"retries: {uow.retry_count}")
+cycles_str = ", ".join(cycles_parts)
+
+# Prescription confidence
+conf_str = ""
+if uow.prescription_confidence is not None:
+    pct = round(uow.prescription_confidence * 100)
+    conf_str = f" ({pct}% confidence)"
+
+lines = [
+    f"UoW: `{uow.id}`",
+    f"Status: {status_str}",
+    f"Summary: {uow.summary or '(none)'}",
+    "",
+    f"Created:   {fmt_ts(uow.created_at)}",
+    f"Started:   {fmt_ts(uow.started_at)}",
+    f"Completed: {fmt_ts(end_ts)}" + (f" ({elapsed})" if elapsed else ""),
+    "",
+    f"Cycles: {cycles_str}{conf_str}",
+    f"Register: {uow.register or '—'}  Source: {uow.source or '—'}",
+]
+
+# Issue link
+if uow.issue_url and uow.source_issue_number:
+    lines.append(f"Issue: {uow.issue_url}")
+elif uow.source_issue_number:
+    lines.append(f"Issue: #{uow.source_issue_number}")
+
+# Gate fired
+if gate_fired and gate_fired not in ("none", "null", ""):
+    lines.append(f"Gate fired: {gate_fired}")
+
+# Close reason (if present and terminal)
+if uow.close_reason:
+    reason = uow.close_reason.strip()
+    if len(reason) > 200:
+        reason = reason[:197] + "..."
+    lines += ["", f"Close reason: {reason}"]
+
+msg = "\n".join(lines)
+```
+
+### Step 5: Send and complete
+
+```python
+send_reply(chat_id=chat_id, text=msg, source=source, task_id=task_id)
+
+write_result(
+    task_id=task_id,
+    chat_id=chat_id,
+    text=msg,
+    sent_reply_to_user=True,
+    status="success",
+    source=source,
+)
+```

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4122,6 +4122,20 @@ PYEOF
         migrated=$((migrated + 1))
     fi
 
+    # Migration 117: Copy dispatcher-wos-uow-detail.md task file to the workspace tasks
+    # directory. This task file is used by the /wos uow <id> dispatcher command.
+    local _wos_uow_task_file="dispatcher-wos-uow-detail.md"
+    local _wos_uow_src="$LOBSTER_DIR/scheduled-tasks/tasks/$_wos_uow_task_file"
+    local _wos_uow_dst="$WORKSPACE_DIR/scheduled-jobs/tasks/$_wos_uow_task_file"
+    if [ -f "$_wos_uow_src" ] && [ ! -f "$_wos_uow_dst" ]; then
+        mkdir -p "$WORKSPACE_DIR/scheduled-jobs/tasks"
+        cp "$_wos_uow_src" "$_wos_uow_dst"
+        substep "Installed dispatcher task file: $_wos_uow_task_file (Migration 117)"
+        migrated=$((migrated + 1))
+    else
+        substep "Migration 117: $_wos_uow_task_file already present or source missing — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -869,11 +869,11 @@ def handle_wos_abort(uow_id: str, *, registry: "Registry") -> str:
 
 def handle_wos_uow(uow_id: str, *, registry: "Registry") -> str:
     """
-    Handle '/wos uow <uow_id>' — return a task file path for dispatcher subagent dispatch.
+    Handle '/wos uow <uow_id>' — validate the UoW and return a sentinel or error string.
 
     This function validates the UoW exists (or could exist via suffix match) and
-    returns the path to the task file that the dispatcher should use when spawning
-    the wos-uow-detail subagent.
+    returns the sentinel string "found" so the dispatcher knows it can proceed to
+    spawn the wos-uow-detail subagent.
 
     The dispatcher is responsible for:
       1. Reading the task file.
@@ -882,9 +882,9 @@ def handle_wos_uow(uow_id: str, *, registry: "Registry") -> str:
       3. Sending an ack reply ("Looking up UoW...").
 
     Returns:
-        A string describing the outcome — either the task file path (success) or an
-        inline not-found message. When the UoW is not found, the dispatcher should
-        send the returned string directly to the user without spawning a subagent.
+        The sentinel string "found" if the UoW exists, or an inline not-found message
+        string if no matching UoW was found. When the UoW is not found, the dispatcher
+        should send the returned string directly to the user without spawning a subagent.
 
     Note: Full detail formatting (timestamps, cycle counts, etc.) happens inside the
     subagent using the task file. This function only performs a lightweight existence

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -9,6 +9,7 @@ The dispatcher calls these handlers when it recognizes:
   /approve <uow-id>                    → handle_approve(uow_id, registry)
   /decide <uow-id> <proceed|abandon|retry> → handle_decide(uow_id, action, registry)
   /wos status [status]                 → handle_wos_status(status, registry)
+  /wos uow <uow-id>                    → handle_wos_uow(uow_id, registry) → dispatcher spawns subagent
   /wos unblock                         → handle_wos_unblock()
   /wos start                           → handle_wos_start()
   /wos stop                            → handle_wos_stop()
@@ -864,6 +865,56 @@ def handle_wos_abort(uow_id: str, *, registry: "Registry") -> str:
             "The subprocess may have exited before the abort command reached it.\n"
             "executor_pid has been cleared. The UoW will be re-queued by heartbeat recovery."
         )
+
+
+def handle_wos_uow(uow_id: str, *, registry: "Registry") -> str:
+    """
+    Handle '/wos uow <uow_id>' — return a task file path for dispatcher subagent dispatch.
+
+    This function validates the UoW exists (or could exist via suffix match) and
+    returns the path to the task file that the dispatcher should use when spawning
+    the wos-uow-detail subagent.
+
+    The dispatcher is responsible for:
+      1. Reading the task file.
+      2. Spawning a lobster-generalist subagent with the task file content, injecting
+         `uow_id` into the prompt header.
+      3. Sending an ack reply ("Looking up UoW...").
+
+    Returns:
+        A string describing the outcome — either the task file path (success) or an
+        inline not-found message. When the UoW is not found, the dispatcher should
+        send the returned string directly to the user without spawning a subagent.
+
+    Note: Full detail formatting (timestamps, cycle counts, etc.) happens inside the
+    subagent using the task file. This function only performs a lightweight existence
+    check so the dispatcher can give an immediate "not found" response instead of
+    spawning a subagent that immediately fails.
+    """
+    # Quick existence check — if the exact ID is not found, try suffix match.
+    uow = registry.get(uow_id)
+    if uow is not None:
+        return "found"
+
+    # Try suffix match (user may have typed the trailing hex only, e.g. "abc123").
+    import sqlite3
+    conn = registry._connect()
+    try:
+        rows = conn.execute(
+            "SELECT id FROM uow_registry WHERE id LIKE ? ORDER BY created_at DESC",
+            (f"%{uow_id}",),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if len(rows) == 0:
+        return f"UoW `{uow_id}` not found in registry."
+    if len(rows) > 1:
+        ids = ", ".join(f"`{r['id']}`" for r in rows[:5])
+        suffix = f" (and {len(rows) - 5} more)" if len(rows) > 5 else ""
+        return f"Ambiguous ID — {len(rows)} UoWs end with `{uow_id}`: {ids}{suffix}"
+    # Exactly one suffix match.
+    return "found"
 
 
 # ---------------------------------------------------------------------------
@@ -2209,6 +2260,7 @@ WOS control:
   wos start  — enable WOS pipeline (all 14 WOS-core jobs + execution_enabled)
   wos stop   — pause WOS pipeline (all 14 WOS-core jobs + execution_enabled)
   wos status [status] — show active + queued UoWs
+  wos uow <uow-id>    — show detail for a specific UoW
   wos unblock         — clear BOOTUP_CANDIDATE_GATE flag
   wos abort <uow-id>  — send SIGTERM to running subprocess for a UoW
 


### PR DESCRIPTION
## Summary

- Adds `handle_wos_uow(uow_id, registry)` to `dispatcher_handlers.py` — does a fast existence/ambiguity check (exact match + LIKE suffix fallback) and returns `"found"` or an inline error string
- Adds `scheduled-tasks/tasks/dispatcher-wos-uow-detail.md` — the lobster-generalist task file that looks up the UoW, fetches extra DB fields (`outcome_category`, `gate_fired`, `completed_at`), formats a detail message, and sends it via `send_reply`
- Updates `sys.dispatcher.bootup.md` with a `## WOS Commands` section documenting the dispatch pseudocode for `/wos uow <id>`
- Adds Migration 112 to `upgrade.sh` to copy the task file into `lobster-workspace/scheduled-jobs/tasks/`
- Updates `COMMAND_HELP` in `dispatcher_handlers.py` to include the new subcommand

The UoW detail view includes: ID, status + outcome_category, summary, created/started/completed timestamps with elapsed time, cycle counts, register/source, issue link, gate_fired, and close_reason (truncated to 200 chars). Suffix ID matching allows typing just the trailing hex (e.g. `abc123` instead of `uow_20260501_abc123`).

## Test plan

- [ ] `/wos uow <full-id>` returns detail for a known UoW
- [ ] `/wos uow <short-suffix>` resolves correctly when exactly one match
- [ ] `/wos uow <ambiguous-suffix>` returns ambiguous-ID error listing up to 5 matches
- [ ] `/wos uow nonexistent` returns "not found" message
- [ ] Completed UoW shows elapsed time in the `Completed:` line
- [ ] `close_reason` longer than 200 chars is truncated with `...`
- [ ] Migration 112 copies `dispatcher-wos-uow-detail.md` on first upgrade.sh run

🤖 Generated with [Claude Code](https://claude.com/claude-code)