### PR TITLE
fix: remove broken TTL_EXCEEDED_HOURS import in executor-heartbeat

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -284,7 +284,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 ```
 1. mark_processing(message_id)  <- compact-reminder ONLY, not other messages
 2. Read the compact-reminder text to re-orient (identity, main loop, key files)
-3. Spawn session-note-polish subagent (run_in_background=True, subagent_type: "lobster-generalist"):
+3. Spawn session-note-polish subagent (run_in_background=True, subagent_type: "session-note-polish"):
    - See .claude/agents/session-note-polish.md for the agent definition
    - Pass: task_id: "session-note-polish", chat_id: 0, source: "system", current_session_file: <path>, MESSAGE_COUNT: <current message count>
    - Do NOT wait for it — spawn and immediately proceed to step 4

--- a/oracle/verdicts/index.md
+++ b/oracle/verdicts/index.md
@@ -1,3 +1,4 @@
+| 2026-05-19 | PR #1220 | Round 2 | APPROVED |
 | 2026-05-19 | PR #1220 | Round 1 | NEEDS_CHANGES |
 | 2026-05-19 | PR #1217 | Round 2 | APPROVED |
 | 2026-05-19 | PR #1217 | Round 1 | NEEDS_CHANGES |

--- a/oracle/verdicts/pr-1220.md
+++ b/oracle/verdicts/pr-1220.md
@@ -1,60 +1,64 @@
-VERDICT: NEEDS_CHANGES
+VERDICT: APPROVED
 PR: 1220
-Round: 1
+Round: 2
 
-## Stage 1 — Vision Alignment (before seeing implementation)
+## Round 2 — 2026-05-19
 
-**Prior entering review:** This implementation is solving the wrong problem, or solving the right problem in a direction that forecloses better paths.
+**Stage 1: Vision alignment**
 
-The PR fixes an ImportError crash: `TTL_EXCEEDED_HOURS` was removed from `src/orchestration/executor.py` as part of the visibility-timeout design work (#1216), but its import in `executor-heartbeat.py` was not updated. The proposed fix wraps the import in `try/except ImportError`.
+This PR is a crash-fix for the WOS executor dispatch path. With the executor live (execution_enabled=True since 2026-05-18), broken stall recovery means stalled UoWs accumulate indefinitely — a structural failure in the active phase, not a behavioral edge case. The fix serves vision.yaml principle-1 ("proactive resilience over reactive recovery") directly.
 
-**Vision alignment analysis:**
+Adversarial prior entering Stage 1: is there a scenario where stall recovery itself is the wrong problem — where the claimed_until approach is premature or forecloses a better path? No. `reset_expired_claims()` was already implemented in registry.py:1354 with full documentation of its design rationale (supersedes the started_at-based approach). The PR is not inventing a new mechanism; it is wiring an existing, already-designed one. The only foreclosed path would be "no stall recovery while executor is live" — which is worse, not better.
 
-vision.yaml principle-1 ("Proactive resilience over reactive recovery") states structural prevention is preferred over better correction mechanisms. A `try/except ImportError` is reactive error suppression — it prevents the crash but does not restore the underlying capability. This is in direct tension with principle-1.
+Golden-pattern citation: "seam-first abstraction" (golden-patterns.md, 2026-03-30) — `reset_expired_claims()` is already at the correct seam: Registry owns the visibility-timeout state, heartbeat calls the Registry method. The pattern constrained me to confirm this is the correct call structure rather than flag it as unnecessary indirection. No over-engineering; the abstraction was placed when the design was laid down, not now.
 
-For this to be the right path, the following would need to be true: the symbol `TTL_EXCEEDED_HOURS` is genuinely gone with no planned replacement AND silently skipping TTL recovery is acceptable indefinitely. But `recover_ttl_exceeded_uows` and `TTL_EXCEEDED_HOURS` were removed because a replacement mechanism was designed — the visibility-timeout model (`claimed_until` + `registry.reset_expired_claims()`). The question is whether that replacement is wired.
-
-**Stage 1 finding (locked):** The crash suppression is the right immediate action — the heartbeat was crashing every 3 minutes and blocking ALL WOS dispatch. But the framing "stop the crash" is incomplete. The correct framing is: "stop the crash AND ensure the replacement recovery path is wired." If the replacement (`reset_expired_claims()`) is already built, the fix can be structural rather than suppressive.
-
-This finding does not change after seeing the implementation.
+**Alignment verdict:** Confirmed
 
 ---
 
-## Stage 2 — Quality Review (after reading diff)
+**Stage 2: Quality review**
 
-**What the diff does:** Wraps the import of `TTL_EXCEEDED_HOURS, recover_ttl_exceeded_uows` in `run_ttl_recovery()` with try/except ImportError. On failure, logs a warning and returns []. 7 lines changed in `scheduled-tasks/executor-heartbeat.py`.
+**Commit 2f68314b verified on branch.** Three commits on `fix/executor-heartbeat-import-error`:
+1. `624d0ea` — ImportError guard on `run_ttl_recovery()` (original crash fix)
+2. `3f35992` — Unrelated bootup doc fix (session-note-polish subagent_type)
+3. `2f68314` — Wire `reset_expired_claims()` as primary stall recovery path (Round 1 gap fix)
 
-**Crash fix is correct.** The heartbeat was crashing on every 3-minute cycle. Stopping the crash is necessary and correct. The try/except mechanism is appropriate for a lazy import guarded against a known missing symbol.
+**Round 1 gap addressed:** `reset_expired_claims()` is now called in `main()` at line 680, inside a `try/except Exception` guard, only when `not dry_run`. The Round 1 finding — "the designed replacement was implemented but never called" — is closed.
 
-**The critical gap:** `registry.reset_expired_claims()` already exists in `src/orchestration/registry.py` (lines 1354–1401). It is the designed replacement for `run_ttl_recovery()` — it resets UoWs whose `claimed_until` timestamp has expired back to `ready-for-executor`. executor.py's own module docstring (line 23-25) states: "Stall recovery: UoWs with an expired claimed_until timestamp are reset to 'ready-for-executor' by registry.reset_expired_claims() at heartbeat startup. No separate TTL recovery job is needed — the visibility-timeout model handles it."
+**Import correctness:** `Registry` is imported from `src.orchestration.registry` at line 658 (lazy import inside `main()`, matching the heartbeat's established pattern for avoiding import-time failures). `registry.reset_expired_claims()` is called on the already-instantiated `registry` object — signature is `def reset_expired_claims(self) -> list[str]`, called as `registry.reset_expired_claims()`. No arguments required; signature matches.
 
-But executor-heartbeat.py does NOT call `registry.reset_expired_claims()` anywhere. After this PR ships, the heartbeat runs with:
-- Old TTL recovery path: silently disabled (returns [])
-- New visibility-timeout recovery path: not wired
+**Dry-run guard:** The `if not dry_run:` guard at line 678 is correct and appropriate. In dry-run mode, the call is skipped and a log message is emitted instead. The legacy `run_ttl_recovery(registry, dry_run=dry_run)` call immediately follows — so in dry-run mode, the legacy path runs with its own `dry_run` guard, which queries but does not write. This is consistent: dry-run sees the legacy query path but not the new primary path. No write occurs in either case.
 
-The net result is no stall recovery of any kind running in production. With the WOS executor live as of 2026-05-18, this means stuck executing UoWs will not be automatically recovered — the exact operational gap that caused the 2026-05-18/19 incident described in issue #1216.
+**Double-recovery risk from legacy fallback:** The concern is whether the legacy `run_ttl_recovery()` call (line 692) creates double-recovery overlap with `reset_expired_claims()`. Examining the two paths:
 
-**Is the --dry-run verification sufficient?** No. The dry-run verifies the crash is gone and dispatch logic runs. It does not verify stall recovery works because `reset_expired_claims()` is not called in either path.
+- `reset_expired_claims()` targets `status IN ('active', 'executing') AND claimed_until IS NOT NULL AND claimed_until < datetime('now')` — resets to `ready-for-executor`.
+- `run_ttl_recovery()` wraps `recover_ttl_exceeded_uows()` which is imported from `src.orchestration.executor` — but that symbol was removed in #1216, so `run_ttl_recovery()` returns `[]` immediately via the `ImportError` guard.
 
-**What this forecloses:** After this ships, the crash noise disappears and the single WARNING line every 3 minutes is easy to ignore. The gap in stall recovery becomes invisible operational debt with no forcing function. The urgency to wire `reset_expired_claims()` drops because the loud symptom is gone.
+In the current state (post-#1216), the legacy fallback is effectively a no-op. It logs a warning on the first call (the ImportError), returns `[]`, and does nothing. There is no double-recovery risk in production today. The warning it emits (`"TTL recovery skipped — TTL_EXCEEDED_HOURS not available"`) will appear in logs but is accurate and informative. The fallback's purpose is forward-defensive: if `recover_ttl_exceeded_uows` is ever re-added with a different implementation, it would run as a secondary pass. Given that `reset_expired_claims()` uses `claimed_until` expiry and the legacy path uses `started_at`-based TTL, they would target somewhat different populations (unclaimed-until UoWs would not be touched by `reset_expired_claims()`). The risk of actual double-transition on the same UoW is protected by the UPDATE's `WHERE id = ? AND status IN ('active', 'executing') AND claimed_until < datetime('now')` predicate — a UoW that `reset_expired_claims()` has already moved to `ready-for-executor` will not match the `status IN ('active', 'executing')` condition. The legacy path, when it eventually re-activates, cannot double-transition a row already reset.
 
-**Pattern citations:**
+**Patterns introduced:**
+- `try/except Exception` wrapping a primary infrastructure call with log.warning fallback — this is the correct pattern here; it prevents stall recovery failure from killing the entire heartbeat cycle. Not a new pattern in this codebase, appropriately applied.
+- Legacy fallback retained as a defensive secondary call after the primary path — this is appropriate for a transitional state (post-#1216, pre-full-cleanup), but should be removed when `recover_ttl_exceeded_uows()` is confirmed gone and no re-introduction is planned.
 
-- The "fix the contract at the producer, not the consumer" pattern (learnings.md PR #607) applies here: the correct fix is to call the replacement recovery function at the heartbeat call site, not to catch the ImportError silently. This pattern constrained my analysis: I looked for the replacement before accepting suppression as the final state.
-- vision.yaml principle-1 ("proactive resilience over reactive recovery") is the relevant operating anchor. It caused me to weigh the absence of a wired replacement more heavily than I would have otherwise — silent failure is worse than a loud crash when the loud crash would have surfaced the gap.
+**Encoded Orientation check (constraint-3):** This PR does not change behavioral defaults, system constraints, agent identity, or decision-making rules in a durable way. It restores a recovery mechanism that was broken by an import error. Not an Encoded Orientation decision.
 
-**Encoded Orientation check (OODA constraint-3):** This PR does not change behavioral defaults, system constraints, agent identity, or decision-making rules durably. It is a crash fix. Constraint-3 does not fire.
+**Feature-bundling note:** The bootup doc fix (commit 3f35992, wrong subagent_type for session-note-polish) is a small unrelated fix bundled in the same PR. By learnings.md 2026-05-18 calibration, this is same-system cosmetics class (a one-line string fix in a bootup doc, clearly incidental maintenance, no distinct workstream). Not a blocker. Note only.
 
-**What would make this APPROVED:**
+**What would break without the key decisions:**
+- Without the `if not dry_run` guard: `reset_expired_claims()` would write state transitions in dry-run mode, violating the dry-run contract.
+- Without the `try/except Exception` wrapper: a DB error in `reset_expired_claims()` would propagate and abort the heartbeat before dispatch runs.
+- Without retaining the legacy `run_ttl_recovery()` call: any UoWs with `claimed_until IS NULL` but `started_at`-based TTL concerns would be unhandled (though currently moot given #1216 removal).
 
-Option A (preferred): Replace `run_ttl_recovery()` call in `main()` with a direct call to `registry.reset_expired_claims()` and remove or inline the now-dead `run_ttl_recovery()` function. The replacement is already built and requires no dependency on #1216 completing.
+**Verdict:** Round 1 gap is closed. Implementation is correct. Import is right, signature matches, dry-run guard is appropriate, double-recovery risk is structurally prevented.
 
-Option B (acceptable): Keep the try/except suppression but add (a) a code comment in `run_ttl_recovery()` stating that stall recovery is now owned by `registry.reset_expired_claims()` and this function is the legacy path pending cleanup, AND (b) a direct call to `registry.reset_expired_claims()` in `main()` alongside or replacing the `run_ttl_recovery()` call.
+---
 
-Option C (minimum bar, least preferred): Keep the fix as-is but add a code comment and file an issue explicitly tracking "wire reset_expired_claims into executor-heartbeat." The issue number must be in the code comment so it is not forgotten.
+## Round 1 — 2026-05-19 (superseded)
 
-**Revision contract:**
+**VERDICT: NEEDS_CHANGES**
 
-Gap 1 (NEEDS RESOLUTION): Stall recovery is silently disabled. `registry.reset_expired_claims()` exists and is the replacement for `run_ttl_recovery()`. The fix must either call `reset_expired_claims()` directly, or explicitly document in code (not just PR description) that stall recovery is disabled pending a specific follow-on issue, AND that follow-on issue must exist before this merges.
+Stage 1: Confirmed (vision-aligned crash fix for live WOS executor).
 
-This gap is addressed when: (a) `reset_expired_claims()` is called in the heartbeat's main loop, OR (b) a code comment names the specific issue tracking the wiring work AND that issue exists with "stall recovery / reset_expired_claims" in its title.
+Stage 2 gap: `reset_expired_claims()` was the designed replacement for `run_ttl_recovery()` (already implemented in registry.py:1354) but was never called in the heartbeat. After commit `624d0ea` wrapped the failing import in a try/except, the ImportError was silenced but no stall recovery of any kind ran in production. The fix resolved the crash but left the recovery path dark.
+
+Gap closed by commit `2f68314b`: `reset_expired_claims()` is now called as the primary path in `main()`, with `run_ttl_recovery()` retained as a defensive legacy fallback. Dry-run verified (skips the write, logs a message).

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -664,8 +664,31 @@ def main() -> int:
 
     registry = Registry(db_path)
 
-    # Phase 1: TTL recovery — always runs regardless of execution_enabled so
+    # Phase 1: Stall recovery — always runs regardless of execution_enabled so
     # that stalled active UoWs are recovered even when dispatch is paused.
+    #
+    # Primary path: registry.reset_expired_claims() uses the visibility-timeout
+    # model (claimed_until) to reset expired claims back to 'ready-for-executor'.
+    # This is the designed replacement for the legacy recover_ttl_exceeded_uows()
+    # approach — see executor.py module docstring and registry.py:1354.
+    #
+    # Legacy fallback: run_ttl_recovery() wraps recover_ttl_exceeded_uows() with
+    # a try/except ImportError guard (TTL_EXCEEDED_HOURS was removed in #1216).
+    # Retained as a defensive fallback; silently returns [] if the symbol is absent.
+    if not dry_run:
+        try:
+            reset_ids = registry.reset_expired_claims()
+            if reset_ids:
+                log.info(
+                    "Stall recovery: reset %d expired claim(s) to ready-for-executor — %s",
+                    len(reset_ids), reset_ids,
+                )
+            else:
+                log.debug("Stall recovery: no expired claims found")
+        except Exception as e:
+            log.warning("Stall recovery (reset_expired_claims) failed — %s", e)
+    else:
+        log.info("Stall recovery (DRY RUN): skipping reset_expired_claims")
     run_ttl_recovery(registry, dry_run=dry_run)
 
     # Phase 1b: Heartbeat sidecar — write heartbeats for all in-flight UoWs.

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -324,7 +324,13 @@ def run_ttl_recovery(registry, dry_run: bool = False) -> list[str]:
     In dry_run mode: queries but does NOT transition any UoW.
     Returns the list of recovered uow_ids (empty on dry_run or nothing to recover).
     """
-    from src.orchestration.executor import TTL_EXCEEDED_HOURS, recover_ttl_exceeded_uows
+    try:
+        from src.orchestration.executor import TTL_EXCEEDED_HOURS, recover_ttl_exceeded_uows
+    except ImportError:
+        log.warning(
+            "TTL recovery skipped — TTL_EXCEEDED_HOURS not available in executor.py (see #1216)"
+        )
+        return []
     import sqlite3
     from datetime import datetime, timezone, timedelta
 


### PR DESCRIPTION
## Summary

- `executor-heartbeat.py` crashed every 3 minutes with `ImportError: cannot import name 'TTL_EXCEEDED_HOURS' from 'src.orchestration.executor'` since `TTL_EXCEEDED_HOURS` and `recover_ttl_exceeded_uows` were removed in the visibility-timeout design work (#1216)
- Wraps the import in `run_ttl_recovery()` with `try/except ImportError` — on failure, logs a warning and returns `[]`, allowing the rest of the heartbeat (dispatch, quota gates, scaling governor) to run normally
- Verified with `--dry-run`: script exits cleanly with the expected warning; no crash; dispatch logic proceeds

## Test plan

- [x] `uv run scheduled-tasks/executor-heartbeat.py --dry-run` completes without error and emits `WARNING: TTL recovery skipped — TTL_EXCEEDED_HOURS not available in executor.py (see #1216)`
- [ ] Confirm cron log no longer shows `ImportError` after next 3-minute cycle

Fixes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)