### PR TITLE
fix: remove dead TTL_EXCEEDED_HOURS and recover_ttl_exceeded_uows imports (pre-existing after #1216)

### DIFF
--- a/tests/integration/test_wos_e2e_harness.py
+++ b/tests/integration/test_wos_e2e_harness.py
@@ -47,7 +47,6 @@ from orchestration.workflow_artifact import from_frontmatter
 # HARNESS UoW issue numbers — well out of real issue range
 HARNESS_001_ISSUE_NUMBER = 9001
 HARNESS_002_ISSUE_NUMBER = 9002
-HARNESS_003_ISSUE_NUMBER = 9003
 HARNESS_004_ISSUE_NUMBER = 9004
 
 # Hard cap on steward cycles before escalation to Dan — imported from steward.py
@@ -547,79 +546,6 @@ class TestHarness002Represcription:
             assert len(uow.steward_log) >= len(steward_log_after_cycle_1), (
                 "steward_log must be appended (not overwritten) between cycles (AC-11)"
             )
-
-
-# ---------------------------------------------------------------------------
-# HARNESS-003: TTL recovery
-# ---------------------------------------------------------------------------
-
-@pytest.mark.wos_e2e
-class TestHarness003TtlRecovery:
-    """
-    HARNESS-003: TTL recovery — UoW stuck active > TTL_EXCEEDED_HOURS.
-
-    Acceptance criteria: AC-16, AC-17.
-    """
-
-    def test_harness_003_ttl_recovery_transitions_to_failed(
-        self, harness_env: dict
-    ) -> None:
-        """
-        AC-16: After recover_ttl_exceeded_uows(), UoW status transitions from
-               'active' to 'failed'.
-        AC-17: audit_log contains 'ttl_exceeded' return_reason.
-        """
-        registry: Registry = harness_env["registry"]
-        db_path: Path = harness_env["db_path"]
-
-        uow_id = _seed_harness_uow(registry, HARNESS_003_ISSUE_NUMBER)
-
-        # Advance to 'active' via set_status_direct (simulates Executor claim)
-        registry.set_status_direct(uow_id, "active")
-
-        # Backdate started_at to 5 hours ago — beyond the TTL_EXCEEDED_HOURS (4h) threshold.
-        # TTL recovery uses: WHERE started_at < (now - TTL_EXCEEDED_HOURS).
-        # Use a timestamp that is definitely in the past relative to any test run.
-        five_hours_ago = "2020-01-01T00:00:00+00:00"
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "UPDATE uow_registry SET started_at = ? WHERE id = ?",
-            (five_hours_ago, uow_id),
-        )
-        conn.commit()
-        conn.close()
-
-        # Run TTL recovery
-        from orchestration.executor import recover_ttl_exceeded_uows
-        recovered = recover_ttl_exceeded_uows(registry)
-
-        # AC-16: UoW transitions from active to failed
-        uow = registry.get(uow_id)
-        assert uow is not None
-        assert uow.status == UoWStatus.FAILED, (
-            f"TTL recovery must transition UoW to 'failed' (AC-16), got {uow.status}"
-        )
-
-        # AC-17: audit_log contains 'ttl_exceeded' in the note (fail_uow reason).
-        # fail_uow() writes event='execution_failed' with note containing the reason
-        # string which includes "ttl_exceeded".
-        conn = sqlite3.connect(str(db_path))
-        conn.row_factory = sqlite3.Row
-        audit_rows = conn.execute(
-            "SELECT event, note FROM audit_log WHERE uow_id = ? ORDER BY id ASC",
-            (uow_id,),
-        ).fetchall()
-        conn.close()
-
-        ttl_found = any(
-            "ttl_exceeded" in (row["note"] or "").lower()
-            or "ttl" in (row["event"] or "").lower()
-            for row in audit_rows
-        )
-        assert ttl_found, (
-            f"audit_log must contain 'ttl_exceeded' in a note entry (AC-17). "
-            f"Audit events: {[(r['event'], (r['note'] or '')[:120]) for r in audit_rows]}"
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_wos_ttl_recovery.py
+++ b/tests/integration/test_wos_ttl_recovery.py
@@ -1,23 +1,13 @@
 """
-Integration tests: TTL recovery and executor_orphan detection.
+Integration tests: executor_orphan detection via startup sweep.
 
-Two scenarios:
+Scenario:
+- UoW seeded, advanced to ready-for-executor, created_at pushed back > 1 hour.
+- run_startup_sweep() called.
+- Assert UoW transitions to 'ready-for-steward' with audit entry
+  classification='executor_orphan'.
 
-1. TTL recovery (active UoW stalled too long):
-   - UoW seeded, claimed by Executor (status → active), started_at pushed
-     back > TTL_EXCEEDED_HOURS.
-   - recover_ttl_exceeded_uows() called.
-   - Assert UoW transitions to 'failed' with return_reason containing
-     'ttl_exceeded'.
-
-2. executor_orphan (startup sweep):
-   - UoW seeded, advanced to ready-for-executor, created_at pushed back
-     > 1 hour.
-   - run_startup_sweep() called.
-   - Assert UoW transitions to 'ready-for-steward' with audit entry
-     classification='executor_orphan'.
-
-Both tests use a SQLite DB (via tmp_path) with all real migrations applied.
+Tests use a SQLite DB (via tmp_path) with all real migrations applied.
 No network calls, no subprocess spawning.
 """
 
@@ -43,10 +33,6 @@ if str(_SRC) not in sys.path:
 
 from orchestration.migrate import run_migrations
 from orchestration.registry import Registry, UpsertInserted, ApproveConfirmed
-from orchestration.executor import (
-    TTL_EXCEEDED_HOURS,
-    recover_ttl_exceeded_uows,
-)
 from orchestration.steward import IssueInfo
 
 _SCHEDULED_TASKS = str(_REPO_ROOT / "scheduled-tasks")
@@ -98,59 +84,6 @@ def conn(db_path: Path, registry: Registry) -> sqlite3.Connection:
 # ---------------------------------------------------------------------------
 
 
-def _seed_and_activate(registry: Registry, conn: sqlite3.Connection) -> str:
-    """
-    Seed a UoW and advance it to 'active' status (simulating a claimed execution).
-
-    Returns the uow_id.
-
-    The 6-step Executor claim sequence sets status='active' and writes started_at.
-    We simulate this directly in SQL so tests remain self-contained and do not
-    depend on a live WorkflowArtifact or dispatch subprocess.
-    """
-    result = registry.upsert(
-        issue_number=9901,
-        title="TTL test: stalled execution",
-        sweep_date="2026-03-31",
-        success_criteria="Test completion.",
-    )
-    assert isinstance(result, UpsertInserted), f"seed failed: {result}"
-    uow_id = result.id
-
-    # proposed → pending
-    confirm = registry.approve(uow_id)
-    assert isinstance(confirm, ApproveConfirmed), f"approve failed: {confirm}"
-
-    # pending → ready-for-steward (trigger evaluator stub)
-    registry.set_status_direct(uow_id, "ready-for-steward")
-
-    # ready-for-steward → ready-for-executor (steward prescription stub)
-    registry.set_status_direct(uow_id, "ready-for-executor")
-
-    # ready-for-executor → active (executor claim stub)
-    now = _now_iso()
-    conn.execute(
-        """
-        UPDATE uow_registry
-        SET status = 'active',
-            started_at = ?,
-            updated_at = ?
-        WHERE id = ?
-        """,
-        (now, now, uow_id),
-    )
-    conn.execute(
-        """
-        INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
-        VALUES (?, ?, 'claimed', 'ready-for-executor', 'active', 'executor', ?)
-        """,
-        (now, uow_id, json.dumps({"actor": "executor_stub", "started_at": now})),
-    )
-    conn.commit()
-
-    return uow_id
-
-
 def _seed_ready_for_executor(registry: Registry) -> str:
     """
     Seed a UoW and advance it to 'ready-for-executor' status.
@@ -174,110 +107,7 @@ def _seed_ready_for_executor(registry: Registry) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Test 1: TTL recovery — active UoW stalled > TTL_EXCEEDED_HOURS
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.integration
-def test_ttl_recovery_transitions_stalled_active_uow_to_failed(
-    registry: Registry,
-    conn: sqlite3.Connection,
-) -> None:
-    """
-    UoWs that stay in 'active' for longer than TTL_EXCEEDED_HOURS are
-    transitioned to 'failed' by recover_ttl_exceeded_uows().
-
-    Proof: set started_at to (now - TTL_EXCEEDED_HOURS - 1 minute), run
-    recovery, assert status='failed' with an audit entry noting ttl_exceeded.
-    """
-    uow_id = _seed_and_activate(registry, conn)
-
-    # Backdate started_at to be beyond the TTL threshold
-    stale_started_at = _ago_iso(hours=TTL_EXCEEDED_HOURS, seconds=60)
-    conn.execute(
-        "UPDATE uow_registry SET started_at = ?, updated_at = ? WHERE id = ?",
-        (stale_started_at, _now_iso(), uow_id),
-    )
-    conn.commit()
-
-    # Verify precondition: UoW is 'active' with stale started_at
-    row = conn.execute(
-        "SELECT status, started_at FROM uow_registry WHERE id = ?",
-        (uow_id,),
-    ).fetchone()
-    assert row["status"] == "active"
-    assert row["started_at"] == stale_started_at
-
-    # Run TTL recovery
-    recovered = recover_ttl_exceeded_uows(registry)
-
-    # Assert the UoW was recovered
-    assert uow_id in recovered, (
-        f"Expected {uow_id!r} in recovered list {recovered!r}"
-    )
-
-    # Assert status is now 'failed'
-    row = conn.execute(
-        "SELECT status FROM uow_registry WHERE id = ?",
-        (uow_id,),
-    ).fetchone()
-    assert row["status"] == "failed", (
-        f"Expected status='failed', got {row['status']!r}"
-    )
-
-    # Assert audit trail contains a ttl_exceeded entry
-    audit_rows = conn.execute(
-        "SELECT event, from_status, to_status, note FROM audit_log WHERE uow_id = ?",
-        (uow_id,),
-    ).fetchall()
-    ttl_entries = [
-        r for r in audit_rows
-        if r["event"] == "execution_failed"
-        and r["from_status"] == "active"
-        and r["to_status"] == "failed"
-    ]
-    assert ttl_entries, (
-        f"No execution_failed audit entry found. All audit entries: "
-        f"{[dict(r) for r in audit_rows]}"
-    )
-
-    note = json.loads(ttl_entries[0]["note"])
-    assert "ttl_exceeded" in note.get("reason", ""), (
-        f"Expected 'ttl_exceeded' in audit note reason, got: {note!r}"
-    )
-
-
-@pytest.mark.integration
-def test_ttl_recovery_ignores_fresh_active_uow(
-    registry: Registry,
-    conn: sqlite3.Connection,
-) -> None:
-    """
-    UoWs in 'active' with a recent started_at are NOT affected by TTL recovery.
-
-    Proof: set started_at to 1 minute ago (well below TTL_EXCEEDED_HOURS),
-    run recovery, assert UoW stays 'active'.
-    """
-    uow_id = _seed_and_activate(registry, conn)
-
-    # started_at is already 'now' from _seed_and_activate — stays fresh
-    recovered = recover_ttl_exceeded_uows(registry)
-
-    assert uow_id not in recovered, (
-        f"Expected fresh UoW {uow_id!r} NOT to be in recovered list"
-    )
-
-    row = conn.execute(
-        "SELECT status FROM uow_registry WHERE id = ?",
-        (uow_id,),
-    ).fetchone()
-    assert row["status"] == "active", (
-        f"Expected status='active' (unchanged), got {row['status']!r}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 2: executor_orphan — startup sweep detects stale ready-for-executor UoW
+# Test 1: executor_orphan — startup sweep detects stale ready-for-executor UoW
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_orchestration/test_executor_false_complete_fix.py
+++ b/tests/unit/test_orchestration/test_executor_false_complete_fix.py
@@ -35,8 +35,6 @@ from orchestration.executor import (
     _noop_dispatcher,
     _dispatcher_is_async,
     _ASYNC_EXECUTOR_TYPES,
-    recover_ttl_exceeded_uows,
-    TTL_EXCEEDED_HOURS,
 )
 
 
@@ -420,52 +418,6 @@ class TestCompleteUowFromExecuting:
         assert _get_uow_status(db_path, uow_id) == STATUS_READY_FOR_STEWARD
         events = _get_audit_events(db_path, uow_id)
         assert AUDIT_EXECUTION_COMPLETE in events
-
-
-# ---------------------------------------------------------------------------
-# Tests: TTL recovery covers 'executing' UoWs
-# ---------------------------------------------------------------------------
-
-class TestTtlRecoveryCoversExecuting:
-    def test_ttl_recovery_fails_executing_uow_past_ttl(self, registry: Registry, db_path: Path) -> None:
-        """TTL recovery must include 'executing' UoWs that have exceeded TTL_EXCEEDED_HOURS."""
-        from datetime import datetime, timezone, timedelta
-
-        uow_id = "uow_ttl_exec_001"
-        # started_at is well past the TTL cutoff
-        stale_started_at = (
-            datetime.now(timezone.utc) - timedelta(hours=TTL_EXCEEDED_HOURS + 1)
-        ).isoformat()
-        _insert_uow_with_status(db_path, uow_id, "executing", started_at=stale_started_at)
-
-        recovered = recover_ttl_exceeded_uows(registry)
-
-        assert uow_id in recovered, (
-            f"TTL recovery must recover 'executing' UoWs past TTL. "
-            f"Recovered: {recovered}"
-        )
-        assert _get_uow_status(db_path, uow_id) == "failed"
-
-    def test_ttl_recovery_does_not_fail_fresh_executing_uow(
-        self, registry: Registry, db_path: Path
-    ) -> None:
-        """TTL recovery must NOT fail 'executing' UoWs that are still within TTL."""
-        from datetime import datetime, timezone, timedelta
-
-        uow_id = "uow_ttl_exec_002"
-        # started_at is recent — well within TTL
-        fresh_started_at = (
-            datetime.now(timezone.utc) - timedelta(minutes=30)
-        ).isoformat()
-        _insert_uow_with_status(db_path, uow_id, "executing", started_at=fresh_started_at)
-
-        recovered = recover_ttl_exceeded_uows(registry)
-
-        assert uow_id not in recovered, (
-            f"TTL recovery must not touch 'executing' UoWs within TTL. "
-            f"Recovered: {recovered}"
-        )
-        assert _get_uow_status(db_path, uow_id) == "executing"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Dead symbols since PR #1216 (partial visibility-timeout implementation), which removed `TTL_EXCEEDED_HOURS` and `recover_ttl_exceeded_uows` from `src/orchestration/executor.py`. Discovered during oracle review of PR #1233.

Three test files had broken imports that prevented collection:

- `tests/integration/test_wos_ttl_recovery.py` — top-level import block removed; two dead test functions deleted; `_seed_and_activate` helper deleted (only called by deleted tests); docstring updated
- `tests/unit/test_orchestration/test_executor_false_complete_fix.py` — two dead symbols removed from import block; `TestTtlRecoveryCoversExecuting` class (2 methods) deleted
- `tests/integration/test_wos_e2e_harness.py` — `TestHarness003TtlRecovery` class deleted (contained local `from orchestration.executor import recover_ttl_exceeded_uows`)

**No behaviour change.** Tests were removed, not ported. The replacement API `reset_expired_claims()` has different semantics (`active`/`executing` → `ready-for-executor`, not `failed`) and belongs in a new dedicated test.

## Test plan

- [ ] `pytest tests/integration/test_wos_ttl_recovery.py tests/unit/test_orchestration/test_executor_false_complete_fix.py tests/integration/test_wos_e2e_harness.py --co -q` produces no `ERROR` or `ImportError` lines
- [ ] `grep -n "from orchestration.executor import" tests/integration/test_wos_ttl_recovery.py tests/unit/test_orchestration/test_executor_false_complete_fix.py` does not include `TTL_EXCEEDED_HOURS` or `recover_ttl_exceeded_uows` on any line
- [ ] Surviving tests pass (executor_orphan startup sweep tests, false-complete fix tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)