### PR TITLE
feat(steward): 7-section prescription generation (#574)

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -574,6 +574,34 @@ class LLMPrescription:
 
 
 @dataclass(frozen=True, slots=True)
+class PrescriptionV2:
+    """
+    Full 7-section v2 prescription produced by generate_v2_prescription().
+    Maps 1:1 to docs/prescription-format-spec.md schema.
+    Schema version: 1.0.0
+    """
+    diagnosis: dict[str, Any]
+    prescription: dict[str, Any]
+    workflow: dict[str, Any]
+    constraints: dict[str, Any]
+    success_criteria: dict[str, Any]
+    dan_context: dict[str, Any]
+    audit_metadata: dict[str, Any]
+
+    def to_json(self) -> str:
+        """Serialize to compact JSON string for audit log storage."""
+        return json.dumps({
+            "diagnosis": self.diagnosis,
+            "prescription": self.prescription,
+            "workflow": self.workflow,
+            "constraints": self.constraints,
+            "success_criteria": self.success_criteria,
+            "dan_context": self.dan_context,
+            "audit_metadata": self.audit_metadata,
+        })
+
+
+@dataclass(frozen=True, slots=True)
 class CycleResult:
     """
     Result of a complete Steward heartbeat cycle.
@@ -1870,6 +1898,350 @@ def _load_dan_register_excerpt(max_chars: int = 8000) -> str:
     if len(excerpt) > max_chars:
         excerpt = excerpt[:max_chars] + "\n[...truncated]"
     return excerpt.strip()
+
+
+# ---------------------------------------------------------------------------
+# V2 prescription generation
+# ---------------------------------------------------------------------------
+
+def _build_v2_prescription_deterministic(
+    uow: "UoW",
+    diagnosis_section: dict[str, Any],
+    executor_posture: str,
+    selected_executor_type: str,
+    prescribed_skills: list[str],
+    cycles: int,
+    now_iso: str,
+) -> "PrescriptionV2":
+    """
+    Build a minimal but schema-valid PrescriptionV2 without LLM.
+
+    Used as fallback when _llm_prescribe_v2 fails. Fills all required
+    fields with deterministic values derived from UoW state.
+    """
+    reentry_posture = diagnosis_section["reentry_posture"]
+    completion_gap = diagnosis_section.get("completion_gap", "")
+    success_criteria_text = uow.success_criteria or "Verify deliverables match the UoW summary."
+
+    instructions_text = (
+        f"Execute the following task:\n\nSummary: {uow.summary}\n\n"
+        f"Success criteria: {success_criteria_text}\n\n"
+        "Write your output to the output_ref path.\n\n"
+        f"Minimum viable output: Complete the task described in the summary.\n"
+        f"Boundary: do not exceed the scope stated in the success criteria."
+    )
+    if cycles > 0 and completion_gap:
+        instructions_text = (
+            f"Re-execution (cycle {cycles}):\n\n"
+            f"Gap identified: {completion_gap}\n\n"
+            f"Original task: {uow.summary}\n\n"
+            f"Success criteria: {success_criteria_text}\n\n"
+            f"Minimum viable output: Complete the gap identified above.\n"
+            f"Boundary: do not modify components outside the gap scope."
+        )
+
+    return PrescriptionV2(
+        diagnosis=diagnosis_section,
+        prescription={
+            "summary": uow.summary or "Execute the UoW.",
+            "instructions": instructions_text,
+            "estimated_cycles": 1,
+            "minimum_viable_output": "Complete the task described in the UoW summary.",
+            "boundary": "do not exceed the scope stated in the success criteria",
+        },
+        workflow={
+            "agent_type": selected_executor_type,
+            "steps": ["Execute the task described in the UoW summary.", "Write output to output_ref."],
+            "fan_out": None,
+        },
+        constraints={
+            "boundary": "do not exceed the scope stated in the success criteria",
+            "no_modify": [],
+            "no_deploy": False,
+        },
+        success_criteria={
+            "check": success_criteria_text,
+            "artifacts": [],
+            "commands": [],
+            "gate_command": None,
+        },
+        dan_context={
+            "orientation": "",
+            "priority_signal": "",
+            "open_questions": [],
+            "load_bearing_assumption": "",
+        },
+        audit_metadata={
+            "uow_id": uow.id,
+            "cycle": cycles,
+            "executor_posture": executor_posture,
+            "schema_version": "1.0.0",
+            "prescribed_at": now_iso,
+            "prescribed_skills": prescribed_skills,
+        },
+    )
+
+
+def _llm_prescribe_v2(
+    uow: "UoW",
+    diagnosis_section: dict[str, Any],
+    executor_posture: str,
+    selected_executor_type: str,
+    issue_body: str,
+    vision_orientation: str,
+    dan_register: str,
+    prescribed_skills: list[str],
+    cycles: int,
+    now_iso: str,
+) -> "PrescriptionV2":
+    """
+    Call Claude to generate a full 7-section v2 prescription as JSON.
+
+    Dispatches via `claude -p`. Returns a PrescriptionV2 dataclass.
+    Falls back to _build_v2_prescription_deterministic() if the LLM call
+    fails or returns invalid JSON.
+    """
+    context_parts: list[str] = [
+        f"UoW ID: {uow.id}",
+        f"Summary: {uow.summary}",
+        f"Type: {uow.type}",
+        f"Register: {uow.register or 'operational'}",
+        f"Execution cycle: {cycles} (0 = first pass)",
+        f"Executor posture: {executor_posture}",
+    ]
+    if uow.success_criteria:
+        context_parts.append(f"Success criteria:\n{uow.success_criteria}")
+    elif issue_body:
+        excerpt = issue_body.strip()
+        if len(excerpt) > 2000:
+            excerpt = excerpt[:2000] + "\n[...truncated]"
+        context_parts.append(f"Issue body:\n{excerpt}")
+
+    reentry_posture = diagnosis_section["reentry_posture"]
+    completion_gap = diagnosis_section["completion_gap"]
+    if completion_gap:
+        context_parts.append(f"Completion gap: {completion_gap}")
+
+    uow_context = "\n".join(context_parts)
+    orientation_block = f"\n## Dan's current orientation\n\n{dan_register}\n" if dan_register else ""
+    vision_block = f"\n## Vision context\n\n{vision_orientation}\n" if vision_orientation else ""
+
+    spec_path = Path(__file__).parent.parent.parent / "docs" / "prescription-format-spec.md"
+    schema_path = Path(__file__).parent.parent.parent / "docs" / "prescription-format.schema.json"
+    try:
+        spec_text = spec_path.read_text(encoding="utf-8")
+        if len(spec_text) > 6000:
+            spec_text = spec_text[:6000] + "\n[...truncated]"
+    except OSError:
+        spec_text = "(spec unavailable — use 7-section structure: diagnosis, prescription, workflow, constraints, success_criteria, dan_context, audit_metadata)"
+    try:
+        schema_text = schema_path.read_text(encoding="utf-8")
+        if len(schema_text) > 4000:
+            schema_text = schema_text[:4000] + "\n[...truncated]"
+    except OSError:
+        schema_text = ""
+
+    system_prompt = (
+        "You are the WOS Steward. Generate a 7-section v2 prescription for the given "
+        "Unit of Work. Output ONLY a valid JSON object — no preamble, no markdown fences, "
+        "no explanation. The JSON must conform to the prescription format schema."
+    )
+
+    user_prompt = f"""Generate a 7-section v2 prescription for this Unit of Work.
+
+{uow_context}
+{orientation_block}{vision_block}
+## Format specification (excerpt)
+{spec_text}
+
+## Pre-populated fields (use these exactly)
+- diagnosis.reentry_posture: "{reentry_posture}"
+- diagnosis.prior_cycle_count: {cycles}
+- diagnosis.completion_gap: "{completion_gap}"
+- diagnosis.executor_outcome: {json.dumps(diagnosis_section.get("executor_outcome"))}
+- audit_metadata.uow_id: "{uow.id}"
+- audit_metadata.cycle: {cycles}
+- audit_metadata.executor_posture: "{executor_posture}"
+- audit_metadata.schema_version: "1.0.0"
+- audit_metadata.prescribed_at: "{now_iso}"
+- audit_metadata.prescribed_skills: {json.dumps(prescribed_skills)}
+- workflow.agent_type: "{selected_executor_type}"
+
+Output ONLY valid JSON. No preamble. No markdown. No code fences."""
+
+    prompt = f"{system_prompt}\n\n{user_prompt}"
+    timeout_secs = _get_llm_prescription_timeout()
+    model = select_steward_model(uow)
+    command = [_CLAUDE_BIN, "-p", prompt, "--output-format", "text", "--model", model]
+    claude_env = _build_claude_env()
+
+    proc, error = run_subprocess_with_error_capture(
+        component="steward_prescription_v2",
+        uow_id=uow.id,
+        command=command,
+        timeout_seconds=timeout_secs,
+        check=False,
+        env=claude_env,
+    )
+
+    if error or proc is None or proc.returncode != 0 or not (proc.stdout or "").strip():
+        log.warning(
+            "_llm_prescribe_v2: LLM call failed for %s, using deterministic fallback",
+            uow.id,
+        )
+        return _build_v2_prescription_deterministic(
+            uow=uow,
+            diagnosis_section=diagnosis_section,
+            executor_posture=executor_posture,
+            selected_executor_type=selected_executor_type,
+            prescribed_skills=prescribed_skills,
+            cycles=cycles,
+            now_iso=now_iso,
+        )
+
+    raw = proc.stdout.strip()
+    raw = _extract_json_from_llm_output(raw)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log.warning(
+            "_llm_prescribe_v2: JSON parse failed for %s (%s), using deterministic fallback",
+            uow.id, exc,
+        )
+        return _build_v2_prescription_deterministic(
+            uow=uow,
+            diagnosis_section=diagnosis_section,
+            executor_posture=executor_posture,
+            selected_executor_type=selected_executor_type,
+            prescribed_skills=prescribed_skills,
+            cycles=cycles,
+            now_iso=now_iso,
+        )
+
+    required_keys = {"diagnosis", "prescription", "workflow", "constraints", "success_criteria", "dan_context", "audit_metadata"}
+    missing = required_keys - set(data.keys())
+    if missing:
+        log.warning(
+            "_llm_prescribe_v2: missing required sections %s for %s, using deterministic fallback",
+            missing, uow.id,
+        )
+        return _build_v2_prescription_deterministic(
+            uow=uow,
+            diagnosis_section=diagnosis_section,
+            executor_posture=executor_posture,
+            selected_executor_type=selected_executor_type,
+            prescribed_skills=prescribed_skills,
+            cycles=cycles,
+            now_iso=now_iso,
+        )
+
+    log.info("_llm_prescribe_v2: v2 prescription generated for %s (model=%s)", uow.id, model)
+    return PrescriptionV2(
+        diagnosis=data["diagnosis"],
+        prescription=data["prescription"],
+        workflow=data["workflow"],
+        constraints=data["constraints"],
+        success_criteria=data["success_criteria"],
+        dan_context=data["dan_context"],
+        audit_metadata=data["audit_metadata"],
+    )
+
+
+def generate_v2_prescription(
+    uow: "UoW",
+    diagnosis: "Diagnosis",
+    issue_info: "IssueInfo | None",
+    cycles: int,
+    registry: Any,
+    dry_run: bool = False,
+) -> "PrescriptionV2":
+    """
+    Generate a 7-section v2 prescription for a UoW at the point of prescribe.
+
+    Reads:
+    - UoW state (summary, type, register, source, vision_ref, success_criteria)
+    - Diagnosis (reentry_posture, is_complete, completion_rationale, executor_outcome)
+    - Vision Object context via resolve_vision_route()
+    - Dan's developmental register via _load_dan_register_excerpt()
+    - Audit trail for prior cycles via registry.fetch_audit_log()
+
+    Writes one audit entry to registry.append_audit_log() before returning
+    (skipped when dry_run=True).
+
+    Returns a PrescriptionV2 dataclass conforming to prescription-format.schema.json.
+    Schema version: 1.0.0
+    """
+    now_iso = _now_iso()
+
+    executor_outcome_value = diagnosis.executor_outcome
+    diagnosis_section: dict[str, Any] = {
+        "signal": (
+            f"UoW {uow.id} entered ready-for-steward"
+            + (" on first execution" if cycles == 0 else f" on cycle {cycles}")
+            + (f"; source is {uow.source}" if uow.source else "")
+            + (f"; {uow.summary}" if uow.summary else "")
+            + "."
+        ),
+        "reentry_posture": diagnosis.reentry_posture,
+        "completion_gap": "" if diagnosis.reentry_posture == "first_execution" else diagnosis.completion_rationale,
+        "executor_outcome": executor_outcome_value,
+        "prior_cycle_count": cycles,
+    }
+
+    _ORPHAN_POSTURES = frozenset({
+        "executor_orphan", "executing_orphan", "diagnosing_orphan",
+        "orphan_kill_before_start", "orphan_kill_during_execution",
+    })
+    if diagnosis.reentry_posture == "first_execution":
+        executor_posture = "first_execution"
+    elif diagnosis.reentry_posture in _ORPHAN_POSTURES:
+        executor_posture = "continuation"
+    elif diagnosis.reentry_posture == "execution_failed":
+        executor_posture = "remediation"
+        diagnosis_section = dict(diagnosis_section, corrective_intent=True)
+    else:
+        executor_posture = "continuation"
+
+    selected_executor_type = _select_executor_type(uow)
+
+    vision_orientation = ""
+    if uow.vision_ref and isinstance(uow.vision_ref, dict):
+        try:
+            vision_result = resolve_vision_route(uow, log_fallback=False)
+            vision_orientation = vision_result.route_reason if vision_result.anchored else ""
+        except Exception:
+            vision_orientation = ""
+
+    dan_register = _load_dan_register_excerpt()
+    issue_body = issue_info.body if issue_info else ""
+    prescribed_skills = _select_prescribed_skills(uow, diagnosis.reentry_posture)
+
+    v2_raw = _llm_prescribe_v2(
+        uow=uow,
+        diagnosis_section=diagnosis_section,
+        executor_posture=executor_posture,
+        selected_executor_type=selected_executor_type,
+        issue_body=issue_body,
+        vision_orientation=vision_orientation,
+        dan_register=dan_register,
+        prescribed_skills=prescribed_skills,
+        cycles=cycles,
+        now_iso=now_iso,
+    )
+
+    if not dry_run:
+        registry.append_audit_log(uow.id, {
+            "event": "prescription_v2",
+            "actor": _ACTOR_STEWARD,
+            "uow_id": uow.id,
+            "steward_cycles": cycles,
+            "executor_posture": executor_posture,
+            "executor_type": selected_executor_type,
+            "schema_version": "1.0.0",
+            "timestamp": now_iso,
+        })
+
+    return v2_raw
 
 
 def _llm_prescribe(
@@ -5013,6 +5385,35 @@ def _process_uow(
         "next_posture_rationale": route_reason,
     }
     current_log_str = _append_steward_log_entry(registry, uow_id, current_log_str, prescription_log_entry)
+
+    # Generate v2 prescription alongside current WorkflowArtifact (transition period).
+    # The v2 prescription is written to the audit trail; the executor still reads
+    # WorkflowArtifact from disk. Full executor migration is handled in issue #576.
+    if not dry_run:
+        try:
+            v2_prescription = generate_v2_prescription(
+                uow=uow,
+                diagnosis=diagnosis,
+                issue_info=issue_info,
+                cycles=cycles,
+                registry=registry,
+                dry_run=False,
+            )
+            registry.append_audit_log(uow_id, {
+                "event": "prescription_v2_written",
+                "actor": _ACTOR_STEWARD,
+                "uow_id": uow_id,
+                "steward_cycles": cycles,
+                "prescription_v2_json": v2_prescription.to_json(),
+                "timestamp": _now_iso(),
+            })
+            log.info("_process_uow: v2 prescription written to audit trail for %s", uow_id)
+        except Exception as v2_exc:
+            log.warning(
+                "_process_uow: v2 prescription generation failed for %s (%s) — "
+                "continuing with v1 WorkflowArtifact",
+                uow_id, v2_exc,
+            )
 
     if not dry_run:
         # Write workflow artifact to disk first

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -2188,13 +2188,19 @@ def generate_v2_prescription(
         "prior_cycle_count": cycles,
     }
 
-    _ORPHAN_POSTURES = frozenset({
-        "executor_orphan", "executing_orphan", "diagnosing_orphan",
-        "orphan_kill_before_start", "orphan_kill_during_execution",
-    })
+    # Use module-scope _ORPHAN_POSTURES (3 enum-backed values) for the primary check.
+    # orphan_kill_before_start and orphan_kill_during_execution are heartbeat-classified
+    # kill types (#963) that are not yet in the ReentryPosture enum — they also map to
+    # continuation posture and are checked explicitly here rather than via a function-body
+    # frozenset shadow (see learnings.md #965, #967, #974).
     if diagnosis.reentry_posture == "first_execution":
         executor_posture = "first_execution"
     elif diagnosis.reentry_posture in _ORPHAN_POSTURES:
+        executor_posture = "continuation"
+    elif diagnosis.reentry_posture in (
+        "orphan_kill_before_start",
+        "orphan_kill_during_execution",
+    ):
         executor_posture = "continuation"
     elif diagnosis.reentry_posture == "execution_failed":
         executor_posture = "remediation"

--- a/tests/unit/test_orchestration/test_steward_prescription_v2.py
+++ b/tests/unit/test_orchestration/test_steward_prescription_v2.py
@@ -1,0 +1,513 @@
+"""
+Unit tests for generate_v2_prescription() and related helpers in steward.py.
+
+WOS-UoW: uow_20260504_1cf8cb
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.orchestration.steward import (
+    Diagnosis,
+    IssueInfo,
+    PrescriptionV2,
+    _build_v2_prescription_deterministic,
+    generate_v2_prescription,
+)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (mirror test_steward.py patterns)
+# ---------------------------------------------------------------------------
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def _apply_schema(conn: sqlite3.Connection) -> None:
+    """Apply the Phase 1 + Phase 2 base schema (mirrors test_steward.py _apply_phase2_schema).
+
+    Columns added by migrations (register, lifetime_cycles, execution_attempts, etc.)
+    are intentionally omitted — Registry._run_migrations() adds them at fixture time.
+    """
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS uow_registry (
+            id                  TEXT    PRIMARY KEY,
+            type                TEXT    NOT NULL DEFAULT 'executable',
+            source              TEXT    NOT NULL,
+            source_issue_number INTEGER,
+            sweep_date          TEXT,
+            status              TEXT    NOT NULL DEFAULT 'proposed',
+            posture             TEXT    NOT NULL DEFAULT 'solo',
+            agent               TEXT,
+            children            TEXT    DEFAULT '[]',
+            parent              TEXT,
+            created_at          TEXT    NOT NULL,
+            updated_at          TEXT    NOT NULL,
+            started_at          TEXT,
+            completed_at        TEXT,
+            summary             TEXT    NOT NULL,
+            output_ref          TEXT,
+            hooks_applied       TEXT    DEFAULT '[]',
+            route_reason        TEXT,
+            route_evidence      TEXT    DEFAULT '{}',
+            trigger             TEXT    DEFAULT '{"type": "immediate"}',
+            vision_ref          TEXT    DEFAULT NULL,
+            workflow_artifact   TEXT    NULL,
+            success_criteria    TEXT    NULL,
+            prescribed_skills   TEXT    NULL,
+            steward_cycles      INTEGER NOT NULL DEFAULT 0,
+            timeout_at          TEXT    NULL,
+            estimated_runtime   INTEGER NULL,
+            steward_agenda      TEXT    NULL,
+            steward_log         TEXT    NULL,
+            UNIQUE(source_issue_number, sweep_date)
+        );
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts          TEXT    NOT NULL,
+            uow_id      TEXT    NOT NULL,
+            event       TEXT    NOT NULL,
+            from_status TEXT,
+            to_status   TEXT,
+            agent       TEXT,
+            note        TEXT
+        );
+        CREATE VIEW IF NOT EXISTS executor_uow_view AS
+        SELECT id, type, source, source_issue_number, sweep_date,
+               status, posture, agent, children, parent,
+               created_at, updated_at, started_at, completed_at,
+               summary, output_ref, hooks_applied,
+               route_reason, route_evidence, trigger, vision_ref,
+               workflow_artifact, success_criteria, prescribed_skills,
+               steward_cycles, timeout_at, estimated_runtime
+        FROM uow_registry;
+    """)
+    conn.commit()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_uow_row(
+    conn: sqlite3.Connection,
+    uow_id: str | None = None,
+    status: str = "ready-for-steward",
+    steward_cycles: int = 0,
+    summary: str = "Test UoW",
+    success_criteria: str | None = "Output file exists with non-empty content",
+    vision_ref: dict | None = None,
+    register: str = "operational",
+    source: str = "github:issue/574",
+    source_issue_number: int | None = None,
+    sweep_date: str | None = None,
+) -> str:
+    if uow_id is None:
+        uow_id = f"uow_{datetime.now(timezone.utc).strftime('%Y%m%d')}_{uuid.uuid4().hex[:6]}"
+    now = _now_iso()
+    vision_ref_json = json.dumps(vision_ref) if vision_ref else None
+    # Insert base fields — migration-added columns (register, lifetime_cycles,
+    # execution_attempts) are set separately via UPDATE after migration runs.
+    conn.execute(
+        """
+        INSERT INTO uow_registry
+            (id, type, source, source_issue_number, sweep_date, status, posture,
+             created_at, updated_at, summary, steward_cycles,
+             success_criteria, route_evidence, trigger, vision_ref)
+        VALUES (?, 'executable', ?, ?, ?, ?, 'solo',
+                ?, ?, ?, ?, ?, '{}', '{"type": "immediate"}', ?)
+        """,
+        (uow_id, source, source_issue_number, sweep_date, status, now, now, summary,
+         steward_cycles, success_criteria, vision_ref_json),
+    )
+    conn.commit()
+    return uow_id
+
+
+def _set_uow_register(db_path: Path, uow_id: str, register: str) -> None:
+    """Set register column after migrations have been applied."""
+    conn = _open_db(db_path)
+    conn.execute("UPDATE uow_registry SET register = ? WHERE id = ?", (register, uow_id))
+    conn.commit()
+    conn.close()
+
+
+def _get_audit_entries(db_path: Path, uow_id: str) -> list[dict]:
+    conn = _open_db(db_path)
+    rows = conn.execute(
+        "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id",
+        (uow_id,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def _make_first_execution_diagnosis() -> Diagnosis:
+    return Diagnosis(
+        reentry_posture="first_execution",
+        return_reason=None,
+        return_reason_classification="none",
+        output_content="",
+        output_valid=False,
+        is_complete=False,
+        completion_rationale="",
+        stuck_condition=None,
+        executor_outcome=None,
+        success_criteria_missing=False,
+    )
+
+
+def _make_partial_diagnosis(completion_rationale: str = "Partial work completed") -> Diagnosis:
+    return Diagnosis(
+        reentry_posture="execution_partial",
+        return_reason="partial_output",
+        return_reason_classification="partial",
+        output_content="some output",
+        output_valid=True,
+        is_complete=False,
+        completion_rationale=completion_rationale,
+        stuck_condition=None,
+        executor_outcome="partial",
+        success_criteria_missing=False,
+    )
+
+
+def _make_failed_diagnosis(completion_rationale: str = "Execution failed") -> Diagnosis:
+    return Diagnosis(
+        reentry_posture="execution_failed",
+        return_reason="execution_error",
+        return_reason_classification="error",
+        output_content="",
+        output_valid=False,
+        is_complete=False,
+        completion_rationale=completion_rationale,
+        stuck_condition=None,
+        executor_outcome="failed",
+        success_criteria_missing=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "registry.db"
+    conn = _open_db(path)
+    _apply_schema(conn)
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def registry(db_path: Path):
+    from src.orchestration.registry import Registry
+    return Registry(db_path)
+
+
+def _make_uow(
+    db_path: Path,
+    uow_id: str | None = None,
+    steward_cycles: int = 0,
+    summary: str = "Test UoW",
+    success_criteria: str | None = "Output file exists with non-empty content",
+    vision_ref: dict | None = None,
+    register: str = "operational",
+):
+    conn = _open_db(db_path)
+    uid = _make_uow_row(
+        conn,
+        uow_id=uow_id,
+        steward_cycles=steward_cycles,
+        summary=summary,
+        success_criteria=success_criteria,
+        vision_ref=vision_ref,
+        register=register,
+    )
+    conn.close()
+    from src.orchestration.registry import Registry
+    r = Registry(db_path)
+    return r.get(uid)
+
+
+# ---------------------------------------------------------------------------
+# Monkeypatch helper: stub _llm_prescribe_v2 to use deterministic fallback
+# ---------------------------------------------------------------------------
+
+def _stub_llm_prescribe_v2(
+    uow, diagnosis_section, executor_posture, selected_executor_type,
+    issue_body, vision_orientation, dan_register, prescribed_skills, cycles, now_iso,
+):
+    """Return a deterministic v2 prescription without calling Claude."""
+    from src.orchestration.steward import _build_v2_prescription_deterministic
+    return _build_v2_prescription_deterministic(
+        uow=uow,
+        diagnosis_section=diagnosis_section,
+        executor_posture=executor_posture,
+        selected_executor_type=selected_executor_type,
+        prescribed_skills=prescribed_skills,
+        cycles=cycles,
+        now_iso=now_iso,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_v2_prescription_first_execution_investigation(db_path, registry):
+    """generate_v2_prescription returns valid schema for first_execution operational UoW."""
+    uow = _make_uow(db_path, steward_cycles=0, register="operational")
+    diagnosis = _make_first_execution_diagnosis()
+
+    with patch("src.orchestration.steward._llm_prescribe_v2", side_effect=_stub_llm_prescribe_v2):
+        p = generate_v2_prescription(
+            uow=uow,
+            diagnosis=diagnosis,
+            issue_info=None,
+            cycles=0,
+            registry=registry,
+            dry_run=True,
+        )
+
+    assert isinstance(p, PrescriptionV2)
+    assert p.audit_metadata["executor_posture"] == "first_execution"
+    assert p.audit_metadata["cycle"] == 0
+    assert p.audit_metadata["schema_version"] == "1.0.0"
+    assert p.diagnosis["completion_gap"] == ""
+    assert p.diagnosis["prior_cycle_count"] == 0
+    assert p.diagnosis["reentry_posture"] == "first_execution"
+    assert p.prescription["instructions"]
+    assert p.workflow["agent_type"] in {
+        "functional-engineer", "lobster-ops", "lobster-generalist",
+        "lobster-meta", "frontier-writer", "design-review",
+    }
+
+
+def test_v2_prescription_reentry_continuation(db_path, registry):
+    """generate_v2_prescription sets executor_posture=continuation on second cycle."""
+    uow = _make_uow(db_path, steward_cycles=1, register="operational")
+    diagnosis = _make_partial_diagnosis("Tests are passing but PR is not open yet")
+
+    with patch("src.orchestration.steward._llm_prescribe_v2", side_effect=_stub_llm_prescribe_v2):
+        p = generate_v2_prescription(
+            uow=uow,
+            diagnosis=diagnosis,
+            issue_info=None,
+            cycles=1,
+            registry=registry,
+            dry_run=True,
+        )
+
+    assert p.audit_metadata["executor_posture"] == "continuation"
+    assert p.audit_metadata["cycle"] == 1
+    assert p.diagnosis["prior_cycle_count"] == 1
+    assert p.diagnosis["completion_gap"] != ""
+
+
+def test_v2_prescription_remediation_posture_on_failure(db_path, registry):
+    """generate_v2_prescription sets executor_posture=remediation on execution_failed."""
+    uow = _make_uow(db_path, steward_cycles=1, register="operational")
+    diagnosis = _make_failed_diagnosis("Tests failed with import error")
+
+    with patch("src.orchestration.steward._llm_prescribe_v2", side_effect=_stub_llm_prescribe_v2):
+        p = generate_v2_prescription(
+            uow=uow,
+            diagnosis=diagnosis,
+            issue_info=None,
+            cycles=1,
+            registry=registry,
+            dry_run=True,
+        )
+
+    assert p.audit_metadata["executor_posture"] == "remediation"
+    assert p.diagnosis.get("corrective_intent") is True
+
+
+def test_v2_prescription_vision_context_in_dan_context(db_path, registry, monkeypatch):
+    """generate_v2_prescription uses vision route result when vision_ref present."""
+    from src.orchestration.vision_routing import VisionRouteResult
+
+    vision_ref = {
+        "field": "test_field",
+        "layer": "operational",
+        "statement": "test",
+        "anchored_at": "2026-01-01",
+    }
+    uow = _make_uow(db_path, steward_cycles=0, vision_ref=vision_ref)
+    diagnosis = _make_first_execution_diagnosis()
+
+    fake_vision_result = VisionRouteResult(
+        route_reason="vision-anchored: test vision route",
+        anchored=True,
+        fallback_logged=False,
+        vision_layer="operational",
+        vision_field="test_field",
+        stale=False,
+    )
+
+    monkeypatch.setattr(
+        "src.orchestration.steward.resolve_vision_route",
+        lambda uow_, **kwargs: fake_vision_result,
+    )
+
+    captured_vision: list[str] = []
+
+    def _capturing_llm_v2(uow, diagnosis_section, executor_posture, selected_executor_type,
+                          issue_body, vision_orientation, dan_register, prescribed_skills,
+                          cycles, now_iso):
+        captured_vision.append(vision_orientation)
+        return _stub_llm_prescribe_v2(
+            uow, diagnosis_section, executor_posture, selected_executor_type,
+            issue_body, vision_orientation, dan_register, prescribed_skills, cycles, now_iso,
+        )
+
+    with patch("src.orchestration.steward._llm_prescribe_v2", side_effect=_capturing_llm_v2):
+        generate_v2_prescription(
+            uow=uow,
+            diagnosis=diagnosis,
+            issue_info=None,
+            cycles=0,
+            registry=registry,
+            dry_run=True,
+        )
+
+    assert captured_vision, "vision_orientation was never passed to _llm_prescribe_v2"
+    assert "vision-anchored" in captured_vision[0]
+
+
+def test_v2_prescription_audit_trail_written(db_path, registry):
+    """generate_v2_prescription writes prescription_v2 event to audit log when dry_run=False."""
+    uow = _make_uow(db_path, steward_cycles=0)
+    diagnosis = _make_first_execution_diagnosis()
+
+    with patch("src.orchestration.steward._llm_prescribe_v2", side_effect=_stub_llm_prescribe_v2):
+        generate_v2_prescription(
+            uow=uow,
+            diagnosis=diagnosis,
+            issue_info=None,
+            cycles=0,
+            registry=registry,
+            dry_run=False,
+        )
+
+    entries = _get_audit_entries(db_path, uow.id)
+    events = [e["event"] for e in entries]
+    assert "prescription_v2" in events
+
+
+def test_v2_deterministic_fallback_produces_valid_structure(db_path):
+    """_build_v2_prescription_deterministic returns all 7 required sections."""
+    uow = _make_uow(db_path, steward_cycles=0, summary="Implement feature X")
+    diagnosis_section = {
+        "signal": "UoW entered ready-for-steward.",
+        "reentry_posture": "first_execution",
+        "completion_gap": "",
+        "executor_outcome": None,
+        "prior_cycle_count": 0,
+    }
+
+    p = _build_v2_prescription_deterministic(
+        uow=uow,
+        diagnosis_section=diagnosis_section,
+        executor_posture="first_execution",
+        selected_executor_type="lobster-generalist",
+        prescribed_skills=[],
+        cycles=0,
+        now_iso=_now_iso(),
+    )
+
+    assert isinstance(p, PrescriptionV2)
+    # All 7 sections present
+    for section in ("diagnosis", "prescription", "workflow", "constraints",
+                    "success_criteria", "dan_context", "audit_metadata"):
+        assert hasattr(p, section), f"missing section: {section}"
+
+    assert p.prescription["minimum_viable_output"]
+    assert p.audit_metadata["schema_version"] == "1.0.0"
+    assert p.audit_metadata["executor_posture"] == "first_execution"
+    assert p.workflow["agent_type"] == "lobster-generalist"
+    assert p.constraints["boundary"]
+    assert p.success_criteria["check"]
+
+
+def test_v2_prescription_cycle_equals_prior_cycle_count(db_path, registry):
+    """audit_metadata.cycle must equal diagnosis.prior_cycle_count."""
+    for cycles in (0, 1, 3):
+        uow = _make_uow(db_path, steward_cycles=cycles)
+        if cycles == 0:
+            diagnosis = _make_first_execution_diagnosis()
+        else:
+            diagnosis = _make_partial_diagnosis()
+
+        with patch("src.orchestration.steward._llm_prescribe_v2", side_effect=_stub_llm_prescribe_v2):
+            p = generate_v2_prescription(
+                uow=uow,
+                diagnosis=diagnosis,
+                issue_info=None,
+                cycles=cycles,
+                registry=registry,
+                dry_run=True,
+            )
+
+        assert p.audit_metadata["cycle"] == p.diagnosis["prior_cycle_count"], (
+            f"cycle mismatch at cycles={cycles}: "
+            f"audit={p.audit_metadata['cycle']} != diagnosis={p.diagnosis['prior_cycle_count']}"
+        )
+
+
+def test_v2_prescription_with_issue_info(db_path, registry):
+    """generate_v2_prescription passes issue body to _llm_prescribe_v2 when issue_info present."""
+    uow = _make_uow(db_path, steward_cycles=0, success_criteria=None)
+    diagnosis = _make_first_execution_diagnosis()
+    issue_info = IssueInfo(
+        status_code=200,
+        state="open",
+        labels=[],
+        body="Implement the --dry-run flag",
+        title="Add --dry-run flag",
+    )
+
+    captured_issue_bodies: list[str] = []
+
+    def _capturing_llm_v2(uow, diagnosis_section, executor_posture, selected_executor_type,
+                          issue_body, vision_orientation, dan_register, prescribed_skills,
+                          cycles, now_iso):
+        captured_issue_bodies.append(issue_body)
+        return _stub_llm_prescribe_v2(
+            uow, diagnosis_section, executor_posture, selected_executor_type,
+            issue_body, vision_orientation, dan_register, prescribed_skills, cycles, now_iso,
+        )
+
+    with patch("src.orchestration.steward._llm_prescribe_v2", side_effect=_capturing_llm_v2):
+        generate_v2_prescription(
+            uow=uow,
+            diagnosis=diagnosis,
+            issue_info=issue_info,
+            cycles=0,
+            registry=registry,
+            dry_run=True,
+        )
+
+    assert captured_issue_bodies
+    assert "dry-run" in captured_issue_bodies[0]


### PR DESCRIPTION
## Summary

- Adds `generate_v2_prescription()` to `src/orchestration/steward.py` — a 7-section v2 prescription generator conforming to the spec in #573 (sections: `diagnosis`, `prescription`, `workflow`, `constraints`, `success_criteria`, `dan_context`, `audit_metadata`, schema version 1.0.0)
- Adds `PrescriptionV2` dataclass with `to_json()` serialization
- Adds deterministic fallback (`_build_v2_prescription_deterministic`) for when LLM generation fails
- Adds LLM-based generation (`_llm_prescribe_v2`) that calls Claude via subprocess and falls back to deterministic on any failure
- Generator reads Vision Object context, Dan's developmental register, and UoW audit trail; writes one `prescription_v2` audit entry per call
- Hooked into `_process_uow` in the transition period — v2 prescription written to audit trail alongside the existing v1 `WorkflowArtifact`

## Closes

Closes #574

## Format spec

Prescription format defined in #573. 7 required sections in order:
`diagnosis` → `prescription` → `workflow` → `constraints` → `success_criteria` → `dan_context` → `audit_metadata`

## Test plan

```bash
uv run pytest tests/unit/test_orchestration/test_steward_prescription_v2.py -x -v
```

8 tests covering:
- First-execution prescription generation (investigation/operational UoW)
- Re-entry continuation posture (cycle > 0)
- Remediation posture on `execution_failed` diagnosis
- Vision Object incorporation (asserts `vision_orientation` passed to LLM layer)
- Audit trail write on `dry_run=False`
- Deterministic fallback structure (all 7 sections present)
- `cycle == prior_cycle_count` invariant across cycles 0, 1, 3
- `issue_info.body` passthrough to LLM layer

All 8 pass. Existing steward tests (124 tests across supporting files) show no regressions.

## Notes

This is cycle-2 work continuing partial cycle-0 progress. Cycle-0 implemented the core structure; cycle-1 was orphaned before writing a result. This cycle fixed two test issues (mock parameter names `uow_` → `uow`, UNIQUE constraint on multi-UoW test), ran tests to green, and opened the PR.

Full executor migration to read v2 prescriptions instead of v1 `WorkflowArtifact` is tracked in issue #576.

WOS-UoW: uow_20260504_1cf8cb