### PR TITLE
fix(steward): add src/ to sys.path so orchestration module resolves

### DIFF
--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -55,6 +55,10 @@ _REPO_ROOT = Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+_SRC_ROOT = _REPO_ROOT / "src"
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
 from orchestration.paths import REGISTRY_DB
 from orchestration.steward import is_bootup_candidate_gate_active, run_steward_cycle
 from orchestration.github_sync import run_post_completion_sync


### PR DESCRIPTION
## Summary

- `steward-heartbeat.py` was missing the `_SRC_ROOT` path setup that `executor-heartbeat.py` already has
- Without `src/` on `sys.path`, all `from orchestration.*` imports failed with `ModuleNotFoundError: No module named 'orchestration'`
- The `orchestration` package lives at `src/orchestration/`, not at the repo root — the script was only adding the repo root to `sys.path`
- Fix: add 3 lines matching the existing pattern in `executor-heartbeat.py`

## Root cause

`_REPO_ROOT = Path(__file__).parent.parent` resolves to `/home/lobster/lobster/`. Without `src/` also on the path, `import orchestration` fails because the package is at `src/orchestration/`, not `orchestration/`.

## Test plan

- [x] Ran `uv run scheduled-tasks/steward-heartbeat.py --dry-run` — completes all phases with no ModuleNotFoundError
- [x] Confirmed 102 `ready-for-steward` UoWs are visible and correctly held behind `execution_enabled=false` gate

Generated with Claude Code