### PR TITLE
fix(wos): add CLOSED to UoWStatus enum — resolves Registry.list() ValueError (#1279)

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -64,6 +64,12 @@ class UoWStatus(StrEnum):
     # Treated as terminal (allows re-proposal). Previously a legacy DB-only value
     # not covered by the enum — UoWStatus('cancelled') raised ValueError.
     CANCELLED = "cancelled"
+    # CLOSED: legacy terminal status that predates the UoWStatus enum.
+    # Semantically equivalent to 'done' — the UoW reached a terminal state.
+    # Was set externally on rows before enum enforcement was introduced (768 such
+    # rows exist in production). Previously not in the enum, causing ValueError
+    # in any code path that called _row_to_uow() on a 'closed' row (issue #1279).
+    CLOSED = "closed"
     # NEEDS_HUMAN_REVIEW: UoW has exceeded MAX_RETRIES re-dispatch attempts.
     # Steward escalates to Dan rather than continuing to re-dispatch.
     # Treated as non-terminal (does not allow automatic re-proposal).
@@ -76,17 +82,14 @@ class UoWStatus(StrEnum):
     AWAITING_OWNER = "awaiting-owner"
 
     def is_terminal(self) -> bool:
-        """True for statuses that allow re-proposal (done, failed, expired, cancelled).
-
-        Note: 'closed' is NOT included here. 'closed' is a legacy DB status that
-        predates the UoWStatus enum — it was set externally on rows that existed
-        before enum enforcement was introduced. Semantically it means "done", but
-        it cannot be expressed as a UoWStatus value (UoWStatus('closed') raises
-        ValueError). SQL queries that need to exclude terminal rows therefore handle
-        'closed' separately via _TERMINAL_STATUSES_FOR_ISSUE_CHECK; this method
-        covers only the enum-representable statuses.
-        """
-        return self in {UoWStatus.DONE, UoWStatus.FAILED, UoWStatus.EXPIRED, UoWStatus.CANCELLED}
+        """True for statuses that allow re-proposal (done, failed, expired, cancelled, closed)."""
+        return self in {
+            UoWStatus.DONE,
+            UoWStatus.FAILED,
+            UoWStatus.EXPIRED,
+            UoWStatus.CANCELLED,
+            UoWStatus.CLOSED,
+        }
 
     def is_in_flight(self) -> bool:
         """True for statuses that block re-proposal (active, executing, pending, ready-for-steward, ready-for-executor, diagnosing, awaiting-owner)."""
@@ -1172,7 +1175,9 @@ class Registry:
         return self.list(status=status)
 
     # Terminal statuses for has_active_uow_for_issue — mirrors the exclusion list
-    # in _upsert_typed. 'closed' is a legacy DB status treated as terminal here.
+    # Terminal statuses used for issue-check queries. Kept as raw strings
+    # so SQL IN clauses work without enum serialization overhead.
+    # Must stay in sync with UoWStatus.is_terminal().
     _TERMINAL_STATUSES_FOR_ISSUE_CHECK = frozenset({
         "done", "failed", "expired", "cancelled", "closed",
     })

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -1608,3 +1608,116 @@ class TestResetExpiredClaims:
         assert row["status"] == "executing", (
             f"Expected status='executing' (unchanged), got {row['status']!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for 'closed' legacy status (Issue #1279)
+# ---------------------------------------------------------------------------
+
+class TestClosedStatus:
+    """
+    'closed' is a legacy DB status that predates the UoWStatus enum.
+    It is semantically equivalent to 'done' — a terminal state.
+    Before the fix, any code path that called _row_to_uow() on a 'closed'
+    row raised ValueError because 'closed' was not in the enum.
+    """
+
+    def _insert_closed_row(self, db_path: Path, issue_number: int = 9999) -> str:
+        """Insert a row with status='closed' directly via SQL, bypassing enum validation."""
+        import uuid
+        uow_id = str(uuid.uuid4())
+        conn = _open_db(db_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO uow_registry
+                    (id, status, summary, source, created_at, updated_at,
+                     type, posture, register, steward_cycles, lifetime_cycles,
+                     heartbeat_ttl, retry_count, execution_attempts, orphan_retry_count,
+                     source_issue_number)
+                VALUES
+                    (?, 'closed', 'Legacy closed UoW', 'test', datetime('now'), datetime('now'),
+                     'executable', 'solo', 'operational', 0, 0,
+                     300, 0, 0, 0,
+                     ?)
+                """,
+                (uow_id, issue_number),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return uow_id
+
+    def test_closed_is_valid_uow_status(self):
+        """UoWStatus('closed') must not raise ValueError."""
+        from src.orchestration.registry import UoWStatus
+        status = UoWStatus("closed")
+        assert status == UoWStatus.CLOSED
+
+    def test_closed_is_terminal(self):
+        """UoWStatus.CLOSED.is_terminal() must return True."""
+        from src.orchestration.registry import UoWStatus
+        assert UoWStatus.CLOSED.is_terminal() is True
+
+    def test_closed_is_not_in_flight(self):
+        """UoWStatus.CLOSED.is_in_flight() must return False."""
+        from src.orchestration.registry import UoWStatus
+        assert UoWStatus.CLOSED.is_in_flight() is False
+
+    def test_registry_list_does_not_raise_on_closed_row(self, registry, db_path):
+        """
+        Registry.list() must not raise ValueError when the DB contains a
+        row with status='closed'. This was the root cause of issue #1279.
+        """
+        self._insert_closed_row(db_path)
+        # Must not raise ValueError
+        results = registry.list()
+        closed_uows = [u for u in results if u.status == "closed"]
+        assert len(closed_uows) == 1
+
+    def test_registry_list_filtered_by_closed_returns_closed_uow(self, registry, db_path):
+        """
+        Registry.list(status='closed') must return only the closed UoW.
+        """
+        uow_id = self._insert_closed_row(db_path)
+        results = registry.list(status="closed")
+        assert len(results) == 1
+        assert results[0].id == uow_id
+        from src.orchestration.registry import UoWStatus
+        assert results[0].status == UoWStatus.CLOSED
+
+    def test_registry_get_does_not_raise_on_closed_row(self, registry, db_path):
+        """
+        Registry.get(uow_id) must not raise ValueError for a 'closed' row.
+        """
+        uow_id = self._insert_closed_row(db_path)
+        uow = registry.get(uow_id)
+        assert uow is not None
+        from src.orchestration.registry import UoWStatus
+        assert uow.status == UoWStatus.CLOSED
+
+    def test_closed_in_terminal_statuses_for_issue_check(self):
+        """
+        _TERMINAL_STATUSES_FOR_ISSUE_CHECK must contain 'closed' so that
+        stale-issue detection correctly skips closed UoWs.
+        """
+        from src.orchestration.registry import Registry
+        assert "closed" in Registry._TERMINAL_STATUSES_FOR_ISSUE_CHECK
+
+    def test_upsert_allows_reproprose_after_closed(self, registry, db_path):
+        """
+        A UoW in 'closed' status is terminal and must allow re-proposal
+        for the same issue. upsert() must return UpsertInserted (not UpsertSkipped)
+        when the existing row for the same issue is 'closed'.
+        """
+        from src.orchestration.registry import UpsertInserted
+        self._insert_closed_row(db_path, issue_number=8888)
+
+        result = registry.upsert(
+            issue_number=8888,
+            title="Re-proposal after closed",
+            success_criteria="The re-proposal was accepted.",
+        )
+        assert isinstance(result, UpsertInserted), (
+            f"Expected UpsertInserted (re-proposal after closed), got {type(result).__name__}: {result!r}"
+        )


### PR DESCRIPTION
## What this fixes

`Registry.list()` (and any code that called `_row_to_uow()`) crashed with `ValueError: 'closed' is not a valid UoWStatus` whenever the registry contained rows with `status='closed'`. 768 such rows exist in production. All CLI tooling, the observation job, and any code that enumerates the registry was broken or forced to use raw SQL workarounds.

The root cause: `'closed'` is a legacy DB status that predates the `UoWStatus` StrEnum. It was written externally before enum enforcement was introduced, and was never added to the enum. The same situation previously existed for `'cancelled'` — `CANCELLED` was added and that fixed it. This PR applies the identical pattern to `'closed'`.

## What changed

**`src/orchestration/registry.py`**

- Added `CLOSED = "closed"` to `UoWStatus` with a comment explaining its legacy provenance
- Added `UoWStatus.CLOSED` to `is_terminal()` — `closed` is semantically equivalent to `done` and allows re-proposal
- Updated `_TERMINAL_STATUSES_FOR_ISSUE_CHECK` comment to reflect it now mirrors `is_terminal()` rather than working around its gap

No migration is needed. The string `'closed'` already exists in the DB; adding the enum member is purely additive. No existing row is modified.

**`tests/unit/test_orchestration/test_registry.py`**

Added `TestClosedStatus` (8 tests) covering:
- `UoWStatus("closed")` no longer raises `ValueError`
- `CLOSED.is_terminal()` returns `True`
- `CLOSED.is_in_flight()` returns `False`
- `Registry.list()` does not raise on a `'closed'` row (the regression test for #1279)
- `Registry.list(status='closed')` returns the correct row
- `Registry.get(uow_id)` does not raise on a `'closed'` row
- `_TERMINAL_STATUSES_FOR_ISSUE_CHECK` contains `'closed'`
- `upsert()` allows re-proposal after `'closed'` (terminal semantics confirmed)

## Functional patterns used

Pure enum addition — no state mutation, no side effects. The fix is a purely additive StrEnum member and a set membership update in a pure predicate method.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py::TestClosedStatus -v` — 8 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py -v` — 97 passed, 0 failed (no regressions)
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py tests/unit/test_orchestration/test_wos_completion.py tests/unit/test_orchestration/test_wos_issue_lifecycle.py tests/unit/test_orchestration/test_wos_metrics_report.py -q` — 222 passed, 0 failed

Note: `tests/unit/test_orchestration/test_registry_cli.py` has a pre-existing `SyntaxError` on main (unclosed parenthesis at line 1183) that prevents collection. This is unrelated to this PR.

## Manual test

N/A — this change is entirely internal to the enum and `_row_to_uow()`. No external service calls, no file I/O, no systemd, no cron. The fix is exercised by the 768 existing `'closed'` rows in the production DB the next time `Registry.list()` runs.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (see above)
- [x] User-visible outcome: not applicable — this is an internal enum fix; no user-visible output is produced
- [x] Side-effect audit: no writes, no sends, no shared state affected — purely additive enum member
- [x] External service calls: none

Closes #1279