### PR TITLE
Add /config commands for reading and editing user bootup files via Telegram (#1018)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1251,6 +1251,72 @@ send_reply(chat_id=chat_id, text=text, source=source, message_id=message_id)
 
 ---
 
+## /config — User Config File Commands (issue #1018)
+
+These commands provide Telegram access to user bootup config files in `~/lobster-user-config/agents/`. System files in `.claude/` are protected and not accessible via these commands.
+
+Match trigger: `msg["text"].strip().lower().startswith("/config")` or `msg["text"].strip().lower().startswith("config ")`
+
+Parse the subcommand:
+```python
+parts = msg["text"].strip().lstrip("/").split(None, 2)
+# parts[0] == "config", parts[1] == subcommand, parts[2] == args (optional)
+subcommand = parts[1].lower() if len(parts) > 1 else ""
+args = parts[2] if len(parts) > 2 else ""
+```
+
+**`/config list`** — inline, no subagent needed:
+
+```python
+from src.orchestration.dispatcher_handlers import handle_config_list
+
+send_reply(chat_id=chat_id, text=handle_config_list(), source=source, message_id=message_id)
+```
+
+**`/config read <filename>`** — inline for short files; chunked reply for long files:
+
+```python
+from src.orchestration.dispatcher_handlers import handle_config_read
+
+filename = args.strip()
+if not filename:
+    send_reply(chat_id=chat_id, text="Usage: /config read <filename>", source=source, message_id=message_id)
+else:
+    content, needs_chunking = handle_config_read(filename)
+    if needs_chunking:
+        # Send first 4000 chars with a note
+        chunk = content[:4000]
+        note = f"\n\n... ({len(content)} chars total, showing first 4000)"
+        send_reply(chat_id=chat_id, text=chunk + note, source=source, message_id=message_id)
+    else:
+        send_reply(chat_id=chat_id, text=content, source=source, message_id=message_id)
+```
+
+**`/config search <query>`** — inline search across all user config files:
+
+```python
+from src.orchestration.dispatcher_handlers import handle_config_search
+
+query = args.strip()
+send_reply(chat_id=chat_id, text=handle_config_search(query), source=source, message_id=message_id)
+```
+
+**`/config append <filename> <text>`** — inline append to a user config file:
+
+```python
+from src.orchestration.dispatcher_handlers import handle_config_append
+
+# args format: "<filename> <text>"
+append_parts = args.split(None, 1)
+if len(append_parts) < 2:
+    send_reply(chat_id=chat_id, text="Usage: /config append <filename> <text>", source=source, message_id=message_id)
+else:
+    filename, text = append_parts[0], append_parts[1]
+    send_reply(chat_id=chat_id, text=handle_config_append(filename, text), source=source, message_id=message_id)
+```
+
+---
+
 ## Skill System
 
 At message processing start (when skills are enabled), call `get_skill_context` to load assembled context from all active skills. Apply returned instructions alongside base context.

--- a/oracle/verdicts/decision-config-commands.md
+++ b/oracle/verdicts/decision-config-commands.md
@@ -1,0 +1,31 @@
+# Design Decision: /config Dispatcher Commands for Mobile Config Access
+
+**Date:** 2026-05-18
+**Status:** ACCEPTED
+**Vision anchor:** constraint-4 (minimize metabolic cost of cybernetic engagement — structural reduction of friction in system operation)
+**Linked PR:** dcetlin/Lobster#1209
+**Approved by:** dcetlin (Dan)
+
+## Decision
+
+Authorize adding `/config list`, `/config read <file>`, `/config search <term>`, and `/config append <file> <content>` commands to the dispatcher to enable mobile read/edit access to bootup config files in `~/lobster-user-config/agents/`.
+
+- **`/config list`** — lists all files in `~/lobster-user-config/agents/`
+- **`/config read <file>`** — reads and returns the contents of the named config file
+- **`/config search <term>`** — searches across config files for a term
+- **`/config append <file> <content>`** — appends content to the named config file
+
+These commands are handled inline in the dispatcher (no subagent spawn required) and are documented in `sys.dispatcher.bootup.md` under the command routing section.
+
+## Rationale
+
+Reading and editing user config files (behavioral preferences, personal context, bootup overrides) previously required SSH access to the server or a separate desktop session. This is a friction point that violates constraint-4: every round-trip to a separate tool to inspect or adjust Lobster's operating parameters is metabolic overhead that the system should eliminate structurally.
+
+The `/config` commands collapse that overhead: the user can inspect and adjust config files directly from Telegram, on mobile, without breaking flow. This is an Encoded Orientation change — the dispatcher now autonomously handles file reads and appends on the user's behalf — and is logged here as the authorizing prior decision per constraint-3.
+
+## Constraints
+
+- Scope is limited to `~/lobster-user-config/agents/` — no access to arbitrary filesystem paths
+- Append-only writes (no overwrite, no delete) to reduce risk of destructive mobile edits
+- Commands are inline dispatcher handlers — no subagent spawn, no LLM round-trip for file I/O
+- The command set is additive; no existing dispatcher behavior is changed

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -2268,6 +2268,12 @@ Decision:
   /approve <uow-id>   — approve a proposed UoW
   /decide <uow-id> <action> — resolve a blocked UoW
 
+Config (user bootup files):
+  /config list                  — list all user config files with line counts
+  /config read <filename>       — show file contents (chunked if long)
+  /config search <query>        — search for text across all user config files
+  /config append <filename> <text> — append text to a user config file
+
 Skills:
   /shop               — list available skills
   /shop install <name> — install and activate a skill
@@ -2591,3 +2597,160 @@ def handle_usage_full() -> str:
     prompt (run usage-report.sh --format full, or fall back to state.json).
     """
     return "Spawning usage report agent..."
+
+
+# ---------------------------------------------------------------------------
+# /config — user bootup file access from Telegram (issue #1018)
+# ---------------------------------------------------------------------------
+
+# Allowlist of user config files accessible via /config commands.
+# System files in .claude/ are not included — those are protected.
+_USER_CONFIG_DIR: Path = Path.home() / "lobster-user-config" / "agents"
+_USER_CONFIG_FILENAMES: tuple[str, ...] = (
+    "user.base.bootup.md",
+    "user.base.context.md",
+    "user.dispatcher.bootup.md",
+    "user.subagent.bootup.md",
+    "system-audit.context.md",
+    "user.development.md",
+    "user.epistemic.md",
+)
+
+# Telegram message size limit (chars). Content beyond this is chunked.
+_TELEGRAM_CHAR_LIMIT: int = 4000
+
+
+def _config_file_path(filename: str) -> Path | None:
+    """Return the resolved path for a user config file, or None if not allowed."""
+    # Strip leading path components — accept bare filename or agents/filename
+    name = Path(filename).name
+    if name not in _USER_CONFIG_FILENAMES:
+        return None
+    p = _USER_CONFIG_DIR / name
+    return p if p.exists() else None
+
+
+def handle_config_list() -> str:
+    """Return a formatted list of user config files with line counts."""
+    lines: list[str] = ["User config files in ~/lobster-user-config/agents/:", ""]
+    found = False
+    for name in _USER_CONFIG_FILENAMES:
+        p = _USER_CONFIG_DIR / name
+        if p.exists():
+            try:
+                line_count = len(p.read_text(encoding="utf-8").splitlines())
+            except OSError:
+                line_count = 0
+            lines.append(f"  {name} ({line_count} lines)")
+            found = True
+    if not found:
+        lines.append("  (no user config files found)")
+    return "\n".join(lines)
+
+
+def handle_config_read(filename: str) -> tuple[str, bool]:
+    """Read a user config file and return (text, needs_chunking).
+
+    Returns (error_message, False) if the file is not found or not allowed.
+    Returns (content, True) if content exceeds _TELEGRAM_CHAR_LIMIT.
+    Returns (content, False) otherwise.
+    """
+    p = _config_file_path(filename)
+    if p is None:
+        name = Path(filename).name
+        if name not in _USER_CONFIG_FILENAMES:
+            return (
+                f"Not allowed: '{name}' is not in the user config allowlist.\n"
+                "Use /config list to see available files.",
+                False,
+            )
+        return (f"File not found: '{name}' (may not exist yet).", False)
+
+    try:
+        content = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        return (f"Could not read '{p.name}': {exc}", False)
+
+    needs_chunking = len(content) > _TELEGRAM_CHAR_LIMIT
+    return (content, needs_chunking)
+
+
+def handle_config_search(query: str) -> str:
+    """Search for a term across all user config files.
+
+    Returns matching lines with filename and line number, formatted for Telegram.
+    """
+    if not query or not query.strip():
+        return "Usage: /config search <query>"
+
+    query = query.strip()
+    results: list[str] = []
+    matched_files = 0
+
+    for name in _USER_CONFIG_FILENAMES:
+        p = _USER_CONFIG_DIR / name
+        if not p.exists():
+            continue
+        try:
+            file_results: list[str] = []
+            for lineno, line in enumerate(
+                p.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if query.lower() in line.lower():
+                    # Truncate long lines for Telegram readability
+                    display = line.rstrip()
+                    if len(display) > 120:
+                        display = display[:117] + "..."
+                    file_results.append(f"  L{lineno}: {display}")
+            if file_results:
+                results.append(f"{name}:")
+                results.extend(file_results)
+                matched_files += 1
+        except OSError:
+            continue
+
+    if not results:
+        return f"No matches for '{query}' in user config files."
+
+    header = f"Search results for '{query}' ({matched_files} file(s)):"
+    body = "\n".join(results)
+    full = f"{header}\n\n{body}"
+
+    # Truncate if over limit, with a note
+    if len(full) > _TELEGRAM_CHAR_LIMIT:
+        truncated = full[: _TELEGRAM_CHAR_LIMIT - 60]
+        full = truncated + f"\n\n... (truncated, {len(full)} chars total)"
+
+    return full
+
+
+def handle_config_append(filename: str, text: str) -> str:
+    """Append text to a user config file.
+
+    Returns a confirmation string or an error message.
+    """
+    if not text or not text.strip():
+        return "Usage: /config append <filename> <text>"
+
+    p = _config_file_path(filename)
+    if p is None:
+        name = Path(filename).name
+        if name not in _USER_CONFIG_FILENAMES:
+            return (
+                f"Not allowed: '{name}' is not in the user config allowlist.\n"
+                "Use /config list to see available files."
+            )
+        # File doesn't exist yet — create it
+        p = _USER_CONFIG_DIR / name
+
+    try:
+        _USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            # Ensure we start on a new line
+            f.write(f"\n{text.strip()}\n")
+        # Return a confirmation with the last 200 chars of the file for verification
+        content = p.read_text(encoding="utf-8")
+        tail = content[-200:].strip()
+        return f"Appended to {p.name}.\n\nTail:\n{tail}"
+    except OSError as exc:
+        return f"Could not write to '{p.name}': {exc}"

--- a/tests/unit/test_orchestration/test_config_commands.py
+++ b/tests/unit/test_orchestration/test_config_commands.py
@@ -1,0 +1,229 @@
+"""
+Tests for /config dispatcher command handlers (issue #1018).
+
+These test pure handler functions — no Telegram, MCP, or network calls required.
+All handlers return formatted strings derived from file reads/writes in a tmp_path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.orchestration.dispatcher_handlers import (
+    handle_config_list,
+    handle_config_read,
+    handle_config_search,
+    handle_config_append,
+    _USER_CONFIG_FILENAMES,
+    _TELEGRAM_CHAR_LIMIT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    """Create a temporary user config directory with sample files."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    return agents_dir
+
+
+@pytest.fixture
+def patched_config_dir(config_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Patch _USER_CONFIG_DIR to point at a tmp directory."""
+    monkeypatch.setattr(
+        "src.orchestration.dispatcher_handlers._USER_CONFIG_DIR", config_dir
+    )
+    return config_dir
+
+
+# ---------------------------------------------------------------------------
+# handle_config_list
+# ---------------------------------------------------------------------------
+
+
+class TestHandleConfigList:
+    """handle_config_list returns a list of user config files with line counts."""
+
+    def test_shows_existing_files(self, patched_config_dir: Path) -> None:
+        """Lists files that exist in the config dir."""
+        (patched_config_dir / "user.base.bootup.md").write_text(
+            "line1\nline2\nline3\n"
+        )
+        result = handle_config_list()
+        assert "user.base.bootup.md" in result
+        assert "3 lines" in result
+
+    def test_skips_missing_files(self, patched_config_dir: Path) -> None:
+        """Does not list files that don't exist."""
+        result = handle_config_list()
+        assert "no user config files found" in result
+
+    def test_multiple_files(self, patched_config_dir: Path) -> None:
+        """Lists multiple files when they exist."""
+        (patched_config_dir / "user.base.bootup.md").write_text("a\nb\n")
+        (patched_config_dir / "user.base.context.md").write_text("x\n")
+        result = handle_config_list()
+        assert "user.base.bootup.md" in result
+        assert "user.base.context.md" in result
+        assert "2 lines" in result
+        assert "1 lines" in result
+
+    def test_header_present(self, patched_config_dir: Path) -> None:
+        """Result includes a descriptive header."""
+        result = handle_config_list()
+        assert "lobster-user-config/agents" in result
+
+
+# ---------------------------------------------------------------------------
+# handle_config_read
+# ---------------------------------------------------------------------------
+
+
+class TestHandleConfigRead:
+    """handle_config_read returns (content, needs_chunking) for a config file."""
+
+    def test_reads_existing_file(self, patched_config_dir: Path) -> None:
+        """Returns file contents for an allowlisted file that exists."""
+        content = "Some bootup content.\nSecond line.\n"
+        (patched_config_dir / "user.base.bootup.md").write_text(content)
+        result, needs_chunking = handle_config_read("user.base.bootup.md")
+        assert result == content
+        assert needs_chunking is False
+
+    def test_needs_chunking_for_long_file(self, patched_config_dir: Path) -> None:
+        """Sets needs_chunking=True when content exceeds _TELEGRAM_CHAR_LIMIT."""
+        long_content = "x" * (_TELEGRAM_CHAR_LIMIT + 100)
+        (patched_config_dir / "user.base.bootup.md").write_text(long_content)
+        result, needs_chunking = handle_config_read("user.base.bootup.md")
+        assert needs_chunking is True
+        assert result == long_content
+
+    def test_rejects_non_allowlisted_filename(self, patched_config_dir: Path) -> None:
+        """Returns an error for filenames not in the allowlist."""
+        result, needs_chunking = handle_config_read("../../etc/passwd")
+        assert "Not allowed" in result
+        assert needs_chunking is False
+
+    def test_rejects_system_file(self, patched_config_dir: Path) -> None:
+        """Does not allow system .claude files."""
+        result, needs_chunking = handle_config_read("sys.dispatcher.bootup.md")
+        assert "Not allowed" in result
+        assert needs_chunking is False
+
+    def test_handles_missing_file(self, patched_config_dir: Path) -> None:
+        """Returns a helpful error when an allowlisted file doesn't exist yet."""
+        result, needs_chunking = handle_config_read("user.base.context.md")
+        assert "not found" in result.lower()
+        assert needs_chunking is False
+
+    def test_strips_path_prefix(self, patched_config_dir: Path) -> None:
+        """Accepts 'agents/user.base.bootup.md' and strips the prefix."""
+        content = "content here"
+        (patched_config_dir / "user.base.bootup.md").write_text(content)
+        result, _ = handle_config_read("agents/user.base.bootup.md")
+        assert result == content
+
+
+# ---------------------------------------------------------------------------
+# handle_config_search
+# ---------------------------------------------------------------------------
+
+
+class TestHandleConfigSearch:
+    """handle_config_search searches across all user config files."""
+
+    def test_finds_match(self, patched_config_dir: Path) -> None:
+        """Returns matching lines with filename and line number."""
+        (patched_config_dir / "user.base.bootup.md").write_text(
+            "line one\nremember this setting\nline three\n"
+        )
+        result = handle_config_search("remember")
+        assert "user.base.bootup.md" in result
+        assert "remember this setting" in result
+        assert "L2" in result
+
+    def test_case_insensitive(self, patched_config_dir: Path) -> None:
+        """Search is case-insensitive."""
+        (patched_config_dir / "user.base.bootup.md").write_text("Always Do X\n")
+        result = handle_config_search("always do x")
+        assert "Always Do X" in result
+
+    def test_no_matches_message(self, patched_config_dir: Path) -> None:
+        """Returns a 'no matches' message when nothing is found."""
+        (patched_config_dir / "user.base.bootup.md").write_text("something else\n")
+        result = handle_config_search("zzz_nonexistent_zzz")
+        assert "No matches" in result
+
+    def test_empty_query(self, patched_config_dir: Path) -> None:
+        """Returns usage hint for empty query."""
+        result = handle_config_search("")
+        assert "Usage" in result
+
+    def test_searches_multiple_files(self, patched_config_dir: Path) -> None:
+        """Returns matches from multiple files."""
+        (patched_config_dir / "user.base.bootup.md").write_text("target in bootup\n")
+        (patched_config_dir / "user.base.context.md").write_text("target in context\n")
+        result = handle_config_search("target")
+        assert "user.base.bootup.md" in result
+        assert "user.base.context.md" in result
+
+    def test_truncates_at_telegram_limit(self, patched_config_dir: Path) -> None:
+        """Long results are truncated with a note."""
+        many_matches = "\n".join(["target " + "x" * 100] * 60)
+        (patched_config_dir / "user.base.bootup.md").write_text(many_matches)
+        result = handle_config_search("target")
+        assert len(result) <= _TELEGRAM_CHAR_LIMIT + 100  # some tolerance for note
+        assert "truncated" in result
+
+
+# ---------------------------------------------------------------------------
+# handle_config_append
+# ---------------------------------------------------------------------------
+
+
+class TestHandleConfigAppend:
+    """handle_config_append appends text to a user config file."""
+
+    def test_appends_to_existing_file(self, patched_config_dir: Path) -> None:
+        """Appends to an existing allowlisted file."""
+        p = patched_config_dir / "user.base.bootup.md"
+        p.write_text("existing content\n")
+        result = handle_config_append("user.base.bootup.md", "new setting")
+        assert "Appended" in result
+        content = p.read_text()
+        assert "new setting" in content
+        assert "existing content" in content
+
+    def test_creates_file_if_missing(self, patched_config_dir: Path) -> None:
+        """Creates the file if it doesn't exist yet (for allowlisted filenames)."""
+        result = handle_config_append("user.base.context.md", "new context entry")
+        assert "Appended" in result
+        p = patched_config_dir / "user.base.context.md"
+        assert p.exists()
+        assert "new context entry" in p.read_text()
+
+    def test_rejects_non_allowlisted_filename(self, patched_config_dir: Path) -> None:
+        """Returns an error for filenames not in the allowlist."""
+        result = handle_config_append("../../etc/passwd", "injected")
+        assert "Not allowed" in result
+
+    def test_empty_text_returns_usage(self, patched_config_dir: Path) -> None:
+        """Returns usage hint when text is empty."""
+        result = handle_config_append("user.base.bootup.md", "")
+        assert "Usage" in result
+
+    def test_shows_tail_in_confirmation(self, patched_config_dir: Path) -> None:
+        """Confirmation message includes the tail of the file."""
+        p = patched_config_dir / "user.base.bootup.md"
+        p.write_text("line1\n")
+        result = handle_config_append("user.base.bootup.md", "my new line")
+        assert "my new line" in result
+        assert "Tail" in result


### PR DESCRIPTION
## Summary

- Adds four `/config` subcommands to the Lobster dispatcher: `list`, `read`, `search`, and `append`
- All operations are scoped to `~/lobster-user-config/agents/` via an explicit allowlist — system `.claude/` files cannot be accessed or modified via these commands
- Updates dispatcher bootup docs (`sys.dispatcher.bootup.md`) with the dispatch pattern for each subcommand
- Updates `COMMAND_HELP` index to include the new commands

## Commands implemented

- `/config list` — list all user config files with line counts
- `/config read <filename>` — show file contents; first 4000 chars with total-size note if over Telegram limit
- `/config search <query>` — case-insensitive grep across all user config files, returns filename + line number
- `/config append <filename> <text>` — append text to a user config file, shows tail for verification

## Test plan

- [ ] 21 unit tests in `tests/unit/test_orchestration/test_config_commands.py` — all passing
- [ ] Tests cover: allowlist enforcement, path stripping, chunking threshold, multi-file search, empty input handling, file creation on append

Closes SiderealPress/lobster#1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)