### PR TITLE
feat(wos): WOS PR pipeline coordinator — single-dispatch oracle→fix→merge loop

### DIFF
--- a/.claude/agents/wos-pr-coordinator.md
+++ b/.claude/agents/wos-pr-coordinator.md
@@ -1,0 +1,172 @@
+---
+name: wos-pr-coordinator
+description: >
+  WOS PR pipeline coordinator. Owns the full oracle→fix→merge loop for a single
+  WOS-originated PR. Spawned once per PR by the dispatcher when a WOS subagent
+  returns a PR URL. Eliminates 6–8 dispatcher round-trips per PR down to 1.
+model: claude-sonnet-4-6
+---
+
+You are the **WOS PR pipeline coordinator**. You own the full oracle→fix→merge loop
+for a single WOS-originated PR. The dispatcher spawned you once; you handle everything
+internally and return exactly one `write_result` when done.
+
+Do NOT call `wait_for_messages`. Do NOT send intermediate oracle/fix status to the
+dispatcher inbox. Only the final `write_result` (merged or escalated) goes to the
+dispatcher.
+
+## Inputs (provided in your task prompt)
+
+- `pr_url` — full GitHub PR URL (e.g. `https://github.com/SiderealPress/lobster/pull/1234`)
+- `pr_number` — integer PR number (e.g. `1234`)
+- `repo` — `owner/repo` string (e.g. `SiderealPress/lobster`)
+- `task_id` — your own task slug (e.g. `wos-pr-coord-1234`)
+- `chat_id` — admin chat_id for Dan notifications at rounds 3+
+- `task_context` — free-text description of the originating UoW (for logging/escalation)
+
+## On start (mandatory — do this before any other work)
+
+```
+1. mkdir -p ~/lobster-workspace/workstreams/<task_id>/
+2. Write ~/lobster-workspace/workstreams/<task_id>/status.md with:
+   - task_id, start timestamp, pr_url, current_round=0
+   - current_step="started", next_step="run oracle round 1"
+3. Update status.md every ~5 minutes throughout execution.
+```
+
+## Main loop
+
+Run this loop, tracking `round` (starts at 1):
+
+### Step 1 — Spawn oracle
+
+Write status.md: `current_round=N, step="spawning oracle", next_step="read verdict"`
+
+Spawn oracle agent (`subagent_type=lobster-oracle`) for this PR.
+Pass `pr_number`, `repo`, and `uow_id` (your task_id) in the prompt so it can
+write `oracle/verdicts/pr-{pr_number}.md` and emit the oracle_approved audit event.
+
+Wait for oracle to complete and write `oracle/verdicts/pr-{pr_number}.md`.
+
+### Step 2 — Read verdict
+
+Read the **first line only** of `oracle/verdicts/pr-{pr_number}.md`.
+
+Write status.md: `current_round=N, step="oracle complete", verdict=<first line>`
+
+### Step 3 — Branch on verdict
+
+**If first line is `VERDICT: APPROVED`:**
+
+```
+write status.md: step="merging"
+
+Spawn merge agent (lobster-generalist) with this prompt:
+  1. Read oracle/verdicts/pr-{pr_number}.md — confirm first line is "VERDICT: APPROVED"
+  2. Run: gh pr merge {pr_number} --repo {repo} --squash
+  3. Run: mv oracle/verdicts/pr-{pr_number}.md oracle/verdicts/archive/pr-{pr_number}.md
+     (create archive/ dir first if needed: mkdir -p oracle/verdicts/archive/)
+  4. Call write_result(task_id=<merge_task_id>, sent_reply_to_user=False, status="success",
+     text="PR #{pr_number} merged and verdict archived")
+  Minimum viable output: PR merged and verdict moved to archive/.
+  Boundary: do not send_reply to Dan; this is a background merge step.
+
+Wait for merge agent to complete.
+
+write status.md: step="merged", outcome="success"
+
+write_result(
+    task_id=task_id,
+    sent_reply_to_user=False,
+    status="success",
+    text="PR #{pr_number} merged after {round} oracle round(s). {pr_url}"
+)
+STOP.
+```
+
+**If first line is `VERDICT: NEEDS_CHANGES` and round <= 2:**
+
+```
+write status.md: step="spawning fix agent", round=N, next_step="re-run oracle"
+
+Spawn fix agent (functional-engineer) with prompt:
+  PR #{pr_number} ({repo}) needs changes per oracle verdict.
+  Read oracle/verdicts/pr-{pr_number}.md for the full NEEDS_CHANGES verdict.
+  Implement the requested changes on the existing PR branch and push.
+  Call write_result when done (sent_reply_to_user=False).
+  Minimum viable output: changes pushed to PR branch.
+  Boundary: do not merge; do not send Dan a message.
+
+Wait for fix agent to complete.
+round += 1
+Continue loop from Step 1.
+```
+
+**If first line is `VERDICT: NEEDS_CHANGES` and round == 3:**
+
+```
+send_reply(
+    chat_id=chat_id,
+    text="PR #{pr_number} needs changes after 3 oracle rounds. Spawning another fix — "
+         "review oracle/verdicts/pr-{pr_number}.md if you want to override. "
+         "Full round history: ~/lobster-workspace/workstreams/{task_id}/status.md"
+)
+
+write status.md: step="notified Dan at round 3, proceeding with fix"
+
+Spawn fix agent (same prompt as round <= 2 above).
+Wait for fix agent to complete.
+round += 1
+Continue loop from Step 1.
+```
+
+**If first line is `VERDICT: NEEDS_CHANGES` and round >= 4:**
+
+```
+# Summarize what gaps keep re-opening from status.md round history
+Prepare a brief summary of which oracle gaps recurred across rounds.
+
+send_reply(
+    chat_id=chat_id,
+    text="PR #{pr_number} escalated after {round} oracle rounds. "
+         "Gaps keep re-opening — see ~/lobster-workspace/workstreams/{task_id}/status.md "
+         "for full round history. Awaiting your decision before proceeding.\n\n"
+         "Latest oracle verdict: oracle/verdicts/pr-{pr_number}.md"
+)
+
+write status.md: step="escalated to Dan", outcome="escalated"
+
+write_result(
+    task_id=task_id,
+    sent_reply_to_user=True,
+    status="escalated",
+    text="PR #{pr_number} escalated to Dan after {round} oracle rounds — "
+         "see workstreams/{task_id}/status.md. {pr_url}"
+)
+STOP.
+```
+
+## Round-cap summary
+
+| Round | Action |
+|-------|--------|
+| 1–2   | Auto-fix + re-oracle, no notification |
+| 3     | Notify Dan, then auto-fix + re-oracle |
+| 4+    | Escalate to Dan, stop |
+
+## Tooling conventions
+
+- Always `uv run` for Python (never bare `python`)
+- Always `gh` CLI for GitHub operations (never `mcp__github__*`)
+- All project repos live in `~/lobster-workspace/projects/`
+- Feature work in git worktrees, never commit directly to main
+
+## Completion
+
+After the loop exits (merged or escalated), call `write_result` with:
+- `task_id`: your coordinator task_id
+- `sent_reply_to_user`: True if you escalated (sent send_reply), False if merged silently
+- `status`: "success" (merged) or "escalated"
+- `text`: one-sentence summary with PR number and pr_url
+
+WOS-UoW: uow_20260516_71b777

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -479,6 +479,26 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
            pr_parts = pr_url.rstrip("/").split("/")
            pr_number = pr_parts[-1]
            pr_repo = f"{pr_parts[-4]}/{pr_parts[-3]}"
+
+           # WOS PR coordinator fast-path: WOS-originated PRs bypass the review
+           # agent and go directly to the coordinator which owns oracle→fix→merge.
+           from src.orchestration.dispatcher_handlers import route_wos_pr_result
+           wos_routing = route_wos_pr_result(
+               pr_url=pr_url,
+               task_id=msg.get("task_id"),
+               chat_id=msg["chat_id"],
+               result_text=msg["text"],
+           )
+           if wos_routing["action"] == "spawn_subagent":
+               Task(
+                   subagent_type=wos_routing["agent_type"],
+                   run_in_background=True,
+                   prompt=wos_routing["prompt"],
+               )
+               mark_processed(message_id)
+               continue
+           # else: task_id does not start with "wos-" — fall through to review agent
+
            # Dedup check: skip if reviewer already running for this PR
            active = get_active_sessions()
            reviewer_task_id = f"review-{msg.get('task_id', 'unknown')}"

--- a/oracle/decisions.md
+++ b/oracle/decisions.md
@@ -417,3 +417,17 @@ If sweep quality degrades, the correct response is to add a signal-quality check
 ### Interaction with Cultivator Dedup
 
 On its next cycle, the cultivator's `promote_to_wos()` will encounter sweep-promoted UoWs via `registry.upsert()`'s non-terminal pre-check. These will be returned as `SKIPPED_DEDUP`. No duplicate UoWs will be created. The cultivator and sweep promoter are independent and dedup correctly.
+
+---
+
+## Reference: WOS PR Results Route to wos-pr-coordinator Agent
+
+**Date:** 2026-05-19
+**PR:** #1223 (feat/wos: WOS PR pipeline coordinator)
+**Full decision:** `oracle/decisions/decision-wos-pr-coordinator.md`
+
+WOS PR results (`task_id.startswith("wos-")`) now route to the `wos-pr-coordinator`
+agent instead of spawning an oracle review agent directly. Non-WOS PRs fall through
+to the existing review agent path unchanged. This is a durable behavioral default
+change anchored to vision.yaml principle-3 and principle-4. See the full decision
+file for constraint-3 authorization and vision anchors.

--- a/oracle/decisions/decision-wos-pr-coordinator.md
+++ b/oracle/decisions/decision-wos-pr-coordinator.md
@@ -1,0 +1,91 @@
+# Decision: WOS PR Results Route to wos-pr-coordinator Agent
+
+**Date:** 2026-05-19
+**Status:** Decided — routing default encoded in dispatcher_handlers.py
+**Related PR:** #1223 (feat/wos: WOS PR pipeline coordinator)
+**WOS Reference:** uow_20260516_71b777
+
+## Decision
+
+WOS PR results (subagent results where `task_id` starts with `"wos-"` and the
+result text contains a GitHub PR URL) are routed to the `wos-pr-coordinator`
+agent instead of being handed directly to the existing oracle review agent path.
+
+This is a durable behavioral default change, not a one-time operational action.
+
+## Behavioral Change Named
+
+Before this PR, every completed subagent result containing a GitHub PR URL
+entered the dispatcher's ENGINEER → REVIEWER routing block and spawned an oracle
+review agent directly. The oracle agent reported back to the dispatcher; the
+dispatcher then spawned a fix agent or merge agent on the next round-trip. Each
+PR required 3–5 dispatcher round-trips to complete (open PR → oracle → fix →
+re-oracle → merge).
+
+After this PR, WOS-originated PRs (`task_id.startswith("wos-")`) are caught by
+`route_wos_pr_result()` in `src/orchestration/dispatcher_handlers.py` before
+the existing review agent block runs. A `wos-pr-coordinator` agent is spawned
+instead. The coordinator internalizes the full oracle→fix→merge loop, returning
+exactly one `write_result` call to the dispatcher when the PR is either merged
+or escalated. Non-WOS PRs receive `action="fallthrough"` and continue through
+the existing review agent path unchanged.
+
+## Why This Is a Behavioral Default Change
+
+The system now routes WOS PR results without the dispatcher deciding per-message
+whether to use the coordinator. The routing key (`task_id.startswith("wos-")`)
+is deterministic and encodes the decision at the code level. Every WOS-originated
+PR result will spawn the coordinator automatically from this point forward. This
+satisfies the conditions under `core.inviolable_constraints.constraint-3`: (a)
+the system acts without Dan's real-time input per PR, (b) it changes a durable
+default in the ENGINEER → REVIEWER routing path, and (c) the behavioral change
+is encoded in `route_wos_pr_result()`, not in a retrievable prompt.
+
+## Vision Anchor
+
+**Primary:** `core.operating_principles.principle-3` — "Determinism over
+judgment for conditionals. If-then logic and field checks are code, not LLM
+instructions. Use LLMs where genuine interpretation is required."
+
+The routing predicate (`task_id.startswith("wos-")`) is a deterministic field
+check. It requires no LLM interpretation — a WOS-originated PR is unambiguously
+identified by its task_id prefix. Encoding this in `route_wos_pr_result()` is
+the correct structural expression of the decision.
+
+**Secondary:** `core.operating_principles.principle-4` — "Integration rate
+before new feature rate. Wire what exists before building more. The missing
+arrows between existing systems are the velocity multiplier."
+
+The coordinator agent and the WOS pipeline both existed as concepts before this
+PR. The missing arrow was between the dispatcher's ENGINEER → REVIEWER block and
+a WOS-aware coordinator that could internalize the pipeline stages. This PR
+wires that arrow without adding new capabilities — it composes existing
+mechanisms (oracle agent, fix agent, merge agent) behind a single coordinator
+interface.
+
+## Routing Default as Durable
+
+The `route_wos_pr_result()` function is wired into the dispatcher's
+ENGINEER → REVIEWER routing section as a guard before the existing review agent
+call. This default is not experimental or temporary. It is the correct routing
+strategy for WOS-originated PRs at current and expected scale.
+
+Non-WOS PRs are structurally unaffected — the existing oracle review agent path
+is reachable only after `route_wos_pr_result()` returns `action="fallthrough"`.
+This means the PR introduces no regression risk for non-WOS code paths.
+
+## What This Decision Does NOT Do
+
+- It does not modify the oracle agent itself.
+- It does not change the oracle→fix→merge logic — those stages remain operative
+  inside the coordinator.
+- It does not establish a precedent that all PR routing should be collapsed into
+  a coordinator. The coordinator is WOS-specific because WOS generates
+  high-volume PR bursts where dispatcher round-trip reduction has material impact
+  on context compaction. Non-WOS PRs do not exhibit the same burst pattern.
+
+## Authorization
+
+Authorized by WOS UoW uow_20260516_71b777. The oracle PR #1223 verdict (Round 1)
+identified the missing decision record as a blocking gap. This document is the
+required logged prior for the behavioral default change under constraint-3.

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -2880,3 +2880,111 @@ def handle_config_append(filename: str, text: str) -> str:
         return f"Appended to {p.name}.\n\nTail:\n{tail}"
     except OSError as exc:
         return f"Could not write to '{p.name}': {exc}"
+
+
+# ---------------------------------------------------------------------------
+# WOS PR coordinator routing (issue uow_20260516_71b777)
+#
+# Called from the dispatcher's ENGINEER → REVIEWER routing block when a
+# completed subagent result contains a GitHub PR URL.  Routes WOS-originated
+# PRs (task_id starts with "wos-") to the wos-pr-coordinator agent, which
+# owns the full oracle→fix→merge loop internally.  Non-WOS PRs fall through
+# to the existing review agent path unchanged.
+#
+# Dispatcher integration (add to ENGINEER → REVIEWER routing, before the
+# existing Task(subagent_type="review", ...) call):
+#
+#     from src.orchestration.dispatcher_handlers import route_wos_pr_result
+#
+#     pr_url_match = re.search(r"https://github\.com/.*/pull/\d+", msg["text"])
+#     if pr_url_match:
+#         routing = route_wos_pr_result(
+#             pr_url=pr_url_match.group(0),
+#             task_id=msg.get("task_id"),
+#             chat_id=msg["chat_id"],
+#             result_text=msg["text"],
+#         )
+#         if routing["action"] == "spawn_subagent":
+#             Task(subagent_type=routing["agent_type"],
+#                  run_in_background=True,
+#                  prompt=routing["prompt"])
+#             mark_processed(message_id)
+#             continue
+#         # else: fallthrough — let existing review agent path handle it
+# ---------------------------------------------------------------------------
+
+
+def route_wos_pr_result(
+    pr_url: str,
+    task_id: str | None,
+    chat_id: int | str,
+    result_text: str,
+) -> dict[str, Any]:
+    """Route a subagent result containing a GitHub PR URL.
+
+    If ``task_id`` starts with ``"wos-"``, builds a coordinator Task prompt
+    that owns the full oracle→fix→merge loop for the PR internally.  Returns
+    ``action="spawn_subagent"`` so the dispatcher can spawn the coordinator
+    without any further logic.
+
+    If ``task_id`` does NOT start with ``"wos-"`` (or is None), returns
+    ``action="fallthrough"`` so the dispatcher falls through to the existing
+    review agent path unchanged.
+
+    Pure function: no side effects, no I/O.
+
+    Args:
+        pr_url:      Full GitHub PR URL extracted from the subagent result text.
+        task_id:     task_id from the subagent result message (may be None).
+        chat_id:     Admin chat_id for Dan notifications (passed through to coordinator).
+        result_text: Full result text from the subagent (used as task_context).
+
+    Returns:
+        ``{"action": "spawn_subagent", "task_id": ..., "prompt": ..., "agent_type": ...}``
+        when routing to coordinator, or ``{"action": "fallthrough"}`` otherwise.
+    """
+    import re as _re
+
+    if not (task_id and task_id.startswith("wos-")):
+        return {"action": "fallthrough"}
+
+    # Extract pr_number and repo from the PR URL.
+    # Expected format: https://github.com/{owner}/{repo}/pull/{number}
+    parts = pr_url.rstrip("/").split("/")
+    try:
+        pr_number = int(parts[-1])
+        repo = f"{parts[-4]}/{parts[-3]}"
+    except (IndexError, ValueError):
+        _log.warning(
+            "route_wos_pr_result: could not parse PR URL %r — falling through",
+            pr_url,
+        )
+        return {"action": "fallthrough"}
+
+    coordinator_task_id = f"wos-pr-coord-{pr_number}"
+
+    prompt = (
+        f"---\n"
+        f"task_id: {coordinator_task_id}\n"
+        f"chat_id: {chat_id}\n"
+        f"source: wos/coordinator\n"
+        f"---\n\n"
+        f"You are the WOS PR pipeline coordinator for PR #{pr_number}.\n\n"
+        f"pr_url: {pr_url}\n"
+        f"pr_number: {pr_number}\n"
+        f"repo: {repo}\n"
+        f"task_id: {coordinator_task_id}\n"
+        f"chat_id: {chat_id}\n"
+        f"task_context: {result_text[:500]}\n\n"
+        f"Follow the wos-pr-coordinator agent definition at "
+        f".claude/agents/wos-pr-coordinator.md exactly.\n\n"
+        f"Minimum viable output: Single write_result call reporting PR merged or escalated.\n"
+        f"Boundary: do not send intermediate oracle/fix status to the dispatcher inbox."
+    )
+
+    return {
+        "action": "spawn_subagent",
+        "task_id": coordinator_task_id,
+        "prompt": prompt,
+        "agent_type": "lobster-generalist",
+    }

--- a/tests/unit/test_orchestration/test_route_wos_pr_result.py
+++ b/tests/unit/test_orchestration/test_route_wos_pr_result.py
@@ -1,0 +1,372 @@
+"""
+Unit tests for route_wos_pr_result() in dispatcher_handlers.py.
+
+Four cases from the PR #1223 description:
+  1. WOS PR (task_id starts with "wos-") → coordinator spawned
+  2. Non-WOS PR (task_id does not start with "wos-") → fallthrough
+  3. Missing / malformed fields handled gracefully → fallthrough, no exception
+  4. Correct routing when both WOS and non-WOS PRs share the same result batch
+     (multiple independent calls behave consistently per task_id prefix)
+
+route_wos_pr_result is a pure function: no I/O, no side effects.
+All test cases verify the returned dict; no mocking required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.orchestration.dispatcher_handlers import route_wos_pr_result
+
+
+# ---------------------------------------------------------------------------
+# Constants used across multiple tests — imported from production module.
+# ---------------------------------------------------------------------------
+
+_WOS_PR_URL = "https://github.com/dcetlin/Lobster/pull/999"
+_NON_WOS_PR_URL = "https://github.com/dcetlin/Lobster/pull/888"
+_WOS_TASK_ID = "wos-executor-fix-pr999"
+_NON_WOS_TASK_ID = "fix-pr-888-r1"
+_CHAT_ID = 12345
+_RESULT_TEXT = "PR opened: https://github.com/dcetlin/Lobster/pull/999\nImplementation complete."
+
+
+# ---------------------------------------------------------------------------
+# Case 1: WOS PR with task_id starting "wos-" → coordinator spawned
+# ---------------------------------------------------------------------------
+
+
+class TestWosPrRoutesToCoordinator:
+    """WOS-originated PRs must spawn the wos-pr-coordinator agent."""
+
+    def test_action_is_spawn_subagent(self) -> None:
+        """Return action must be 'spawn_subagent' for a WOS task_id."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "spawn_subagent"
+
+    def test_agent_type_is_lobster_generalist(self) -> None:
+        """Agent type must be 'lobster-generalist' for coordinator dispatch."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["agent_type"] == "lobster-generalist"
+
+    def test_task_id_encodes_pr_number(self) -> None:
+        """Coordinator task_id must contain the PR number from the URL."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert "999" in result["task_id"]
+
+    def test_task_id_prefixed_wos_pr_coord(self) -> None:
+        """Coordinator task_id follows the 'wos-pr-coord-{number}' pattern."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["task_id"] == "wos-pr-coord-999"
+
+    def test_prompt_contains_pr_number(self) -> None:
+        """Coordinator prompt must reference the PR number."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert "999" in result["prompt"]
+
+    def test_prompt_contains_pr_url(self) -> None:
+        """Coordinator prompt must include the PR URL verbatim."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert _WOS_PR_URL in result["prompt"]
+
+    def test_prompt_contains_repo(self) -> None:
+        """Coordinator prompt must include the repo identifier parsed from the URL."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert "dcetlin/Lobster" in result["prompt"]
+
+    def test_prompt_contains_wos_pr_coordinator_reference(self) -> None:
+        """Coordinator prompt must point to the agent definition file."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert "wos-pr-coordinator" in result["prompt"]
+
+    def test_prompt_has_yaml_frontmatter(self) -> None:
+        """Coordinator prompt must start with YAML frontmatter (dispatch template gate)."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["prompt"].startswith("---\n")
+
+    def test_result_text_truncated_in_prompt(self) -> None:
+        """result_text included in coordinator prompt must be capped at 500 chars."""
+        long_text = "x" * 1000
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=long_text,
+        )
+        # The raw long_text should not appear verbatim (it's 1000 chars; only 500 inserted)
+        assert long_text not in result["prompt"]
+        assert long_text[:500] in result["prompt"]
+
+    def test_wos_prefix_exact_match(self) -> None:
+        """task_id must start with 'wos-' — bare 'wos' without dash falls through."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id="wos_executor_fix",  # underscore, not dash
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "fallthrough"
+
+
+# ---------------------------------------------------------------------------
+# Case 2: Non-WOS PR → falls through to existing path, action is "fallthrough"
+# ---------------------------------------------------------------------------
+
+
+class TestNonWosPrFallsThrough:
+    """Non-WOS PRs must return action='fallthrough', leaving existing path intact."""
+
+    def test_non_wos_task_id_falls_through(self) -> None:
+        """A task_id not starting with 'wos-' must produce action='fallthrough'."""
+        result = route_wos_pr_result(
+            pr_url=_NON_WOS_PR_URL,
+            task_id=_NON_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result == {"action": "fallthrough"}
+
+    def test_fallthrough_result_has_no_extra_keys(self) -> None:
+        """Fallthrough result must contain only the 'action' key — no leakage."""
+        result = route_wos_pr_result(
+            pr_url=_NON_WOS_PR_URL,
+            task_id=_NON_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert set(result.keys()) == {"action"}
+
+    def test_task_id_oracle_prefix_falls_through(self) -> None:
+        """task_id 'oracle-pr-888' (oracle agent, not WOS) must fall through."""
+        result = route_wos_pr_result(
+            pr_url=_NON_WOS_PR_URL,
+            task_id="oracle-pr-888-review",
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "fallthrough"
+
+
+# ---------------------------------------------------------------------------
+# Case 3: Missing / malformed fields handled gracefully — no exception raised
+# ---------------------------------------------------------------------------
+
+
+class TestMissingOrMalformedFields:
+    """Malformed inputs must return fallthrough, never raise exceptions."""
+
+    def test_none_task_id_falls_through(self) -> None:
+        """task_id=None must produce fallthrough, not an AttributeError."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=None,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "fallthrough"
+
+    def test_empty_task_id_falls_through(self) -> None:
+        """task_id='' (empty string) must produce fallthrough."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id="",
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "fallthrough"
+
+    def test_malformed_pr_url_falls_through(self) -> None:
+        """A PR URL that cannot be parsed must produce fallthrough, not ValueError."""
+        result = route_wos_pr_result(
+            pr_url="not-a-valid-url",
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "fallthrough"
+
+    def test_pr_url_with_non_integer_pr_number_falls_through(self) -> None:
+        """PR URL ending in a non-integer segment must produce fallthrough."""
+        result = route_wos_pr_result(
+            pr_url="https://github.com/dcetlin/Lobster/pull/not-a-number",
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "fallthrough"
+
+    def test_pr_url_with_trailing_slash_parsed_correctly(self) -> None:
+        """PR URL with trailing slash must still parse to the correct PR number."""
+        result = route_wos_pr_result(
+            pr_url="https://github.com/dcetlin/Lobster/pull/999/",
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "spawn_subagent"
+        assert "999" in result["task_id"]
+
+    def test_empty_result_text_does_not_raise(self) -> None:
+        """result_text='' must not cause any exception."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text="",
+        )
+        assert result["action"] == "spawn_subagent"
+
+    def test_integer_chat_id_passthrough(self) -> None:
+        """Integer chat_id must be accepted and included in the prompt."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=99999,
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "spawn_subagent"
+        assert "99999" in result["prompt"]
+
+    def test_string_chat_id_passthrough(self) -> None:
+        """String chat_id (Slack channel IDs) must be accepted and included in the prompt."""
+        result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id="C0123456789",
+            result_text=_RESULT_TEXT,
+        )
+        assert result["action"] == "spawn_subagent"
+        assert "C0123456789" in result["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Correct routing when both WOS and non-WOS PRs are in the same batch
+#
+# The function is stateless — it routes each call independently based on the
+# task_id prefix. Calling it for WOS and non-WOS inputs in sequence must
+# produce the correct action for each call, with no cross-call state leakage.
+# ---------------------------------------------------------------------------
+
+
+class TestMixedBatchRouting:
+    """WOS and non-WOS calls interleaved must route independently and correctly."""
+
+    def test_wos_call_in_batch_spawns_coordinator(self) -> None:
+        """A WOS call in a mixed batch must still produce spawn_subagent."""
+        wos_result = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert wos_result["action"] == "spawn_subagent"
+
+    def test_non_wos_call_in_batch_falls_through(self) -> None:
+        """A non-WOS call in a mixed batch must still produce fallthrough."""
+        non_wos_result = route_wos_pr_result(
+            pr_url=_NON_WOS_PR_URL,
+            task_id=_NON_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert non_wos_result["action"] == "fallthrough"
+
+    def test_wos_and_non_wos_calls_produce_independent_results(self) -> None:
+        """Interleaving WOS and non-WOS calls must not affect each other's routing."""
+        # Call order: WOS → non-WOS → WOS — middle call must not infect neighbors
+        r1 = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        r2 = route_wos_pr_result(
+            pr_url=_NON_WOS_PR_URL,
+            task_id=_NON_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        r3 = route_wos_pr_result(
+            pr_url=_WOS_PR_URL,
+            task_id=_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert r1["action"] == "spawn_subagent"
+        assert r2["action"] == "fallthrough"
+        assert r3["action"] == "spawn_subagent"
+
+    def test_distinct_wos_prs_get_distinct_coordinator_task_ids(self) -> None:
+        """Two WOS PRs with different PR numbers must produce different task_ids."""
+        r_999 = route_wos_pr_result(
+            pr_url="https://github.com/dcetlin/Lobster/pull/999",
+            task_id="wos-executor-fix-pr999",
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        r_1000 = route_wos_pr_result(
+            pr_url="https://github.com/dcetlin/Lobster/pull/1000",
+            task_id="wos-executor-fix-pr1000",
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert r_999["task_id"] != r_1000["task_id"]
+        assert r_999["task_id"] == "wos-pr-coord-999"
+        assert r_1000["task_id"] == "wos-pr-coord-1000"
+
+    def test_non_wos_fallthrough_has_no_coordinator_artifacts(self) -> None:
+        """Fallthrough result must not leak any coordinator fields into the dict."""
+        non_wos_result = route_wos_pr_result(
+            pr_url=_NON_WOS_PR_URL,
+            task_id=_NON_WOS_TASK_ID,
+            chat_id=_CHAT_ID,
+            result_text=_RESULT_TEXT,
+        )
+        assert "prompt" not in non_wos_result
+        assert "task_id" not in non_wos_result
+        assert "agent_type" not in non_wos_result


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/wos-pr-coordinator.md`: new agent that owns the full oracle→fix→merge loop for a single WOS-originated PR. Encodes round-cap rules: rounds 1–2 auto-fix, round 3 notify Dan, round 4+ escalate. Maintains workstream status file throughout execution.
- Adds `route_wos_pr_result()` pure function to `src/orchestration/dispatcher_handlers.py`: routes WOS PR results (task_id starting with `wos-`) to the coordinator; non-WOS paths fall through to the existing review agent path unchanged.
- Updates `.claude/sys.dispatcher.bootup.md`: wires `route_wos_pr_result()` into the ENGINEER→REVIEWER routing section before the existing review agent block.

**Motivation:** During WOS drain bursts (6+ UoWs), the current per-stage dispatcher round-trip pattern generates 36–48 dispatcher reads in a single session, causing repeated context compaction. The coordinator internalizes all pipeline stages so the dispatcher sees exactly one result per PR.

## Test plan

- [x] `route_wos_pr_result()` manual test: WOS task_id routes to coordinator, non-WOS falls through, None falls through — all pass
- [x] `tests/unit/test_orchestration/test_dispatcher_commands.py` — 130 tests pass
- [x] `tests/unit/test_orchestration/test_dispatcher_integration.py` — all pass
- [x] Pre-existing test failures verified as unrelated (token tracking, executor failure summaries)

## Completion check

- [x] `.claude/agents/wos-pr-coordinator.md` exists and contains round-cap logic (rounds 1–2 auto-fix, round 3 notify Dan, round 4+ escalate)
- [x] `src/orchestration/dispatcher_handlers.py` routes WOS PR results (`task_id.startswith("wos-")`) to coordinator
- [x] Non-WOS oracle path is structurally unchanged — only an early `return {"action": "fallthrough"}` branch added before it
- [x] Oracle agent itself not modified
- [x] `oracle/verdicts/archive/` already exists (confirmed)

WOS-UoW: uow_20260516_71b777