### PR TITLE
fix: correct STATUS_ORDER in dispatcher-wos-query.md

### DIFF
--- a/scheduled-tasks/tasks/dispatcher-wos-query.md
+++ b/scheduled-tasks/tasks/dispatcher-wos-query.md
@@ -46,17 +46,20 @@ if dashboard_path.exists():
 # Build pipeline summary lines, ordered by relevance
 STATUS_ORDER = [
     "active",
+    "executing",
+    "ready-for-executor",
     "ready-for-steward",
+    "diagnosing",
     "needs-human-review",
+    "awaiting-owner",
     "blocked",
     "pending",
     "proposed",
-    "executing",
-    "paused",
-    "completed",
+    "failed",
     "done",
     "expired",
     "cancelled",
+    "closed",
 ]
 
 active_count = status_counts.get("active", 0)


### PR DESCRIPTION
## Problem

`STATUS_ORDER` in `scheduled-tasks/tasks/dispatcher-wos-query.md` contained phantom status values that no `UoWStatus` DB row can ever carry, and was missing real statuses from the canonical `UoWStatus` enum.

**Phantom values** (in STATUS_ORDER, absent from UoWStatus enum):
- `"paused"` — never a valid UoWStatus value
- `"completed"` — never a valid UoWStatus value (the correct terminal value is `"done"`)

**Missing values** (in UoWStatus enum, absent from STATUS_ORDER):
- `"ready-for-executor"` — queued for executor dispatch
- `"diagnosing"` — investigation/diagnosis state
- `"awaiting-owner"` — waiting on owner decision
- `"failed"` — terminal failure state (highest-signal failure, was falling to the `extras` fallback at the bottom of the display)
- `"closed"` — legacy terminal status (equivalent to `"done"`, exists in production DB rows)

## Changes

- Removed phantom values: `"paused"`, `"completed"`
- Added missing values: `"ready-for-executor"`, `"diagnosing"`, `"awaiting-owner"`, `"failed"`, `"closed"`
- Reordered for signal priority:
  1. Execution states: `active`, `executing`, `ready-for-executor`, `ready-for-steward`
  2. Escalation/blocked: `diagnosing`, `needs-human-review`, `awaiting-owner`, `blocked`
  3. Intake queue: `pending`, `proposed`
  4. Terminal (failure first): `failed`, `done`, `expired`, `cancelled`, `closed`

## Verification

STATUS_ORDER values now exactly match the canonical status set defined in `src/orchestration/registry.py:47` (`UoWStatus` StrEnum). The `extras` fallback still handles any future status additions gracefully.

This issue was previously recorded in `oracle/learnings.md` (PR #1172 entry) as a detection-pattern learning. This PR closes the actual fix.

WOS-UoW: uow_20260525_835c08