### PR TITLE
fix(health-check): downgrade proactive-restart alert from crisis to info

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1578,10 +1578,7 @@ check_session_age() {
     # restarts Claude. This is a graceful exit, not a crash.
     if kill -TERM "$dispatcher_pid" 2>/dev/null; then
         log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
-        send_telegram_alert_deduped "proactive-session-restart" "Lobster: proactive restart at ${session_age}s (before the 7440s CC hard limit).
-
-Dispatcher PID $dispatcher_pid sent SIGTERM. Stop hook will fire, session will restart cleanly.
-Next session will start fresh — no context lost from hard limit."
+        send_telegram_alert_deduped "proactive-session-restart" "[Routine] Session rotation at ${session_age}s — restarting before the 7440s CC hard limit. Stop hook will fire cleanly; no context lost. This happens every ~2h and is expected."
         # Delete the start timestamp so a subsequent health check run (within the
         # next 4 minutes) does not send a second SIGTERM before the restart completes.
         rm -f "$DISPATCHER_SESSION_START_FILE" 2>/dev/null || true


### PR DESCRIPTION
## Summary

The 2h session rotation is expected, designed behavior — CC enforces a 7440s hard limit, and the health check fires SIGTERM at 7200s so the Stop hook runs cleanly and context is preserved. However, the previous alert text read like a crash notification: "Lobster: proactive restart... Dispatcher PID $pid sent SIGTERM. Stop hook will fire..." This caused Dan to receive 14 alarming messages in a single day and believe the dispatcher was crashing.

The fix rewrites the alert to clearly identify it as routine: `[Routine] Session rotation at Xs — restarting before the 7440s CC hard limit. Stop hook will fire cleanly; no context lost. This happens every ~2h and is expected.`

**What is not changed:** The dedup mechanism, the dedup key (`proactive-session-restart`), the 15-minute cooldown, the SIGTERM logic, or any restart flow. Only the text the user sees.

## Tests run
- [x] Reviewed `tests/test-health-check-session-age.sh` — the test checks for the presence of the dedup key `"proactive-session-restart"` in the alert log, not the message text. My change preserves the same key, so existing tests remain valid.
- [ ] `bash tests/test-health-check-session-age.sh` — skipped: requires a running dispatcher process; this is a shell integration test that fires SIGTERM to a real PID. The change is a single string substitution with no logic impact.

## Manual test
This change affects only what text Dan receives in Telegram on each ~2h session rotation. The previous message was: "Lobster: proactive restart at ${session_age}s (before the 7440s CC hard limit).\n\nDispatcher PID X sent SIGTERM. Stop hook will fire, session will restart cleanly.\nNext session will start fresh — no context lost from hard limit."

The new message is: "[Routine] Session rotation at Xs — restarting before the 7440s CC hard limit. Stop hook will fire cleanly; no context lost. This happens every ~2h and is expected."

User-visible outcome: Dan asked to confirm the alert is no longer alarming after the next session rotation. Unable to self-verify (requires live session rotation to fire); user confirmation expected post-deploy.

## Definition of Done
- [x] Unit tests pass (no automated tests for alert text; logic is unchanged)
- [ ] User-visible outcome verified — pending Dan's confirmation after next session rotation
- [x] Side-effect audit complete: no floods, no unscoped writes; dedup cooldown and key are unchanged
- [x] External service calls: none (only text content changed)