### PR TITLE
fix: replace chat_id=0 proactive-send exemption with proactive=True flag

### DIFF
--- a/hooks/require-reply-to-message-id.py
+++ b/hooks/require-reply-to-message-id.py
@@ -8,7 +8,7 @@ but omit or set reply_to_message_id=0.
 
 Exemptions (always allowed):
   - Non-Telegram sources (slack, sms, whatsapp, bot-talk, system, ...)
-  - System/proactive sends where chat_id == 0 (no incoming message context)
+  - Proactive/system sends where proactive=True (no incoming message context)
   - Calls where reply_to_message_id is already set to a positive integer
 
 Exit codes:
@@ -42,13 +42,9 @@ def main() -> None:
     if source != "telegram":
         sys.exit(0)
 
-    # Exempt proactive/system sends: chat_id == 0 means no originating user message
-    chat_id = tool_input.get("chat_id")
-    try:
-        if int(chat_id) == 0:
-            sys.exit(0)
-    except (TypeError, ValueError):
-        # chat_id absent or non-numeric — cannot determine, allow
+    # Exempt proactive/system sends: proactive=True means no originating user message,
+    # so no reply_to_message_id is available or required.
+    if tool_input.get("proactive") is True:
         sys.exit(0)
 
     # Check reply_to_message_id: must be present and a positive integer
@@ -66,7 +62,8 @@ def main() -> None:
         "Telegram message ID shown in wait_for_messages output as\n"
         "'pass as reply_to_message_id') to thread the reply correctly.\n\n"
         "If this is a proactive/system send with no originating message,\n"
-        "pass chat_id=0 to exempt this check.",
+        "pass proactive=True (and keep chat_id set to the real recipient).\n"
+        "Do NOT pass chat_id=0 — the bot gate treats 0 as falsy and drops the message.",
         file=sys.stderr,
     )
     sys.exit(2)

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1947,6 +1947,15 @@ async def list_tools() -> list[Tool]:
                             "even if the subagent forgets to pass sent_reply_to_user=True."
                         ),
                     },
+                    "proactive": {
+                        "type": "boolean",
+                        "description": (
+                            "Set to true for proactive/system sends that have no originating user message "
+                            "and therefore no reply_to_message_id to thread against. "
+                            "Bypasses the require-reply-to-message-id hook without corrupting chat_id. "
+                            "chat_id must still be the real recipient — do not pass chat_id=0."
+                        ),
+                    },
                 },
                 "required": ["chat_id", "text"],
             },

--- a/tests/unit/test_hooks/test_require_reply_to_message_id.py
+++ b/tests/unit/test_hooks/test_require_reply_to_message_id.py
@@ -7,7 +7,7 @@ Tests cover:
 - Telegram send_reply missing reply_to_message_id is blocked (exit 2)
 - Telegram send_reply with reply_to_message_id=0 is blocked (exit 2)
 - Non-Telegram source passes through (exit 0)
-- chat_id=0 (proactive/system send) passes through (exit 0)
+- proactive=True (proactive/system send) passes through (exit 0)
 - Absent source defaults to telegram enforcement (exit 2 when no reply_to_message_id)
 - Malformed input passes through (exit 0 fail-open)
 - Block message contains actionable text in stderr
@@ -103,14 +103,36 @@ class TestRequireReplyToMessageId:
         })
         assert rc == 0
 
-    def test_proactive_send_chat_id_zero_is_exempt(self):
-        """chat_id=0 means no originating message — proactive send is allowed."""
+    def test_proactive_send_flag_is_exempt(self):
+        """proactive=True means no originating message — proactive send is allowed."""
         rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Good morning!",
+            "proactive": True,
+        })
+        assert rc == 0
+
+    def test_proactive_false_does_not_exempt(self):
+        """proactive=False does not bypass the reply_to_message_id requirement."""
+        rc, _, stderr = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+            "proactive": False,
+        })
+        assert rc == 2
+        assert "reply_to_message_id" in stderr
+
+    def test_chat_id_zero_is_no_longer_exempt(self):
+        """chat_id=0 alone no longer bypasses the hook — proactive=True is required."""
+        rc, _, stderr = _run({
             "source": "telegram",
             "chat_id": 0,
             "text": "Good morning!",
         })
-        assert rc == 0
+        assert rc == 2
+        assert "reply_to_message_id" in stderr
 
     def test_malformed_input_fails_open(self):
         """Unparseable JSON input allows the call rather than blocking it."""
@@ -140,4 +162,4 @@ class TestRequireReplyToMessageId:
             "text": "Hello!",
         })
         assert rc == 2
-        assert "chat_id=0" in stderr
+        assert "proactive=True" in stderr


### PR DESCRIPTION
## Summary

- **Bug**: `require-reply-to-message-id` hook exempted proactive sends via `chat_id=0`, but the Telegram bot send gate (`if chat_id and text and bot_app:`) treats `0` as falsy — silently dropping those messages
- **Fix**: Add a `proactive` boolean parameter to `send_reply`; hook checks `proactive=True` instead of `chat_id==0`; chat_id must always be the real recipient
- **Caller audit**: No existing callers use `chat_id=0` as a `send_reply` proactive bypass — all `chat_id=0` usages in the codebase are internal inbox message routing (JSON files written directly), not MCP `send_reply` calls

## Changes

**`src/mcp/inbox_server.py`** — Added `proactive` boolean to `send_reply` inputSchema with description explaining the correct usage pattern.

**`hooks/require-reply-to-message-id.py`** — Replaced `int(chat_id) == 0` exemption block with `tool_input.get("proactive") is True` check. Updated error message to guide callers toward `proactive=True` and away from `chat_id=0`.

**`tests/unit/test_hooks/test_require_reply_to_message_id.py`** — Updated tests: `test_proactive_send_flag_is_exempt` (real chat_id + `proactive=True` passes), `test_proactive_false_does_not_exempt`, `test_chat_id_zero_is_no_longer_exempt`, and guidance stderr assertion updated from `chat_id=0` to `proactive=True`.

## Test plan

- [x] All 13 hook unit tests pass in both main worktree and clean worktree
- [x] `proactive=True` with real `chat_id` → exit 0 (allowed)
- [x] `proactive=False` without `reply_to_message_id` → exit 2 (blocked)
- [x] `chat_id=0` without `proactive=True` → exit 2 (no longer exempt)
- [x] Caller audit: zero callers use `chat_id=0` as a send_reply proactive bypass

WOS-UoW: uow_20260525_75dceb

🤖 Generated with [Claude Code](https://claude.com/claude-code)