### PR TITLE
fix: surface scheduled task crashes to Telegram rather than swallowing

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -705,6 +705,22 @@ Dead/failed agent events routed by the reconciler. These are system-internal —
 
 ---
 
+### scheduled_task_crash (`type: "scheduled_task_crash"`)
+
+Written by heartbeat scripts (`executor-heartbeat.py`, `steward-heartbeat.py`) when `main()` raises an unhandled exception. The script catches the exception in its outer crash handler, writes this inbox message, and exits with code 1.
+
+```
+1. mark_processing(message_id)
+2. send_reply(chat_id=msg["chat_id"], text=msg["text"])
+3. mark_processed(message_id)
+```
+
+**Key fields:** `job_name` (which heartbeat crashed), `text` (human-readable crash summary with traceback, pre-formatted for Telegram).
+
+No subagent needed — relay the `text` field directly. The crash alert is already formatted for user delivery by the heartbeat script.
+
+---
+
 ### cron_reminder (`type: "cron_reminder"`)
 
 System cron jobs write a `cron_reminder` when they finish. Always delegate output triage to a subagent.

--- a/memory/canonical-templates/sweep-context.md
+++ b/memory/canonical-templates/sweep-context.md
@@ -99,6 +99,63 @@ Before the detection pass on Night 5 (Code layer), run a cron-vs-jobs.json consi
 
 This pre-scan runs before any code-layer detection reading. Its output becomes the structural context for the rest of the Night 5 pass.
 
+### Step 1c-N4: Night 4 Pipeline Pre-flight (Night 4 only)
+
+**Gate: Run this step only on Night 4, before any other Night 4 steps.** Its purpose is to detect setup failures before they surface mid-sweep — a misconfigured pipeline discovered at step 1f is more costly than one found here.
+
+#### Pre-flight checks
+
+**1. Night agreement check**
+
+Read `~/lobster-workspace/hygiene/rotation-state.json` and note the `current_night` value. Independently assess which night this is based on the rotation schedule (count from the last known Night 1 start, or derive from the cycle position). If the two assessments disagree:
+- Log the disagreement in the sweep file: "Pre-flight: rotation-state.json reports Night N but independent assessment indicates Night M. Proceeding with rotation-state.json value as authoritative."
+- Do NOT abort — proceed using the rotation-state.json value. The disagreement is itself an entropy item to include in the Detection Pass.
+
+If the two agree, log: "Pre-flight: Night agreement confirmed (Night 4)."
+
+**2. decay-detector.py existence and runtime check**
+
+Check whether `~/lobster/scheduled-tasks/decay-detector.py` exists:
+- If the file does not exist: log "Pre-flight: decay-detector.py not found — skipping decay detection this run" and continue. Add to Detection Pass as a missing dependency.
+- If the file exists, run it: `uv run ~/lobster/scheduled-tasks/decay-detector.py --dry-run 2>&1 | head -20` (or the appropriate invocation if `--dry-run` is not supported — check the script's `--help` first).
+  - If it runs without error: log "Pre-flight: decay-detector.py ran cleanly."
+  - If it reports an internal state that disagrees with rotation-state.json (e.g., "not Night 4" while rotation-state.json says Night 4): log the disagreement — "Pre-flight: decay-detector.py internal state disagrees with rotation-state.json (script says: [X], state file says: Night 4)." Do NOT abort; log it as an entropy item for the Detection Pass.
+  - If it errors: log the error output and continue. Add to Detection Pass as a broken dependency.
+
+**3. Pipeline Mode B script existence check**
+
+Check whether the Pipeline Mode B script exists. The canonical location is `~/lobster/scheduled-tasks/pipeline-mode-b.py` (or equivalent — check `~/lobster-workspace/scheduled-jobs/jobs.json` for a job referencing "mode-b" or "pipeline" to find the actual path).
+
+- If the script does not exist: log "Pre-flight: Pipeline Mode B script not found. Falling back to inline ripeness classification (Step 1f protocol)." Continue with the inline 1f protocol as normal — the pre-flight makes this explicit rather than a silent gap.
+- If the script exists: log "Pre-flight: Pipeline Mode B script found at [path]." Proceed normally.
+
+**4. Other Night 4 dependency scan**
+
+Scan for any other files referenced in Night 4 steps (Steps 1d, 1e, 1f) before running them:
+- `~/lobster-workspace/hygiene/pipeline-ripeness-state.json` — if absent, note "will be created fresh this run" (not an error)
+- `~/lobster-workspace/hygiene/rotation-state.json` — already checked above
+- Verify `gh` CLI is available and authenticated: `gh auth status 2>&1 | head -5`
+
+If `gh` is not authenticated, log this as a blocking pre-flight failure: "Pre-flight BLOCKED: gh CLI not authenticated — Night 4 issue scan cannot proceed." In this case, write the pre-flight findings to the sweep file, send Ping 1 with "Night 4 aborted: gh authentication failure", and exit without running Steps 1d–1f.
+
+#### Pre-flight output
+
+Write a `## Night 4 Pre-flight` section at the top of the sweep file (before the Detection Pass), with a one-line result for each check:
+
+```markdown
+## Night 4 Pre-flight
+
+- Night agreement: [confirmed / disagreement: state file=N, assessment=M]
+- decay-detector.py: [not found / ran cleanly / internal state disagrees (details) / errored (details)]
+- Pipeline Mode B script: [found at path / not found — falling back to 1f inline protocol]
+- pipeline-ripeness-state.json: [exists / absent — will be created fresh]
+- gh CLI: [authenticated / NOT AUTHENTICATED — blocked]
+```
+
+Only after writing this section and confirming no blocking failures: proceed to Step 1d.
+
+---
+
 ### Step 1d: Memory Pre-Pass (Night 4 only)
 
 Before reading memory entries for Night 4 (Issues + memory domain), run a signal-flood check:

--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -40,6 +40,8 @@ import logging
 import os
 import subprocess
 import sys
+import traceback
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -68,6 +70,63 @@ logging.basicConfig(
     datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 log = logging.getLogger("executor-heartbeat")
+
+# Admin chat_id for crash alerts (env-injected, falls back to hardcoded)
+_ADMIN_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
+
+
+# ---------------------------------------------------------------------------
+# Crash alert — write a system inbox message so the dispatcher relays it to Dan
+# ---------------------------------------------------------------------------
+
+def _write_crash_alert(job_name: str, exc: BaseException, extra: str = "") -> None:
+    """Write a scheduled_task_crash inbox message so the dispatcher alerts Dan.
+
+    This is a best-effort fire-and-forget write. Failures here are logged but
+    do not mask the original exception — the caller must re-raise or sys.exit
+    after calling this function.
+
+    The inbox message shape is intentionally simple: source=system,
+    type=scheduled_task_crash, text=human-readable alert. The dispatcher's
+    LLM loop reads the message and relays it to Dan as a Telegram notification.
+    """
+    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    tb_str = "".join(tb_lines).strip()
+    # Truncate traceback to avoid oversized messages (keep last 2000 chars)
+    if len(tb_str) > 2000:
+        tb_str = "...(truncated)...\n" + tb_str[-2000:]
+
+    text = (
+        f"[CRASH] {job_name} crashed with {type(exc).__name__}: {exc}\n\n"
+        f"```\n{tb_str}\n```"
+    )
+    if extra:
+        text += f"\n\n{extra}"
+
+    from datetime import datetime as _datetime, timezone as _timezone
+
+    msg_id = str(uuid.uuid4())
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "type": "scheduled_task_crash",
+        "chat_id": _ADMIN_CHAT_ID,
+        "job_name": job_name,
+        "timestamp": _datetime.now(_timezone.utc).isoformat(),
+        "text": text,
+    }
+
+    try:
+        messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+        inbox_dir = messages_base / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        tmp_path = inbox_dir / f"{msg_id}.json.tmp"
+        dest_path = inbox_dir / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+        tmp_path.rename(dest_path)
+        log.info("Crash alert written to inbox (%s)", msg_id)
+    except Exception as write_exc:
+        log.error("Failed to write crash alert to inbox: %s", write_exc)
 
 
 # ---------------------------------------------------------------------------
@@ -327,8 +386,23 @@ def run_ttl_recovery(registry, dry_run: bool = False) -> list[str]:
     try:
         from src.orchestration.executor import TTL_EXCEEDED_HOURS, recover_ttl_exceeded_uows
     except ImportError:
-        log.warning(
-            "TTL recovery skipped — TTL_EXCEEDED_HOURS not available in executor.py (see #1216)"
+        log.error(
+            "TTL recovery skipped — TTL_EXCEEDED_HOURS not available in executor.py (see #1216). "
+            "Stall recovery is degraded: active UoWs past TTL will NOT be marked failed by this path. "
+            "The reset_expired_claims() path (Phase 1 primary) is unaffected."
+        )
+        _write_crash_alert(
+            job_name="executor-heartbeat",
+            exc=ImportError(
+                "TTL_EXCEEDED_HOURS missing from executor.py (#1216 partial implementation). "
+                "TTL-based stall recovery is degraded."
+            ),
+            extra=(
+                "Structural gap: TTL_EXCEEDED_HOURS was removed during #1216 but "
+                "run_ttl_recovery() still imports it. "
+                "The primary reset_expired_claims() path is unaffected. "
+                "Fix: restore TTL_EXCEEDED_HOURS in executor.py or remove run_ttl_recovery()."
+            ),
         )
         return []
     import sqlite3
@@ -626,6 +700,16 @@ def main() -> int:
 
     Returns exit code: 0 on success, 1 on unhandled error.
     """
+    try:
+        return _main_inner()
+    except Exception as exc:
+        log.error("executor-heartbeat crashed with unhandled exception: %s", exc, exc_info=True)
+        _write_crash_alert(job_name="executor-heartbeat", exc=exc)
+        return 1
+
+
+def _main_inner() -> int:
+    """Inner implementation of main() — wrapped by main() for crash alerting."""
     parser = argparse.ArgumentParser(description="Executor Heartbeat — WOS Phase 2")
     parser.add_argument(
         "--dry-run",

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -41,6 +41,8 @@ import json
 import logging
 import os
 import sys
+import traceback
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from enum import StrEnum
@@ -81,8 +83,62 @@ logging.basicConfig(
 )
 log = logging.getLogger("steward-heartbeat")
 
+# Admin chat_id for crash alerts (env-injected, falls back to hardcoded)
+_ADMIN_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
+
 
 # ---------------------------------------------------------------------------
+# Crash alert — write a system inbox message so the dispatcher relays it to Dan
+# ---------------------------------------------------------------------------
+
+def _write_crash_alert(job_name: str, exc: BaseException, extra: str = "") -> None:
+    """Write a scheduled_task_crash inbox message so the dispatcher alerts Dan.
+
+    This is a best-effort fire-and-forget write. Failures here are logged but
+    do not mask the original exception — the caller must re-raise or sys.exit
+    after calling this function.
+
+    The inbox message shape is intentionally simple: source=system,
+    type=scheduled_task_crash, text=human-readable alert. The dispatcher's
+    LLM loop reads the message and relays it to Dan as a Telegram notification.
+    """
+    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    tb_str = "".join(tb_lines).strip()
+    # Truncate traceback to avoid oversized messages (keep last 2000 chars)
+    if len(tb_str) > 2000:
+        tb_str = "...(truncated)...\n" + tb_str[-2000:]
+
+    text = (
+        f"[CRASH] {job_name} crashed with {type(exc).__name__}: {exc}\n\n"
+        f"```\n{tb_str}\n```"
+    )
+    if extra:
+        text += f"\n\n{extra}"
+
+    msg_id = str(uuid.uuid4())
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "type": "scheduled_task_crash",
+        "chat_id": _ADMIN_CHAT_ID,
+        "job_name": job_name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "text": text,
+    }
+
+    try:
+        messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+        inbox_dir = messages_base / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        tmp_path = inbox_dir / f"{msg_id}.json.tmp"
+        dest_path = inbox_dir / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+        tmp_path.rename(dest_path)
+        log.info("Crash alert written to inbox (%s)", msg_id)
+    except Exception as write_exc:
+        log.error("Failed to write crash alert to inbox: %s", write_exc)
+
+
 # ---------------------------------------------------------------------------
 # Named constants
 # ---------------------------------------------------------------------------
@@ -923,6 +979,16 @@ def main() -> int:
 
     Returns exit code: 0 on success, 1 on unhandled error.
     """
+    try:
+        return _main_inner()
+    except Exception as exc:
+        log.error("steward-heartbeat crashed with unhandled exception: %s", exc, exc_info=True)
+        _write_crash_alert(job_name="steward-heartbeat", exc=exc)
+        return 1
+
+
+def _main_inner() -> int:
+    """Inner implementation of main() — wrapped by main() for crash alerting."""
     parser = argparse.ArgumentParser(description="Steward Heartbeat — WOS Phase 2")
     parser.add_argument(
         "--dry-run",

--- a/scripts/user-update.sh
+++ b/scripts/user-update.sh
@@ -781,7 +781,7 @@ You are running as a scheduled task. Your purpose is to read the week's oracle l
 
 ### 1. Read oracle/learnings.md
 
-Read `~/lobster-workspace/oracle/learnings.md` (Layer 2 archive section preferred; fall back to Layer 1 index if Layer 2 is empty).
+Read `~/lobster/oracle/learnings.md` (Layer 2 archive section preferred; fall back to Layer 1 index if Layer 2 is empty).
 
 Filter to entries dated within the past 7 days. If no entries exist in that window, write a task output noting "No new learnings this week — no proposal generated" and exit.
 

--- a/src/mcp/message_types.py
+++ b/src/mcp/message_types.py
@@ -56,6 +56,7 @@ INBOX_SYSTEM_TYPES: frozenset[str] = frozenset({
     "debug_observation",      # debug output from inbox_server.py internals; excluded from skill processing
     "session_note_reminder",  # MCP counter reached 20 user messages — dispatcher should spawn session-note-appender
     "wos_execute",            # WOS executor dispatched a UoW — dispatcher must call route_wos_message() to spawn subagent (issue #856)
+    "scheduled_task_crash",   # heartbeat script caught an unhandled exception and wrote a crash alert (fields: job_name, text)
 })
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: Unhandled exceptions in `executor-heartbeat.py` and `steward-heartbeat.py` exit to cron's log with no Telegram notification. The ImportError crashing executor-heartbeat every 3 minutes (#1220) went undetected until a log sweep found it.
- **Part 1 — Outer crash handler**: Both scripts now wrap `main()` around an inner `_main_inner()`. Any unhandled exception writes a `scheduled_task_crash` inbox message (picked up by the dispatcher and relayed to Dan via Telegram), logs `ERROR` with full traceback, and returns exit code 1 so cron records the failure.
- **Part 2 — Tighten ImportError in `run_ttl_recovery()`**: The `except ImportError` block that was silently returning `[]` after a `log.warning` now uses `log.error` and sends a crash alert explicitly naming the structural gap (TTL_EXCEEDED_HOURS removed in #1216 but the import still exists).
- **Round 1 oracle fixes**: Registered `scheduled_task_crash` in `INBOX_SYSTEM_TYPES` and added named dispatcher handler in `sys.dispatcher.bootup.md`.

## Message format

The inbox message written on crash:
```json
{
  "source": "system",
  "type": "scheduled_task_crash",
  "chat_id": "<admin_chat_id>",
  "job_name": "executor-heartbeat",
  "text": "[CRASH] executor-heartbeat crashed with FooError: ...\n\n```\nTraceback...\n```"
}
```

The dispatcher's LLM loop sees `type=scheduled_task_crash` and relays the `text` field to Dan as a Telegram notification (same pattern as fast-path system messages).

## Test plan

- [ ] Manually inject a crashing import at the top of `_main_inner()` in each script and verify a `scheduled_task_crash` inbox message appears in `~/messages/inbox/`
- [ ] Verify the ImportError path in `run_ttl_recovery()` now logs `ERROR` (not `WARNING`) and writes an inbox crash alert
- [ ] Verify cron sees exit code 1 on crash (not 0)
- [ ] Verify write failures in `_write_crash_alert` are logged but do not mask the original exception

## Follow-up

- Issue #1227: extract `_write_crash_alert` to `src/utils/inbox_write.py` (oracle gap 2 — function is copy-pasted identically into both heartbeat scripts)
- A follow-up issue should audit other scheduled tasks for the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)