### PR TITLE
feat(wos): wire outcome_category into daily digest, add gate churn + spec format

### DIFF
--- a/scheduled-tasks/wos-metabolic-digest.py
+++ b/scheduled-tasks/wos-metabolic-digest.py
@@ -2,28 +2,42 @@
 """
 WOS Metabolic Digest — daily pipeline health signal.
 
-Runs once per day (default 09:00 UTC). On each invocation:
-1. Reads UoWs completed (status changed to 'done' or 'failed') in the past 24h.
-2. Classifies each as pearl/heat/seed/shit based on outcome heuristics.
-3. Computes aggregates: total by classification, average duration, register breakdown.
-4. Sends a Telegram message to the admin chat_id with the digest.
-5. Writes output to the scheduled-jobs log.
+Runs once per day (default 10:00 UTC / 6 AM ET). On each invocation:
+1. Reads UoWs that transitioned to a terminal status (done/failed/expired/cancelled)
+   in the past 24h.
+2. Uses outcome_category from uow_registry (real-time classification set at
+   write_result time) — no heuristic re-classification needed.
+3. Computes aggregates: total by outcome category, average tokens, average cycles,
+   seeds surfaced (interim: from artifacts table), gate churn (from gate_fired column).
+4. Formats a Telegram-friendly digest per the WOS completion report spec.
+5. Writes an inbox message for the dispatcher to relay, then writes job output.
 
-Classification heuristics (from the audit doc and WOS architecture):
-  pearl — UoW produced a PR or implementation (output_ref has content, outcome 'complete',
-           close_reason mentions 'pr' or 'implementation')
-  heat  — UoW produced a review or analysis (output_ref has content, outcome 'complete',
-           close_reason mentions 'review' or 'analysis' or 'design')
-  seed  — UoW created a new issue or follow-up (close_reason matches phrase-level patterns
-           like 'opened issue #N', 'spawned issue', 'created uow', 'seeded', 'follow-up')
-  shit  — UoW failed, expired, hit TTL, or produced no verifiable output
+Classification source:
+  outcome_category is set at write_result time by the subagent (pearl/heat/seed/shit).
+  UoWs without outcome_category (pre-migration, or subagent did not classify) are
+  counted as 'shit' (no verifiable outcome signal) for digest purposes.
 
-Cron schedule (daily at 09:00 UTC):
-    0 9 * * * cd ~/lobster && uv run scheduled-tasks/wos-metabolic-digest.py >> ~/lobster-workspace/scheduled-jobs/logs/wos-metabolic-digest.log 2>&1 # LOBSTER-WOS-METABOLIC-DIGEST
+Digest suppression:
+  - Zero completed UoWs today → no message sent (idle-day suppression per spec).
+  - 1–2 completed UoWs → one-liner format.
+  - 3+ completed UoWs → full digest format per spec.
 
-Type C dispatch: cron calls this script directly (no inbox/ message, no dispatcher
-involvement). The jobs.json enabled gate is checked at the top of main() so that
-runtime enable/disable is respected without touching cron.
+Gate churn (requires migration 0019 gate_fired column):
+  - spiral   — escalate verdict (infinite-loop risk)
+  - dead_end — pause verdict (stuck UoW)
+  - burst    — throttle verdict (queue overload)
+  - none     — clean dispatch path
+
+Seeds surfaced (interim approximation):
+  Count of artifacts with category='seed' across completed UoWs (over-counts
+  auto-extracted issue refs but acceptable until migration 0020 lands structured seeds).
+
+Cron schedule (daily at 10:00 UTC / 6 AM ET):
+    0 10 * * * cd ~/lobster && uv run scheduled-tasks/wos-metabolic-digest.py >> ~/lobster-workspace/scheduled-jobs/logs/wos-metabolic-digest.log 2>&1 # LOBSTER-WOS-METABOLIC-DIGEST
+
+Type B dispatch: cron calls this script directly (no inbox/ message, no LLM round-trip).
+The jobs.json enabled gate is checked at the top of main() so that runtime enable/disable
+is respected without touching cron.
 
 Run standalone:
     uv run ~/lobster/scheduled-tasks/wos-metabolic-digest.py [--dry-run] [--hours N]
@@ -35,7 +49,6 @@ import argparse
 import json
 import logging
 import os
-import re
 import sqlite3
 import sys
 import uuid
@@ -78,11 +91,28 @@ ADMIN_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
 # Terminal statuses that indicate a UoW completed in some form
 TERMINAL_STATUSES: tuple[str, ...] = ("done", "failed", "expired", "cancelled")
 
-# Outcome category names (from the audit doc and WOS architecture)
+# Outcome category names per WOS metabolic taxonomy
 OUTCOME_PEARL = "pearl"
 OUTCOME_HEAT = "heat"
 OUTCOME_SEED = "seed"
 OUTCOME_SHIT = "shit"
+
+# All valid outcome categories (any other value or NULL → shit)
+VALID_OUTCOME_CATEGORIES: frozenset[str] = frozenset({
+    OUTCOME_PEARL, OUTCOME_HEAT, OUTCOME_SEED, OUTCOME_SHIT,
+})
+
+# Gate churn labels (from migration 0019 gate_fired column)
+GATE_SPIRAL = "spiral"
+GATE_DEAD_END = "dead_end"
+GATE_BURST = "burst"
+GATE_NONE = "none"
+
+# Minimum UoW count to emit the full digest format (per spec)
+FULL_DIGEST_THRESHOLD: int = 3
+
+# Default stall threshold for still-running UoWs
+STALL_THRESHOLD_HOURS: int = 6
 
 
 # ---------------------------------------------------------------------------
@@ -106,171 +136,6 @@ def _inbox_dir() -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Classification heuristics — pure functions, testable without DB
-# ---------------------------------------------------------------------------
-
-def classify_uow(uow: dict) -> str:
-    """
-    Classify a completed UoW into one of: pearl, heat, seed, shit.
-
-    Classification is based on close_reason, output_ref size, and status.
-    The heuristics are intentionally simple and conservative — when in doubt,
-    classify as 'shit' (no verifiable output). Callers can tune thresholds
-    by modifying the keyword sets below.
-
-    Args:
-        uow: A dict with keys: id, status, close_reason, output_ref, register,
-             steward_cycles, started_at, closed_at.
-
-    Returns:
-        One of: "pearl", "heat", "seed", "shit"
-    """
-    status = (uow.get("status") or "").lower()
-    close_reason = (uow.get("close_reason") or "").lower()
-    output_ref = uow.get("output_ref") or ""
-
-    # shit: definitively failed, expired, or TTL-exceeded
-    if status in ("failed", "expired", "cancelled"):
-        return OUTCOME_SHIT
-    if "ttl_exceeded" in close_reason or "ttl" in close_reason:
-        return OUTCOME_SHIT
-    if "hard_cap" in close_reason or "user_closed" in close_reason:
-        return OUTCOME_SHIT
-
-    # For 'done' UoWs, classify by close_reason and output content
-    if status != "done":
-        return OUTCOME_SHIT  # any non-terminal status that reached here is unexpected
-
-    # seed: spawned a new issue or seeded future work.
-    # Use phrase-level patterns to avoid false positives from close_reason values
-    # that merely reference a source issue without creating a new one.
-    # "issue" as a bare substring is too broad — "issue #456 was referenced in this
-    # pr" or "issue analysis complete" would incorrectly classify as seed.
-    _SEED_ISSUE_PATTERN = re.compile(
-        r"(opened|created|filed|new|spawned)\s+issue\s*#?\d*",
-        re.IGNORECASE,
-    )
-    _SEED_UOW_PATTERN = re.compile(
-        r"(spawned|created|spawn)\s+(uow|new\s+uow)",
-        re.IGNORECASE,
-    )
-    if (
-        _SEED_ISSUE_PATTERN.search(close_reason)
-        or _SEED_UOW_PATTERN.search(close_reason)
-        or "seeded" in close_reason
-        or "follow-up" in close_reason
-        or "follow_up" in close_reason
-    ):
-        return OUTCOME_SEED
-
-    # pearl: produced a PR, implementation, or code change
-    pearl_keywords = {"pr", "pull request", "implementation", "commit", "merge", "patch", "fix"}
-    if any(kw in close_reason for kw in pearl_keywords):
-        return OUTCOME_PEARL
-
-    # Check output_ref size — a substantial output file suggests real work
-    if output_ref:
-        try:
-            output_path = Path(output_ref)
-            if output_path.exists() and output_path.stat().st_size > 500:
-                # heat: review/analysis/design output
-                heat_keywords = {"review", "analysis", "design", "synthesis", "assessment", "report"}
-                if any(kw in close_reason for kw in heat_keywords):
-                    return OUTCOME_HEAT
-                # Default for done + substantial output = pearl (best-effort)
-                return OUTCOME_PEARL
-        except Exception:
-            pass
-
-    # heat: review or analysis output (by close_reason alone)
-    heat_keywords = {"review", "analysis", "design", "synthesis", "assessment", "report"}
-    if any(kw in close_reason for kw in heat_keywords):
-        return OUTCOME_HEAT
-
-    # No clear signal — default to shit (no verifiable output)
-    return OUTCOME_SHIT
-
-
-def compute_duration_minutes(uow: dict) -> float | None:
-    """
-    Compute UoW duration in minutes from started_at to closed_at.
-
-    Returns None if either timestamp is missing or unparseable.
-    """
-    started = uow.get("started_at") or uow.get("created_at")
-    closed = uow.get("closed_at") or uow.get("updated_at")
-    if not started or not closed:
-        return None
-    try:
-        start_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
-        close_dt = datetime.fromisoformat(closed.replace("Z", "+00:00"))
-        delta = (close_dt - start_dt).total_seconds()
-        return round(delta / 60, 1) if delta >= 0 else None
-    except (ValueError, TypeError):
-        return None
-
-
-def aggregate_by_classification(classified: list[tuple[dict, str]]) -> dict[str, list[dict]]:
-    """
-    Group (uow, classification) pairs by classification label.
-
-    Returns a dict mapping classification → list of uow dicts.
-    All four keys are always present (possibly empty lists).
-    """
-    groups: dict[str, list[dict]] = {
-        OUTCOME_PEARL: [],
-        OUTCOME_HEAT: [],
-        OUTCOME_SEED: [],
-        OUTCOME_SHIT: [],
-    }
-    for uow, label in classified:
-        groups[label].append(uow)
-    return groups
-
-
-def compute_avg_duration(uows: list[dict]) -> str:
-    """
-    Compute average duration in minutes for a list of UoWs.
-
-    Returns "N/A" if no durations available.
-    """
-    durations = [d for d in (compute_duration_minutes(u) for u in uows) if d is not None]
-    if not durations:
-        return "N/A"
-    avg = round(sum(durations) / len(durations), 1)
-    return f"{avg} min"
-
-
-def aggregate_token_usage(uows: list[dict]) -> int | None:
-    """
-    Sum token_usage across UoWs that reported it.
-
-    Returns the total token count, or None if no UoW reported usage.
-    UoWs with NULL token_usage (pre-migration or unreported) are excluded from
-    the sum but do not invalidate it — partial data is better than no data.
-    """
-    values = [u["token_usage"] for u in uows if u.get("token_usage") is not None]
-    return sum(values) if values else None
-
-
-def compute_wall_clock_stats(uows: list[dict]) -> dict:
-    """
-    Compute wall_clock_seconds statistics across UoWs.
-
-    Returns a dict with keys: count (UoWs with data), total_seconds, avg_seconds.
-    All values are None when no UoWs reported wall_clock_seconds.
-    """
-    values = [u["wall_clock_seconds"] for u in uows if u.get("wall_clock_seconds") is not None]
-    if not values:
-        return {"count": 0, "total_seconds": None, "avg_seconds": None}
-    return {
-        "count": len(values),
-        "total_seconds": sum(values),
-        "avg_seconds": round(sum(values) / len(values)),
-    }
-
-
-# ---------------------------------------------------------------------------
 # Registry query — reads completed UoWs in the lookback window
 # ---------------------------------------------------------------------------
 
@@ -279,7 +144,12 @@ def query_completed_uows(db_path: Path, lookback_hours: int) -> list[dict]:
     Return UoWs that transitioned to a terminal status in the past lookback_hours.
 
     Uses audit_log to find UoWs that entered a terminal state (done, failed,
-    expired, cancelled) within the window. Returns full UoW rows for each match.
+    expired, cancelled) within the window. Returns full UoW rows for each match,
+    including outcome_category (migration 0018), gate_fired (migration 0019),
+    token_usage (migration 0015), and steward_cycles.
+
+    gate_fired and seeds_surfaced columns are selected defensively — they fall back
+    to NULL when the column is absent (pre-migration instance).
 
     Returns [] if DB absent or table missing.
     """
@@ -311,22 +181,23 @@ def query_completed_uows(db_path: Path, lookback_hours: int) -> list[dict]:
             uow_ids = [r["uow_id"] for r in transition_rows]
             id_placeholders = ",".join("?" * len(uow_ids))
 
-            # Fetch full UoW records for each matched ID.
-            # token_usage: per-UoW cost telemetry (issue #990); NULL for pre-migration rows.
-            # wall_clock_seconds: derived from completed_at - started_at delta at query time.
+            # Check which optional columns exist (defensive for pre-migration instances)
+            col_info = conn.execute(
+                "PRAGMA table_info(uow_registry)"
+            ).fetchall()
+            col_names = {row["name"] for row in col_info}
+
+            gate_fired_col = "gate_fired" if "gate_fired" in col_names else "NULL AS gate_fired"
+            seeds_surfaced_col = "seeds_surfaced" if "seeds_surfaced" in col_names else "NULL AS seeds_surfaced"
+
             rows = conn.execute(
                 f"""
                 SELECT id, status, summary, register, close_reason, output_ref,
-                       started_at, closed_at, updated_at, created_at, steward_cycles,
-                       token_usage,
-                       CASE
-                         WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
-                         THEN CAST(
-                           (julianday(completed_at) - julianday(started_at)) * 86400.0
-                           AS INTEGER
-                         )
-                         ELSE NULL
-                       END AS wall_clock_seconds
+                       started_at, closed_at, updated_at, created_at, completed_at,
+                       steward_cycles, token_usage,
+                       outcome_category,
+                       {gate_fired_col},
+                       {seeds_surfaced_col}
                 FROM uow_registry
                 WHERE id IN ({id_placeholders})
                   AND status IN ({terminal_placeholders})
@@ -340,6 +211,38 @@ def query_completed_uows(db_path: Path, lookback_hours: int) -> list[dict]:
     except Exception as exc:
         log.warning("Completed UoW query failed: %s", exc)
         return []
+
+
+def query_seeds_from_artifacts(db_path: Path, uow_ids: list[str]) -> int:
+    """
+    Interim seeds count from artifacts table (migration 0020 approximation).
+
+    Counts artifacts with category='seed' across the given UoW IDs.
+    Over-counts auto-extracted issue refs but is acceptable until structured
+    seeds_surfaced field (migration 0020) lands.
+
+    Returns 0 if the artifacts table is absent or query fails.
+    """
+    if not db_path.exists() or not uow_ids:
+        return 0
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        try:
+            id_placeholders = ",".join("?" * len(uow_ids))
+            row = conn.execute(
+                f"""
+                SELECT COUNT(*) AS cnt FROM artifacts
+                WHERE uow_id IN ({id_placeholders})
+                  AND category = 'seed'
+                """,
+                uow_ids,
+            ).fetchone()
+            return int(row[0]) if row else 0
+        finally:
+            conn.close()
+    except Exception:
+        return 0
 
 
 def query_still_running(db_path: Path, threshold_hours: int) -> list[dict]:
@@ -377,6 +280,115 @@ def query_still_running(db_path: Path, threshold_hours: int) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Classification — reads outcome_category from the DB row
+# ---------------------------------------------------------------------------
+
+def resolve_outcome_category(uow: dict) -> str:
+    """
+    Return the metabolic outcome category for a UoW.
+
+    Uses outcome_category if present and valid. Falls back to 'shit' for:
+    - NULL outcome_category (subagent did not classify, or pre-migration)
+    - unrecognized outcome_category value
+    - non-done terminal statuses (failed, expired, cancelled) regardless of
+      outcome_category (these are definitively shit unless reclassified)
+
+    Note: unlike the old heuristic classifier, this function trusts the
+    subagent's classification from write_result time. The only override is
+    terminal failure: failed/expired/cancelled always map to shit.
+    """
+    status = (uow.get("status") or "").lower()
+
+    # Hard override: failure/expiry/cancellation → shit regardless of outcome_category
+    if status in ("failed", "expired", "cancelled"):
+        return OUTCOME_SHIT
+
+    cat = (uow.get("outcome_category") or "").lower()
+    if cat in VALID_OUTCOME_CATEGORIES:
+        return cat
+
+    # Null or unrecognized outcome_category → shit (no verifiable signal)
+    return OUTCOME_SHIT
+
+
+def aggregate_by_category(uows: list[dict]) -> dict[str, list[dict]]:
+    """
+    Group UoWs by resolved outcome category.
+
+    Returns a dict mapping category → list of uow dicts.
+    All four keys are always present (possibly empty lists).
+    """
+    groups: dict[str, list[dict]] = {
+        OUTCOME_PEARL: [],
+        OUTCOME_HEAT: [],
+        OUTCOME_SEED: [],
+        OUTCOME_SHIT: [],
+    }
+    for uow in uows:
+        label = resolve_outcome_category(uow)
+        groups[label].append(uow)
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Aggregate helpers
+# ---------------------------------------------------------------------------
+
+def _avg_int(values: list[int | None]) -> float | None:
+    nums = [v for v in values if v is not None]
+    return round(sum(nums) / len(nums), 1) if nums else None
+
+
+def aggregate_token_usage(uows: list[dict]) -> int | None:
+    values = [u["token_usage"] for u in uows if u.get("token_usage") is not None]
+    return sum(values) if values else None
+
+
+def aggregate_gate_churn(uows: list[dict]) -> dict[str, int]:
+    """
+    Count UoWs by gate_fired value.
+
+    Returns dict with keys spiral, dead_end, burst (zero-filled for absent values).
+    The 'none' gate (clean path) is excluded from the churn signal — churn is
+    specifically about non-clean paths.
+    """
+    churn: dict[str, int] = {GATE_SPIRAL: 0, GATE_DEAD_END: 0, GATE_BURST: 0}
+    for uow in uows:
+        gate = (uow.get("gate_fired") or GATE_NONE).lower()
+        if gate in churn:
+            churn[gate] += 1
+    return churn
+
+
+def count_seeds_surfaced(uows: list[dict], db_path: Path) -> int:
+    """
+    Return total seeds surfaced across completed UoWs.
+
+    Prefers the structured seeds_surfaced column (migration 0020) per UoW.
+    Falls back to the artifacts-table approximation when seeds_surfaced is absent
+    or NULL for all UoWs (interim until migration 0020 is universally deployed).
+    """
+    # Try structured seeds_surfaced column first
+    structured_values = []
+    for uow in uows:
+        sv = uow.get("seeds_surfaced")
+        if sv is not None:
+            try:
+                parsed = json.loads(sv) if isinstance(sv, str) else sv
+                count = len(parsed) if isinstance(parsed, list) else int(parsed)
+                structured_values.append(count)
+            except (ValueError, TypeError):
+                pass
+
+    if structured_values:
+        return sum(structured_values)
+
+    # Interim: count from artifacts table
+    uow_ids = [u["id"] for u in uows]
+    return query_seeds_from_artifacts(db_path, uow_ids)
+
+
+# ---------------------------------------------------------------------------
 # Digest formatter — pure function, returns Telegram-ready text
 # ---------------------------------------------------------------------------
 
@@ -384,19 +396,21 @@ def format_digest(
     groups: dict[str, list[dict]],
     stalled: list[dict],
     lookback_hours: int,
-    now_iso: str,
-) -> str:
+    now_dt: datetime,
+    seeds_total: int,
+) -> str | None:
     """
     Format the metabolic digest as a Telegram message.
 
-    Args:
-        groups:        Classification groups from aggregate_by_classification.
-        stalled:       UoWs still running past the stall threshold.
-        lookback_hours: The window used for the digest.
-        now_iso:        ISO timestamp for the report header.
+    Returns None if no UoWs completed (idle-day suppression per spec).
+    Returns a one-liner for 1-2 UoWs, full format for 3+.
 
-    Returns:
-        A multi-line string ready to send via Telegram.
+    Args:
+        groups:         Classification groups from aggregate_by_category.
+        stalled:        UoWs still running past the stall threshold.
+        lookback_hours: The window used for the digest.
+        now_dt:         Current datetime (UTC) for the report header.
+        seeds_total:    Total seeds surfaced count.
     """
     pearl_count = len(groups[OUTCOME_PEARL])
     heat_count = len(groups[OUTCOME_HEAT])
@@ -404,54 +418,79 @@ def format_digest(
     shit_count = len(groups[OUTCOME_SHIT])
     total = pearl_count + heat_count + seed_count + shit_count
 
-    # Register breakdown — count by register across all classified UoWs
-    register_counts: dict[str, int] = {}
-    all_uows: list[dict] = []
-    for label, uows in groups.items():
-        all_uows.extend(uows)
-        for uow in uows:
-            reg = uow.get("register") or "operational"
-            register_counts[reg] = register_counts.get(reg, 0) + 1
+    # Idle-day suppression: no UoWs completed → no digest
+    if total == 0:
+        return None
 
-    register_parts = ", ".join(
-        f"{count} {reg}" for reg, count in sorted(register_counts.items())
-    ) if register_counts else "none"
+    all_uows = [u for uows in groups.values() for u in uows]
+    date_str = now_dt.strftime("%Y-%m-%d")
 
-    # Average durations per category
-    pearl_avg = compute_avg_duration(groups[OUTCOME_PEARL])
-    heat_avg = compute_avg_duration(groups[OUTCOME_HEAT])
+    # One-liner for < FULL_DIGEST_THRESHOLD completed UoWs
+    if total < FULL_DIGEST_THRESHOLD:
+        total_tokens = aggregate_token_usage(all_uows)
+        token_str = f" — {total_tokens:,} tokens" if total_tokens is not None else ""
+        parts = []
+        if pearl_count:
+            parts.append(f"pearl {pearl_count}")
+        if heat_count:
+            parts.append(f"heat {heat_count}")
+        if seed_count:
+            parts.append(f"seed {seed_count}")
+        if shit_count:
+            parts.append(f"shit {shit_count}")
+        categories = ", ".join(parts) if parts else "none"
+        return f"WOS: {total} completed ({categories}){token_str}"
 
-    # Telemetry: aggregate token_usage and wall_clock_seconds (issue #990)
-    total_tokens = aggregate_token_usage(all_uows)
-    wall_clock = compute_wall_clock_stats(all_uows)
-
-    # Stalled display
-    stalled_line = ""
-    if stalled:
-        stalled_ids = ", ".join(u["id"] for u in stalled[:5])
-        stalled_line = f"\nStalled (>6h): {stalled_ids}"
-        if len(stalled) > 5:
-            stalled_line += f" (+{len(stalled) - 5} more)"
-
+    # Full digest format (per spec)
     lines = [
-        "WOS Daily Metabolic Report",
-        f"Last {lookback_hours}h: {pearl_count} pearl / {heat_count} heat / {seed_count} seed / {shit_count} shit",
+        f"WOS Daily — {date_str}",
+        f"Completed : {total} UoW(s)",
+        f"  pearl {pearl_count}  seed {seed_count}  heat {heat_count}  shit {shit_count}",
     ]
 
-    if total > 0:
-        lines.append(f"Register breakdown: {register_parts}")
-        lines.append(f"Avg duration: {pearl_avg} (pearl), {heat_avg} (heat)")
-        # Token and wall-clock telemetry — only show when data is available
-        if total_tokens is not None:
-            lines.append(f"Tokens: {total_tokens:,} total")
-        if wall_clock["avg_seconds"] is not None:
-            avg_min = round(wall_clock["avg_seconds"] / 60, 1)
-            lines.append(f"Wall-clock avg: {avg_min} min ({wall_clock['count']} UoWs with data)")
-    else:
-        lines.append("No UoWs completed in this window.")
+    # Seeds surfaced
+    if seeds_total > 0:
+        lines.append(f"  Seeds surfaced: {seeds_total}")
 
-    if stalled_line:
-        lines.append(stalled_line)
+    # Average tokens and cycles
+    avg_tokens = _avg_int([u.get("token_usage") for u in all_uows])
+    avg_cycles = _avg_int([u.get("steward_cycles") for u in all_uows])
+    if avg_tokens is not None:
+        lines.append(f"  Avg tokens: {int(avg_tokens):,}")
+    if avg_cycles is not None:
+        lines.append(f"  Avg cycles: {avg_cycles}")
+
+    # Failed UoWs (non-done terminal statuses are already counted in shit)
+    failed_uows = [u for u in all_uows if u.get("status") in ("failed", "expired", "cancelled")]
+    if failed_uows:
+        # Dominant gate among failed UoWs
+        gate_counts: dict[str, int] = {}
+        for u in failed_uows:
+            g = (u.get("gate_fired") or GATE_NONE).lower()
+            gate_counts[g] = gate_counts.get(g, 0) + 1
+        dominant_gate = max(gate_counts, key=gate_counts.__getitem__) if gate_counts else GATE_NONE
+        lines.append(f"Failed    : {len(failed_uows)} UoW(s) ({dominant_gate})")
+
+    # Gate churn across all completed UoWs
+    churn = aggregate_gate_churn(all_uows)
+    churn_total = sum(churn.values())
+    if churn_total > 0:
+        churn_parts = []
+        if churn[GATE_SPIRAL]:
+            churn_parts.append(f"{churn[GATE_SPIRAL]} spiral")
+        if churn[GATE_DEAD_END]:
+            churn_parts.append(f"{churn[GATE_DEAD_END]} dead-end")
+        if churn[GATE_BURST]:
+            churn_parts.append(f"{churn[GATE_BURST]} burst")
+        lines.append(f"Churn     : {' / '.join(churn_parts)} today")
+
+    # Stalled UoWs
+    if stalled:
+        stalled_ids = ", ".join(u["id"] for u in stalled[:5])
+        stall_line = f"Stalled   : {stalled_ids}"
+        if len(stalled) > 5:
+            stall_line += f" (+{len(stalled) - 5} more)"
+        lines.append(stall_line)
 
     return "\n".join(lines)
 
@@ -493,40 +532,45 @@ def _write_inbox_digest(text: str, dry_run: bool = False) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Main
+# Main runner
 # ---------------------------------------------------------------------------
 
 def run_digest(db_path: Path, lookback_hours: int, dry_run: bool = False) -> dict:
     """
     Run the metabolic digest and return a structured result dict.
     """
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_dt = datetime.now(timezone.utc)
+    now_iso = now_dt.isoformat()
 
     # Query completed UoWs
     completed = query_completed_uows(db_path, lookback_hours)
     log.info("Completed UoWs in last %dh: %d", lookback_hours, len(completed))
 
-    # Classify each
-    classified = [(uow, classify_uow(uow)) for uow in completed]
-    groups = aggregate_by_classification(classified)
-
+    # Group by outcome_category
+    groups = aggregate_by_category(completed)
     for label, uows in groups.items():
         log.info("  %s: %d", label, len(uows))
 
+    # Seeds surfaced (structured or interim artifact approximation)
+    seeds_total = count_seeds_surfaced(completed, db_path)
+
     # Stalled UoWs (>6h in flight)
-    stalled = query_still_running(db_path, threshold_hours=6)
+    stalled = query_still_running(db_path, threshold_hours=STALL_THRESHOLD_HOURS)
     if stalled:
-        log.warning("Still running >6h: %d", len(stalled))
+        log.warning("Still running >%dh: %d", STALL_THRESHOLD_HOURS, len(stalled))
 
-    # Format and send digest
-    digest_text = format_digest(groups, stalled, lookback_hours, now_iso)
-    log.info("Digest:\n%s", digest_text)
+    # Format digest (may return None for idle days)
+    digest_text = format_digest(groups, stalled, lookback_hours, now_dt, seeds_total)
 
-    _write_inbox_digest(digest_text, dry_run=dry_run)
+    if digest_text is None:
+        log.info("No UoWs completed in last %dh — suppressing idle-day digest", lookback_hours)
+    else:
+        log.info("Digest:\n%s", digest_text)
+        _write_inbox_digest(digest_text, dry_run=dry_run)
 
-    all_uows = [uow for uows in groups.values() for uow in uows]
+    all_uows = [u for uows in groups.values() for u in uows]
     total_tokens = aggregate_token_usage(all_uows)
-    wall_stats = compute_wall_clock_stats(all_uows)
+    churn = aggregate_gate_churn(all_uows)
 
     return {
         "timestamp": now_iso,
@@ -536,13 +580,15 @@ def run_digest(db_path: Path, lookback_hours: int, dry_run: bool = False) -> dic
         "heat": len(groups[OUTCOME_HEAT]),
         "seed": len(groups[OUTCOME_SEED]),
         "shit": len(groups[OUTCOME_SHIT]),
+        "seeds_surfaced": seeds_total,
         "stalled_count": len(stalled),
+        "gate_churn_spiral": churn[GATE_SPIRAL],
+        "gate_churn_dead_end": churn[GATE_DEAD_END],
+        "gate_churn_burst": churn[GATE_BURST],
+        "total_tokens": total_tokens,
+        "suppressed": digest_text is None,
         "dry_run": dry_run,
         "digest_text": digest_text,
-        # Telemetry (issue #990) — None when no UoWs reported data
-        "total_tokens": total_tokens,
-        "wall_clock_uow_count": wall_stats["count"],
-        "wall_clock_avg_seconds": wall_stats["avg_seconds"],
     }
 
 
@@ -565,8 +611,9 @@ def main() -> int:
 
     result = run_digest(db_path, lookback_hours=args.hours, dry_run=args.dry_run)
     log.info(
-        "Digest complete — pearl=%d heat=%d seed=%d shit=%d stalled=%d",
-        result["pearl"], result["heat"], result["seed"], result["shit"], result["stalled_count"],
+        "Digest complete — pearl=%d heat=%d seed=%d shit=%d stalled=%d suppressed=%s",
+        result["pearl"], result["heat"], result["seed"], result["shit"],
+        result["stalled_count"], result["suppressed"],
     )
     return 0
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4136,6 +4136,42 @@ PYEOF
         substep "Migration 117: $_wos_uow_task_file already present or source missing — skipping"
     fi
 
+    # Migration 118: Update wos-metabolic-digest cron schedule from 09:00 UTC to
+    # 10:00 UTC (6 AM ET), aligning delivery with Dan's morning window
+    # (6-10 AM Eastern per user.base.bootup.md). The digest now uses
+    # outcome_category from the registry (real-time classification at write_result
+    # time) instead of heuristic re-classification, per the WOS completion report
+    # spec (docs/wos/wos-completion-report-spec.md).
+    local WOS_DIGEST_OLD="0 9 * * * cd $LOBSTER_DIR && uv run scheduled-tasks/wos-metabolic-digest.py"
+    local WOS_DIGEST_NEW="0 10 * * * cd $LOBSTER_DIR && uv run scheduled-tasks/wos-metabolic-digest.py >> $LOBSTER_WORKSPACE/scheduled-jobs/logs/wos-metabolic-digest.log 2>&1 # LOBSTER-WOS-METABOLIC-DIGEST"
+    local WOS_DIGEST_MARKER_118="# LOBSTER-WOS-METABOLIC-DIGEST"
+    if crontab -l 2>/dev/null | grep -F "0 9 * * *" | grep -q "wos-metabolic-digest"; then
+        # Remove old 09:00 entry and add new 10:00 entry
+        "$LOBSTER_DIR/scripts/cron-manage.sh" remove "$WOS_DIGEST_MARKER_118" 2>/dev/null || true
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$WOS_DIGEST_MARKER_118" "$WOS_DIGEST_NEW" \
+            && substep "Migration 118: updated wos-metabolic-digest cron from 09:00 to 10:00 UTC" \
+            || warn "Migration 118: could not update wos-metabolic-digest cron — check cron-manage.sh"
+        migrated=$((migrated + 1))
+    elif ! crontab -l 2>/dev/null | grep -qF "$WOS_DIGEST_MARKER_118"; then
+        # No entry at all — add the 10:00 entry fresh
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$WOS_DIGEST_MARKER_118" "$WOS_DIGEST_NEW" \
+            && substep "Migration 118: added wos-metabolic-digest cron entry at 10:00 UTC" \
+            || warn "Migration 118: could not add wos-metabolic-digest cron — check cron-manage.sh"
+        migrated=$((migrated + 1))
+    else
+        substep "Migration 118: wos-metabolic-digest cron already present — checking schedule"
+        if crontab -l 2>/dev/null | grep -F "$WOS_DIGEST_MARKER_118" | grep -q "^0 9 "; then
+            # Present but still at old 09:00 — update it
+            "$LOBSTER_DIR/scripts/cron-manage.sh" remove "$WOS_DIGEST_MARKER_118" 2>/dev/null || true
+            "$LOBSTER_DIR/scripts/cron-manage.sh" add "$WOS_DIGEST_MARKER_118" "$WOS_DIGEST_NEW" \
+                && substep "Migration 118: rescheduled wos-metabolic-digest from 09:00 to 10:00 UTC" \
+                || warn "Migration 118: reschedule failed — check cron-manage.sh"
+            migrated=$((migrated + 1))
+        else
+            substep "Migration 118: wos-metabolic-digest already at correct schedule — skipping"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_wos_metabolic_digest.py
+++ b/tests/unit/test_wos_metabolic_digest.py
@@ -2,14 +2,13 @@
 Tests for scheduled-tasks/wos-metabolic-digest.py and the heartbeat contract
 in dispatcher_handlers.py.
 
-Tests are derived from the spec in the WOS audit doc (wos-audit-20260422.md)
-and issue #849:
-
-- classify_uow: pearl/heat/seed/shit classification heuristics
-- aggregate_by_classification: all four keys always present
-- compute_duration_minutes: handles valid, missing, and malformed timestamps
-- format_digest: produces the required header and summary line
+Tests cover:
+- resolve_outcome_category: uses outcome_category field from DB, falls back to shit
+- aggregate_by_category: all four keys always present, UoWs routed correctly
+- aggregate_gate_churn: counts gate_fired values, excludes 'none'
+- format_digest: spec-compliant format — idle suppression, one-liner, full digest
 - jobs.json enabled gate
+- query_completed_uows / query_still_running: DB-backed queries
 - handle_wos_execute: heartbeat contract section present in dispatched prompt
 """
 
@@ -80,24 +79,32 @@ def _uow(
     *,
     uow_id: str = "uow-test",
     status: str = "done",
+    outcome_category: str | None = None,
     close_reason: str = "",
     output_ref: str = "",
     register: str = "operational",
+    steward_cycles: int = 1,
+    token_usage: int | None = None,
+    gate_fired: str | None = None,
     started_hours_ago: float = 2.0,
     closed_hours_ago: float = 1.0,
 ) -> dict:
     return {
         "id": uow_id,
         "status": status,
+        "outcome_category": outcome_category,
         "close_reason": close_reason,
         "output_ref": output_ref,
         "register": register,
-        "steward_cycles": 1,
+        "steward_cycles": steward_cycles,
+        "token_usage": token_usage,
+        "gate_fired": gate_fired,
         "started_at": _hours_ago_iso(started_hours_ago),
         "closed_at": _hours_ago_iso(closed_hours_ago),
         "created_at": _hours_ago_iso(started_hours_ago + 1),
         "updated_at": _hours_ago_iso(closed_hours_ago),
         "summary": "test uow",
+        "seeds_surfaced": None,
     }
 
 
@@ -125,7 +132,10 @@ def db_path(tmp_path: Path) -> Path:
             heartbeat_at TEXT,
             heartbeat_ttl INTEGER DEFAULT 300,
             steward_cycles INTEGER DEFAULT 0,
-            token_usage INTEGER NULL
+            token_usage INTEGER NULL,
+            outcome_category TEXT NULL,
+            gate_fired TEXT NULL,
+            seeds_surfaced TEXT NULL
         )
     """)
     conn.execute("""
@@ -151,8 +161,9 @@ def _insert_uow_row(db: Path, uow: dict) -> None:
         """
         INSERT INTO uow_registry
             (id, status, summary, register, close_reason, output_ref,
-             started_at, closed_at, updated_at, created_at, steward_cycles)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             started_at, closed_at, updated_at, created_at, steward_cycles,
+             outcome_category, gate_fired)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             uow["id"], uow["status"], uow.get("summary", "test uow"),
@@ -160,6 +171,8 @@ def _insert_uow_row(db: Path, uow: dict) -> None:
             uow.get("output_ref", ""), uow.get("started_at"),
             uow.get("closed_at"), uow.get("updated_at"), uow["created_at"],
             uow.get("steward_cycles", 0),
+            uow.get("outcome_category"),
+            uow.get("gate_fired"),
         ),
     )
     conn.commit()
@@ -181,128 +194,71 @@ def _insert_audit_entry(db: Path, uow_id: str, to_status: str, hours_ago: float 
 
 
 # ---------------------------------------------------------------------------
-# classify_uow — classification heuristics
+# resolve_outcome_category — uses outcome_category field, falls back to shit
 # ---------------------------------------------------------------------------
 
-class TestClassifyUow:
-    def test_failed_status_is_shit(self):
-        uow = _uow(status="failed", close_reason="execution error")
-        assert md.classify_uow(uow) == md.OUTCOME_SHIT
+class TestResolveOutcomeCategory:
+    def test_pearl_outcome_category_resolved(self):
+        uow = _uow(status="done", outcome_category="pearl")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_PEARL
 
-    def test_expired_status_is_shit(self):
-        uow = _uow(status="expired", close_reason="ttl exceeded")
-        assert md.classify_uow(uow) == md.OUTCOME_SHIT
+    def test_heat_outcome_category_resolved(self):
+        uow = _uow(status="done", outcome_category="heat")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_HEAT
 
-    def test_cancelled_status_is_shit(self):
-        uow = _uow(status="cancelled", close_reason="user_closed")
-        assert md.classify_uow(uow) == md.OUTCOME_SHIT
+    def test_seed_outcome_category_resolved(self):
+        uow = _uow(status="done", outcome_category="seed")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_SEED
 
-    def test_ttl_in_close_reason_is_shit(self):
-        uow = _uow(status="done", close_reason="ttl_exceeded after 4h")
-        assert md.classify_uow(uow) == md.OUTCOME_SHIT
+    def test_shit_outcome_category_explicit(self):
+        uow = _uow(status="done", outcome_category="shit")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_SHIT
 
-    def test_hard_cap_in_close_reason_is_shit(self):
-        uow = _uow(status="done", close_reason="hard_cap reached")
-        assert md.classify_uow(uow) == md.OUTCOME_SHIT
+    def test_null_outcome_category_falls_back_to_shit(self):
+        uow = _uow(status="done", outcome_category=None)
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_SHIT
 
-    def test_user_closed_in_close_reason_is_shit(self):
-        uow = _uow(status="done", close_reason="user_closed by admin")
-        assert md.classify_uow(uow) == md.OUTCOME_SHIT
+    def test_unrecognized_outcome_category_falls_back_to_shit(self):
+        uow = _uow(status="done", outcome_category="unknown_value")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_SHIT
 
-    def test_pr_in_close_reason_is_pearl(self):
-        uow = _uow(status="done", close_reason="opened pr #123")
-        assert md.classify_uow(uow) == md.OUTCOME_PEARL
+    def test_failed_status_overrides_outcome_category(self):
+        # Terminal failure overrides any subagent classification
+        uow = _uow(status="failed", outcome_category="pearl")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_SHIT
 
-    def test_implementation_in_close_reason_is_pearl(self):
-        uow = _uow(status="done", close_reason="implementation complete")
-        assert md.classify_uow(uow) == md.OUTCOME_PEARL
+    def test_expired_status_overrides_outcome_category(self):
+        uow = _uow(status="expired", outcome_category="heat")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_SHIT
 
-    def test_commit_in_close_reason_is_pearl(self):
-        uow = _uow(status="done", close_reason="committed changes")
-        assert md.classify_uow(uow) == md.OUTCOME_PEARL
-
-    def test_issue_in_close_reason_is_seed(self):
-        uow = _uow(status="done", close_reason="spawned issue #456")
-        assert md.classify_uow(uow) == md.OUTCOME_SEED
-
-    def test_seed_keyword_in_close_reason_is_seed(self):
-        uow = _uow(status="done", close_reason="seeded follow-on work")
-        assert md.classify_uow(uow) == md.OUTCOME_SEED
-
-    def test_spawn_keyword_in_close_reason_is_seed(self):
-        uow = _uow(status="done", close_reason="spawn new uow for subtask")
-        assert md.classify_uow(uow) == md.OUTCOME_SEED
-
-    def test_review_in_close_reason_is_heat(self):
-        uow = _uow(status="done", close_reason="completed review of design doc")
-        assert md.classify_uow(uow) == md.OUTCOME_HEAT
-
-    def test_analysis_in_close_reason_is_heat(self):
-        uow = _uow(status="done", close_reason="analysis complete")
-        assert md.classify_uow(uow) == md.OUTCOME_HEAT
-
-    def test_design_in_close_reason_is_heat(self):
-        uow = _uow(status="done", close_reason="design specification written")
-        assert md.classify_uow(uow) == md.OUTCOME_HEAT
-
-    def test_done_with_no_signal_is_shit(self):
-        # Done with empty close_reason and no output_ref: no verifiable output
-        uow = _uow(status="done", close_reason="", output_ref="")
-        assert md.classify_uow(uow) == md.OUTCOME_SHIT
-
-    def test_source_issue_mention_without_creation_is_not_seed(self):
-        # "issue analysis complete" mentions an issue being worked on, not a new issue
-        # created. Bare "issue" substring must NOT classify as seed — this is the
-        # false-positive the phrase-level matching is designed to prevent.
-        uow = _uow(status="done", close_reason="issue analysis complete")
-        assert md.classify_uow(uow) == md.OUTCOME_HEAT
-
-    def test_pr_closing_source_issue_is_pearl_not_seed(self):
-        # "issue referenced in pr" describes a PR that closes a source issue —
-        # the UoW produced a PR (pearl), not a new seed issue.
-        # Bare "issue" substring must NOT win over "pr" here.
-        uow = _uow(status="done", close_reason="issue referenced in pr")
-        assert md.classify_uow(uow) == md.OUTCOME_PEARL
-
-    def test_creation_phrase_opened_issue_is_seed(self):
-        # Explicit creation verb + "issue" → seed, regardless of other keywords
-        uow = _uow(status="done", close_reason="opened issue #789 for follow-up")
-        assert md.classify_uow(uow) == md.OUTCOME_SEED
-
-    def test_creation_phrase_created_issue_is_seed(self):
-        uow = _uow(status="done", close_reason="created issue #100 to track regressions")
-        assert md.classify_uow(uow) == md.OUTCOME_SEED
+    def test_cancelled_status_overrides_outcome_category(self):
+        uow = _uow(status="cancelled", outcome_category="seed")
+        assert md.resolve_outcome_category(uow) == md.OUTCOME_SHIT
 
 
 # ---------------------------------------------------------------------------
-# aggregate_by_classification
+# aggregate_by_category
 # ---------------------------------------------------------------------------
 
-class TestAggregateByClassification:
+class TestAggregateByCategory:
     def test_all_four_keys_always_present(self):
-        groups = md.aggregate_by_classification([])
+        groups = md.aggregate_by_category([])
         assert set(groups.keys()) == {md.OUTCOME_PEARL, md.OUTCOME_HEAT, md.OUTCOME_SEED, md.OUTCOME_SHIT}
 
     def test_all_keys_present_even_when_categories_empty(self):
-        pairs = [(_uow(close_reason="opened pr #1"), md.OUTCOME_PEARL)]
-        groups = md.aggregate_by_classification(pairs)
+        uows = [_uow(uow_id="p1", outcome_category="pearl")]
+        groups = md.aggregate_by_category(uows)
         assert md.OUTCOME_HEAT in groups
         assert md.OUTCOME_SEED in groups
         assert md.OUTCOME_SHIT in groups
 
     def test_uows_routed_to_correct_group(self):
-        pearl = _uow(uow_id="p1", close_reason="opened pr #1")
-        heat = _uow(uow_id="h1", close_reason="review complete")
-        seed = _uow(uow_id="s1", close_reason="spawned issue")
+        pearl = _uow(uow_id="p1", outcome_category="pearl")
+        heat = _uow(uow_id="h1", outcome_category="heat")
+        seed = _uow(uow_id="s1", outcome_category="seed")
         shit = _uow(uow_id="sh1", status="failed")
 
-        pairs = [
-            (pearl, md.OUTCOME_PEARL),
-            (heat, md.OUTCOME_HEAT),
-            (seed, md.OUTCOME_SEED),
-            (shit, md.OUTCOME_SHIT),
-        ]
-        groups = md.aggregate_by_classification(pairs)
+        groups = md.aggregate_by_category([pearl, heat, seed, shit])
 
         assert len(groups[md.OUTCOME_PEARL]) == 1
         assert len(groups[md.OUTCOME_HEAT]) == 1
@@ -310,93 +266,172 @@ class TestAggregateByClassification:
         assert len(groups[md.OUTCOME_SHIT]) == 1
         assert groups[md.OUTCOME_PEARL][0]["id"] == "p1"
 
-
-# ---------------------------------------------------------------------------
-# compute_duration_minutes
-# ---------------------------------------------------------------------------
-
-class TestComputeDurationMinutes:
-    def test_basic_duration_computed_correctly(self):
-        uow = {
-            "started_at": "2026-04-22T09:00:00+00:00",
-            "closed_at": "2026-04-22T09:30:00+00:00",
-        }
-        result = md.compute_duration_minutes(uow)
-        assert result == 30.0
-
-    def test_missing_started_at_returns_none(self):
-        uow = {"started_at": None, "closed_at": "2026-04-22T09:30:00+00:00"}
-        assert md.compute_duration_minutes(uow) is None
-
-    def test_missing_closed_at_falls_back_to_updated_at(self):
-        uow = {
-            "started_at": "2026-04-22T09:00:00+00:00",
-            "closed_at": None,
-            "updated_at": "2026-04-22T09:20:00+00:00",
-        }
-        result = md.compute_duration_minutes(uow)
-        assert result == 20.0
-
-    def test_negative_duration_returns_none(self):
-        # closed_at before started_at — malformed data
-        uow = {
-            "started_at": "2026-04-22T10:00:00+00:00",
-            "closed_at": "2026-04-22T09:00:00+00:00",
-        }
-        assert md.compute_duration_minutes(uow) is None
-
-    def test_malformed_timestamp_returns_none(self):
-        uow = {"started_at": "not-a-date", "closed_at": "also-not-a-date"}
-        assert md.compute_duration_minutes(uow) is None
+    def test_null_outcome_category_goes_to_shit(self):
+        uow = _uow(uow_id="no-cat", status="done", outcome_category=None)
+        groups = md.aggregate_by_category([uow])
+        assert len(groups[md.OUTCOME_SHIT]) == 1
+        assert groups[md.OUTCOME_SHIT][0]["id"] == "no-cat"
 
 
 # ---------------------------------------------------------------------------
-# format_digest
+# aggregate_gate_churn
+# ---------------------------------------------------------------------------
+
+class TestAggregateGateChurn:
+    def test_empty_uows_all_zeros(self):
+        churn = md.aggregate_gate_churn([])
+        assert churn == {md.GATE_SPIRAL: 0, md.GATE_DEAD_END: 0, md.GATE_BURST: 0}
+
+    def test_spiral_counted(self):
+        uows = [_uow(gate_fired="spiral"), _uow(gate_fired="spiral")]
+        churn = md.aggregate_gate_churn(uows)
+        assert churn[md.GATE_SPIRAL] == 2
+
+    def test_dead_end_counted(self):
+        uows = [_uow(gate_fired="dead_end")]
+        churn = md.aggregate_gate_churn(uows)
+        assert churn[md.GATE_DEAD_END] == 1
+
+    def test_burst_counted(self):
+        uows = [_uow(gate_fired="burst")]
+        churn = md.aggregate_gate_churn(uows)
+        assert churn[md.GATE_BURST] == 1
+
+    def test_none_gate_excluded_from_churn(self):
+        uows = [_uow(gate_fired="none"), _uow(gate_fired=None)]
+        churn = md.aggregate_gate_churn(uows)
+        assert sum(churn.values()) == 0
+
+    def test_mixed_gates_counted_correctly(self):
+        uows = [
+            _uow(gate_fired="spiral"),
+            _uow(gate_fired="dead_end"),
+            _uow(gate_fired="burst"),
+            _uow(gate_fired="none"),
+        ]
+        churn = md.aggregate_gate_churn(uows)
+        assert churn[md.GATE_SPIRAL] == 1
+        assert churn[md.GATE_DEAD_END] == 1
+        assert churn[md.GATE_BURST] == 1
+
+
+# ---------------------------------------------------------------------------
+# format_digest — idle suppression, one-liner, full format
 # ---------------------------------------------------------------------------
 
 class TestFormatDigest:
-    def _empty_groups(self) -> dict:
-        return md.aggregate_by_classification([])
+    _now_dt = datetime(2026, 5, 18, 10, 0, 0, tzinfo=timezone.utc)
 
-    def test_header_line_present(self):
-        text = md.format_digest(self._empty_groups(), [], 24, "2026-04-22T09:00:00+00:00")
-        assert "WOS Daily Metabolic Report" in text
+    def _groups_with(self, **kwargs) -> dict:
+        """Build groups dict with specified count per category."""
+        uows: list = []
+        for cat, count in kwargs.items():
+            for i in range(count):
+                uows.append(_uow(uow_id=f"{cat}-{i}", outcome_category=cat))
+        return md.aggregate_by_category(uows)
 
-    def test_summary_line_contains_counts(self):
-        pearl = _uow(uow_id="p1", close_reason="opened pr #1")
-        shit = _uow(uow_id="sh1", status="failed")
-        groups = md.aggregate_by_classification([
-            (pearl, md.OUTCOME_PEARL),
-            (shit, md.OUTCOME_SHIT),
-        ])
-        text = md.format_digest(groups, [], 24, "2026-04-22T09:00:00+00:00")
-        assert "1 pearl" in text
-        assert "1 shit" in text
+    def test_idle_day_returns_none(self):
+        groups = md.aggregate_by_category([])
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert result is None
 
-    def test_zero_completed_shows_no_uows_message(self):
-        text = md.format_digest(self._empty_groups(), [], 24, "2026-04-22T09:00:00+00:00")
-        assert "No UoWs completed" in text
+    def test_one_liner_for_one_uow(self):
+        groups = self._groups_with(pearl=1)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert result is not None
+        assert "WOS:" in result
+        assert "pearl 1" in result
+        # One-liner should NOT contain the multi-line header
+        assert "WOS Daily" not in result
+
+    def test_one_liner_for_two_uows(self):
+        groups = self._groups_with(shit=2)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert result is not None
+        assert "WOS:" in result
+
+    def test_full_format_for_three_or_more_uows(self):
+        groups = self._groups_with(pearl=1, heat=1, shit=1)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert result is not None
+        assert "WOS Daily" in result
+        assert "2026-05-18" in result
+
+    def test_full_format_counts_line(self):
+        groups = self._groups_with(pearl=2, heat=1, seed=1, shit=3)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "Completed : 7 UoW(s)" in result
+
+    def test_full_format_category_distribution_line(self):
+        groups = self._groups_with(pearl=2, seed=1, heat=0, shit=3)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "pearl 2" in result
+        assert "shit 3" in result
+
+    def test_seeds_surfaced_shown_when_nonzero(self):
+        groups = self._groups_with(seed=3)
+        result = md.format_digest(groups, [], 24, self._now_dt, 5)
+        assert "Seeds surfaced: 5" in result
+
+    def test_seeds_surfaced_omitted_when_zero(self):
+        groups = self._groups_with(pearl=3)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "Seeds" not in result
+
+    def test_gate_churn_shown_when_nonzero(self):
+        uows = [
+            _uow(uow_id="s1", outcome_category="shit", gate_fired="spiral"),
+            _uow(uow_id="s2", outcome_category="shit", gate_fired="dead_end"),
+            _uow(uow_id="s3", outcome_category="shit"),
+        ]
+        groups = md.aggregate_by_category(uows)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "Churn" in result
+        assert "spiral" in result
+        assert "dead-end" in result
+
+    def test_gate_churn_omitted_when_all_clean(self):
+        uows = [
+            _uow(uow_id="p1", outcome_category="pearl", gate_fired="none"),
+            _uow(uow_id="p2", outcome_category="pearl"),
+            _uow(uow_id="p3", outcome_category="pearl"),
+        ]
+        groups = md.aggregate_by_category(uows)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "Churn" not in result
 
     def test_stalled_line_included_when_stalled_present(self):
         stalled = [{"id": "uow-stalled", "status": "active"}]
-        text = md.format_digest(self._empty_groups(), stalled, 24, "2026-04-22T09:00:00+00:00")
-        assert "Stalled" in text
-        assert "uow-stalled" in text
+        groups = self._groups_with(pearl=3)
+        result = md.format_digest(groups, stalled, 24, self._now_dt, 0)
+        assert "Stalled" in result
+        assert "uow-stalled" in result
 
     def test_stalled_line_absent_when_no_stalled(self):
-        text = md.format_digest(self._empty_groups(), [], 24, "2026-04-22T09:00:00+00:00")
-        assert "Stalled" not in text
+        groups = self._groups_with(pearl=3)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "Stalled" not in result
 
-    def test_lookback_hours_reflected_in_output(self):
-        text = md.format_digest(self._empty_groups(), [], 48, "2026-04-22T09:00:00+00:00")
-        assert "48h" in text
+    def test_avg_tokens_shown_when_available(self):
+        uows = [
+            _uow(uow_id="p1", outcome_category="pearl", token_usage=1000),
+            _uow(uow_id="p2", outcome_category="pearl", token_usage=2000),
+            _uow(uow_id="p3", outcome_category="pearl", token_usage=3000),
+        ]
+        groups = md.aggregate_by_category(uows)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "Avg tokens" in result
+        assert "2,000" in result
 
-    def test_register_breakdown_present_when_uows_exist(self):
-        pearl = _uow(uow_id="p1", close_reason="opened pr", register="operational")
-        groups = md.aggregate_by_classification([(pearl, md.OUTCOME_PEARL)])
-        text = md.format_digest(groups, [], 24, "2026-04-22T09:00:00+00:00")
-        assert "Register breakdown" in text
-        assert "operational" in text
+    def test_avg_tokens_omitted_when_all_null(self):
+        uows = [
+            _uow(uow_id="p1", outcome_category="pearl"),
+            _uow(uow_id="p2", outcome_category="pearl"),
+            _uow(uow_id="p3", outcome_category="pearl"),
+        ]
+        groups = md.aggregate_by_category(uows)
+        result = md.format_digest(groups, [], 24, self._now_dt, 0)
+        assert "Avg tokens" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -404,27 +439,33 @@ class TestFormatDigest:
 # ---------------------------------------------------------------------------
 
 class TestJobsJsonGate:
-    def test_job_skips_when_disabled(self, tmp_path, monkeypatch):
-        jobs_file = tmp_path / "jobs.json"
-        jobs_file.write_text(json.dumps({"jobs": {"wos-metabolic-digest": {"enabled": False}}}))
-        monkeypatch.setattr(md, "_jobs_file", lambda: jobs_file)
-        assert md._is_job_enabled() is False
+    def test_job_gate_fires_when_disabled(self, tmp_path, monkeypatch):
+        """is_job_enabled returns False → job skips execution."""
+        monkeypatch.setattr(md, "is_job_enabled", lambda name: False)
+        assert md.is_job_enabled(md.JOB_NAME) is False
 
-    def test_job_runs_when_enabled(self, tmp_path, monkeypatch):
-        jobs_file = tmp_path / "jobs.json"
-        jobs_file.write_text(json.dumps({"jobs": {"wos-metabolic-digest": {"enabled": True}}}))
-        monkeypatch.setattr(md, "_jobs_file", lambda: jobs_file)
-        assert md._is_job_enabled() is True
+    def test_job_gate_passes_when_enabled(self, monkeypatch):
+        """is_job_enabled returns True → job proceeds."""
+        monkeypatch.setattr(md, "is_job_enabled", lambda name: True)
+        assert md.is_job_enabled(md.JOB_NAME) is True
 
-    def test_job_defaults_to_enabled_when_absent(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(md, "_jobs_file", lambda: tmp_path / "nonexistent.json")
-        assert md._is_job_enabled() is True
+    def test_job_defaults_to_enabled_when_jobs_json_absent(self, tmp_path, monkeypatch):
+        """is_job_enabled defaults to True when jobs.json is absent."""
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        # jobs.json absent — LOBSTER_WORKSPACE set but no scheduled-jobs/jobs.json
+        import importlib
+        utils_jobs = importlib.import_module("src.utils.jobs")
+        assert utils_jobs.is_job_enabled(md.JOB_NAME) is True
 
     def test_job_defaults_to_enabled_when_entry_missing(self, tmp_path, monkeypatch):
-        jobs_file = tmp_path / "jobs.json"
-        jobs_file.write_text(json.dumps({"jobs": {}}))
-        monkeypatch.setattr(md, "_jobs_file", lambda: jobs_file)
-        assert md._is_job_enabled() is True
+        """is_job_enabled defaults to True when the job entry is absent from jobs.json."""
+        jobs_json = tmp_path / "scheduled-jobs" / "jobs.json"
+        jobs_json.parent.mkdir(parents=True)
+        jobs_json.write_text(json.dumps({"jobs": {}}))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        import importlib
+        utils_jobs = importlib.import_module("src.utils.jobs")
+        assert utils_jobs.is_job_enabled(md.JOB_NAME) is True
 
 
 # ---------------------------------------------------------------------------
@@ -433,16 +474,25 @@ class TestJobsJsonGate:
 
 class TestQueryCompletedUows:
     def test_uow_transitioned_to_done_within_window_is_returned(self, db_path):
-        u = _uow(uow_id="uow-done", status="done", close_reason="pr merged")
+        u = _uow(uow_id="uow-done", status="done", outcome_category="pearl")
         _insert_uow_row(db_path, u)
         _insert_audit_entry(db_path, "uow-done", "done", hours_ago=1)
         results = md.query_completed_uows(db_path, md.DEFAULT_LOOKBACK_HOURS)
         ids = [r["id"] for r in results]
         assert "uow-done" in ids
 
+    def test_outcome_category_included_in_returned_row(self, db_path):
+        u = _uow(uow_id="uow-pearl", status="done", outcome_category="pearl")
+        _insert_uow_row(db_path, u)
+        _insert_audit_entry(db_path, "uow-pearl", "done", hours_ago=1)
+        results = md.query_completed_uows(db_path, md.DEFAULT_LOOKBACK_HOURS)
+        row = next((r for r in results if r["id"] == "uow-pearl"), None)
+        assert row is not None
+        assert row["outcome_category"] == "pearl"
+
     def test_uow_not_in_audit_window_is_excluded(self, db_path):
         # Transition happened 48h ago — outside the default 24h window
-        u = _uow(uow_id="uow-old", status="done", close_reason="pr merged")
+        u = _uow(uow_id="uow-old", status="done", outcome_category="pearl")
         _insert_uow_row(db_path, u)
         _insert_audit_entry(db_path, "uow-old", "done", hours_ago=48)
         results = md.query_completed_uows(db_path, md.DEFAULT_LOOKBACK_HOURS)
@@ -520,7 +570,7 @@ class TestHandleWosExecuteHeartbeatContract:
 
     def test_60_90_second_interval_documented(self, prompt):
         # The prompt uses an en-dash (U+2013) between 60 and 90.
-        assert "60\u201390 seconds" in prompt
+        assert "60–90 seconds" in prompt
 
     def test_stop_on_zero_return_value_documented(self, prompt):
         # Agent must stop if write_heartbeat returns 0 (UoW re-queued)


### PR DESCRIPTION
## Summary

- Replace heuristic `close_reason` classification in `wos-metabolic-digest.py` with `outcome_category` from `uow_registry` (real-time classification set at `write_result` time, migration 0018 — already live since PR #759)
- Format now follows the WOS completion report spec (`docs/wos/wos-completion-report-spec.md`): idle-day suppression (no message on zero completions), one-liner for <3 UoWs, full digest for 3+ with `gate_fired` churn stats (migration 0019), seeds surfaced (interim artifacts approximation until migration 0020), avg tokens, avg cycles
- Migration 118 in `upgrade.sh` reschedules cron from `0 9 * * *` (09:00 UTC) to `0 10 * * *` (10:00 UTC / 6 AM ET), landing in Dan's morning delivery window per `user.base.bootup.md`
- Tests fully updated: 50 passing — new tests for `resolve_outcome_category`, `aggregate_gate_churn`, `format_digest` idle suppression, full format, one-liner

## Digest format (3+ UoWs completed)

```
WOS Daily — 2026-05-18
Completed : 7 UoW(s)
  pearl 2  seed 1  heat 1  shit 3
  Seeds surfaced: 4
  Avg tokens: 1,200
  Avg cycles: 1.5
Failed    : 3 UoW(s) (dead_end)
Churn     : 1 spiral / 1 dead-end today
```

## Architecture decision honored

`outcome_category` is set at `write_result` time — real-time classification is the architecture. No morning archaeology pass needed. Pre-migration rows (NULL `outcome_category`) fall back to `shit` conservatively.

## Test plan

- [ ] `uv run pytest tests/unit/test_wos_metabolic_digest.py -v` — 50 tests pass
- [ ] `uv run scheduled-tasks/wos-metabolic-digest.py --dry-run` — runs without error, suppresses on idle day
- [ ] `uv run scheduled-tasks/wos-metabolic-digest.py --dry-run --hours 720` — full digest format rendered
- [ ] `upgrade.sh` migration 118 updates cron schedule from 09:00 to 10:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)