### PR TITLE
fix: sweep night 2 — 4 doc/config corrections (#1280, #1281, #1282, #1284)

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -230,4 +230,4 @@ This is a fire-and-forget call. If it fails (DB absent, UoW not found), log the 
 
 ## Completion
 
-Call `write_result`. If alignment verdict is `Questioned` or `Misaligned`, or if a premise-review item was written, set `forward=true` so the dispatcher surfaces it to the user. Otherwise `forward=false` -- findings are in the oracle files.
+Call `write_result` with `sent_reply_to_user=False` (the oracle never calls `send_reply` directly — the dispatcher reads the result and decides whether to surface it). If alignment verdict is `Questioned` or `Misaligned`, or if a premise-review item was written, make the verdict prominent in the `text` field so the dispatcher surfaces it to the user. Otherwise the dispatcher will see that findings are in the oracle files and route accordingly.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -174,6 +174,13 @@ Note: The Telegram bot sends "📨 Message received. Processing..." automaticall
 
 Never say "Noted." alone — it doesn't tell the user whether work is happening. Use "On it — [what]" when kicking off background work. If just answering, reply directly with no preamble.
 
+**Personality-flavor ack messages (`.claude/compact-ack-messages.json`):** A set of lobster-personality ack messages is available for post-compaction/restart catchup. Selection rule:
+
+- **Use personality-flavor** (pick randomly from `compact-ack-messages.json`) only when acknowledging that you are recovering from a compaction or restart — i.e., when sending the "catching up" signal during `compact-catchup` startup. These messages are specifically calibrated for the "I lost context and am fetching it back" moment. Example trigger: user asks a question right as a compaction-restart is completing and you need to signal a brief re-orientation delay.
+- **Use plain "On it — [what]"** for all direct user requests, normal task dispatches, and any non-restart ack. The personality messages are not for routine task acknowledgment — they signal context recovery, not task initiation.
+
+The distinction is: *what happened to you* (compaction → personality-flavor) vs. *what the user asked* (direct request → plain "On it").
+
 **Preferred pattern (use `claim_and_ack` for long tasks):**
 ```
 1. claim_and_ack(message_id, ack_text="On it — [brief description of what you're doing]", chat_id=chat_id, source=source)

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -167,9 +167,9 @@ mcp__lobster-inbox__write_result(
 
 **What to put in `text`:** Include the artifact reference (PR URL, file path), a one-sentence description of what was done, and any context the reviewer agent needs to start its work. Do not summarize for a human reader — summarize for the next agent.
 
-**ET conversion — required for all user-visible timestamps:**
+**Timezone conversion — required for all user-visible timestamps:**
 
-Before including any timestamp in a `send_reply` call, convert it from UTC to Eastern Time. Rule: EDT (UTC-4) from mid-March through early November; EST (UTC-5) otherwise. Format as "5:29 AM ET" or "2:30 PM ET". Never send raw UTC ISO strings or "UTC" suffixes to users. This applies to all subagents that produce output containing times — calendar events, log summaries, job results, event timelines, and any other user-facing sentence with a time.
+Before including any timestamp in a `send_reply` call, convert it from UTC to the user's local timezone. Determine the timezone dynamically: check `LOBSTER_USER_TZ` in the environment first; if absent, read it from `~/lobster-user-config/agents/user.base.bootup.md` (look for a `LOBSTER_USER_TZ=` line or the timezone preference). Format times with the appropriate timezone abbreviation (e.g. "5:29 AM ET", "2:30 PM PT"). Never send raw UTC ISO strings or "UTC" suffixes to users. This applies to all subagents that produce output containing times — calendar events, log summaries, job results, event timelines, and any other user-facing sentence with a time.
 
 **Large results — use artifacts, not inline text:**
 
@@ -405,7 +405,7 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 **Agent model assignments:**
 
 - **Opus**: `functional-engineer`, `lobster-oracle`, `review` -- tasks requiring deep adversarial reasoning or thorough code review
-- **Sonnet**: `brain-dumps`, `compact-catchup`, `lobster-auditor`, `lobster-generalist`, `lobster-hygiene`, `lobster-meta`, `nightly-consolidation`, `session-note-polish` -- structured work, synthesis, planning
+- **Sonnet**: `brain-dumps`, `compact-catchup`, `lobster-auditor`, `lobster-generalist`, `lobster-hygiene`, `lobster-meta`, `nightly-consolidation`, `session-note-polish`, `wos-pr-coordinator` -- structured work, synthesis, planning
 - **Haiku**: `lobster-ops`, `session-note-appender` -- lightweight ops and incremental logging
 
 **When to override:** If a task normally handled by a Sonnet agent requires unusually deep reasoning (e.g., a complex multi-system execution plan), consider using `functional-engineer` (Opus) instead.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

Four doc/config issues identified in the Night 2 negentropic sweep. No Python or data files changed — doc/config only.

---

### Fix #1280 (URGENT — deadline 2026-05-29): Dynamic timezone in sys.subagent.bootup.md

The subagent bootup had a hardcoded Eastern Time rule that will break when Dan moves to PT on 2026-05-29. The dispatcher already received this fix in PR #1169 (LOBSTER_USER_TZ env var). This PR applies the same pattern to subagents.

**Before:** "convert it from UTC to Eastern Time. Rule: EDT (UTC-4)..."
**After:** "Determine the timezone dynamically: check LOBSTER_USER_TZ in the environment first; if absent, read it from ~/lobster-user-config/agents/user.base.bootup.md"

Closes #1280

---

### Fix #1281: Replace nonexistent forward= parameter in lobster-oracle.md

The oracle's Completion section used `forward=true` and `forward=false` — a parameter that does not exist in `write_result`. The correct parameter is `sent_reply_to_user`. Replaced with the correct pattern: oracle always passes `sent_reply_to_user=False` (it never calls `send_reply` directly), and communicates whether the dispatcher should surface the result via the `text` field content.

Closes #1281

---

### Fix #1282: Add ack message selection rule in sys.dispatcher.bootup.md

`compact-ack-messages.json` contains 100 lobster-personality humor messages for the post-compaction "I'm catching up" moment, but the dispatcher bootup had no documented rule for when to use them vs. the plain "On it — [what]" pattern.

Added explicit selection rule:
- **Personality-flavor**: only during compaction/restart catchup (the "I lost context and am fetching it back" signal)
- **Plain "On it — [what]"**: all direct user requests and normal task dispatches

Distinguishing principle: *what happened to you* (compaction) vs. *what the user asked* (request).

Closes #1282

---

### Fix #1284: Add wos-pr-coordinator to model tier table in sys.subagent.bootup.md

The `wos-pr-coordinator` agent type was missing from the model tier table. Confirmed via `.claude/agents/wos-pr-coordinator.md` frontmatter: `model: claude-sonnet-4-6`. Added to the Sonnet tier alongside other structured coordination agents.

Closes #1284

---

## Tests run

- [x] `git diff` reviewed — all 4 changes are precisely scoped, no Python or data files modified
- [ ] Live dispatcher test — not applicable for doc-only changes; no behavioral change that could be observed in a bounded test

## Manual test

N/A — these are doc/config corrections only. The changes to `.claude/` files are live immediately via the symlink `~/lobster-workspace/.claude → ~/lobster/.claude/`.

## Definition of Done

- [x] Unit tests pass with proper mocking — N/A (doc-only)
- [x] Integration/manual test — N/A (doc-only)
- [x] User-visible outcome verified — N/A (doc-only)
- [x] Side-effect audit — no data files, no Python, no side effects
- [x] External service calls — none