### PR TITLE
fix: remove hardcoded WOS source file boundary from handle_wos_execute template

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -693,7 +693,6 @@ def handle_wos_execute(uow_id: str, instructions: str, output_ref: str) -> str:
         f"response across all turns and report the total. This enables per-UoW cost telemetry.\n"
         f"Omit token_usage if you did not track it.\n\n"
         f"Minimum viable output: {output_ref} with uow_id, outcome, and success fields.\n"
-        f"Boundary: do not modify executor.py, registry.py, or any WOS source files.\n"
     )
 
 


### PR DESCRIPTION
## Bug

`handle_wos_execute` in `dispatcher_handlers.py` appended a hardcoded boundary to every WOS UoW dispatch prompt:

```
Boundary: do not modify executor.py, registry.py, or any WOS source files.
```

This line was inserted unconditionally regardless of what the UoW was implementing. It directly contradicts any WOS-internal implementation task — for example, `uow_20260519_5f17b8` required modifying `executor.py` and `registry.py` to implement the visibility-timeout model. The subagent received contradictory instructions: the prescription told it to modify those files, and the dispatch template told it not to.

## Fix

Remove the hardcoded boundary line from the dispatch template. Each UoW's prescription is responsible for defining its own scope and boundaries. The generic template should not add blanket restrictions that can conflict with prescription-level intent.

## Impact

`uow_20260519_5f17b8` failed due to this contradiction. Any future WOS-internal implementation task was similarly blocked.

## Change

One line deleted from `src/orchestration/dispatcher_handlers.py` in `handle_wos_execute`.