### PR TITLE
fix(slow_reclassifier): add deduplication gate to pattern_observation writes

### DIFF
--- a/.claude/agents/lobster-hygiene.md
+++ b/.claude/agents/lobster-hygiene.md
@@ -44,6 +44,19 @@ The form-function lens sharpens this question. An element is load-bearing when r
 
 **Question 3 — Accumulation without signal:** Is total instruction volume increasing without corresponding increase in precision or behavioral distinctiveness of outputs? Name specific files that have grown without commensurate behavioral signal.
 
+**Step 2b: HYPOTHESIS Section Review**
+
+For each bootup file with a `# HYPOTHESIS` section, list all entries:
+- Entry title
+- Added date
+- Expiry date
+- Whether expiry has passed (flag as EXPIRED if so)
+- Review question
+
+Bootup files to check: `.claude/sys.dispatcher.bootup.md`, `.claude/sys.subagent.bootup.md`, `~/lobster-user-config/agents/user.base.bootup.md`, `~/lobster-user-config/agents/user.dispatcher.bootup.md`, `~/lobster-user-config/agents/user.subagent.bootup.md`.
+
+Surface entries expiring within 7 days or already expired. Do not graduate or discard — surface only. Graduation is a Dan decision.
+
 **Step 3: Write output**
 
 Append to `~/lobster-workspace/meta/hygiene-review.md`:

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -947,7 +947,7 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
        else:
            send_reply(chat_id=chat_id, text=f"Unknown todo callback: {data}", source=source)
 
-8. elif data.startswith("decide_retry:") or data.startswith("decide_close:"):
+8. elif data.startswith("decide_retry:") or data.startswith("decide_close:") or data.startswith("routing_pref_confirm:") or data.startswith("routing_pref_reject:"):
        from src.orchestration.dispatcher_handlers import route_callback_message
        result = route_callback_message(msg)
        if result["handled"]:
@@ -1086,6 +1086,31 @@ IFTTT rules are loaded at startup (step 2b) and applied throughout the session. 
 **Applying:** Before responding to any user message, scan for matching rules. Use `list_rules(enabled_only=true, resolve=true)` at startup to pre-load behavioral content. Batch all lookups — do not call `get_rule` one at a time in a loop.
 
 **Adding:** Call `add_rule(condition, action_content)` when a recurring pattern is observed. Never add after a single request — a pattern must be established. Never write the YAML index directly. All access through MCP tools. Cap: 100 rules.
+
+---
+
+## Routing Preferences (HITL-confirmed agent routing rules)
+
+Routing preferences are stored in `~/lobster-user-config/routing-preferences.yaml` and confirmed by Dan via Telegram inline buttons (proposed by the morning briefing job when recurring `pattern_observation` events cross a confidence threshold).
+
+**Applying:** Before determining which subagent to route a user message to, check routing preferences:
+
+```python
+from src.orchestration.dispatcher_handlers import check_routing_preferences
+
+agent_hint = check_routing_preferences(msg["text"])
+if agent_hint and not is_explicit_command(msg["text"]):
+    subagent_type = agent_hint  # prefer the matched routing preference
+# else: proceed with normal routing decision
+```
+
+- `check_routing_preferences` reads from disk on every call (no caching) and returns the `agent_hint` for the first matching preference, or `None` if none match.
+- Matching uses case-insensitive substring check against each preference's `condition` field.
+- **Do not override explicit commands.** If the message is a `/command`, a named WOS operation, or a `/decide`/`/approve` action, skip routing preference checks.
+- When a preference fires, `check_routing_preferences` logs `routing_preference_applied: <id>` to the Python logger. No additional logging needed.
+- This check costs a single file read (~1ms) — do it on every user message (not just at startup).
+
+**Callback handling:** Routing preference confirmations and rejections arrive as `type: "callback"` with `callback_data` starting with `routing_pref_confirm:` or `routing_pref_reject:`. These are handled by `route_callback_message` in `src/orchestration/dispatcher_handlers.py` (already wired into the callback dispatch table above — step 8).
 
 ---
 
@@ -1828,4 +1853,11 @@ No background subagent is needed — `create_task` is a synchronous MCP call.
 **Idempotency:** Before creating a deferred task, check `list_tasks()` for an existing task with the same `DEFERRED:` subject. Do not create duplicates.
 
 **Scope:** Only direct questions or explicit commitments from the user. Do not apply to internal system events, subagent status queries, or rhetorical questions.
+
+# HYPOTHESIS
+
+<!-- Entries here are provisional. Do not treat as stable configuration.
+     Each entry carries an expiry. Review before expiry; graduate or discard.
+     Graduation = moving the entry into the main body of this file (poiema).
+     Expiry without review = entry is discarded, not silently promoted. -->
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1089,31 +1089,6 @@ IFTTT rules are loaded at startup (step 2b) and applied throughout the session. 
 
 ---
 
-## Routing Preferences (HITL-confirmed agent routing rules)
-
-Routing preferences are stored in `~/lobster-user-config/routing-preferences.yaml` and confirmed by Dan via Telegram inline buttons (proposed by the morning briefing job when recurring `pattern_observation` events cross a confidence threshold).
-
-**Applying:** Before determining which subagent to route a user message to, check routing preferences:
-
-```python
-from src.orchestration.dispatcher_handlers import check_routing_preferences
-
-agent_hint = check_routing_preferences(msg["text"])
-if agent_hint and not is_explicit_command(msg["text"]):
-    subagent_type = agent_hint  # prefer the matched routing preference
-# else: proceed with normal routing decision
-```
-
-- `check_routing_preferences` reads from disk on every call (no caching) and returns the `agent_hint` for the first matching preference, or `None` if none match.
-- Matching uses case-insensitive substring check against each preference's `condition` field.
-- **Do not override explicit commands.** If the message is a `/command`, a named WOS operation, or a `/decide`/`/approve` action, skip routing preference checks.
-- When a preference fires, `check_routing_preferences` logs `routing_preference_applied: <id>` to the Python logger. No additional logging needed.
-- This check costs a single file read (~1ms) — do it on every user message (not just at startup).
-
-**Callback handling:** Routing preference confirmations and rejections arrive as `type: "callback"` with `callback_data` starting with `routing_pref_confirm:` or `routing_pref_reject:`. These are handled by `route_callback_message` in `src/orchestration/dispatcher_handlers.py` (already wired into the callback dispatch table above — step 8).
-
----
-
 ## Session File Management
 
 One session note file per session. Lives in `~/lobster-user-config/memory/canonical/sessions/`, named `YYYYMMDD-NNN.md`.
@@ -1860,4 +1835,34 @@ No background subagent is needed — `create_task` is a synchronous MCP call.
      Each entry carries an expiry. Review before expiry; graduate or discard.
      Graduation = moving the entry into the main body of this file (poiema).
      Expiry without review = entry is discarded, not silently promoted. -->
+
+## [HYPOTHESIS] routing-preferences-dispatcher-check
+**Added:** 2026-05-22
+**Expires:** 2026-06-05
+**Confidence:** forming
+**Observation basis:** routing-preferences.yaml and check_routing_preferences() exist in dispatcher_handlers.py; callback wiring for routing_pref_confirm:/routing_pref_reject: was added in uow_20260522_c2b5a0 without a prior oracle decision.
+
+Routing preferences are stored in `~/lobster-user-config/routing-preferences.yaml` and confirmed by Dan via Telegram inline buttons (proposed by the morning briefing job when recurring `pattern_observation` events cross a confidence threshold).
+
+**Applying:** Before determining which subagent to route a user message to, check routing preferences:
+
+```python
+from src.orchestration.dispatcher_handlers import check_routing_preferences
+
+agent_hint = check_routing_preferences(msg["text"])
+# Do not apply if message is an explicit command (/command, wos operation, /decide, /approve)
+if agent_hint and not msg["text"].startswith("/"):
+    subagent_type = agent_hint  # prefer the matched routing preference
+# else: proceed with normal routing decision
+```
+
+- `check_routing_preferences` reads from disk on every call (no caching) and returns the `agent_hint` for the first matching preference, or `None` if none match.
+- Matching uses case-insensitive substring check against each preference's `condition` field.
+- **Do not override explicit commands.** If the message is a `/command`, a named WOS operation, or a `/decide`/`/approve` action, skip routing preference checks.
+- When a preference fires, `check_routing_preferences` logs `routing_preference_applied: <id>` to the Python logger. No additional logging needed.
+- This check costs a single file read (~1ms) — do it on every user message (not just at startup).
+
+**Callback handling:** Routing preference confirmations and rejections arrive as `type: "callback"` with `callback_data` starting with `routing_pref_confirm:` or `routing_pref_reject:`. These are handled by `route_callback_message` in `src/orchestration/dispatcher_handlers.py` (already wired into the callback dispatch table — step 8).
+
+**Review question:** Has the routing preferences feature shipped a complete HITL loop (morning briefing proposes → Dan confirms → preference fires in dispatch) and been verified correct at least twice in production?
 

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -304,6 +304,16 @@ mcp__lobster-inbox__write_observation(
 - The write is synchronous; the dispatcher picks it up in its next loop iteration
 - Do NOT use it as a substitute for `write_result` — always call both if you have a primary result and observations
 
+### write_observation vs. memory_store
+
+Two persistence paths exist for agent observations. Choose the right one:
+
+**Use `write_observation`** when you want the dispatcher to receive a real-time signal — the message enters the dispatcher inbox and may surface to Dan via Telegram if the category warrants it (`user_context`, or escalation-class `system_error`). Use this path for: urgent structural issues, gate misses, stuck-agent signals, and anything the operator should know about *now*.
+
+**Use `memory_store` (with `valence='smell'` or `valence='golden'`)** when you want the observation stored for future retrieval without triggering a real-time dispatcher notification. The write goes directly to the vector DB and is available via `memory_search`. Use this path for: named pattern instances, sweep-level findings, and non-urgent observations that contribute to the oracle vocabulary over time.
+
+Rule of thumb: if the observation should change behavior *today*, use `write_observation`. If it is archival evidence that accumulates value over time, use `memory_store`.
+
 ## Proprioceptive Memory (`record_mirroring_instance`)
 
 Proprioceptive memory tracks specific moments where Lobster's semantic alignment with Dan was notably good or notably bad. These are concrete instances, not general preferences — the exact language used, the specific framing decision, the moment where basin-capture was detected or avoided.
@@ -538,3 +548,10 @@ When updating a body:
 - Prioritize clarity for a future reader over preserving the original framing
 
 Apply this to both PRs and issues. When you post a comment that changes the design, resolves a concern, or updates scope — also update the body.
+
+# HYPOTHESIS
+
+<!-- Entries here are provisional. Do not treat as stable configuration.
+     Each entry carries an expiry. Review before expiry; graduate or discard.
+     Graduation = moving the entry into the main body of this file (poiema).
+     Expiry without review = entry is discarded, not silently promoted. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,32 @@ This file provides shared context. Depending on your role, read the appropriate 
 
 User context files are private and not committed to git. They contain user-specific preferences, decisions, and constraints that extend the system defaults. When the user says "remember X" and it belongs to a specific scope, write it to the appropriate user file.
 
+## Bootup File Edit Protocol
+
+Bootup file edits fall into two categories. Use the right posture for each:
+
+**Maintenance edits** (correct an existing instruction, fix a calibration drift, remove an outdated constraint): edit the main body of the file directly.
+
+**Learning-phase edits** (new behavioral pattern, structural discovery, attunement hypothesis not yet confirmed stable): add to the `# HYPOTHESIS` section at the end of the file, not the main body. Include expiry date (default: +14 days from today), confidence level, observation basis, and a yes/no review question.
+
+**Graduation:** When a HYPOTHESIS entry's review question can be answered "yes" based on observed behavior, move the entry's core instruction into the main body of the file and remove the HYPOTHESIS entry. This is the explicit poiesis→poiema transition.
+
+**Expiry:** If a HYPOTHESIS entry reaches its expiry date without a graduation decision, discard it. Expiry without review is discard, not silent promotion.
+
+The format for a HYPOTHESIS entry is:
+
+```markdown
+## [HYPOTHESIS] <short-title>
+**Added:** YYYY-MM-DD
+**Expires:** YYYY-MM-DD (or: after N sessions)
+**Confidence:** low | medium | forming
+**Observation basis:** <one sentence — what triggered this hypothesis>
+
+<the actual behavioral instruction or configuration change>
+
+**Review question:** <the specific question a reviewer must answer yes/no to graduate this entry>
+```
+
 ## System Architecture
 
 ```

--- a/oracle/verdicts/pr-1264.md
+++ b/oracle/verdicts/pr-1264.md
@@ -1,0 +1,28 @@
+VERDICT: APPROVED
+PR: 1264
+Round: 2
+
+## Round 1 — NEEDS_CHANGES (2026-05-22)
+
+See round 1 verdict content in git history. Gaps identified:
+
+- **Gap 1 (blocker):** Feature-bundling — two distinct WOS UoWs in one PR, PR description only covered one.
+- **Gap 2 (blocker):** Routing Preferences section added to dispatcher bootup main body without a prior logged oracle decision.
+- **Gap 3 (advisory):** `_recent_duplicate_exists()` call site used implicit 12-hour default with no named constant.
+- **Gap 4 (advisory):** `is_explicit_command()` pseudocode referenced a nonexistent function.
+
+## Round 2 — APPROVED (2026-05-22)
+
+All 4 gaps resolved:
+
+**Gap 1:** PR description updated to cover both UoWs explicitly, with separate summary sections for `uow_20260522_121905` (dedup gate) and `uow_20260522_c2b5a0` (HYPOTHESIS bootup protocol).
+
+**Gap 2:** Routing Preferences section removed from main body of `sys.dispatcher.bootup.md`. Moved to a `## [HYPOTHESIS] routing-preferences-dispatcher-check` entry with expiry 2026-06-05, confidence "forming", and a graduation question requiring a complete HITL loop to be verified in production.
+
+**Gap 3:** `_DEDUP_WINDOW_HOURS = 12` added as module-level constant at line 111 of `slow_reclassifier.py`. Used as the default value in `_recent_duplicate_exists(hours: int = _DEDUP_WINDOW_HOURS)`. 4/4 tests pass.
+
+**Gap 4:** `is_explicit_command(msg["text"])` replaced with `msg["text"].startswith("/")` — a concrete, callable pattern consistent with the rest of the codebase.
+
+**Final check:** Callback dispatch wiring for `routing_pref_confirm:`/`routing_pref_reject:` remains in the main body (step 8 of callback dispatch table) — this is structural plumbing, not the Routing Preferences policy instruction, so it correctly stays in the main body.
+
+Approved for merge.

--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -905,8 +905,8 @@ def run_pass(conn: sqlite3.Connection) -> tuple[int, int, int]:
                 pattern.event_ids,
             )
 
-            # Write a pattern_observation event — skip if identical entry exists within 12 hours
-            if _recent_duplicate_exists(conn, pattern):
+            # Write a pattern_observation event — skip if identical entry exists within the dedup window
+            if _recent_duplicate_exists(conn, pattern, hours=_DEDUP_WINDOW_HOURS):
                 log.debug(
                     "Dedup gate: skipping duplicate pattern_observation %s source=%s",
                     pattern.pattern_type,

--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -108,6 +108,8 @@ META_THREAD_WINDOW_MINUTES = 120
 PHILOSOPHY_THREAD_THRESHOLD = 2    # 2+ philosophy events within 4 hours → philosophy_thread
 PHILOSOPHY_THREAD_WINDOW_MINUTES = 240
 
+_DEDUP_WINDOW_HOURS = 12            # suppress duplicate pattern_observation within this window
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -426,7 +428,7 @@ def write_pattern_event(conn: sqlite3.Connection, obs: PatternObservation) -> in
 def _recent_duplicate_exists(
     conn: sqlite3.Connection,
     obs: PatternObservation,
-    hours: int = 12,
+    hours: int = _DEDUP_WINDOW_HOURS,
 ) -> bool:
     """Return True if an identical pattern_observation exists within the last `hours` hours.
 

--- a/src/classifiers/slow_reclassifier.py
+++ b/src/classifiers/slow_reclassifier.py
@@ -423,6 +423,31 @@ def write_pattern_event(conn: sqlite3.Connection, obs: PatternObservation) -> in
     return event_id
 
 
+def _recent_duplicate_exists(
+    conn: sqlite3.Connection,
+    obs: PatternObservation,
+    hours: int = 12,
+) -> bool:
+    """Return True if an identical pattern_observation exists within the last `hours` hours.
+
+    Checks pattern_type + source match. Prevents accumulation of structurally
+    identical entries when the same signal recurs within a short window.
+    """
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    row = conn.execute(
+        """
+        SELECT 1 FROM events
+        WHERE type = 'pattern_observation'
+          AND source = ?
+          AND json_extract(metadata, '$.pattern_type') = ?
+          AND timestamp >= ?
+        LIMIT 1
+        """,
+        (obs.source, obs.pattern_type, cutoff),
+    ).fetchone()
+    return row is not None
+
+
 def write_run_log(
     processed: int,
     revised: int,
@@ -878,8 +903,15 @@ def run_pass(conn: sqlite3.Connection) -> tuple[int, int, int]:
                 pattern.event_ids,
             )
 
-            # Write a pattern_observation event to the events table
-            write_pattern_event(conn, pattern)
+            # Write a pattern_observation event — skip if identical entry exists within 12 hours
+            if _recent_duplicate_exists(conn, pattern):
+                log.debug(
+                    "Dedup gate: skipping duplicate pattern_observation %s source=%s",
+                    pattern.pattern_type,
+                    pattern.source,
+                )
+            else:
+                write_pattern_event(conn, pattern)
 
             # Revise the classification tag for each contributing event
             for event_id in pattern.event_ids:

--- a/tests/unit/test_slow_reclassifier_dedup.py
+++ b/tests/unit/test_slow_reclassifier_dedup.py
@@ -1,0 +1,129 @@
+"""
+Tests for the _recent_duplicate_exists deduplication gate in slow_reclassifier.
+
+Covers:
+- Gate returns True when a recent identical pattern_observation exists
+- Gate returns False when no entry exists
+- Gate returns False when existing entry is older than 12 hours
+- Gate returns False when existing entry has a different pattern_type
+
+WOS-UoW: uow_20260522_121905
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from src.classifiers.slow_reclassifier import (
+    PatternObservation,
+    _recent_duplicate_exists,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _open_inmemory_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _seed_events_table(conn: sqlite3.Connection, events: list[dict]) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            type TEXT NOT NULL,
+            source TEXT NOT NULL,
+            content TEXT NOT NULL,
+            metadata TEXT NOT NULL DEFAULT '{}'
+        )
+    """)
+    for ev in events:
+        conn.execute(
+            "INSERT INTO events (timestamp, type, source, content, metadata) VALUES (?, ?, ?, ?, ?)",
+            (
+                ev["timestamp"],
+                ev.get("type", "user_message"),
+                ev.get("source", "chat-123"),
+                ev.get("content", "test content"),
+                json.dumps(ev.get("metadata", {})),
+            ),
+        )
+    conn.commit()
+
+
+def _make_obs(pattern_type: str = "design_session", source: str = "chat-123") -> PatternObservation:
+    return PatternObservation(
+        pattern_type=pattern_type,
+        source=source,
+        event_ids=[1, 2, 3],
+        signal_type="design_session",
+        urgency="normal",
+        posture_hint="structural_coherence",
+    )
+
+
+def _recent_ts(hours_ago: float = 0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestRecentDuplicateExists:
+
+    def test_dedup_gate_skips_when_recent_identical_exists(self):
+        """Returns True when a pattern_observation with same source+pattern_type exists within 12 hours."""
+        conn = _open_inmemory_db()
+        _seed_events_table(conn, [
+            {
+                "timestamp": _recent_ts(hours_ago=1),
+                "type": "pattern_observation",
+                "source": "chat-123",
+                "metadata": {"pattern_type": "design_session"},
+            }
+        ])
+        obs = _make_obs(pattern_type="design_session", source="chat-123")
+        assert _recent_duplicate_exists(conn, obs) is True
+
+    def test_dedup_gate_allows_when_no_recent_entry(self):
+        """Returns False when no pattern_observation exists for the source+pattern_type."""
+        conn = _open_inmemory_db()
+        _seed_events_table(conn, [])
+        obs = _make_obs(pattern_type="design_session", source="chat-123")
+        assert _recent_duplicate_exists(conn, obs) is False
+
+    def test_dedup_gate_allows_when_entry_is_old(self):
+        """Returns False when existing entry is older than 12 hours."""
+        conn = _open_inmemory_db()
+        _seed_events_table(conn, [
+            {
+                "timestamp": _recent_ts(hours_ago=13),
+                "type": "pattern_observation",
+                "source": "chat-123",
+                "metadata": {"pattern_type": "design_session"},
+            }
+        ])
+        obs = _make_obs(pattern_type="design_session", source="chat-123")
+        assert _recent_duplicate_exists(conn, obs) is False
+
+    def test_dedup_gate_allows_different_pattern_type(self):
+        """Returns False when existing entry has a different pattern_type."""
+        conn = _open_inmemory_db()
+        _seed_events_table(conn, [
+            {
+                "timestamp": _recent_ts(hours_ago=1),
+                "type": "pattern_observation",
+                "source": "chat-123",
+                "metadata": {"pattern_type": "design_session"},
+            }
+        ])
+        obs = _make_obs(pattern_type="brainstorm_mode", source="chat-123")
+        assert _recent_duplicate_exists(conn, obs) is False


### PR DESCRIPTION
## Summary

This PR bundles two distinct WOS UoWs. Both are described below.

### uow_20260522_121905 — slow_reclassifier dedup gate

- **Problem:** `write_pattern_event()` in `src/classifiers/slow_reclassifier.py` had no deduplication gate. The night-4 negentropic sweep (2026-03-29) found 528 structurally-identical `pattern_observation` entries from source `health-check-v3` — all written with no check for a recent identical entry. When the same pattern fires repeatedly (rapid philosophy threads, design sessions, health checks), a new DB entry is written on every cycle.
- **Already fixed in PR #210:** `quick_classifier.py` excludes health-check event types from classification input; `detect_complex_request` filters out `health-check%` sources before clustering. Those fixes prevent new health-check events from triggering patterns.
- **This PR adds:** `_recent_duplicate_exists()` helper that checks for an identical `pattern_observation` (same `source` + `pattern_type`) within the last `_DEDUP_WINDOW_HOURS` (12 hours) before writing. Wired in `run_pass()` before `write_pattern_event()` with explicit `hours=_DEDUP_WINDOW_HOURS`. Tag revisions for contributing events are still written even when the event write is skipped — the pattern was genuinely detected, only the redundant DB entry is suppressed.
- **Consumer check:** No code queries `events` for `type='pattern_observation'` to consume it downstream. `backfill_pattern_embeddings.py` adds embeddings to existing entries (maintenance, not consumption). The accumulated health-check-v3 entries have no downstream reader.
- **Tests:** 4 unit tests covering: recent duplicate exists → True; no entry → False; old entry (>12h) → False; different pattern_type → False.

### uow_20260522_c2b5a0 — HYPOTHESIS bootup protocol

- **Problem:** Bootup files (`sys.dispatcher.bootup.md`, `sys.subagent.bootup.md`, `CLAUDE.md`) had no mechanism for distinguishing stable behavioral configuration from provisional learning-phase changes. New patterns would be encoded as permanent behavioral defaults even when not yet confirmed stable.
- **This PR adds:** A HYPOTHESIS section protocol to CLAUDE.md and a `# HYPOTHESIS` structural placeholder to `sys.dispatcher.bootup.md` and `sys.subagent.bootup.md`. Learning-phase changes go into the HYPOTHESIS section with expiry date, confidence level, observation basis, and a yes/no review question. Graduation (poiesis→poiema) requires explicit decision; expiry without review discards the entry.
- **Hygiene agent update:** `lobster-hygiene.md` Step 2b updated to surface HYPOTHESIS entries approaching expiry for human review, without graduating them autonomously.
- **First use:** The routing preferences dispatcher instruction (previously encoded in the main body without a logged oracle prior) has been moved to a HYPOTHESIS entry in `sys.dispatcher.bootup.md` as the inaugural application of this protocol.

## Test plan

- [x] `uv run pytest tests/unit/test_slow_reclassifier_dedup.py -v` — 4/4 passing
- [x] `_recent_duplicate_exists` defined in `src/classifiers/slow_reclassifier.py` and called in `run_pass()` with explicit `hours=_DEDUP_WINDOW_HOURS`
- [x] `_DEDUP_WINDOW_HOURS = 12` module-level constant present in `slow_reclassifier.py`
- [x] Tag revision loop after the guard is unchanged — contributing events still get revised tags
- [x] `# HYPOTHESIS` section present in `sys.dispatcher.bootup.md` and `sys.subagent.bootup.md`
- [x] Routing preferences section moved from main body to HYPOTHESIS entry in `sys.dispatcher.bootup.md`
- [x] `is_explicit_command()` pseudocode replaced with `msg["text"].startswith("/")` check

WOS-UoWs: uow_20260522_121905, uow_20260522_c2b5a0

🤖 Generated with [Claude Code](https://claude.com/claude-code)