### PR TITLE
fix: sweep orchestration/outputs/ in artifacts cleanup script

### DIFF
--- a/scheduled-tasks/orchestration-artifacts-cleanup.py
+++ b/scheduled-tasks/orchestration-artifacts-cleanup.py
@@ -32,6 +32,7 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 ARTIFACTS_DIR = Path.home() / "lobster-workspace/orchestration/artifacts"
+OUTPUTS_DIR = Path.home() / "lobster-workspace/orchestration/outputs"
 KEEP_DAYS = 14
 KEEP_MIN_COUNT = 500
 DELETE_AFTER_DAYS = 30
@@ -84,6 +85,20 @@ def main() -> None:
         deleted,
         after,
     )
+
+    if not OUTPUTS_DIR.exists():
+        log.warning("Directory not found: %s — skipping.", OUTPUTS_DIR)
+    else:
+        before_out = sum(1 for f in OUTPUTS_DIR.iterdir() if f.is_file())
+        kept_out, deleted_out = cleanup_dir(OUTPUTS_DIR)
+        after_out = sum(1 for f in OUTPUTS_DIR.iterdir() if f.is_file())
+        log.info(
+            "orchestration/outputs/: before=%d kept=%d deleted=%d after=%d",
+            before_out,
+            kept_out,
+            deleted_out,
+            after_out,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `OUTPUTS_DIR = Path.home() / "lobster-workspace/orchestration/outputs"` constant directly below `ARTIFACTS_DIR`
- In `main()`, adds a parallel `cleanup_dir(OUTPUTS_DIR)` block after the existing `artifacts/` block with the same guard and logging pattern
- Reuses existing constants (`KEEP_DAYS=14`, `KEEP_MIN_COUNT=500`, `DELETE_AFTER_DAYS=30`) — no new constants introduced
- Verified: script runs cleanly and logs two lines (`orchestration/artifacts/:` and `orchestration/outputs/:`)

Before this fix, `outputs/` had accumulated 3,582 files with no retention enforcement. After first run: reduced to 1,523 files.

## Test plan

- [x] Run `uv run scheduled-tasks/orchestration-artifacts-cleanup.py` — confirmed two log lines appear with plausible kept/deleted counts
- [x] Script exits cleanly (no errors)
- [x] `OUTPUTS_DIR` referenced in the script and `cleanup_dir()` called on it in `main()`

WOS-UoW: uow_20260525_84ddc8