### PR TITLE
fix(health-check): remove noisy session-age Telegram alert

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1577,8 +1577,10 @@ check_session_age() {
     # Send SIGTERM. The Stop hook fires, writes the tombstone, and claude-persistent.sh
     # restarts Claude. This is a graceful exit, not a crash.
     if kill -TERM "$dispatcher_pid" 2>/dev/null; then
-        log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
-        send_telegram_alert_deduped "proactive-session-restart" "Session age test in progress (threshold: ${SESSION_AGE_LIMIT_SECONDS}s / $(( SESSION_AGE_LIMIT_SECONDS / 3600 ))h). This session has been running ${session_age}s — normally we'd have restarted at 7200s. Watching for: CC hard-kill at ~7440s (no Stop hook) = limit still exists; session survives past 7440s = limit removed or raised. Data basis: 2 observed hard-kills at ~7440s on 2026-05-09. No hard-kills observed since (every restart has been from SIGTERM at 7200s). Stop hook will fire cleanly; no context lost."
+        log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid — graceful rotation initiated"
+        # No Telegram alert: proactive session rotation is designed behavior that
+        # fires every ~2h. The log entry above is sufficient internal evidence.
+        # Alert was removed because it never correlated with an actionable condition.
         # Delete the start timestamp so a subsequent health check run (within the
         # next 4 minutes) does not send a second SIGTERM before the restart completes.
         rm -f "$DISPATCHER_SESSION_START_FILE" 2>/dev/null || true

--- a/tests/test-health-check-session-age.sh
+++ b/tests/test-health-check-session-age.sh
@@ -21,6 +21,7 @@
 #   9. Start file deleted after SIGTERM (prevents double-fire on next health check)
 #  10. Boot grace suppression: caller suppresses check during boot grace period
 #      (check_session_age itself does not implement boot grace — suppression is in main())
+#  11. No Telegram alert sent on SIGTERM (alert removed — routine rotation is not actionable)
 #
 # Usage: bash tests/test-health-check-session-age.sh
 #===============================================================================
@@ -215,8 +216,9 @@ echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
 check_session_age
 assert_exit $? 0
 
-# 11. Telegram alert is sent when SIGTERM fires
-begin_test "telegram_alert_sent_on_sigterm"
+# 11. No Telegram alert is sent when SIGTERM fires (alert removed — routine rotation
+#     is designed behavior that never correlated with an actionable condition)
+begin_test "no_telegram_alert_on_sigterm"
 reset_state
 sleep 600 &
 target_pid=$!
@@ -225,10 +227,10 @@ past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
 echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
 check_session_age
 kill "$target_pid" 2>/dev/null || true
-if [[ -f "$TELEGRAM_ALERTS_FILE" ]] && grep -q "proactive-session-restart" "$TELEGRAM_ALERTS_FILE"; then
+if [[ ! -f "$TELEGRAM_ALERTS_FILE" ]] || ! grep -q "proactive-session-restart" "$TELEGRAM_ALERTS_FILE"; then
     pass
 else
-    fail "no Telegram alert with key 'proactive-session-restart' found after SIGTERM"
+    fail "unexpected Telegram alert fired — routine rotation should produce no Telegram alert"
 fi
 
 #===============================================================================


### PR DESCRIPTION
## What and why

Every ~2 hours, the health check fires SIGTERM to the dispatcher so the Stop hook runs cleanly before CC's 7440s hard session limit. This is designed behavior — the restart is graceful, no context is lost, and the next session picks up normally.

The current code sends a Telegram alert every time this happens. The text reads: \"Session age test in progress... Watching for: CC hard-kill at ~7440s...\" — investigative language from a May 2026 diagnostic to determine if CC's hard-kill limit was still active. Dan has confirmed: this alert has never correlated with anything actionable. The investigation is over.

The removal is straightforward: delete the `send_telegram_alert_deduped` call from the SIGTERM success path. The `log_warn` line that precedes it remains, so health-check.log still records that a rotation happened.

**History:** PR #1275 briefly softened this alert to \`[Routine] Session rotation at Xs...\` — still a Telegram noise event, just with less alarming text. That text was then reverted in commit 1189d812 when the session age limit was experimentally raised to 86400s. The experiment is over; the alert text was never reverted back to [Routine]. This PR takes the correct final step: remove the alert entirely rather than iterate on its wording.

## What is not changed

- The SIGTERM logic is unchanged
- The session age limit (SESSION_AGE_LIMIT_SECONDS) is unchanged
- The log_warn entry in health-check.log is preserved (log output is not affected)
- All other `send_telegram_alert_deduped` calls are untouched — crash alerts (restart-failed-pid, restart-aborted-pid, etc.) are unaffected and use separate dedup keys

## Tests run
- [x] `bash tests/test-health-check-session-age.sh` — 11 passed, 0 failed
  - Test 11 was updated: previously asserted the alert fires; now asserts it does not
  - All other session age tests (SIGTERM behavior, start-file deletion, PID validation) pass unchanged

## Manual test
N/A — the change is purely the removal of one `send_telegram_alert_deduped` call. The SIGTERM logic and all other behavior is unaffected. User-visible outcome: Dan will no longer receive a Telegram message on each proactive session rotation. The health-check.log still records the rotation via log_warn.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (shell string removal, no logic change)
- [x] User-visible outcome verified — Dan stops receiving the alert; no other alert path affected
- [x] Side-effect audit complete: removing one dedup key call cannot cause floods or unintended volume
- [x] External service calls: none introduced