### PR TITLE
refactor: extract _write_crash_alert to src/utils/inbox_write.py

### DIFF
--- a/scheduled-tasks/executor-heartbeat.py
+++ b/scheduled-tasks/executor-heartbeat.py
@@ -40,8 +40,6 @@ import logging
 import os
 import subprocess
 import sys
-import traceback
-import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -59,6 +57,7 @@ if str(_SRC_ROOT) not in sys.path:
 
 from src.orchestration.paths import REGISTRY_DB
 from src.utils.jobs import is_job_enabled
+from src.utils.inbox_write import write_crash_alert
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -70,63 +69,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 log = logging.getLogger("executor-heartbeat")
-
-# Admin chat_id for crash alerts (env-injected, falls back to hardcoded)
-_ADMIN_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
-
-
-# ---------------------------------------------------------------------------
-# Crash alert — write a system inbox message so the dispatcher relays it to Dan
-# ---------------------------------------------------------------------------
-
-def _write_crash_alert(job_name: str, exc: BaseException, extra: str = "") -> None:
-    """Write a scheduled_task_crash inbox message so the dispatcher alerts Dan.
-
-    This is a best-effort fire-and-forget write. Failures here are logged but
-    do not mask the original exception — the caller must re-raise or sys.exit
-    after calling this function.
-
-    The inbox message shape is intentionally simple: source=system,
-    type=scheduled_task_crash, text=human-readable alert. The dispatcher's
-    LLM loop reads the message and relays it to Dan as a Telegram notification.
-    """
-    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
-    tb_str = "".join(tb_lines).strip()
-    # Truncate traceback to avoid oversized messages (keep last 2000 chars)
-    if len(tb_str) > 2000:
-        tb_str = "...(truncated)...\n" + tb_str[-2000:]
-
-    text = (
-        f"[CRASH] {job_name} crashed with {type(exc).__name__}: {exc}\n\n"
-        f"```\n{tb_str}\n```"
-    )
-    if extra:
-        text += f"\n\n{extra}"
-
-    from datetime import datetime as _datetime, timezone as _timezone
-
-    msg_id = str(uuid.uuid4())
-    msg = {
-        "id": msg_id,
-        "source": "system",
-        "type": "scheduled_task_crash",
-        "chat_id": _ADMIN_CHAT_ID,
-        "job_name": job_name,
-        "timestamp": _datetime.now(_timezone.utc).isoformat(),
-        "text": text,
-    }
-
-    try:
-        messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
-        inbox_dir = messages_base / "inbox"
-        inbox_dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = inbox_dir / f"{msg_id}.json.tmp"
-        dest_path = inbox_dir / f"{msg_id}.json"
-        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
-        tmp_path.rename(dest_path)
-        log.info("Crash alert written to inbox (%s)", msg_id)
-    except Exception as write_exc:
-        log.error("Failed to write crash alert to inbox: %s", write_exc)
 
 
 # ---------------------------------------------------------------------------
@@ -627,7 +569,7 @@ def main() -> int:
         return _main_inner()
     except Exception as exc:
         log.error("executor-heartbeat crashed with unhandled exception: %s", exc, exc_info=True)
-        _write_crash_alert(job_name="executor-heartbeat", exc=exc)
+        write_crash_alert(job_name="executor-heartbeat", exc=exc)
         return 1
 
 

--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -41,8 +41,6 @@ import json
 import logging
 import os
 import sys
-import traceback
-import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from enum import StrEnum
@@ -62,6 +60,7 @@ from src.orchestration.steward import is_bootup_candidate_gate_active, run_stewa
 from src.orchestration.github_sync import run_post_completion_sync
 from src.orchestration.dispatcher_handlers import read_wos_config, _PAUSE_REASON_USER_COMMAND
 from src.utils.jobs import is_job_enabled
+from src.utils.inbox_write import write_crash_alert
 
 # ---------------------------------------------------------------------------
 # Startup sweep — imported from startup_sweep.py (Phase 1 concern)
@@ -82,61 +81,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 log = logging.getLogger("steward-heartbeat")
-
-# Admin chat_id for crash alerts (env-injected, falls back to hardcoded)
-_ADMIN_CHAT_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
-
-
-# ---------------------------------------------------------------------------
-# Crash alert — write a system inbox message so the dispatcher relays it to Dan
-# ---------------------------------------------------------------------------
-
-def _write_crash_alert(job_name: str, exc: BaseException, extra: str = "") -> None:
-    """Write a scheduled_task_crash inbox message so the dispatcher alerts Dan.
-
-    This is a best-effort fire-and-forget write. Failures here are logged but
-    do not mask the original exception — the caller must re-raise or sys.exit
-    after calling this function.
-
-    The inbox message shape is intentionally simple: source=system,
-    type=scheduled_task_crash, text=human-readable alert. The dispatcher's
-    LLM loop reads the message and relays it to Dan as a Telegram notification.
-    """
-    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
-    tb_str = "".join(tb_lines).strip()
-    # Truncate traceback to avoid oversized messages (keep last 2000 chars)
-    if len(tb_str) > 2000:
-        tb_str = "...(truncated)...\n" + tb_str[-2000:]
-
-    text = (
-        f"[CRASH] {job_name} crashed with {type(exc).__name__}: {exc}\n\n"
-        f"```\n{tb_str}\n```"
-    )
-    if extra:
-        text += f"\n\n{extra}"
-
-    msg_id = str(uuid.uuid4())
-    msg = {
-        "id": msg_id,
-        "source": "system",
-        "type": "scheduled_task_crash",
-        "chat_id": _ADMIN_CHAT_ID,
-        "job_name": job_name,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "text": text,
-    }
-
-    try:
-        messages_base = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
-        inbox_dir = messages_base / "inbox"
-        inbox_dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = inbox_dir / f"{msg_id}.json.tmp"
-        dest_path = inbox_dir / f"{msg_id}.json"
-        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
-        tmp_path.rename(dest_path)
-        log.info("Crash alert written to inbox (%s)", msg_id)
-    except Exception as write_exc:
-        log.error("Failed to write crash alert to inbox: %s", write_exc)
 
 
 # ---------------------------------------------------------------------------
@@ -1103,7 +1047,7 @@ def main() -> int:
         return _main_inner()
     except Exception as exc:
         log.error("steward-heartbeat crashed with unhandled exception: %s", exc, exc_info=True)
-        _write_crash_alert(job_name="steward-heartbeat", exc=exc)
+        write_crash_alert(job_name="steward-heartbeat", exc=exc)
         return 1
 
 

--- a/src/utils/inbox_write.py
+++ b/src/utils/inbox_write.py
@@ -12,6 +12,10 @@ write_inbox_message(job_name, chat_id, text, timestamp) -> str
     Non-urgent messages sent outside the morning window are queued in
     pending-deliveries.jsonl instead of the inbox (circadian delivery).
 
+write_crash_alert(job_name, exc, extra) -> None
+    Write a scheduled_task_crash inbox message so the dispatcher alerts Dan.
+    Best-effort; failures are logged but do not mask the original exception.
+
 _inbox_dir() -> Path
 _task_outputs_dir() -> Path
     Directory helpers; exposed for scripts that need the raw path (e.g. to
@@ -21,9 +25,14 @@ _task_outputs_dir() -> Path
 from __future__ import annotations
 
 import json
+import logging
 import os
+import traceback
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 
 def _inbox_dir() -> Path:
@@ -106,3 +115,45 @@ def write_inbox_message(
     tmp_path.write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
     tmp_path.replace(out_path)
     return msg_id
+
+
+def write_crash_alert(job_name: str, exc: BaseException, extra: str = "") -> None:
+    """Write a scheduled_task_crash inbox message so the dispatcher alerts Dan.
+
+    Best-effort fire-and-forget. Failures are logged but do not mask the
+    original exception — the caller must re-raise or sys.exit after this call.
+    """
+    admin_chat_id: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "8075091586")
+
+    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    tb_str = "".join(tb_lines).strip()
+    if len(tb_str) > 2000:
+        tb_str = "...(truncated)...\n" + tb_str[-2000:]
+
+    text = (
+        f"[CRASH] {job_name} crashed with {type(exc).__name__}: {exc}\n\n"
+        f"```\n{tb_str}\n```"
+    )
+    if extra:
+        text += f"\n\n{extra}"
+
+    msg_id = str(uuid.uuid4())
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "type": "scheduled_task_crash",
+        "chat_id": admin_chat_id,
+        "job_name": job_name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "text": text,
+    }
+
+    try:
+        inbox = _inbox_dir()
+        tmp_path = inbox / f"{msg_id}.json.tmp"
+        dest_path = inbox / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+        tmp_path.rename(dest_path)
+        log.info("Crash alert written to inbox (%s)", msg_id)
+    except Exception as write_exc:
+        log.error("Failed to write crash alert to inbox: %s", write_exc)


### PR DESCRIPTION
## Summary

- Extracts the identically-duplicated `_write_crash_alert` function from `executor-heartbeat.py` and `steward-heartbeat.py` into `src/utils/inbox_write.write_crash_alert` — the shared-utility module created for this pattern in PR #805
- Renames to `write_crash_alert` (public, no leading underscore) since it is now part of the module's public API
- Both heartbeat scripts now import from `src.utils.inbox_write` and their local `_ADMIN_CHAT_ID` constants and `_write_crash_alert` definitions are removed

Closes Gap 2 from oracle round 1 on PR #1222.

## Test plan

- [ ] `uv run -m pytest tests/unit/test_inbox_write.py` — passes
- [ ] `uv run -m pytest tests/unit/test_orchestration/test_executor_heartbeat.py` — 33 pass, 4 pre-existing failures (claimed_until schema gap, present on main before this PR)
- [ ] Confirm `src/utils/inbox_write.py` contains `write_crash_alert(job_name, exc, extra="")`
- [ ] Confirm neither heartbeat file contains a local `_write_crash_alert` definition or `_ADMIN_CHAT_ID` constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)