### PR TITLE
Add _lobster_meta pre-classification envelope to inbox messages (#1023)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -899,6 +899,7 @@ wait_for_messages() returns with message
          │
          ▼
 mark_processing(message_id)  ← claim it first
+  (injects _lobster_meta hints — see below)
          │
          ▼
 Route by message type and source
@@ -918,6 +919,38 @@ wait_for_messages() ← loop back
 ```
 
 **State directories:** `inbox/` → `processing/` → `processed/` (or → `failed/` → retried back to `inbox/`)
+
+### `_lobster_meta` Pre-Classification Envelope (issue #1023)
+
+`inbox_server.py` populates a `_lobster_meta` field on every message at `mark_processing()` time. These are **hints only** — fast heuristics (<5ms, no LLM calls). Never trust them blindly; a message could trigger false matches.
+
+Available fields after `mark_processing()`:
+
+```json
+"_lobster_meta": {
+  "intent_class": "operational" | "emotional" | "code" | "question" | "reaction" | "system",
+  "urgency": "high" | "normal" | "low",
+  "is_user_facing": true | false,
+  "preprocessed_at": "2026-03-28T..."
+}
+```
+
+**`intent_class`** — keyword-matched message category:
+- `"system"` — message type is a system type (wos_execute, subagent_result, etc.)
+- `"reaction"` — Telegram emoji reaction
+- `"code"` — bug, PR, fix, error, import, test, deploy, etc.
+- `"question"` — ends with ?, or starts with what/how/why/can you/etc.
+- `"emotional"` — feel, anxious, stressed, excited, grateful, etc.
+- `"operational"` — schedule, task, config, wos, lobster, job, etc. (default fallback)
+
+**`urgency`** — keyword urgency signal:
+- `"high"` — urgent, asap, broken, down, critical, emergency, etc.
+- `"low"` — whenever, no rush, low priority, eventually, fyi, etc.
+- `"normal"` — no urgency keyword found
+
+**`is_user_facing`** — `true` when source is in the user-facing sources set, `chat_id != 0`, and type is not a system type.
+
+**Usage guidance:** Use `_lobster_meta` to help route messages — e.g., prioritize high-urgency replies, or skip context injection for system messages. The dispatcher must always verify routing decisions against the actual message content; `_lobster_meta` is a speed hint, not an authoritative classification.
 
 ---
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -849,6 +849,7 @@ from message_types import (  # noqa: E402 — placed after path-setup at top of 
     INBOX_MESSAGE_SOURCES,
     USER_FACING_TYPES,
 )
+from lobster_meta import build_lobster_meta  # noqa: E402 — same path-setup above
 
 # ---------------------------------------------------------------------------
 # Message type normalization (issue #635)
@@ -5844,9 +5845,13 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
     # Shared helper handles filtering, incrementing, and reminder injection.
     _tick_user_message_counter(msg_type, msg_source)
 
-    # Stamp _processing_started_at so stale detection uses actual claim time, not file mtime.
+    # Stamp _processing_started_at and _lobster_meta (issue #1023) so stale detection
+    # uses actual claim time and downstream consumers have pre-computed routing hints.
     try:
         msg_data["_processing_started_at"] = datetime.now(timezone.utc).isoformat()
+        # _lobster_meta: fast heuristic classification (<5ms, no LLM calls).
+        # Fields are hints only — dispatcher must never trust them blindly.
+        msg_data["_lobster_meta"] = build_lobster_meta(msg_data)
         atomic_write_json(dest, msg_data)
     except Exception:
         pass  # non-fatal; stale recovery falls back to mtime

--- a/src/mcp/lobster_meta.py
+++ b/src/mcp/lobster_meta.py
@@ -6,8 +6,8 @@ time. Fields are hints only — the dispatcher must never trust them blindly (a
 user message could trigger false matches). All classification is synchronous,
 pure Python, and <5ms — no LLM calls on this path.
 
-This module is intentionally dependency-free (like message_types.py) so it can
-be imported and tested without pulling in the full inbox_server stack.
+This module depends only on message_types.py (also dependency-free) and can be
+imported and tested without pulling in the full inbox_server stack.
 
 Fields populated:
   intent_class: "operational" | "emotional" | "code" | "question" | "reaction"
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
+
+from src.mcp.message_types import INBOX_SYSTEM_TYPES as _SYSTEM_TYPES
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +106,7 @@ _URGENCY_LOW_PATTERN: re.Pattern[str] = re.compile(
 # Sources that produce user-facing messages
 # ---------------------------------------------------------------------------
 
+# bot-talk and gmail are system-originated; not user-facing even though they carry user content
 _USER_FACING_SOURCES: frozenset[str] = frozenset({
     "telegram",
     "slack",
@@ -111,32 +114,6 @@ _USER_FACING_SOURCES: frozenset[str] = frozenset({
     "signal",
     "whatsapp",
     "bisque",
-})
-
-# System message types that are never user-facing regardless of source
-_SYSTEM_TYPES: frozenset[str] = frozenset({
-    "self_check",
-    "subagent_result",
-    "subagent_error",
-    "subagent_ack",
-    "subagent_notification",
-    "subagent_observation",
-    "subagent_stale_check",
-    "subagent_recovered",
-    "agent_failed",
-    "compact_group",
-    "compact_reminder",
-    "cron_reminder",
-    "scheduled_reminder",
-    "update_notification",
-    "consolidation",
-    "observation",
-    "health_check",
-    "system",
-    "task-output",
-    "debug_observation",
-    "session_note_reminder",
-    "wos_execute",
 })
 
 

--- a/src/mcp/lobster_meta.py
+++ b/src/mcp/lobster_meta.py
@@ -1,0 +1,218 @@
+"""
+_lobster_meta envelope classifier for inbox messages (issue #1023).
+
+Populates a ``_lobster_meta`` dict on each incoming message at mark_processing()
+time. Fields are hints only — the dispatcher must never trust them blindly (a
+user message could trigger false matches). All classification is synchronous,
+pure Python, and <5ms — no LLM calls on this path.
+
+This module is intentionally dependency-free (like message_types.py) so it can
+be imported and tested without pulling in the full inbox_server stack.
+
+Fields populated:
+  intent_class: "operational" | "emotional" | "code" | "question" | "reaction"
+               | "system"
+  urgency: "high" | "normal" | "low"
+  is_user_facing: bool
+  preprocessed_at: ISO 8601 UTC timestamp string
+
+Classification scope (issue spec):
+  - Start with is_user_facing and intent_class (required).
+  - urgency implemented here; add more fields in follow-ups.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# Intent class — keyword patterns (checked in order; first match wins)
+# ---------------------------------------------------------------------------
+
+# Each entry is (intent_class, compiled_pattern).
+# Patterns are case-insensitive and match anywhere in the text.
+_INTENT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "code",
+        re.compile(
+            r"\b(bug|fix|error|traceback|exception|crash|pr|pull request|"
+            r"commit|deploy|branch|test|lint|import|module|function|class|"
+            r"variable|type error|attribute error|syntax|diff|patch|merge|"
+            r"rebase|refactor|implement|feature|issue\s*#\d+)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "question",
+        re.compile(
+            r"(\?$|\?\s*$|^(what|who|where|when|why|how|which|can you|"
+            r"could you|do you|did|does|is there|are there|tell me|"
+            r"explain|show me))",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+    ),
+    (
+        "emotional",
+        re.compile(
+            r"\b(feel|feeling|anxious|anxiety|scared|afraid|overwhelmed|"
+            r"stressed|stress|worry|worried|sad|depressed|depression|"
+            r"excited|frustrated|angry|upset|happy|grateful|thankful|"
+            r"struggling|hard time|difficult|exhausted|tired|burnout|"
+            r"lonely|alone|miss|love|hate|fear|hope|proud|shame|guilt|"
+            r"nervous|panic|doubt|insecure|vulnerable)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "operational",
+        re.compile(
+            r"\b(schedule|remind|task|todo|calendar|meeting|appointment|"
+            r"deadline|status|update|check|run|start|stop|restart|enable|"
+            r"disable|config|setting|turn on|turn off|list|show|wos|"
+            r"lobster|subagent|job|cron|deploy|upgrade|migrate|backup|"
+            r"notification|alert|report|digest|sync)\b",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+# Reaction-type: Telegram emoji reactions are classified separately
+_REACTION_TYPE = "reaction"
+
+# ---------------------------------------------------------------------------
+# Urgency — keyword patterns
+# ---------------------------------------------------------------------------
+
+_URGENCY_HIGH_PATTERN: re.Pattern[str] = re.compile(
+    r"\b(urgent|asap|as soon as possible|immediately|right now|broken|"
+    r"down|outage|critical|emergency|help|fix now|need now|blocked|"
+    r"p0|p1|hotfix|production|prod is down|failing)\b",
+    re.IGNORECASE,
+)
+
+_URGENCY_LOW_PATTERN: re.Pattern[str] = re.compile(
+    r"\b(whenever|no rush|low priority|eventually|when you get a chance|"
+    r"someday|not urgent|backlog|nice to have|fyi|heads up|just letting "
+    r"you know|when possible)\b",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sources that produce user-facing messages
+# ---------------------------------------------------------------------------
+
+_USER_FACING_SOURCES: frozenset[str] = frozenset({
+    "telegram",
+    "slack",
+    "sms",
+    "signal",
+    "whatsapp",
+    "bisque",
+})
+
+# System message types that are never user-facing regardless of source
+_SYSTEM_TYPES: frozenset[str] = frozenset({
+    "self_check",
+    "subagent_result",
+    "subagent_error",
+    "subagent_ack",
+    "subagent_notification",
+    "subagent_observation",
+    "subagent_stale_check",
+    "subagent_recovered",
+    "agent_failed",
+    "compact_group",
+    "compact_reminder",
+    "cron_reminder",
+    "scheduled_reminder",
+    "update_notification",
+    "consolidation",
+    "observation",
+    "health_check",
+    "system",
+    "task-output",
+    "debug_observation",
+    "session_note_reminder",
+    "wos_execute",
+})
+
+
+def _classify_intent(text: str, msg_type: str) -> str:
+    """Return the intent_class for a message.
+
+    For system types, returns "system" immediately.
+    For reaction types, returns "reaction".
+    Otherwise, runs keyword patterns in order (first match wins).
+    Falls back to "operational" when no pattern matches.
+    """
+    if msg_type in _SYSTEM_TYPES:
+        return "system"
+    if msg_type == "reaction":
+        return "reaction"
+
+    for intent, pattern in _INTENT_PATTERNS:
+        if pattern.search(text):
+            return intent
+
+    return "operational"
+
+
+def _classify_urgency(text: str, msg_type: str) -> str:
+    """Return "high", "normal", or "low" based on keyword signals.
+
+    System messages and reactions are always "normal".
+    """
+    if msg_type in _SYSTEM_TYPES or msg_type == "reaction":
+        return "normal"
+    if _URGENCY_HIGH_PATTERN.search(text):
+        return "high"
+    if _URGENCY_LOW_PATTERN.search(text):
+        return "low"
+    return "normal"
+
+
+def _is_user_facing(source: str, chat_id: int | None, msg_type: str) -> bool:
+    """Return True when the message is from a real user channel.
+
+    Conditions for user-facing:
+    - source is in _USER_FACING_SOURCES
+    - chat_id is non-zero (0 = system/internal)
+    - msg_type is not in _SYSTEM_TYPES
+    """
+    if msg_type in _SYSTEM_TYPES:
+        return False
+    if source == "system":
+        return False
+    if chat_id is not None and chat_id == 0:
+        return False
+    return source in _USER_FACING_SOURCES
+
+
+def build_lobster_meta(msg: dict) -> dict:
+    """Classify a message and return a ``_lobster_meta`` dict.
+
+    This is the single entry point. Call it at mark_processing() time and
+    attach the result to the message before writing it to the processing dir.
+
+    Arguments:
+        msg: The raw message dict. Reads: text, type, source, chat_id.
+
+    Returns a dict with keys:
+        intent_class, urgency, is_user_facing, preprocessed_at.
+
+    This function is pure: no side effects, no I/O.
+    """
+    text: str = (msg.get("text") or msg.get("transcription") or "").strip()
+    msg_type: str = (msg.get("type") or "").strip()
+    source: str = (msg.get("source") or "").strip()
+    chat_id: int | None = msg.get("chat_id")
+
+    return {
+        "intent_class": _classify_intent(text, msg_type),
+        "urgency": _classify_urgency(text, msg_type),
+        "is_user_facing": _is_user_facing(source, chat_id, msg_type),
+        "preprocessed_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/tests/unit/test_mcp_server/test_lobster_meta.py
+++ b/tests/unit/test_mcp_server/test_lobster_meta.py
@@ -1,0 +1,247 @@
+"""
+Tests for the _lobster_meta pre-classification envelope (issue #1023).
+
+All tests are pure unit tests against lobster_meta.py — no MCP, Telegram,
+or network calls. The module is dependency-free (like message_types.py) so
+it can be imported and tested in isolation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# lobster_meta.py lives in src/mcp/ alongside inbox_server.py.
+# Add that directory to sys.path so we can import it directly.
+_MCP_DIR = str(Path(__file__).resolve().parents[3] / "src" / "mcp")
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+from lobster_meta import (  # noqa: E402
+    build_lobster_meta,
+    _classify_intent,
+    _classify_urgency,
+    _is_user_facing,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg(
+    text: str = "",
+    msg_type: str = "text",
+    source: str = "telegram",
+    chat_id: int = 12345,
+) -> dict:
+    """Build a minimal message dict for testing."""
+    return {"text": text, "type": msg_type, "source": source, "chat_id": chat_id}
+
+
+# ---------------------------------------------------------------------------
+# _classify_intent
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyIntent:
+    """_classify_intent returns the right intent_class for various inputs."""
+
+    def test_system_type_returns_system(self) -> None:
+        """Any system message type maps to 'system'."""
+        assert _classify_intent("whatever text", "wos_execute") == "system"
+        assert _classify_intent("scheduled task", "scheduled_reminder") == "system"
+        assert _classify_intent("done", "subagent_result") == "system"
+
+    def test_reaction_type_returns_reaction(self) -> None:
+        """reaction type maps to 'reaction'."""
+        assert _classify_intent("", "reaction") == "reaction"
+
+    def test_code_keywords(self) -> None:
+        """Messages with code keywords map to 'code'."""
+        assert _classify_intent("There's a bug in the auth module", "text") == "code"
+        assert _classify_intent("open a pull request for this fix", "text") == "code"
+        assert _classify_intent("deploy failed with traceback", "text") == "code"
+        assert _classify_intent("refactor the user model class", "text") == "code"
+
+    def test_question_keywords(self) -> None:
+        """Messages that are questions map to 'question'."""
+        assert _classify_intent("What is the status?", "text") == "question"
+        assert _classify_intent("How do I restart the dispatcher?", "text") == "question"
+        assert _classify_intent("Can you explain the WOS pipeline?", "text") == "question"
+        assert _classify_intent("Is there a log for this?", "text") == "question"
+
+    def test_emotional_keywords(self) -> None:
+        """Messages with emotional content map to 'emotional'."""
+        assert _classify_intent("I'm feeling really anxious about the launch", "text") == "emotional"
+        assert _classify_intent("I'm overwhelmed with all these tasks", "text") == "emotional"
+        assert _classify_intent("I'm grateful for your help", "text") == "emotional"
+
+    def test_operational_keywords(self) -> None:
+        """Messages with operational keywords map to 'operational'."""
+        assert _classify_intent("Schedule a reminder for tomorrow", "text") == "operational"
+        assert _classify_intent("Check the WOS status", "text") == "operational"
+        assert _classify_intent("Update the config settings", "text") == "operational"
+
+    def test_fallback_to_operational(self) -> None:
+        """Messages with no recognized keywords fall back to 'operational'."""
+        result = _classify_intent("hi there", "text")
+        assert result == "operational"
+
+    def test_code_takes_priority_over_question(self) -> None:
+        """Code patterns are checked before question patterns."""
+        # Has "bug" (code) AND ends with "?" (question) — code wins because it's first
+        result = _classify_intent("Is there a bug in the deploy script?", "text")
+        # "bug" matches code, "?" matches question — code pattern checked first
+        assert result == "code"
+
+    def test_empty_text_returns_operational(self) -> None:
+        """Empty text defaults to 'operational' (not a crash)."""
+        assert _classify_intent("", "text") == "operational"
+
+
+# ---------------------------------------------------------------------------
+# _classify_urgency
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyUrgency:
+    """_classify_urgency returns the right urgency level."""
+
+    def test_high_urgency_keywords(self) -> None:
+        """Messages with high-urgency keywords return 'high'."""
+        assert _classify_urgency("This is urgent", "text") == "high"
+        assert _classify_urgency("Fix this ASAP", "text") == "high"
+        assert _classify_urgency("Production is down", "text") == "high"
+        assert _classify_urgency("The service is broken", "text") == "high"
+        assert _classify_urgency("Critical issue in prod", "text") == "high"
+
+    def test_low_urgency_keywords(self) -> None:
+        """Messages with low-urgency keywords return 'low'."""
+        assert _classify_urgency("Whenever you get a chance", "text") == "low"
+        assert _classify_urgency("No rush on this", "text") == "low"
+        assert _classify_urgency("Low priority task for the backlog", "text") == "low"
+        assert _classify_urgency("FYI, just letting you know", "text") == "low"
+
+    def test_normal_urgency_is_default(self) -> None:
+        """Messages with no urgency signals return 'normal'."""
+        assert _classify_urgency("Can you check on this?", "text") == "normal"
+        assert _classify_urgency("Update the documentation", "text") == "normal"
+
+    def test_system_messages_are_normal(self) -> None:
+        """System message types always return 'normal'."""
+        assert _classify_urgency("urgent fix needed", "subagent_result") == "normal"
+        assert _classify_urgency("broken", "wos_execute") == "normal"
+
+    def test_reaction_messages_are_normal(self) -> None:
+        """Reaction type always returns 'normal'."""
+        assert _classify_urgency("broken", "reaction") == "normal"
+
+
+# ---------------------------------------------------------------------------
+# _is_user_facing
+# ---------------------------------------------------------------------------
+
+
+class TestIsUserFacing:
+    """_is_user_facing correctly identifies user-facing vs system messages."""
+
+    def test_telegram_user_message_is_user_facing(self) -> None:
+        """Regular telegram messages with non-zero chat_id are user-facing."""
+        assert _is_user_facing("telegram", 12345, "text") is True
+
+    def test_slack_message_is_user_facing(self) -> None:
+        """Slack messages with non-zero chat_id are user-facing."""
+        assert _is_user_facing("slack", 99999, "text") is True
+
+    def test_system_source_is_not_user_facing(self) -> None:
+        """Messages from source='system' are never user-facing."""
+        assert _is_user_facing("system", 12345, "text") is False
+
+    def test_chat_id_zero_is_not_user_facing(self) -> None:
+        """Messages with chat_id=0 are not user-facing (system/internal)."""
+        assert _is_user_facing("telegram", 0, "text") is False
+
+    def test_system_type_is_not_user_facing(self) -> None:
+        """System message types are never user-facing regardless of source."""
+        assert _is_user_facing("telegram", 12345, "wos_execute") is False
+        assert _is_user_facing("telegram", 12345, "subagent_result") is False
+        assert _is_user_facing("telegram", 12345, "scheduled_reminder") is False
+
+    def test_unknown_source_is_not_user_facing(self) -> None:
+        """Unknown sources are not user-facing."""
+        assert _is_user_facing("unknown-channel", 12345, "text") is False
+
+    def test_none_chat_id_is_user_facing_for_valid_source(self) -> None:
+        """None chat_id (missing field) is not treated as zero."""
+        # chat_id=None means the field is absent, not zero — should not block
+        assert _is_user_facing("telegram", None, "text") is True
+
+
+# ---------------------------------------------------------------------------
+# build_lobster_meta — full integration
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLobsterMeta:
+    """build_lobster_meta returns a complete _lobster_meta dict."""
+
+    def test_returns_all_required_fields(self) -> None:
+        """Result always contains all four fields."""
+        result = build_lobster_meta(_msg("hello"))
+        assert "intent_class" in result
+        assert "urgency" in result
+        assert "is_user_facing" in result
+        assert "preprocessed_at" in result
+
+    def test_preprocessed_at_is_iso_string(self) -> None:
+        """preprocessed_at is an ISO 8601 string."""
+        result = build_lobster_meta(_msg("hello"))
+        ts = result["preprocessed_at"]
+        assert isinstance(ts, str)
+        assert "T" in ts  # ISO format
+
+    def test_user_message_is_user_facing(self) -> None:
+        """Standard telegram user message has is_user_facing=True."""
+        result = build_lobster_meta(_msg("hello", "text", "telegram", 12345))
+        assert result["is_user_facing"] is True
+
+    def test_system_message_is_not_user_facing(self) -> None:
+        """System source message has is_user_facing=False."""
+        result = build_lobster_meta(
+            _msg("job done", "scheduled_reminder", "system", 0)
+        )
+        assert result["is_user_facing"] is False
+
+    def test_system_type_intent_class(self) -> None:
+        """System message type gets intent_class='system'."""
+        result = build_lobster_meta(
+            _msg("execute now", "wos_execute", "system", 0)
+        )
+        assert result["intent_class"] == "system"
+
+    def test_urgent_user_message(self) -> None:
+        """High-urgency user message is classified correctly."""
+        result = build_lobster_meta(
+            _msg("Production is broken, fix ASAP!", "text", "telegram", 12345)
+        )
+        assert result["urgency"] == "high"
+        assert result["intent_class"] == "code"
+        assert result["is_user_facing"] is True
+
+    def test_uses_transcription_field_when_text_absent(self) -> None:
+        """Falls back to 'transcription' field when 'text' is missing."""
+        msg = {"type": "voice", "source": "telegram", "chat_id": 12345,
+               "transcription": "urgent fix for production"}
+        result = build_lobster_meta(msg)
+        assert result["urgency"] == "high"
+
+    def test_missing_fields_dont_crash(self) -> None:
+        """build_lobster_meta does not crash on a minimal/empty message."""
+        result = build_lobster_meta({})
+        assert "intent_class" in result
+        assert "is_user_facing" in result
+        assert result["is_user_facing"] is False


### PR DESCRIPTION
## Summary

- Adds `src/mcp/lobster_meta.py` — a new dependency-free classifier module (mirrors `message_types.py` in design) that populates a `_lobster_meta` dict for each incoming message at `mark_processing()` time
- `inbox_server.py` now stamps `_lobster_meta` on every message alongside `_processing_started_at`
- Updates dispatcher bootup docs with a full description of available `_lobster_meta` fields and usage guidance

## Fields populated

```json
"_lobster_meta": {
  "intent_class": "operational" | "emotional" | "code" | "question" | "reaction" | "system",
  "urgency": "high" | "normal" | "low",
  "is_user_facing": true | false,
  "preprocessed_at": "2026-..."
}
```

All classification is synchronous, pure Python, <5ms — no LLM calls. Fields are hints only; the dispatcher should never trust them blindly.

## Test plan

- [ ] 29 unit tests in `tests/unit/test_mcp_server/test_lobster_meta.py` — all passing
- [ ] Tests cover: all intent_class variants, urgency levels, is_user_facing conditions, system type handling, empty/missing field handling, transcription fallback

Closes SiderealPress/lobster#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)