### PR TITLE
docs: annotate haiku tier table with model pin and review trigger

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -400,7 +400,9 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 |------|-------|---------|------|
 | **High** | `opus` | Complex coding, architecture, debugging | 1x (baseline) |
 | **Standard** | `sonnet` | Planning, research, execution, synthesis | 0.6x |
-| **Light** | `haiku` | Verification, plan-checking, integration checks | 0.2x |
+| **Light** | `haiku` (pinned: `claude-haiku-4-5-20251001`) | Verification, plan-checking, integration checks | 0.2x |
+
+> **Haiku pin note:** Haiku agents are currently pinned to `claude-haiku-4-5-20251001` rather than the shorthand `claude-haiku-4-5`, for release stability and cost predictability. When `claude-haiku-4-6` is confirmed available (consistent with the 4-6 naming pattern used by Opus and Sonnet), update both `lobster-ops.md` and `session-note-appender.md` frontmatter and remove this note.
 
 **Agent model assignments:**
 


### PR DESCRIPTION
## Summary

- The tier table in `sys.subagent.bootup.md` showed only `haiku` with no model specifier, hiding the fact that haiku agents are pinned to `claude-haiku-4-5-20251001`
- Added the specific pinned model ID inline in the Haiku row
- Added a pin rationale note explaining the stability/cost motivation and a review trigger for when `claude-haiku-4-6` ships

## Files changed

- `.claude/sys.subagent.bootup.md` — tier table Haiku row + pin note

## Test plan

- [x] Read the tier table in `sys.subagent.bootup.md` and confirm the Haiku row shows the pinned model ID
- [x] Confirm the pin rationale note appears between the table and the agent assignments list
- [x] No other files changed

WOS-UoW: uow_20260525_e2f317

🤖 Generated with [Claude Code](https://claude.com/claude-code)