### PR TITLE
fix: redirect WOS subagent subprocess output to log files

### DIFF
--- a/src/daemons/wos_execute_router.py
+++ b/src/daemons/wos_execute_router.py
@@ -326,6 +326,12 @@ _CLAUDE_BIN: str = "claude"
 #: Maximum turns for a dispatched claude -p agent.
 _MAX_TURNS: int = 40
 
+#: Directory for per-execution subprocess log files (stdout + stderr combined).
+#: Created on first use.  Each file is named ``<run_id>.log``.
+_SUBPROCESS_LOG_DIR: Path = (
+    Path.home() / "lobster-workspace" / "orchestration" / "logs"
+)
+
 
 def _dispatch_via_popen(
     instructions: str,
@@ -386,15 +392,23 @@ def _dispatch_via_popen(
     except Exception:
         env = None  # Fall back to inheriting the current environment
 
-    proc = subprocess.Popen(
-        command,
-        start_new_session=True,  # Insulates child from SIGTERM sent to daemon
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        close_fds=True,
-        env=env,
-    )
+    # Redirect child stdout+stderr to a per-execution log file so that silent
+    # exits (OOM kills, unhandled exceptions, Claude binary crashes) leave
+    # forensic evidence.  Without this, DEVNULL swallows all exit context and
+    # post-mortem analysis is impossible.
+    _SUBPROCESS_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_path = _SUBPROCESS_LOG_DIR / f"{run_id}.log"
+
+    with open(log_path, "w") as log_fh:
+        proc = subprocess.Popen(
+            command,
+            start_new_session=True,  # Insulates child from SIGTERM sent to daemon
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            close_fds=True,
+            env=env,
+        )
 
     # Write PID to registry so `wos abort` can send SIGTERM to the process group.
     # Best-effort: any failure is logged but does not abort the dispatch.
@@ -413,8 +427,9 @@ def _dispatch_via_popen(
             )
 
     log.info(
-        "dispatch: spawned claude -p for uow_id=%s run_id=%s (non-blocking, new session)",
-        uow_id, run_id,
+        "dispatch: spawned claude -p for uow_id=%s run_id=%s (non-blocking, new session) "
+        "log=%s",
+        uow_id, run_id, log_path,
     )
     return run_id
 

--- a/tests/test_wos_execute_router.py
+++ b/tests/test_wos_execute_router.py
@@ -638,9 +638,10 @@ class TestDispatchViaPopen:
             f"Got kwargs: {kwargs}"
         )
 
-    def test_stdin_stdout_stderr_devnull(self):
-        """Child process inherits no file descriptors from daemon (clean isolation)."""
+    def test_stdin_devnull_stdout_stderr_log_file(self):
+        """stdin is DEVNULL; stdout and stderr are redirected to a per-execution log file."""
         import importlib.util
+        import io
         repo_root = Path(__file__).resolve().parent.parent
         spec = importlib.util.spec_from_file_location(
             "wos_execute_router_fds",
@@ -665,8 +666,19 @@ class TestDispatchViaPopen:
 
         kwargs = mock_popen.call_args.kwargs
         assert kwargs.get("stdin") == subprocess.DEVNULL, "stdin must be DEVNULL"
-        assert kwargs.get("stdout") == subprocess.DEVNULL, "stdout must be DEVNULL"
-        assert kwargs.get("stderr") == subprocess.DEVNULL, "stderr must be DEVNULL"
+        # stdout and stderr must be redirected to a writable file object, not DEVNULL,
+        # so that subagent exits leave forensic evidence for post-mortem analysis.
+        stdout = kwargs.get("stdout")
+        stderr = kwargs.get("stderr")
+        assert stdout != subprocess.DEVNULL, (
+            "stdout must not be DEVNULL — redirect to a log file for observability"
+        )
+        assert stderr != subprocess.DEVNULL, (
+            "stderr must not be DEVNULL — redirect to a log file for observability"
+        )
+        assert hasattr(stdout, "write"), "stdout must be a writable file object"
+        assert hasattr(stderr, "write"), "stderr must be a writable file object"
+        assert stdout is stderr, "stdout and stderr must share the same log file handle"
 
     def test_command_includes_claude_p_flags(self):
         """Popen command includes -p, --dangerously-skip-permissions, --max-turns."""


### PR DESCRIPTION
## Summary

- `_dispatch_via_popen` previously passed `stdout=DEVNULL, stderr=DEVNULL` to the `claude -p` subprocess, which completely suppressed all output from spawned subagents
- When a subagent exited silently (OOM kill, unhandled exception, Claude binary crash), there was zero forensic evidence — no way to distinguish a clean exit from a crash
- This PR replaces DEVNULL suppression with per-execution log files at `~/lobster-workspace/orchestration/logs/<run_id>.log` (stdout+stderr combined), created with `mkdir -p` on first use
- `stdin` remains `DEVNULL` (no interactive input is needed)
- The log filename embeds `run_id` (`<uow_id>-<timestamp>`), so logs are directly correlated to registry entries
- Test `test_stdin_stdout_stderr_devnull` renamed and updated to assert the new contract: stdin is DEVNULL, stdout/stderr are writable file handles that share the same log file

## Test plan

- [ ] All 30 `test_wos_execute_router.py` tests pass (verified locally)
- [ ] Confirm `~/lobster-workspace/orchestration/logs/` is created on first dispatch
- [ ] Confirm log files appear after a dispatch cycle and contain subagent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)