### PR TITLE
fix(mcp): register pr_review_sweeper in INBOX_MESSAGE_SOURCES

### DIFF
--- a/src/mcp/message_types.py
+++ b/src/mcp/message_types.py
@@ -58,6 +58,8 @@ INBOX_SYSTEM_TYPES: frozenset[str] = frozenset({
     "wos_execute",            # WOS executor dispatched a UoW — dispatcher must call route_wos_message() to spawn subagent (issue #856)
     "wos_owner_required",     # WOS subagent escalated with outcome=owner_decision_required; UoW is awaiting-owner; dispatcher relays to Dan
     "scheduled_task_crash",   # heartbeat script caught an unhandled exception and wrote a crash alert (fields: job_name, text)
+    "pr_review_request",      # PR-review sweeper coordinator requests oracle review for a specific PR (source: pr_review_sweeper)
+    "wos_pr_sweep_result",    # WOS PR sweeper reports stale/merged PRs with pending UoWs (source: wos_pr_sweep)
 })
 
 # ---------------------------------------------------------------------------
@@ -76,8 +78,10 @@ INBOX_MESSAGE_SOURCES: frozenset[str] = frozenset({
     "whatsapp",
     "bisque",
     "system",
-    "bot-talk",  # cross-Lobster bot-to-bot messages (issue #1350)
-    "gmail",     # email poller injects messages with source="gmail"
+    "bot-talk",           # cross-Lobster bot-to-bot messages (issue #1350)
+    "gmail",              # email poller injects messages with source="gmail"
+    "pr_review_sweeper",  # PR-review sweep coordinator — dispatches pr_review_request messages (issue #1268)
+    "wos_pr_sweep",       # WOS PR sweep cron script — reports stale/merged PRs (scheduled-tasks/wos-pr-sweeper.py)
 })
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py
+++ b/tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py
@@ -113,7 +113,9 @@ class TestUnrecognizedSourceQuarantine:
 
         from src.mcp.inbox_server import handle_check_inbox
 
-        result = asyncio.run(handle_check_inbox({}))
+        # Pass an explicit limit matching the source count so the test stays
+        # correct as INBOX_MESSAGE_SOURCES grows beyond the default limit of 10.
+        result = asyncio.run(handle_check_inbox({"limit": len(recognized_sources)}))
         result_text = result[0].text
 
         # All recognized-source messages should be returned


### PR DESCRIPTION
## Summary

Every message from the PR-review sweeper coordinator was being permanently quarantined to `failed/` on arrival because `pr_review_sweeper` (and `wos_pr_sweep`) were absent from `INBOX_MESSAGE_SOURCES`. Because messages never reached the dispatcher, no dedup state was ever written — causing the sweeper to re-dispatch on every invocation and producing the 2862-message flood observed on May 22.

Changes:
- Added `pr_review_sweeper` and `wos_pr_sweep` to `INBOX_MESSAGE_SOURCES` in `src/mcp/message_types.py`
- Added `pr_review_request` and `wos_pr_sweep_result` to `INBOX_SYSTEM_TYPES` so the type guard doesn't fire after the source guard is cleared
- Fixed `test_quarantine_does_not_affect_recognized_sources` to pass an explicit limit matching `len(INBOX_MESSAGE_SOURCES)` — the default limit of 10 was less than the now-expanded source count, causing spurious test failures

**Implementation approach:** Pure data change — adds constants to two frozensets. No logic changes. The test fix is defensive: the test was designed to "stay in sync with the constant automatically" but failed to account for growth past the default limit.

**Functional patterns:** Immutable frozenset extension — no mutation of existing structure.

**What is not changed:** The quarantine mechanism itself, the dedup logic in the sweeper, or any dispatcher routing code. This is purely a registration fix.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_message_taxonomy.py tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py -v` — 28 passed, 0 failed
- [ ] `uv run pytest tests/unit/test_script_inbox_sources.py` — 1 pre-existing failure on origin/main (`sync-upstream.sh` using `"internal"` and `token-ledger-collect.sh` using `"steward"`, unrelated to this change; verified by stash-testing against origin/main)

## Manual test
N/A — this change is entirely internal (frozenset registration). No external service calls, no Telegram output, no file I/O changes. The effect (messages no longer quarantined) is observable by checking `~/messages/failed/` after deploy for absence of new `pr_review_sweeper` quarantine entries.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, see above
- [x] User-visible outcome verified — not applicable (internal routing fix; no user-facing output)
- [x] Side-effect audit complete: no floods possible from this change (registration only prevents quarantine; dedup in the sweeper itself controls re-dispatch frequency)
- [x] External service calls: none