### PR TITLE
fix(journal-pipeline): register los-action-scanner and build vault journal file scanner

### DIFF
--- a/scheduled-tasks/vault-journal-scanner.py
+++ b/scheduled-tasks/vault-journal-scanner.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+vault-journal-scanner.py — Extract unchecked todo items from Obsidian journal files.
+
+Runs hourly. Scans all vault journal files (*.md, excluding ACTIVE TODOS.md and
+files in .obsidian/) for unchecked checkbox items (``- [ ] ...``). For each file
+not yet seen, persists extracted items to self_action_items.db via the LOS
+extractor API.
+
+Items are extracted without LLM involvement — pure regex scan. The decision to
+use Type B (cron-direct) rather than Type A (LLM subagent) is deliberate:
+
+- Extraction is deterministic: a ``- [ ] <text>`` line is unambiguously a todo.
+- The job runs hourly. Spinning up an LLM session every hour for structural
+  checkbox extraction adds latency and cost with no quality benefit.
+- "Did I write '- [ ] call Sarah' in my journal?" is not a reasoning task.
+
+Dedup is handled by src.los.db.find_duplicate, which computes a normalized
+content hash and skips items already in the DB under any source.
+
+Type B dispatch pattern:
+    0 * * * * cd ~/lobster && uv run scheduled-tasks/vault-journal-scanner.py >> ~/lobster-workspace/scheduled-jobs/logs/vault-journal-scanner.log 2>&1 # LOBSTER-VAULT-JOURNAL-SCANNER
+
+jobs.json entry:
+    {
+        "name": "vault-journal-scanner",
+        "type": "B",
+        "dispatch": "cron-direct",
+        "schedule": "0 * * * *",
+        "schedule_human": "Hourly",
+        "task_file": null,
+        "enabled": true
+    }
+
+Run standalone (for testing):
+    uv run ~/lobster/scheduled-tasks/vault-journal-scanner.py [--dry-run] [--vault PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.los.db import connect  # noqa: E402
+from src.los.extractor import extract_action_items  # noqa: E402
+from src.utils.jobs import is_job_enabled  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("vault-journal-scanner")
+
+# ---------------------------------------------------------------------------
+# Constants — named after spec requirements (never magic literals)
+# ---------------------------------------------------------------------------
+
+JOB_NAME = "vault-journal-scanner"
+
+# Files and directories to exclude when scanning the vault
+SCAN_EXCLUDES: frozenset[str] = frozenset({".git", ".obsidian", ".trash"})
+
+# The managed todo file — exclude so we don't double-extract its items
+ACTIVE_TODOS_FILENAME = "✅ ACTIVE TODOS.md"
+
+# State file records which journal files have been fully scanned.
+# Lives outside the repo so it persists across upgrades.
+_WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+_USER_CONFIG = Path(os.environ.get("LOBSTER_USER_CONFIG", Path.home() / "lobster-user-config"))
+
+STATE_FILE_PATH = _WORKSPACE / "data" / "vault-journal-scanner-state.json"
+DB_PATH_DEFAULT = _USER_CONFIG / "data" / "self_action_items.db"
+
+# Checkbox pattern: "- [ ] <text>" (leading whitespace allowed for nested items)
+UNCHECKED_CHECKBOX_RE = re.compile(r"^[ \t]*- \[ \]\s+(.+)$", re.MULTILINE)
+
+# Priority assigned to all journal-extracted items (spec: medium, can be edited)
+JOURNAL_ITEM_DEFAULT_PRIORITY = 5
+
+
+# ---------------------------------------------------------------------------
+# State management — pure load/save, no mutation
+# ---------------------------------------------------------------------------
+
+
+def load_scanner_state(state_path: Path) -> dict[str, str]:
+    """Load the scanner state from disk.
+
+    Returns a dict mapping file path (str) → ISO timestamp of last scan.
+    Returns {} on any error so the scanner degrades gracefully.
+    """
+    if not state_path.exists():
+        return {}
+    try:
+        raw = state_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return {k: v for k, v in data.items() if isinstance(k, str) and isinstance(v, str)}
+        return {}
+    except Exception as exc:
+        log.warning("Could not load scanner state from %s: %s", state_path, exc)
+        return {}
+
+
+def save_scanner_state(state_path: Path, state: dict[str, str]) -> None:
+    """Persist the scanner state to disk (atomic write via temp file).
+
+    Side effect: writes to state_path. Isolated at the boundary.
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = state_path.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+        tmp.replace(state_path)
+    except Exception as exc:
+        log.error("Could not save scanner state to %s: %s", state_path, exc)
+
+
+# ---------------------------------------------------------------------------
+# Pure extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_checkboxes(content: str) -> list[str]:
+    """Extract all unchecked checkbox item texts from markdown content.
+
+    Pure function — no I/O.
+
+    Matches: ``- [ ] <text>`` (with optional leading whitespace for nesting).
+    Returns a list of stripped text strings (empty list if none found).
+    """
+    return [m.group(1).strip() for m in UNCHECKED_CHECKBOX_RE.finditer(content)
+            if m.group(1).strip()]
+
+
+def _file_key(vault_path: Path, file_path: Path) -> str:
+    """Return a stable string key for a vault file (vault-relative path as str)."""
+    try:
+        return str(file_path.relative_to(vault_path))
+    except ValueError:
+        return str(file_path)
+
+
+def _source_name(vault_path: Path, file_path: Path) -> str:
+    """Compute the source name for DB entries from a journal file path.
+
+    Format: ``journal:<vault-relative-stem>`` — consistent with existing
+    manual extractions (e.g. ``journal-121`` for entry 121).
+    """
+    try:
+        rel = file_path.relative_to(vault_path)
+    except ValueError:
+        rel = file_path
+    # Use the stem (filename without .md) as the source slug
+    stem = rel.stem if rel.stem else str(rel)
+    # Collapse spaces and special chars to hyphens for readability
+    slug = re.sub(r"[^a-z0-9]+", "-", stem.lower()).strip("-")
+    return f"journal:{slug}"
+
+
+# ---------------------------------------------------------------------------
+# Vault scanning
+# ---------------------------------------------------------------------------
+
+
+def collect_journal_files(vault_path: Path) -> list[Path]:
+    """Return all markdown files in the vault that are candidate journal files.
+
+    Exclusions (pure — no side effects):
+    - Files inside excluded directories (.git, .obsidian, .trash)
+    - The ACTIVE TODOS.md file (managed separately by vault-processor)
+
+    Returns sorted list of absolute Paths.
+    """
+    result: list[Path] = []
+    for md_file in vault_path.rglob("*.md"):
+        # Skip excluded directories anywhere in the path
+        parts = set(md_file.relative_to(vault_path).parts)
+        if parts & SCAN_EXCLUDES:
+            continue
+        # Skip the managed todo file
+        if md_file.name == ACTIVE_TODOS_FILENAME:
+            continue
+        result.append(md_file)
+    return sorted(result)
+
+
+def _is_file_changed(file_path: Path, last_scanned_iso: Optional[str]) -> bool:
+    """Return True if the file has been modified since last_scanned_iso.
+
+    Compares file mtime to the recorded scan timestamp. Files with no recorded
+    scan timestamp are always treated as new/changed.
+    """
+    if last_scanned_iso is None:
+        return True
+    try:
+        mtime = file_path.stat().st_mtime
+        mtime_dt = datetime.fromtimestamp(mtime, tz=timezone.utc)
+        last_scan_dt = datetime.fromisoformat(last_scanned_iso.replace("Z", "+00:00"))
+        return mtime_dt > last_scan_dt
+    except Exception:
+        return True  # Default: treat as new on any error
+
+
+# ---------------------------------------------------------------------------
+# Main scan logic
+# ---------------------------------------------------------------------------
+
+
+def scan_vault(
+    vault_path: Path,
+    db_path: Path,
+    state: dict[str, str],
+    dry_run: bool = False,
+) -> tuple[int, int, dict[str, str]]:
+    """Scan vault journal files and persist new todo items.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        db_path: Path to self_action_items.db.
+        state: Current scanner state (file_key → last_scanned_iso).
+        dry_run: If True, log what would be extracted but don't write.
+
+    Returns:
+        (files_scanned, items_extracted, updated_state)
+
+    Side effects (when not dry_run):
+        - Writes to self_action_items.db via extract_action_items
+        - Returns updated state dict (caller is responsible for saving)
+    """
+    journal_files = collect_journal_files(vault_path)
+    log.info("Found %d markdown files in vault (after exclusions)", len(journal_files))
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    files_scanned = 0
+    items_extracted = 0
+    updated_state = dict(state)  # immutable input — build new state
+
+    conn = connect(db_path) if not dry_run else None
+    try:
+        for file_path in journal_files:
+            key = _file_key(vault_path, file_path)
+            last_scanned = state.get(key)
+
+            if not _is_file_changed(file_path, last_scanned):
+                log.debug("Skipping unchanged file: %s", key)
+                continue
+
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="replace")
+            except Exception as exc:
+                log.warning("Could not read %s: %s", key, exc)
+                continue
+
+            checkboxes = extract_checkboxes(content)
+            if not checkboxes:
+                # No unchecked items — still mark as scanned to avoid re-reading
+                updated_state[key] = now_iso
+                continue
+
+            source = _source_name(vault_path, file_path)
+            log.info("  %s: found %d unchecked item(s)", key, len(checkboxes))
+
+            if dry_run:
+                for text in checkboxes:
+                    log.info("    [dry-run] would extract: %r (source=%s)", text[:80], source)
+                items_extracted += len(checkboxes)
+            else:
+                # Build items in the format extract_action_items expects
+                items = [{"text": text, "priority": JOURNAL_ITEM_DEFAULT_PRIORITY}
+                         for text in checkboxes]
+                saved = extract_action_items(
+                    conn=conn,
+                    items=items,
+                    source=source,
+                    source_message_id=key,  # vault-relative path as message ID
+                )
+                new_count = len(saved)
+                items_extracted += new_count
+                log.info("    Persisted %d item(s) from %s (dedup skipped duplicates)",
+                         new_count, key)
+
+            updated_state[key] = now_iso
+            files_scanned += 1
+
+    finally:
+        if conn is not None:
+            conn.close()
+
+    return files_scanned, items_extracted, updated_state
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+def _load_vault_path() -> Optional[Path]:
+    """Resolve vault path from vault-watch-config.json.
+
+    Returns None if config is missing or vault_path is not set.
+    """
+    config_path = _USER_CONFIG / "data" / "vault-watch-config.json"
+    if not config_path.exists():
+        log.warning("vault-watch-config.json not found at %s", config_path)
+        return None
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        raw = data.get("vault_path", "")
+        if not raw:
+            log.warning("vault_path not set in vault-watch-config.json")
+            return None
+        return Path(raw).expanduser()
+    except Exception as exc:
+        log.error("Could not read vault-watch-config.json: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Vault journal scanner — extract todo items")
+    parser.add_argument("--dry-run", action="store_true", help="Log what would be extracted without writing to DB")
+    parser.add_argument("--vault", help="Override vault path (default: from vault-watch-config.json)")
+    parser.add_argument("--db", default=str(DB_PATH_DEFAULT), help="Override DB path")
+    parser.add_argument("--state", default=str(STATE_FILE_PATH), help="Override state file path")
+    args = parser.parse_args()
+
+    if not is_job_enabled(JOB_NAME):
+        log.info("Job %s is disabled in jobs.json — exiting.", JOB_NAME)
+        return
+
+    # Resolve vault path
+    vault_path: Optional[Path] = Path(args.vault).expanduser() if args.vault else _load_vault_path()
+    if vault_path is None:
+        log.error("Cannot determine vault path — exiting. Set vault_path in vault-watch-config.json or pass --vault.")
+        sys.exit(1)
+
+    if not vault_path.exists():
+        log.error("Vault path does not exist: %s — exiting.", vault_path)
+        sys.exit(1)
+
+    db_path = Path(args.db)
+    state_path = Path(args.state)
+
+    log.info("Starting vault journal scan (vault=%s, dry_run=%s)", vault_path, args.dry_run)
+
+    state = load_scanner_state(state_path)
+    log.info("Loaded state: %d previously scanned files", len(state))
+
+    files_scanned, items_extracted, updated_state = scan_vault(
+        vault_path=vault_path,
+        db_path=db_path,
+        state=state,
+        dry_run=args.dry_run,
+    )
+
+    if not args.dry_run:
+        save_scanner_state(state_path, updated_state)
+
+    log.info(
+        "Scan complete: %d file(s) scanned, %d item(s) extracted%s.",
+        files_scanned,
+        items_extracted,
+        " (dry-run)" if args.dry_run else "",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4454,6 +4454,110 @@ PYEOF
             substep "Migration 125: TELEGRAM_ADMIN_CHAT_ID already set — skipping"
         fi
     fi
+    # Migration 126: Register los-action-scanner in jobs.json.
+    # The script and task file existed since issue #1285 but the job was never
+    # added to jobs.json, so it never ran automatically. This migration adds
+    # the entry so the hourly Telegram message scanner is activated.
+    local _JOBS_FILE="$WORKSPACE_DIR/scheduled-jobs/jobs.json"
+    if [ -f "$_JOBS_FILE" ]; then
+        if ! uv run python3 -c "import json,sys; d=json.load(open('$_JOBS_FILE')); sys.exit(0 if 'los-action-scanner' in d.get('jobs',{}) else 1)" 2>/dev/null; then
+            substep "Migration 126: adding los-action-scanner to jobs.json"
+            local _m126_tmp
+            _m126_tmp=$(mktemp)
+            uv run python3 - <<'PY126' "$_JOBS_FILE" "$_m126_tmp"
+import json, sys
+from datetime import datetime, timezone
+jobs_path, tmp_path = sys.argv[1], sys.argv[2]
+with open(jobs_path) as f:
+    data = json.load(f)
+data.setdefault("jobs", {})["los-action-scanner"] = {
+    "name": "los-action-scanner",
+    "schedule": "0 * * * *",
+    "schedule_human": "Hourly",
+    "task_file": "tasks/los-action-scanner.md",
+    "created_at": datetime.now(timezone.utc).isoformat(),
+    "updated_at": datetime.now(timezone.utc).isoformat(),
+    "enabled": True,
+    "last_run": None,
+    "last_status": None,
+    "description": "Hourly: scan Telegram conversation history for action commitments and persist to self_action_items.db",
+}
+with open(tmp_path, "w") as f:
+    json.dump(data, f, indent=2, default=str)
+print("OK")
+PY126
+            if [ -s "$_m126_tmp" ]; then
+                mv "$_m126_tmp" "$_JOBS_FILE"
+                substep "Migration 126: los-action-scanner added to jobs.json"
+                migrated=$((migrated + 1))
+            else
+                rm -f "$_m126_tmp"
+                warn "Migration 126: failed to update jobs.json — add los-action-scanner manually"
+            fi
+        else
+            substep "Migration 126: los-action-scanner already in jobs.json — skipping"
+        fi
+    else
+        warn "Migration 126: jobs.json not found at $_JOBS_FILE — los-action-scanner not registered"
+    fi
+
+    # Migration 127: Register vault-journal-scanner in jobs.json and add cron entry.
+    # New Type B script that scans Obsidian vault journal files for unchecked
+    # checkbox items (- [ ] ...) and persists them to self_action_items.db hourly.
+    # This closes the core gap in the journal → TODO pipeline (issue #1285).
+    local VAULT_JOURNAL_SCANNER_MARKER="# LOBSTER-VAULT-JOURNAL-SCANNER"
+    if [ -f "$_JOBS_FILE" ]; then
+        if ! uv run python3 -c "import json,sys; d=json.load(open('$_JOBS_FILE')); sys.exit(0 if 'vault-journal-scanner' in d.get('jobs',{}) else 1)" 2>/dev/null; then
+            substep "Migration 127: adding vault-journal-scanner to jobs.json"
+            local _m127_tmp
+            _m127_tmp=$(mktemp)
+            uv run python3 - <<'PY127' "$_JOBS_FILE" "$_m127_tmp"
+import json, sys
+from datetime import datetime, timezone
+jobs_path, tmp_path = sys.argv[1], sys.argv[2]
+with open(jobs_path) as f:
+    data = json.load(f)
+data.setdefault("jobs", {})["vault-journal-scanner"] = {
+    "name": "vault-journal-scanner",
+    "type": "B",
+    "dispatch": "cron-direct",
+    "schedule": "0 * * * *",
+    "schedule_human": "Hourly",
+    "task_file": None,
+    "created_at": datetime.now(timezone.utc).isoformat(),
+    "updated_at": datetime.now(timezone.utc).isoformat(),
+    "enabled": True,
+    "last_run": None,
+    "last_status": None,
+    "description": "Hourly: scan new Obsidian vault journal files for unchecked - [ ] items; persist to self_action_items.db",
+}
+with open(tmp_path, "w") as f:
+    json.dump(data, f, indent=2, default=str)
+print("OK")
+PY127
+            if [ -s "$_m127_tmp" ]; then
+                mv "$_m127_tmp" "$_JOBS_FILE"
+                substep "Migration 127: vault-journal-scanner added to jobs.json"
+                migrated=$((migrated + 1))
+            else
+                rm -f "$_m127_tmp"
+                warn "Migration 127: failed to update jobs.json — add vault-journal-scanner manually"
+            fi
+        else
+            substep "Migration 127: vault-journal-scanner already in jobs.json — skipping"
+        fi
+    fi
+
+    if ! crontab -l 2>/dev/null | grep -qF "$VAULT_JOURNAL_SCANNER_MARKER"; then
+        local VAULT_JOURNAL_SCANNER_ENTRY="0 * * * * cd $LOBSTER_DIR && uv run scheduled-tasks/vault-journal-scanner.py >> $WORKSPACE_DIR/scheduled-jobs/logs/vault-journal-scanner.log 2>&1 $VAULT_JOURNAL_SCANNER_MARKER"
+        (crontab -l 2>/dev/null; echo "$VAULT_JOURNAL_SCANNER_ENTRY") | crontab - && {
+            substep "Migration 127: added LOBSTER-VAULT-JOURNAL-SCANNER cron entry (hourly)"
+            migrated=$((migrated + 1))
+        } || warn "Could not add LOBSTER-VAULT-JOURNAL-SCANNER cron entry — add manually"
+    else
+        substep "Migration 127: LOBSTER-VAULT-JOURNAL-SCANNER cron entry already present — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/los/test_vault_journal_scanner.py
+++ b/tests/unit/los/test_vault_journal_scanner.py
@@ -1,0 +1,396 @@
+"""
+Tests for vault-journal-scanner.py
+
+Tests are written against behaviors derived from the spec (issue #1285):
+- Unchecked checkbox items in journal files are extracted
+- Checked items, ACTIVE TODOS.md, and excluded directories are skipped
+- Files not changed since last scan are skipped (state tracking)
+- State is loaded and saved correctly
+- Dedup via src.los.db ensures the same item from multiple sources is not doubled
+- dry-run mode logs but does not write to DB or update state
+
+No external services, no API calls, no Telegram output.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.los.db import connect, get_open_items
+
+
+# Import the scanner module — path manipulation in the script itself ensures
+# this works when the test is run from the repo root via pytest.
+import importlib.util
+import sys
+
+_SCANNER_PATH = Path(__file__).parent.parent.parent.parent / "scheduled-tasks" / "vault-journal-scanner.py"
+
+
+def _load_scanner():
+    """Dynamically load vault-journal-scanner as a module."""
+    spec = importlib.util.spec_from_file_location("vault_journal_scanner", _SCANNER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+scanner = _load_scanner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault_path(tmp_path: Path) -> Path:
+    v = tmp_path / "vault"
+    v.mkdir()
+    return v
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "self_action_items.db"
+
+
+@pytest.fixture
+def state_path(tmp_path: Path) -> Path:
+    return tmp_path / "scanner-state.json"
+
+
+# ---------------------------------------------------------------------------
+# extract_checkboxes — pure function, no I/O
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCheckboxes:
+    def test_finds_unchecked_items(self):
+        content = "- [ ] Call Sarah\n- [ ] Buy milk\n"
+        result = scanner.extract_checkboxes(content)
+        assert result == ["Call Sarah", "Buy milk"]
+
+    def test_skips_checked_items(self):
+        content = "- [x] Done thing\n- [X] Also done\n"
+        result = scanner.extract_checkboxes(content)
+        assert result == []
+
+    def test_skips_partially_checked_variants(self):
+        # Only standard - [ ] pattern is extracted; everything else is skipped
+        content = "- [-] In progress\n- [/] Half done\n"
+        result = scanner.extract_checkboxes(content)
+        assert result == []
+
+    def test_handles_nested_items_with_leading_whitespace(self):
+        content = "\t- [ ] Nested item\n  - [ ] Another nested\n"
+        result = scanner.extract_checkboxes(content)
+        assert result == ["Nested item", "Another nested"]
+
+    def test_returns_empty_for_no_todos(self):
+        content = "# Just a journal entry\n\nSome prose text.\n"
+        assert scanner.extract_checkboxes(content) == []
+
+    def test_strips_trailing_whitespace_from_item_text(self):
+        content = "- [ ]   Lots of leading spaces   \n"
+        result = scanner.extract_checkboxes(content)
+        assert result == ["Lots of leading spaces"]
+
+    def test_mixed_content(self):
+        content = (
+            "# Journal\n\n"
+            "Some thoughts.\n\n"
+            "- [ ] Action item 1\n"
+            "- [x] Already done\n"
+            "- [ ] Action item 2\n"
+            "\nMore prose.\n"
+        )
+        result = scanner.extract_checkboxes(content)
+        assert result == ["Action item 1", "Action item 2"]
+
+
+# ---------------------------------------------------------------------------
+# collect_journal_files — pure scanner over directory tree
+# ---------------------------------------------------------------------------
+
+
+class TestCollectJournalFiles:
+    def test_finds_md_files_in_vault(self, vault_path):
+        (vault_path / "journal-1.md").write_text("entry")
+        (vault_path / "journal-2.md").write_text("entry")
+        files = scanner.collect_journal_files(vault_path)
+        names = {f.name for f in files}
+        assert "journal-1.md" in names
+        assert "journal-2.md" in names
+
+    def test_excludes_active_todos(self, vault_path):
+        (vault_path / "✅ ACTIVE TODOS.md").write_text("- [ ] Something")
+        (vault_path / "journal.md").write_text("- [ ] Real item")
+        files = scanner.collect_journal_files(vault_path)
+        names = {f.name for f in files}
+        assert "✅ ACTIVE TODOS.md" not in names
+        assert "journal.md" in names
+
+    def test_excludes_obsidian_directory(self, vault_path):
+        obsidian_dir = vault_path / ".obsidian"
+        obsidian_dir.mkdir()
+        (obsidian_dir / "config.md").write_text("# config")
+        (vault_path / "journal.md").write_text("entry")
+        files = scanner.collect_journal_files(vault_path)
+        paths = {str(f) for f in files}
+        assert not any(".obsidian" in p for p in paths)
+
+    def test_excludes_git_directory(self, vault_path):
+        git_dir = vault_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "COMMIT_EDITMSG").write_text("msg")
+        (vault_path / "journal.md").write_text("entry")
+        files = scanner.collect_journal_files(vault_path)
+        paths = {str(f) for f in files}
+        assert not any(".git" in p for p in paths)
+
+    def test_finds_nested_journal_files(self, vault_path):
+        week_dir = vault_path / "Journal Entries" / "2026" / "Week 1"
+        week_dir.mkdir(parents=True)
+        (week_dir / "entry.md").write_text("entry")
+        files = scanner.collect_journal_files(vault_path)
+        assert any("entry.md" == f.name for f in files)
+
+
+# ---------------------------------------------------------------------------
+# State management
+# ---------------------------------------------------------------------------
+
+
+class TestLoadScannerState:
+    def test_returns_empty_dict_when_file_missing(self, state_path):
+        result = scanner.load_scanner_state(state_path)
+        assert result == {}
+
+    def test_loads_valid_state(self, state_path):
+        state = {"journal/entry.md": "2026-05-01T00:00:00+00:00"}
+        state_path.write_text(json.dumps(state))
+        result = scanner.load_scanner_state(state_path)
+        assert result == state
+
+    def test_returns_empty_on_malformed_json(self, state_path):
+        state_path.write_text("not json{{{")
+        result = scanner.load_scanner_state(state_path)
+        assert result == {}
+
+    def test_filters_non_string_values(self, state_path):
+        state = {"journal.md": "2026-01-01T00:00Z", "bad": 12345}
+        state_path.write_text(json.dumps(state))
+        result = scanner.load_scanner_state(state_path)
+        assert "journal.md" in result
+        assert "bad" not in result
+
+
+class TestSaveScannerState:
+    def test_saves_and_loads_roundtrip(self, state_path):
+        state = {"a.md": "2026-01-01T00:00:00Z", "b.md": "2026-02-01T00:00:00Z"}
+        scanner.save_scanner_state(state_path, state)
+        assert state_path.exists()
+        loaded = scanner.load_scanner_state(state_path)
+        assert loaded == state
+
+    def test_creates_parent_directories(self, tmp_path):
+        nested_path = tmp_path / "deep" / "nested" / "state.json"
+        scanner.save_scanner_state(nested_path, {"x.md": "2026-01-01T00:00:00Z"})
+        assert nested_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# _is_file_changed
+# ---------------------------------------------------------------------------
+
+
+class TestIsFileChanged:
+    def test_file_with_no_last_scan_is_always_changed(self, tmp_path):
+        f = tmp_path / "new.md"
+        f.write_text("content")
+        assert scanner._is_file_changed(f, None) is True
+
+    def test_file_modified_after_last_scan_is_changed(self, tmp_path):
+        f = tmp_path / "modified.md"
+        f.write_text("content")
+        # Set last_scanned to 10 minutes in the past relative to file mtime
+        mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc)
+        past_iso = (mtime - timedelta(minutes=10)).isoformat()
+        assert scanner._is_file_changed(f, past_iso) is True
+
+    def test_file_not_modified_since_scan_is_unchanged(self, tmp_path):
+        f = tmp_path / "unchanged.md"
+        f.write_text("content")
+        # Set last_scanned to 10 minutes AFTER file mtime
+        mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc)
+        future_iso = (mtime + timedelta(minutes=10)).isoformat()
+        assert scanner._is_file_changed(f, future_iso) is False
+
+
+# ---------------------------------------------------------------------------
+# scan_vault — integration-style tests using a real in-memory DB
+# ---------------------------------------------------------------------------
+
+
+class TestScanVault:
+    def test_extracts_items_from_new_journal_file(self, vault_path, db_path):
+        journal = vault_path / "122 (5.15.26).md"
+        journal.write_text("- [ ] Call Sarah\n- [ ] Buy milk\n")
+
+        files_scanned, items_extracted, new_state = scanner.scan_vault(
+            vault_path=vault_path,
+            db_path=db_path,
+            state={},
+            dry_run=False,
+        )
+
+        assert files_scanned == 1
+        assert items_extracted == 2
+
+        conn = connect(db_path)
+        items = get_open_items(conn)
+        conn.close()
+        texts = {i.text for i in items}
+        assert "Call Sarah" in texts
+        assert "Buy milk" in texts
+
+    def test_skips_file_not_changed_since_last_scan(self, vault_path, db_path):
+        journal = vault_path / "old.md"
+        journal.write_text("- [ ] Old item\n")
+        # Set last_scanned AFTER file mtime so file appears unchanged
+        mtime = datetime.fromtimestamp(journal.stat().st_mtime, tz=timezone.utc)
+        future_iso = (mtime + timedelta(minutes=10)).isoformat()
+        state = {scanner._file_key(vault_path, journal): future_iso}
+
+        files_scanned, items_extracted, new_state = scanner.scan_vault(
+            vault_path=vault_path,
+            db_path=db_path,
+            state=state,
+            dry_run=False,
+        )
+
+        assert files_scanned == 0
+        assert items_extracted == 0
+
+    def test_does_not_write_on_dry_run(self, vault_path, db_path):
+        journal = vault_path / "dry.md"
+        journal.write_text("- [ ] Should not be saved\n")
+
+        files_scanned, items_extracted, new_state = scanner.scan_vault(
+            vault_path=vault_path,
+            db_path=db_path,
+            state={},
+            dry_run=True,
+        )
+
+        # items_extracted is still populated so caller can see what would be extracted
+        assert items_extracted == 1
+        # But the DB was not written (db_path may not even exist)
+        if db_path.exists():
+            conn = connect(db_path)
+            items = get_open_items(conn)
+            conn.close()
+            assert len(items) == 0
+
+    def test_dedup_prevents_double_insertion(self, vault_path, db_path):
+        """Same text in two different files should only produce one DB row."""
+        j1 = vault_path / "entry1.md"
+        j2 = vault_path / "entry2.md"
+        j1.write_text("- [ ] Pack for Boston trip\n")
+        j2.write_text("- [ ] Pack for Boston trip\n")
+
+        files_scanned, items_extracted, _ = scanner.scan_vault(
+            vault_path=vault_path,
+            db_path=db_path,
+            state={},
+            dry_run=False,
+        )
+
+        conn = connect(db_path)
+        items = get_open_items(conn)
+        conn.close()
+        # Only one open row despite two files having the same text
+        matching = [i for i in items if i.text == "Pack for Boston trip"]
+        assert len(matching) == 1
+
+    def test_excludes_active_todos_file(self, vault_path, db_path):
+        todos_file = vault_path / "✅ ACTIVE TODOS.md"
+        todos_file.write_text("- [ ] Should be excluded\n")
+        journal = vault_path / "journal.md"
+        journal.write_text("- [ ] Real journal item\n")
+
+        _, items_extracted, _ = scanner.scan_vault(
+            vault_path=vault_path,
+            db_path=db_path,
+            state={},
+            dry_run=False,
+        )
+
+        conn = connect(db_path)
+        items = get_open_items(conn)
+        conn.close()
+        texts = {i.text for i in items}
+        assert "Should be excluded" not in texts
+        assert "Real journal item" in texts
+
+    def test_updates_state_for_scanned_files(self, vault_path, db_path):
+        journal = vault_path / "new-entry.md"
+        journal.write_text("- [ ] Track me\n")
+
+        _, _, new_state = scanner.scan_vault(
+            vault_path=vault_path,
+            db_path=db_path,
+            state={},
+            dry_run=False,
+        )
+
+        key = scanner._file_key(vault_path, journal)
+        assert key in new_state
+
+    def test_handles_file_with_no_checkboxes(self, vault_path, db_path):
+        journal = vault_path / "prose.md"
+        journal.write_text("Just some prose. No todos here.\n")
+
+        files_scanned, items_extracted, new_state = scanner.scan_vault(
+            vault_path=vault_path,
+            db_path=db_path,
+            state={},
+            dry_run=False,
+        )
+
+        # File with no todos still gets marked as scanned (mtime tracking)
+        assert items_extracted == 0
+        key = scanner._file_key(vault_path, journal)
+        assert key in new_state
+
+
+# ---------------------------------------------------------------------------
+# _source_name — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestSourceName:
+    def test_produces_journal_prefixed_source(self, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        f = vault / "122 (5.15.26).md"
+        f.touch()
+        source = scanner._source_name(vault, f)
+        assert source.startswith("journal:")
+
+    def test_stem_is_slugified(self, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        f = vault / "Journal Entries" / "2026" / "Week 19.md"
+        f.parent.mkdir(parents=True)
+        f.touch()
+        source = scanner._source_name(vault, f)
+        # Should be lowercase with hyphens, no spaces or dots
+        slug = source.removeprefix("journal:")
+        assert " " not in slug
+        assert slug == slug.lower()


### PR DESCRIPTION
## What this fixes

The journal → parse → TODO pipeline has been structurally broken since it was designed. Two gaps:

**Gap 1: los-action-scanner was never registered.** The script (`scheduled-tasks/los-action-scanner.py`) and task file (`tasks/los-action-scanner.md`) existed but `los-action-scanner` was never added to `jobs.json`. The job has never run automatically. Migration 126 closes this.

**Gap 2: No journal file scanner existed.** Even with los-action-scanner running, there was no step that extracts `- [ ] ...` items from Obsidian vault journal markdown files. Journal 122 (May 15) and all journals written since have produced zero auto-extracted todos. Migration 127 closes this.

## What changed

**New: `scheduled-tasks/vault-journal-scanner.py`** (Type B, cron-direct, hourly)

- Scans all vault `.md` files, excluding `✅ ACTIVE TODOS.md`, `.obsidian/`, `.git/`, `.trash/`
- Extracts unchecked `- [ ] <text>` items using a single regex — no LLM, no reasoning
- Persists to `self_action_items.db` via the existing `src.los.extractor.extract_action_items` API
- Dedup via content hash (`src.los.db.find_duplicate`) — same text from two files → one DB row
- Tracks scanned files by mtime in `~/lobster-workspace/data/vault-journal-scanner-state.json` to skip unchanged files on each hourly run
- State file is written atomically (temp-file swap)

Type B rationale: "Did I write `- [ ] call Sarah` in my journal?" is not a reasoning task. Pure regex extraction is correct here; an LLM subagent adds latency, cost, and nondeterminism with no quality benefit.

**Dry-run verified against the real vault**: 26 files, 250 unchecked items found (not written — dry-run mode).

**Upgrade migrations 126 + 127** in `scripts/upgrade.sh`:
- 126: Registers `los-action-scanner` in `jobs.json` (task_file = `tasks/los-action-scanner.md`, hourly)
- 127: Registers `vault-journal-scanner` in `jobs.json` (Type B) and adds `# LOBSTER-VAULT-JOURNAL-SCANNER` cron entry

## Functional patterns used

- Pure functions for extraction and state management (`extract_checkboxes`, `collect_journal_files`, `load_scanner_state`, `_is_file_changed`) — no I/O
- Side effects (DB writes, state file writes) isolated at `scan_vault` boundary
- Immutable state input: `scan_vault` receives `state: dict` and returns a new `updated_state` dict rather than mutating
- Atomic state file write (temp-file swap) prevents partial writes from corrupting state

## What is NOT in scope

- Deduplicating the 8 existing duplicate DB items (Fix 3 from the audit) — separate concern
- Pinning the `DISABLE PROCESSING` priority oscillation (Fix 4) — separate concern
- Wiring vault-processor to call the scanner in-process — the hourly cron is sufficient and avoids making vault-processor depend on a new script

## Tests run

- [x] `uv run pytest tests/unit/los/test_vault_journal_scanner.py -v` — 30 passed, 0 failed
- [x] `uv run pytest tests/unit/los/ -q` — 239 passed (9 pre-existing failures unrelated to this change: attribution rendering and subtask rendering tests)
- [x] `/home/lobster/.cache/uv/.../ruff check scheduled-tasks/vault-journal-scanner.py` — clean
- [x] `uv run scheduled-tasks/vault-journal-scanner.py --dry-run` — 26 files, 250 items found, no writes

## Manual test

The scanner was run in `--dry-run` mode against the real vault (`~/lobster-workspace/obsidian-vault/`). It correctly:
- Found journal entries 113 and 117 with checkbox items
- Found Tania's Creative Domains files with checkbox items
- Excluded `✅ ACTIVE TODOS.md`

No writes were made to `self_action_items.db`. The live run (without --dry-run) has not been executed — that happens once the cron entry is active after migration 127 runs.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — dry-run against real vault, observed correct file selection and item extraction
- [ ] User-visible outcome verified — the first cron run after `upgrade.sh` will populate todos; Dan can verify in ACTIVE TODOS.md on next vault-processor cycle
- [x] Side-effect audit complete: scanner only reads vault files and writes to DB + state file; no floods, no Telegram output, bounded by mtime tracking
- [x] External service calls: none — all I/O is local file and SQLite

Closes #1285