### PR TITLE
feat(wos): token usage tracking

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -1009,6 +1009,14 @@ def _build_wos_context_block(uow_id: str) -> str:
         f"(create the label if it does not exist)\n"
         f"  - Commit messages: optionally include WOS-UoW: {uow_id} in the footer\n"
         f"---\n"
+        f"Token tracking: report your total token usage on completion.\n"
+        f"  - In your final mcp__lobster-inbox__write_result call, pass token_usage=<N>\n"
+        f"    where N is the total input+output tokens consumed across all API turns.\n"
+        f"  - In each mcp__lobster-inbox__write_wos_heartbeat call, pass token_usage=<N>.\n"
+        f"  - If your Claude Code session does not expose token counts directly, omit\n"
+        f"    token_usage (pass None / leave it out) — the field is optional and the\n"
+        f"    Steward handles absent values gracefully.\n"
+        f"---\n"
     )
 
 

--- a/src/orchestration/result_writer.py
+++ b/src/orchestration/result_writer.py
@@ -27,6 +27,7 @@ Schema written to ``<output_ref>.result.json``:
         "success":    true | false,             # Steward-compatible convenience field
         "summary":    "<human-readable one-line summary>",
         "artifacts":  ["<path1>", "<path2>", ...],   # optional
+        "token_usage": <int>,                        # optional
         "written_at": "<ISO-8601 UTC timestamp>"
     }
 
@@ -56,6 +57,7 @@ def write_result(
     status: Literal["done", "complete", "failed"],
     summary: str,
     artifacts: list[str] | None = None,
+    token_usage: int | None = None,
 ) -> Path:
     """
     Write a result.json file at the path derived from ``output_ref``.
@@ -82,6 +84,8 @@ def write_result(
         artifacts: Optional list of absolute file paths produced during
             execution (e.g. PR URLs, generated report paths). The Steward
             reads this list when building its diagnosis context.
+        token_usage: Optional total token count (input + output tokens) consumed
+            across all API turns during execution. Used for per-UoW cost telemetry.
 
     Returns:
         The Path where the result file was written.
@@ -111,6 +115,8 @@ def write_result(
     }
     if artifacts:
         payload["artifacts"] = artifacts
+    if token_usage is not None:
+        payload["token_usage"] = token_usage
 
     _atomic_write(result_path, json.dumps(payload, indent=2))
     return result_path

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -39,6 +39,7 @@ from orchestration.executor import (
     _dispatch_via_inbox,
     _dispatch_via_claude_p,
     _noop_dispatcher,
+    _build_wos_context_block,
 )
 
 
@@ -923,3 +924,18 @@ class TestDispatchViaInbox:
         output_ref = _get_output_ref(db_path, uow_id)
         result_data = _read_result_json(output_ref)
         assert result_data.get("executor_id") == expected_run_id
+
+
+# ---------------------------------------------------------------------------
+# WOS context block tests
+# ---------------------------------------------------------------------------
+
+class TestWOSContextBlock:
+    def test_wos_context_block_includes_token_tracking(self) -> None:
+        """The WOS context block must include token tracking instructions."""
+        uow_id = "uow_test123"
+        result = _build_wos_context_block(uow_id)
+
+        assert "token_usage" in result
+        assert "write_wos_heartbeat" in result
+        assert "mcp__lobster-inbox__write_result" in result

--- a/tests/unit/test_result_writer.py
+++ b/tests/unit/test_result_writer.py
@@ -100,6 +100,16 @@ class TestWriteResultSchema:
         data = json.loads(_result_json_path(output_ref).read_text())
         assert "artifacts" not in data
 
+    def test_token_usage_included_when_provided(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="ok", token_usage=1234)
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert data["token_usage"] == 1234
+
+    def test_token_usage_omitted_when_none(self, output_ref: str) -> None:
+        write_result(output_ref, status="done", summary="ok")
+        data = json.loads(_result_json_path(output_ref).read_text())
+        assert "token_usage" not in data
+
 
 # ---------------------------------------------------------------------------
 # Path derivation tests


### PR DESCRIPTION
WOS UoW uow_20260504_089962. Code changes complete, tests pass. Previous PR attempt failed due to wrong repo target (SiderealPress/Lobster 403).

## Changes

- Add `token_usage` param to `write_result()` in `src/orchestration/result_writer.py`
- Add token tracking instructions to `_build_wos_context_block()` in `src/orchestration/executor.py`
- Add tests for both changes

Token tracking infrastructure is now complete end-to-end:
- Subagents receive instructions to track tokens in prompts
- Python `write_result()` helper accepts `token_usage` param
- MCP `write_result` handler already passes through to registry
- Registry `complete_uow()` writes to `uow_registry.token_usage` column