### PR TITLE
feat(hooks): implement ⚖️ decided signal — routing hook + legend entry

### DIFF
--- a/hooks/signal-footer-check.py
+++ b/hooks/signal-footer-check.py
@@ -18,8 +18,11 @@ Exit codes:
 """
 
 import json
+import os
 import re
+import sqlite3
 import sys
+from datetime import datetime, timezone
 
 
 # Match a side-effects code block with the canonical label.
@@ -56,6 +59,15 @@ WRONG_NULL_PATTERNS = [
     re.compile(r"^(signals|effects|side_effects):\s*none\s*$", re.MULTILINE | re.IGNORECASE),
 ]
 
+# Extracts content inside a side-effects block.
+SIDE_EFFECTS_CONTENT_RE = re.compile(r"```side-effects:\s*\n(.*?)```", re.DOTALL)
+
+# Matches "decided" (optionally preceded by ⚖️ and whitespace) at the start of a trimmed line.
+DECIDED_LINE_RE = re.compile(r"^(?:⚖️\s*)?decided\b", re.IGNORECASE)
+
+DB_PATH = os.environ.get("DECIDED_DB_PATH", os.path.expanduser("~/lobster-workspace/data/memory.db"))
+DECISIONS_LEDGER_PATH = os.environ.get("DECIDED_LEDGER_PATH", os.path.expanduser("~/lobster-workspace/data/decisions-ledger.md"))
+
 
 def has_side_effects_none(text: str) -> bool:
     """Returns True if the message contains a banned 'side-effects: none' in any form."""
@@ -85,6 +97,65 @@ def detect_wrong_label(text: str) -> str | None:
             return m.group(1) + ": none"
 
     return None
+
+
+def route_decided(text: str, task_id: str | None = None) -> None:
+    """
+    If the message's side-effects block contains a 'decided' signal line,
+    write the decision to memory.db and append a dated entry to decisions-ledger.md.
+    Failures are swallowed — routing must not block the send_reply.
+    """
+    m = SIDE_EFFECTS_CONTENT_RE.search(text)
+    if not m:
+        return
+
+    description = None
+    for raw_line in m.group(1).splitlines():
+        line = raw_line.strip()
+        if DECIDED_LINE_RE.match(line):
+            description = DECIDED_LINE_RE.sub("", line).strip() or "decision reached"
+            break
+
+    if description is None:
+        return
+
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    try:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS decisions (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    date       TEXT NOT NULL,
+                    category   TEXT,
+                    task_id    TEXT,
+                    summary    TEXT NOT NULL,
+                    source     TEXT,
+                    created_at TEXT DEFAULT (datetime('now'))
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_decisions_dedup
+                    ON decisions(date, summary);
+                CREATE INDEX IF NOT EXISTS idx_decisions_category
+                    ON decisions(category);
+                CREATE INDEX IF NOT EXISTS idx_decisions_task_id
+                    ON decisions(task_id);
+                CREATE INDEX IF NOT EXISTS idx_decisions_date
+                    ON decisions(date);
+            """)
+            conn.execute(
+                "INSERT OR IGNORE INTO decisions (date, category, task_id, summary, source) VALUES (?, ?, ?, ?, ?)",
+                (date_str, "decision", task_id, description, "decided-signal"),
+            )
+            conn.commit()
+    except Exception:
+        pass
+
+    try:
+        entry = f"\n---\n**{date_str}** — {description}\n"
+        with open(DECISIONS_LEDGER_PATH, "a", encoding="utf-8") as f:
+            f.write(entry)
+    except Exception:
+        pass
 
 
 def main():
@@ -130,6 +201,9 @@ def main():
                 file=sys.stderr,
             )
             sys.exit(2)
+
+    # Route any 'decided' signal found in the side-effects block.
+    route_decided(text, tool_input.get("task_id"))
 
     sys.exit(0)
 

--- a/tests/unit/test_hooks/test_signal_footer_decided.py
+++ b/tests/unit/test_hooks/test_signal_footer_decided.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for ⚖️ decided signal routing in hooks/signal-footer-check.py.
+
+Tests cover:
+- Messages with no side-effects block pass without routing
+- Side-effects blocks without 'decided' pass without writing anything
+- 'decided' with emoji routes to decisions table in DB
+- 'decided' without emoji also triggers routing
+- Routing appends a dated entry to decisions-ledger.md
+- Bare 'decided' with no description falls back to 'decision reached'
+- DB write failure does not block the send_reply (exit 0)
+- Non-send_reply tool calls are skipped
+
+WOS-UoW: uow_20260525_4e9b36
+"""
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "signal-footer-check.py"
+
+
+def _run(
+    tool_input: dict,
+    tool_name: str = "mcp__lobster-inbox__send_reply",
+    env_overrides: dict | None = None,
+) -> tuple[int, str, str]:
+    payload = {"tool_name": tool_name, "tool_input": tool_input}
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _make_text(side_effects_content: str) -> str:
+    return f"Here is my reply.\n\n```side-effects:\n{side_effects_content}\n```"
+
+
+class TestDecidedSignalDetection:
+
+    def test_no_side_effects_block_passes(self):
+        """Messages with no side-effects block pass without routing."""
+        rc, _, _ = _run({"chat_id": 6036, "text": "Just a message, no footer."})
+        assert rc == 0
+
+    def test_side_effects_without_decided_passes(self):
+        """A side-effects block that has no 'decided' line is allowed without writing anything."""
+        text = _make_text("🤖 spawned  some-agent\n✅ done     task complete\n")
+        rc, _, _ = _run({"chat_id": 6036, "text": text})
+        assert rc == 0
+
+    def test_decided_line_routes_to_db(self, tmp_path):
+        """A side-effects block with '⚖️ decided <desc>' writes to decisions table."""
+        db_path = tmp_path / "memory.db"
+        ledger_path = tmp_path / "decisions-ledger.md"
+        ledger_path.write_text("")
+
+        text = _make_text("⚖️ decided  use OAuth for authentication\n")
+        rc, _, _ = _run(
+            {"chat_id": 6036, "text": text},
+            env_overrides={
+                "DECIDED_DB_PATH": str(db_path),
+                "DECIDED_LEDGER_PATH": str(ledger_path),
+            },
+        )
+        assert rc == 0
+
+        with sqlite3.connect(str(db_path)) as conn:
+            rows = conn.execute("SELECT summary, source, category FROM decisions").fetchall()
+        assert len(rows) == 1
+        assert "use OAuth for authentication" in rows[0][0]
+        assert rows[0][1] == "decided-signal"
+        assert rows[0][2] == "decision"
+
+    def test_decided_line_without_emoji_routes_to_db(self, tmp_path):
+        """'decided <desc>' without the emoji also triggers routing."""
+        db_path = tmp_path / "memory.db"
+        ledger_path = tmp_path / "decisions-ledger.md"
+        ledger_path.write_text("")
+
+        text = _make_text("decided  use Redis for caching\n")
+        rc, _, _ = _run(
+            {"chat_id": 6036, "text": text},
+            env_overrides={
+                "DECIDED_DB_PATH": str(db_path),
+                "DECIDED_LEDGER_PATH": str(ledger_path),
+            },
+        )
+        assert rc == 0
+
+        with sqlite3.connect(str(db_path)) as conn:
+            rows = conn.execute("SELECT summary FROM decisions").fetchall()
+        assert len(rows) == 1
+        assert "use Redis for caching" in rows[0][0]
+
+    def test_decided_line_appends_to_ledger(self, tmp_path):
+        """Routing appends a dated markdown entry to decisions-ledger.md."""
+        db_path = tmp_path / "memory.db"
+        ledger_path = tmp_path / "decisions-ledger.md"
+        ledger_path.write_text("# Decisions\n")
+
+        text = _make_text("⚖️ decided  ship the feature as-is\n")
+        rc, _, _ = _run(
+            {"chat_id": 6036, "text": text},
+            env_overrides={
+                "DECIDED_DB_PATH": str(db_path),
+                "DECIDED_LEDGER_PATH": str(ledger_path),
+            },
+        )
+        assert rc == 0
+
+        content = ledger_path.read_text()
+        assert "ship the feature as-is" in content
+        assert "---" in content
+
+    def test_decided_with_no_description_uses_fallback(self, tmp_path):
+        """A bare 'decided' line with no description writes 'decision reached' to DB."""
+        db_path = tmp_path / "memory.db"
+        ledger_path = tmp_path / "decisions-ledger.md"
+        ledger_path.write_text("")
+
+        text = _make_text("⚖️ decided\n")
+        rc, _, _ = _run(
+            {"chat_id": 6036, "text": text},
+            env_overrides={
+                "DECIDED_DB_PATH": str(db_path),
+                "DECIDED_LEDGER_PATH": str(ledger_path),
+            },
+        )
+        assert rc == 0
+
+        with sqlite3.connect(str(db_path)) as conn:
+            rows = conn.execute("SELECT summary FROM decisions").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "decision reached"
+
+    def test_routing_failure_does_not_block_send(self, tmp_path):
+        """If the DB path is unwritable, the hook still exits 0 (does not block send_reply)."""
+        ledger_path = tmp_path / "decisions-ledger.md"
+        ledger_path.write_text("")
+
+        text = _make_text("⚖️ decided  proceed with plan B\n")
+        rc, _, _ = _run(
+            {"chat_id": 6036, "text": text},
+            env_overrides={
+                "DECIDED_DB_PATH": "/nonexistent/path/memory.db",
+                "DECIDED_LEDGER_PATH": str(ledger_path),
+            },
+        )
+        assert rc == 0
+
+    def test_non_send_reply_tool_is_skipped(self):
+        """The hook ignores non-send_reply tool calls."""
+        text = _make_text("⚖️ decided  something important\n")
+        rc, _, _ = _run(
+            {"chat_id": 6036, "text": text},
+            tool_name="mcp__lobster-inbox__mark_processed",
+        )
+        assert rc == 0


### PR DESCRIPTION
## Summary

- **`hooks/signal-footer-check.py`** — Added `route_decided()` function and a call to it in `main()` before `sys.exit(0)`. When a `side-effects:` block contains a `decided` line (with or without the ⚖️ emoji), the function writes the decision description to `memory.db` (decisions table, tagged `decision`) and appends a dated entry to `~/lobster-workspace/data/decisions-ledger.md`. All DB/file writes are wrapped in `try/except` so failures cannot block `send_reply`. Uses `DECIDED_DB_PATH` and `DECIDED_LEDGER_PATH` env vars for test isolation.
- **`tests/unit/test_hooks/test_signal_footer_decided.py`** — 8 tests covering: no-footer passthrough, side-effects without decided passthrough, emoji routing to DB, no-emoji routing to DB, ledger append, bare-decided fallback description, DB failure resilience, non-send_reply passthrough. All pass.
- **`~/lobster-workspace/design/dispatcher-emoji-legend.md`** (workspace file, not in repo) — Updated Core Legend from 10 to 11 signals, added ⚖️ decided row, added "The decide → decided pair" section, updated version history to v6.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_hooks/test_signal_footer_decided.py -v` — all 8 pass
- [x] Legend updated: ⚖️ decided row visible in Core Legend (11 signals)
- [x] Routing does not block send_reply on DB failure (exit 0 confirmed)

WOS-UoW: uow_20260525_4e9b36

🤖 Generated with [Claude Code](https://claude.com/claude-code)