### PR TITLE
fix(wos): raise context pressure threshold 5→20 to unblock 168 stalled UoWs

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -696,13 +696,11 @@ def main() -> int:
     # reliable proxy for context pressure and a contributing cause of the
     # 2026-04 restart storm (WOS running at full speed → faster compaction cycles).
     #
-    # Raised from 5 → 20 (2026-05-19): the old threshold of 5 caused the pipeline
-    # to stall when 5 long-running "executing" UoWs occupied session slots but had
-    # no live subagents — the heartbeat sidecar kept their heartbeat_at fresh,
-    # preventing TTL recovery. With 168 UoWs ready-for-steward and only 1 real
-    # session active, the effective cap was 5, blocking all new dispatch.
-    # The quota gate (CC quota, GitHub rate limit) remains the real throttle;
-    # this threshold is now a safety backstop rather than an active dispatch cap.
+    # get_active_sessions() reads agent_sessions (Claude session store), not
+    # uow_registry executing status — these are separate tracking systems.
+    # Real throttles: CC quota gate (90%) and GitHub rate limit gate. This
+    # threshold is a safety backstop against session accumulation (e.g. orphaned
+    # agent_sessions rows from subagents that died without writing results).
     #
     # TTL recovery (Phase 1) and heartbeat sidecar (Phase 1b) always run above —
     # only new dispatch is throttled here.

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -696,9 +696,17 @@ def main() -> int:
     # reliable proxy for context pressure and a contributing cause of the
     # 2026-04 restart storm (WOS running at full speed → faster compaction cycles).
     #
+    # Raised from 5 → 20 (2026-05-19): the old threshold of 5 caused the pipeline
+    # to stall when 5 long-running "executing" UoWs occupied session slots but had
+    # no live subagents — the heartbeat sidecar kept their heartbeat_at fresh,
+    # preventing TTL recovery. With 168 UoWs ready-for-steward and only 1 real
+    # session active, the effective cap was 5, blocking all new dispatch.
+    # The quota gate (CC quota, GitHub rate limit) remains the real throttle;
+    # this threshold is now a safety backstop rather than an active dispatch cap.
+    #
     # TTL recovery (Phase 1) and heartbeat sidecar (Phase 1b) always run above —
     # only new dispatch is throttled here.
-    CONTEXT_PRESSURE_AGENT_THRESHOLD: int = 5
+    CONTEXT_PRESSURE_AGENT_THRESHOLD: int = 20
     try:
         from src.agents.session_store import get_active_sessions
         active_session_count = len(get_active_sessions())


### PR DESCRIPTION
## Problem

The WOS pipeline had 168 UoWs in `ready-for-steward` state, all blocked because `CONTEXT_PRESSURE_AGENT_THRESHOLD = 5` was saturated — but not by 5 real active subagents.

**Root cause:**

The context pressure check reads from `agent_sessions` (the Claude session store), not from `uow_registry`. Specifically:

```python
from src.agents.session_store import get_active_sessions
active_session_count = len(get_active_sessions())
```

`get_active_sessions()` queries `agent_sessions WHERE status IN ('running', 'starting') AND agent_type NOT IN ('dispatcher', 'hook')`. This counts live Claude Code subagent processes — it does NOT count WOS UoW executing status.

The blockage was caused by **5 orphaned `agent_sessions` rows** left behind when subagents died without writing a result. When a subagent dies without calling `write_result`, its `agent_sessions` row stays in `running` status indefinitely. The session reconciler (`prune_dead_sessions`) should clean these up, but a gap in reconciler coverage allowed 5 rows to accumulate — keeping the context pressure count at 5 and blocking all further dispatch.

**What the heartbeat sidecar does and does not do:**

The heartbeat sidecar (`executor-heartbeat.py` Phase 1b) refreshes `heartbeat_at` every 3 minutes for active/executing UoWs. This is a real behavior, but it is a red herring for this specific blockage: TTL recovery uses `started_at`, not `heartbeat_at`, as the cutoff:

```sql
WHERE status IN ('active', 'executing')
  AND started_at IS NOT NULL
  AND started_at < ?
```

The 4 UoWs that stayed just under the 24h cutoff did so because of their actual `started_at` age — not because `heartbeat_at` was being refreshed. The heartbeat sidecar did not prevent TTL recovery here.

**The two tracking systems that were conflated:**
- `uow_registry.status = 'executing'` — WOS Registry, counts dispatched work orders
- `agent_sessions.status = 'running'` — Session Store, counts live Claude processes

The context pressure check reads only the second. Dead UoWs in `uow_registry` only block dispatch via the context pressure check if their corresponding `agent_sessions` rows were never cleaned up.

## Fix

**Code change (`CONTEXT_PRESSURE_AGENT_THRESHOLD: 5 → 20`):**

Raising the threshold from 5 to 20 means the dispatch gate can tolerate more orphaned `agent_sessions` rows before blocking. The threshold is now a safety backstop for genuinely runaway session counts rather than an active dispatch cap. The real throttles — CC quota gate (blocks at ≥90% usage) and GitHub rate limit gate (blocks when remaining calls < 100) — already prevent resource exhaustion and remain in place at the same thresholds.

**Immediate unblock (applied directly to registry DB):**

All 5 stale executing UoWs were reset to `ready-for-steward` with `audit_log` entries explaining the reset. The pipeline now has 173 UoWs ready for the steward.

| UoW | Age when reset |
|-----|---------------|
| uow_20260504_1cf8cb | 23.0h |
| uow_20260506_0c3032 | 23.1h |
| uow_20260517_4827ef | 23.7h |
| uow_20260517_e0fccf | 24.0h |
| uow_20260518_f729fe | 22.4h |

## Structural follow-up

A companion GitHub issue is being filed for the proper fix: replacing the `executing` status + TTL recovery pattern with a `claimed_until` timestamp (visibility-timeout model). This eliminates the leaked-slot problem structurally — no TTL needed, no heartbeat sidecar needed for liveness, no max_parallel cap needed.

The reconciler gap (orphaned `agent_sessions` rows not being pruned) is a separate structural issue: subagents that die without writing a result should have their `agent_sessions` rows transitioned to `dead` status by the reconciler promptly. This is the actual root of the `threshold = 5` saturation problem.

## Test plan
- [ ] Verify executor-heartbeat.py runs with `--dry-run` and no longer hits the threshold on normal workloads
- [ ] Confirm steward picks up the 173 ready-for-steward UoWs on next cycle
- [ ] Confirm no new dispatch storms (CC quota gate is the backstop)

WOS-UoW: wos-concurrency-fix