### PR TITLE
fix(wos): route expired claims through steward; stop sidecar from refreshing dead UoWs

### DIFF
--- a/src/orchestration/heartbeat_sidecar.py
+++ b/src/orchestration/heartbeat_sidecar.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 log = logging.getLogger("heartbeat_sidecar")
 
@@ -130,14 +131,52 @@ def write_heartbeats_for_active_uows(registry: object) -> HeartbeatSidecarResult
 
 def _collect_in_flight_uows(registry: object) -> list:
     """
-    Return all UoWs in 'active' or 'executing' status.
+    Return UoWs in 'active' or 'executing' status whose claim has not yet expired.
 
     Pure read: no side effects. Uses registry.list(status=...) for each status
-    and merges the results. Returns a flat list of UoW objects.
+    and merges the results. Filters out UoWs whose claimed_until is in the past —
+    those have a dead agent by definition (the claim window closed without the
+    agent completing or renewing), so refreshing their heartbeat_at would mask
+    stall detection in the steward's observation loop.
+
+    Returns a flat list of UoW objects eligible for heartbeat refresh.
     """
+    now = datetime.now(timezone.utc)
     active = _safe_list(registry, "active")
     executing = _safe_list(registry, "executing")
-    return active + executing
+    candidates = []
+    for uow in active + executing:
+        if _claim_expired(uow, now):
+            log.debug(
+                "Heartbeat sidecar: skipping UoW %s — claimed_until %s is in the past",
+                uow.id, getattr(uow, "claimed_until", None),
+            )
+            continue
+        candidates.append(uow)
+    return candidates
+
+
+def _claim_expired(uow: object, now: datetime) -> bool:
+    """
+    Return True if the UoW's claimed_until deadline has already passed.
+
+    A UoW with no claimed_until (NULL) is not considered expired — it either
+    has not been claimed yet or was claimed before the visibility-timeout schema
+    migration. Such UoWs are included in the heartbeat candidates.
+
+    Pure function: reads only from the uow object and the provided now timestamp.
+    No database access, no side effects.
+    """
+    claimed_until = getattr(uow, "claimed_until", None)
+    if not claimed_until:
+        return False
+    try:
+        deadline = datetime.fromisoformat(claimed_until.replace("Z", "+00:00"))
+        if deadline.tzinfo is None:
+            deadline = deadline.replace(tzinfo=timezone.utc)
+        return deadline < now
+    except (ValueError, AttributeError):
+        return False
 
 
 def _safe_list(registry: object, status: str) -> list:

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -225,6 +225,11 @@ class UoW:
     #   to 'active' status. Used by startup sweep for per-UoW age threshold when
     #   combined with estimated_runtime (#572). NULL until execution begins.
     started_at: str | None = None
+    # claimed_until: ISO timestamp deadline for the current execution claim (migration 0025).
+    #   Set by the Executor to 2× estimated_runtime at dispatch time.
+    #   If now() > claimed_until, the claim has expired and the UoW is reclaimable.
+    #   NULL when not currently claimed (proposed/ready/done states).
+    claimed_until: str | None = None
     # GardenCaretaker source tracking fields (populated after migration 0004)
     source_ref: str | None = None
     source_last_seen_at: str | None = None
@@ -522,6 +527,7 @@ class Registry:
             juice_rationale=d.get("juice_rationale"),
             prescription_confidence=d.get("prescription_confidence"),
             trigger_message_id=d.get("trigger_message_id"),
+            claimed_until=d.get("claimed_until"),
         )
 
     def _write_audit(
@@ -1497,8 +1503,9 @@ class Registry:
 
     def reset_expired_claims(self) -> list[str]:
         """
-        Reset UoWs whose visibility-timeout (claimed_until) has expired back to
-        'ready-for-executor' so the next executor-heartbeat cycle can re-dispatch them.
+        Reset UoWs whose visibility-timeout (claimed_until) has expired to
+        'ready-for-steward' so the steward can apply orphan retry logic before
+        re-dispatching.
 
         A UoW claim expires when:
           status IN ('active', 'executing')
@@ -1508,6 +1515,12 @@ class Registry:
         Supersedes the started_at-based recover_ttl_exceeded_uows() approach:
         claimed_until is set to 2× estimated_runtime at dispatch time, so expiry
         means the agent had enough headroom and genuinely stalled or crashed.
+
+        Routes to 'ready-for-steward' (not 'ready-for-executor') so the steward
+        can apply orphan_retry_count checks, MAX_RETRIES, and ORPHAN_KILL_RETRY_BUDGET
+        before deciding whether to re-dispatch. The audit note carries
+        return_reason='executing_orphan' so _most_recent_return_reason_from_audit
+        can classify the event correctly.
 
         Returns the list of uow_ids that were reset (may be empty).
         """
@@ -1534,14 +1547,19 @@ class Registry:
                 conn2.execute(
                     """
                     INSERT INTO audit_log (ts, uow_id, event, from_status, to_status, agent, note)
-                    VALUES (?, ?, 'claim_expired', NULL, 'ready-for-executor', 'executor', ?)
+                    VALUES (?, ?, 'claim_expired', NULL, 'ready-for-steward', 'executor', ?)
                     """,
-                    (now, uow_id, json.dumps({"actor": "executor", "reason": "claimed_until expired", "timestamp": now})),
+                    (now, uow_id, json.dumps({
+                        "actor": "executor",
+                        "reason": "claimed_until expired",
+                        "return_reason": "executing_orphan",
+                        "timestamp": now,
+                    })),
                 )
                 cursor = conn2.execute(
                     """
                     UPDATE uow_registry
-                    SET status = 'ready-for-executor', claimed_until = NULL, updated_at = ?
+                    SET status = 'ready-for-steward', claimed_until = NULL, updated_at = ?
                     WHERE id = ? AND status IN ('active', 'executing') AND claimed_until < datetime('now')
                     """,
                     (now, uow_id),

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1531,7 +1531,7 @@ class Registry:
                 SELECT id FROM uow_registry
                 WHERE status IN ('active', 'executing')
                   AND claimed_until IS NOT NULL
-                  AND claimed_until < datetime('now')
+                  AND datetime(claimed_until) < datetime('now')
                 """
             ).fetchall()
         finally:
@@ -1560,7 +1560,7 @@ class Registry:
                     """
                     UPDATE uow_registry
                     SET status = 'ready-for-steward', claimed_until = NULL, updated_at = ?
-                    WHERE id = ? AND status IN ('active', 'executing') AND claimed_until < datetime('now')
+                    WHERE id = ? AND status IN ('active', 'executing') AND datetime(claimed_until) < datetime('now')
                     """,
                     (now, uow_id),
                 )

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -980,6 +980,14 @@ def _most_recent_return_reason(audit_entries: list[dict]) -> str | None:
             clf = note_data.get("return_reason") or note_data.get("classification")
             if clf:
                 return clf
+        elif event == "claim_expired":
+            # Claim window expired while the UoW was active/executing — the agent is
+            # dead. Extract return_reason from the audit note (written by
+            # reset_expired_claims as "executing_orphan") so the steward can apply
+            # orphan_retry_count and ORPHAN_KILL_RETRY_BUDGET correctly.
+            rr = note_data.get("return_reason")
+            if rr:
+                return rr
 
     return None
 

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -985,6 +985,11 @@ def _most_recent_return_reason(audit_entries: list[dict]) -> str | None:
             # dead. Extract return_reason from the audit note (written by
             # reset_expired_claims as "executing_orphan") so the steward can apply
             # orphan_retry_count and ORPHAN_KILL_RETRY_BUDGET correctly.
+            #
+            # Note: the generic `if "return_reason" in note_data` check above this
+            # loop already catches this case (the audit note carries return_reason
+            # explicitly). This elif branch is defense-in-depth: it ensures correct
+            # behavior if the generic check above is ever removed or modified.
             rr = note_data.get("return_reason")
             if rr:
                 return rr

--- a/tests/integration/test_wos_visibility_timeout.py
+++ b/tests/integration/test_wos_visibility_timeout.py
@@ -4,7 +4,7 @@ Integration tests: WOS visibility-timeout (claimed_until) model.
 Tests cover reset_expired_claims() and the claimed_until lifecycle:
 - Dispatch sets claimed_until
 - complete_uow clears claimed_until
-- Expired claim resets UoW to ready-for-executor
+- Expired claim resets UoW to ready-for-steward (via steward for orphan retry logic)
 - Unexpired claim is not reset
 - Multiple expired claims all reset without blocking dispatch slots
 
@@ -178,12 +178,12 @@ def test_complete_uow_clears_claimed_until(
 
 
 # ---------------------------------------------------------------------------
-# Test C — Expired claim resets UoW to ready-for-executor
+# Test C — Expired claim resets UoW to ready-for-steward
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-def test_expired_claim_resets_to_ready_for_executor(
+def test_expired_claim_resets_to_ready_for_steward(
     registry: Registry,
     conn: sqlite3.Connection,
 ) -> None:
@@ -191,7 +191,11 @@ def test_expired_claim_resets_to_ready_for_executor(
     When claimed_until has expired, reset_expired_claims() must:
     - Return the uow_id in its result list
     - Set claimed_until to NULL
-    - Set status back to 'ready-for-executor'
+    - Set status to 'ready-for-steward' (not 'ready-for-executor')
+
+    The steward path is required so that orphan_retry_count, MAX_RETRIES, and
+    ORPHAN_KILL_RETRY_BUDGET are applied before the UoW is re-dispatched.
+    Routing directly to 'ready-for-executor' bypasses all of that logic.
     """
     uow_id = _seed_ready_for_executor(registry)
 
@@ -217,8 +221,8 @@ def test_expired_claim_resets_to_ready_for_executor(
         (uow_id,),
     ).fetchone()
 
-    assert row["status"] == "ready-for-executor", (
-        f"Expected status='ready-for-executor', got {row['status']!r}"
+    assert row["status"] == "ready-for-steward", (
+        f"Expected status='ready-for-steward', got {row['status']!r}"
     )
     assert row["claimed_until"] is None, (
         f"Expected claimed_until IS NULL after reset, got {row['claimed_until']!r}"
@@ -274,7 +278,7 @@ def test_multiple_expired_claims_all_reset(
 ) -> None:
     """
     When 5 UoWs all have expired claimed_until values, reset_expired_claims()
-    must reset all 5 back to 'ready-for-executor' and leave no UoWs in 'executing'.
+    must reset all 5 back to 'ready-for-steward' and leave no UoWs in 'executing'.
     """
     uow_ids = []
     for i in range(5):
@@ -306,14 +310,14 @@ def test_multiple_expired_claims_all_reset(
         f"Expected no UoWs in 'executing' after reset, still executing: {executing_ids!r}"
     )
 
-    # All 5 should now be 'ready-for-executor'
+    # All 5 should now be 'ready-for-steward'
     for uow_id in uow_ids:
         row = conn.execute(
             "SELECT status, claimed_until FROM uow_registry WHERE id = ?",
             (uow_id,),
         ).fetchone()
-        assert row["status"] == "ready-for-executor", (
-            f"UoW {uow_id!r}: expected 'ready-for-executor', got {row['status']!r}"
+        assert row["status"] == "ready-for-steward", (
+            f"UoW {uow_id!r}: expected 'ready-for-steward', got {row['status']!r}"
         )
         assert row["claimed_until"] is None, (
             f"UoW {uow_id!r}: expected claimed_until IS NULL, got {row['claimed_until']!r}"

--- a/tests/unit/test_orchestration/test_heartbeat_sidecar.py
+++ b/tests/unit/test_orchestration/test_heartbeat_sidecar.py
@@ -129,6 +129,7 @@ def _insert_uow_with_status(
     heartbeat_at: str | None = None,
     heartbeat_ttl: int = DEFAULT_HEARTBEAT_TTL_SECONDS,
     started_at: str | None = None,
+    claimed_until: str | None = None,
 ) -> str:
     """Insert a UoW directly via SQLite, returning the uow_id."""
     uow_id = f"uow_test_{uuid.uuid4().hex[:8]}"
@@ -144,10 +145,12 @@ def _insert_uow_with_status(
             INSERT INTO uow_registry
                 (id, type, source, source_issue_number, sweep_date, status, posture,
                  created_at, updated_at, summary, success_criteria, started_at,
-                 heartbeat_at, heartbeat_ttl, route_evidence, trigger, register, uow_mode)
+                 heartbeat_at, heartbeat_ttl, route_evidence, trigger, register, uow_mode,
+                 claimed_until)
             VALUES (?, 'executable', ?, ?, '2026-01-01', ?, 'solo',
                     ?, ?, 'Test UoW', 'Test done.', ?,
-                    ?, ?, '{}', '{"type": "immediate"}', 'operational', 'operational')
+                    ?, ?, '{}', '{"type": "immediate"}', 'operational', 'operational',
+                    ?)
             """,
             (
                 uow_id,
@@ -159,6 +162,7 @@ def _insert_uow_with_status(
                 started_at or now,
                 heartbeat_at,
                 heartbeat_ttl,
+                claimed_until,
             ),
         )
         conn.commit()
@@ -416,3 +420,70 @@ class TestSidecarPreventsFlaseStalls:
         assert uow_id not in stale_ids, (
             "Sidecar should have refreshed heartbeat_at so the UoW is not stale"
         )
+
+
+# Named constant for the claim expiry tests — matches the spec phrase
+# "whose claimed_until is non-null and already past".
+CLAIM_EXPIRED_PAST_SECONDS: int = 600   # 10 minutes in the past — unambiguously expired
+CLAIM_FUTURE_SECONDS: int = 3600        # 1 hour in the future — unambiguously live
+
+
+class TestSidecarSkipsExpiredClaims:
+    """Sidecar must not refresh heartbeat_at for UoWs whose agent is dead.
+
+    A UoW with claimed_until in the past has a dead agent by definition — the
+    claim window closed without the executor finishing or renewing. Refreshing its
+    heartbeat_at would prevent the steward's observation loop from detecting the
+    orphan (it needs now - heartbeat_at > heartbeat_ttl + buffer, which can never
+    fire if the sidecar keeps heartbeat_at fresh).
+    """
+
+    def test_sidecar_skips_uow_with_expired_claimed_until(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """UoW with claimed_until in the past is excluded from heartbeat candidates.
+
+        Expected: result.checked == 0 and write_heartbeat is never called for
+        this UoW. The sidecar should log a debug skip and move on.
+        """
+        expired_claim = _iso_offset(-CLAIM_EXPIRED_PAST_SECONDS)
+        _insert_uow_with_status(
+            db_path,
+            status="active",
+            heartbeat_at=_iso_offset(-120),   # 2 minutes ago — would normally need refresh
+            claimed_until=expired_claim,
+        )
+
+        result = write_heartbeats_for_active_uows(registry)
+
+        # The UoW was skipped before reaching write_heartbeat, so checked == 0
+        assert result.checked == 0, (
+            "UoW with expired claimed_until should be excluded from heartbeat candidates"
+        )
+        assert result.written == 0
+        assert result.errors == 0
+
+    def test_sidecar_writes_heartbeat_for_uow_with_future_claimed_until(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """UoW with claimed_until in the future receives a normal heartbeat write.
+
+        The claim is still live, so the agent may be alive and the sidecar should
+        keep heartbeat_at fresh to prevent false stall detection.
+        """
+        future_claim = _iso_offset(CLAIM_FUTURE_SECONDS)
+        old_heartbeat = _iso_offset(-120)   # 2 minutes ago — needs refresh
+        uow_id = _insert_uow_with_status(
+            db_path,
+            status="active",
+            heartbeat_at=old_heartbeat,
+            claimed_until=future_claim,
+        )
+
+        result = write_heartbeats_for_active_uows(registry)
+
+        new_heartbeat = _read_heartbeat_at(db_path, uow_id)
+        assert result.checked == 1, "Live-claim UoW should be a heartbeat candidate"
+        assert result.written == 1
+        assert new_heartbeat is not None
+        assert new_heartbeat > old_heartbeat, "heartbeat_at should be updated"

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -1444,3 +1444,167 @@ class TestFileScopeUpsert:
         ).fetchone()
         conn.close()
         assert _json.loads(row["file_scope"]) == paths
+
+
+# ---------------------------------------------------------------------------
+# reset_expired_claims() — visibility-timeout orphan recovery
+# ---------------------------------------------------------------------------
+
+# Named constant for the claim expiry tests — matches the spec phrase
+# "executing_orphan" return_reason embedded in the audit note.
+CLAIM_EXPIRED_RETURN_REASON: str = "executing_orphan"
+
+# Time offsets for claim deadline tests
+PAST_CLAIM_OFFSET_HOURS: int = 1    # claimed_until 1 hour ago — unambiguously expired
+FUTURE_CLAIM_OFFSET_HOURS: int = 1  # claimed_until 1 hour from now — not expired
+
+
+def _seed_uow_in_executing(registry, db_path: Path) -> str:
+    """
+    Seed a UoW and advance it to 'executing' status with a claimed_until set.
+
+    Returns the uow_id. Uses set_status_direct to bypass the full executor
+    dispatch path — we only need the status + claimed_until for these tests.
+    """
+    today = datetime.now(timezone.utc).date().isoformat()
+    from src.orchestration.registry import UpsertInserted
+    result = registry.upsert(
+        issue_number=int(datetime.now(timezone.utc).timestamp()) % 90000 + 10000,
+        title="Claim expiry test UoW",
+        sweep_date=today,
+        success_criteria="Test completion.",
+    )
+    assert isinstance(result, UpsertInserted)
+    uow_id = result.id
+
+    registry.approve(uow_id)
+    registry.set_status_direct(uow_id, "ready-for-steward")
+    registry.set_status_direct(uow_id, "ready-for-executor")
+    registry.set_status_direct(uow_id, "active")
+    registry.set_status_direct(uow_id, "executing")
+
+    # Manually set claimed_until so we can backdate or advance it in tests
+    conn = _open_db(db_path)
+    future = (datetime.now(timezone.utc) + timedelta(hours=FUTURE_CLAIM_OFFSET_HOURS)).isoformat()
+    conn.execute(
+        "UPDATE uow_registry SET claimed_until = ? WHERE id = ?",
+        (future, uow_id),
+    )
+    conn.commit()
+    conn.close()
+
+    return uow_id
+
+
+class TestResetExpiredClaims:
+    """reset_expired_claims() routes expired-claim UoWs to ready-for-steward.
+
+    Behavior verified (derived from spec, not from implementation):
+
+    - Expired claims transition to 'ready-for-steward' (not 'ready-for-executor')
+      so the steward can apply orphan_retry_count / ORPHAN_KILL_RETRY_BUDGET.
+    - The audit log entry carries to_status='ready-for-steward' and note JSON
+      containing return_reason='executing_orphan'.
+    - UoWs with claimed_until in the future are not touched.
+    """
+
+    def test_reset_expired_claims_transitions_to_ready_for_steward(
+        self, registry, db_path: Path
+    ) -> None:
+        """Expired-claim UoW transitions to ready-for-steward, not ready-for-executor.
+
+        Routing through the steward is required so the steward can apply
+        orphan_retry_count, MAX_RETRIES, and ORPHAN_KILL_RETRY_BUDGET before
+        deciding to re-dispatch. Bypassing to ready-for-executor skips all of
+        that logic and causes indefinite retry cycles.
+        """
+        uow_id = _seed_uow_in_executing(registry, db_path)
+
+        # Backdate claimed_until to the past so the claim is expired
+        past = (
+            datetime.now(timezone.utc) - timedelta(hours=PAST_CLAIM_OFFSET_HOURS)
+        ).isoformat()
+        conn = _open_db(db_path)
+        conn.execute(
+            "UPDATE uow_registry SET claimed_until = ? WHERE id = ?",
+            (past, uow_id),
+        )
+        conn.commit()
+        conn.close()
+
+        reset_ids = registry.reset_expired_claims()
+
+        assert uow_id in reset_ids, (
+            f"Expected uow_id {uow_id!r} to be in reset_ids; got {reset_ids!r}"
+        )
+
+        # Check status and claimed_until
+        conn = _open_db(db_path)
+        row = conn.execute(
+            "SELECT status, claimed_until FROM uow_registry WHERE id = ?",
+            (uow_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row["status"] == "ready-for-steward", (
+            f"Expected status='ready-for-steward', got {row['status']!r}"
+        )
+        assert row["claimed_until"] is None, (
+            "Expected claimed_until IS NULL after reset"
+        )
+
+        # Check the audit log entry has the correct to_status and return_reason
+        conn = _open_db(db_path)
+        audit_rows = conn.execute(
+            """
+            SELECT to_status, note FROM audit_log
+            WHERE uow_id = ? AND event = 'claim_expired'
+            ORDER BY id DESC LIMIT 1
+            """,
+            (uow_id,),
+        ).fetchall()
+        conn.close()
+
+        assert len(audit_rows) == 1, (
+            "Expected exactly one 'claim_expired' audit entry"
+        )
+        audit_row = audit_rows[0]
+        assert audit_row["to_status"] == "ready-for-steward", (
+            f"Audit entry to_status should be 'ready-for-steward', got {audit_row['to_status']!r}"
+        )
+
+        note = json.loads(audit_row["note"])
+        assert note.get("return_reason") == CLAIM_EXPIRED_RETURN_REASON, (
+            f"Audit note must carry return_reason={CLAIM_EXPIRED_RETURN_REASON!r}; "
+            f"got {note!r}"
+        )
+
+    def test_reset_expired_claims_does_not_touch_future_claimed_until(
+        self, registry, db_path: Path
+    ) -> None:
+        """UoW with claimed_until in the future is NOT reset.
+
+        The agent is presumed alive while the claim window is open. Resetting
+        it would race with a live agent and corrupt the execution state.
+        """
+        uow_id = _seed_uow_in_executing(registry, db_path)
+        # claimed_until is already set to 1 hour in the future by _seed_uow_in_executing
+
+        reset_ids = registry.reset_expired_claims()
+
+        assert uow_id not in reset_ids, (
+            f"UoW {uow_id!r} has a future claimed_until — must not be reset; "
+            f"reset_ids={reset_ids!r}"
+        )
+
+        # Status should remain 'executing'
+        conn = _open_db(db_path)
+        row = conn.execute(
+            "SELECT status FROM uow_registry WHERE id = ?",
+            (uow_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row["status"] == "executing", (
+            f"Expected status='executing' (unchanged), got {row['status']!r}"
+        )


### PR DESCRIPTION
## What this fixes

Dead UoWs were cycling indefinitely through `claim_expired → ready-for-executor → executor dispatch`, permanently bypassing the steward's orphan retry logic (`orphan_retry_count`, `ORPHAN_KILL_RETRY_BUDGET`, `MAX_RETRIES`). A UoW whose agent had crashed would be re-dispatched indefinitely, never reaching the orphan kill path.

Two interacting bugs caused this cycle.

## Root cause and fixes

### Bug 1 — Sidecar kept dead agents' heartbeats fresh

`heartbeat_sidecar.py:_collect_in_flight_uows()` iterated every UoW in `active/executing` status and wrote a fresh `heartbeat_at`, including UoWs whose `claimed_until` had already expired. A UoW with an expired claim has a dead agent by definition — the claim window closed without completion. With the sidecar running every 3 minutes and `heartbeat_ttl` defaulting to 300s, the unconditional refresh meant `now - heartbeat_at > heartbeat_ttl + buffer` could never fire for these UoWs. The steward's Phase 2b stall detection was permanently masked.

**Fix:** `_collect_in_flight_uows` now filters out UoWs whose `claimed_until` is non-null and already past. A new pure helper `_claim_expired(uow, now)` performs the check. UoWs with no `claimed_until` (NULL) are not filtered — they predate the visibility-timeout migration and are included as before.

### Bug 2 — Expired claims routed to executor, bypassing the steward

`registry.py:reset_expired_claims()` transitioned expired UoWs to `ready-for-executor`. The executor immediately picked them up. The steward never saw them. `execution_attempts`, `orphan_retry_count`, `MAX_RETRIES`, and `ORPHAN_KILL_RETRY_BUDGET` were all bypassed. The cycle repeated indefinitely.

**Fix:** `reset_expired_claims()` now transitions to `ready-for-steward`. The audit note carries `return_reason: "executing_orphan"` so the steward can classify the event correctly and apply the orphan retry budget before deciding to re-dispatch.

### Supporting fix — steward extracts return_reason from claim_expired events

`steward.py:_most_recent_return_reason()` now has an explicit `elif event == "claim_expired"` branch. The generic `return_reason` check at the top of the loop already handles this (the note carries `return_reason` explicitly), but the explicit branch makes the intent self-documenting and provides defense-in-depth if the generic check changes.

### UoW dataclass — claimed_until exposed

`claimed_until: str | None = None` added to the `UoW` dataclass and `_row_to_uow()`. The column has existed since migration 0025; this just exposes it so the sidecar can read it from the value object without a raw DB query.

## Before / After flow

```
Before (broken):
  Agent crashes
    → claimed_until expires
    → reset_expired_claims: status → ready-for-executor   ← bypasses steward
    → sidecar refreshes heartbeat_at every 3 min           ← masks stall detection
    → executor re-dispatches immediately
    → cycle repeats forever; orphan budgets never checked

After (fixed):
  Agent crashes
    → claimed_until expires
    → sidecar sees expired claim, skips heartbeat write     ← heartbeat goes stale
    → reset_expired_claims: status → ready-for-steward     ← steward sees it
    → steward reads return_reason=executing_orphan from audit
    → steward applies orphan_retry_count / ORPHAN_KILL_RETRY_BUDGET
    → re-dispatch or kill based on retry budget
```

## Changed files

- `src/orchestration/heartbeat_sidecar.py` — `_collect_in_flight_uows` filters expired claims; new `_claim_expired` pure helper; `datetime/timezone` import added
- `src/orchestration/registry.py` — `reset_expired_claims` routes to `ready-for-steward` with `return_reason: executing_orphan` in audit note; `claimed_until` added to `UoW` dataclass and `_row_to_uow`
- `src/orchestration/steward.py` — `_most_recent_return_reason` handles `claim_expired` events explicitly
- `tests/integration/test_wos_visibility_timeout.py` — Tests C and E updated to assert `ready-for-steward` (not `ready-for-executor`)
- `tests/unit/test_orchestration/test_heartbeat_sidecar.py` — Two new tests: `test_sidecar_skips_uow_with_expired_claimed_until`, `test_sidecar_writes_heartbeat_for_uow_with_future_claimed_until`
- `tests/unit/test_orchestration/test_registry.py` — Two new tests: `test_reset_expired_claims_transitions_to_ready_for_steward`, `test_reset_expired_claims_does_not_touch_future_claimed_until`

## Functional patterns used

- Pure functions: `_claim_expired(uow, now)` — takes two arguments, returns bool, no side effects
- Immutability: UoW dataclass remains frozen; `claimed_until` is a read-only field
- Explicit error isolation: `_collect_in_flight_uows` still uses the `_safe_list` boundary for list errors; the new filter is a pure in-memory pass over the result

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_heartbeat_sidecar.py tests/unit/test_orchestration/test_registry.py -v` — 101 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/ --ignore=tests/unit/test_orchestration/test_registry_cli.py -q` — 2164 passed, 38 failed (all 38 failures confirmed pre-existing on `main` before this PR; verified by running the same tests on the main branch)
- [ ] Integration tests (`tests/integration/test_wos_visibility_timeout.py`) — not run in the unit test sweep but the test file was updated; the unit test equivalents cover the same assertions against a real SQLite DB

## Manual test

N/A — this change is entirely internal to the WOS orchestration pipeline. No Telegram output, no external service calls, no file I/O beyond the SQLite registry. The fix is exercised by the real SQLite DB in unit tests.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] User-visible outcome: not applicable — this is an internal loop correctness fix; no user-visible output produced
- [x] Side-effect audit complete: `reset_expired_claims` writes one audit log entry and one status UPDATE per expired UoW — bounded by the number of expired claims; no flood risk
- [x] External service calls: none — all changes operate on the local SQLite registry

Closes #1257