### PR TITLE
fix: correct stale data/registry.db default path in wos-status scripts (#1293)

### DIFF
--- a/scripts/wos-status.sh
+++ b/scripts/wos-status.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-DB_PATH="${1:-${REGISTRY_DB_PATH:-${HOME}/lobster-workspace/data/registry.db}}"
+DB_PATH="${1:-${REGISTRY_DB_PATH:-${HOME}/lobster-workspace/orchestration/registry.db}}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/scripts/wos_active_summary.py
+++ b/scripts/wos_active_summary.py
@@ -33,7 +33,7 @@ def main() -> None:
     else:
         db_path_str = os.environ.get(
             "REGISTRY_DB_PATH",
-            str(Path.home() / "lobster-workspace" / "data" / "registry.db"),
+            str(Path.home() / "lobster-workspace" / "orchestration" / "registry.db"),
         )
 
     db_path = Path(db_path_str).expanduser()


### PR DESCRIPTION
## Summary

- Fixes `scripts/wos-status.sh` default DB path from `data/registry.db` to `orchestration/registry.db`
- Fixes `scripts/wos_active_summary.py` default DB path from `data/registry.db` to `orchestration/registry.db`
- Closes #1293

## Context

`~/lobster-workspace/data/registry.db` (73 KB, last updated 2026-05-18) is a stale orphan. The live registry is `~/lobster-workspace/orchestration/registry.db` (645 MB). These two scripts were the only remaining consumers using the wrong default path. Every other consumer in the codebase (`src/orchestration/paths.py`, `executor-heartbeat.py`, `steward-heartbeat.py`, `registry_cli.py`, `analytics.py`, etc.) already uses `orchestration/registry.db`.

Running `wos-status.sh` without the `REGISTRY_DB_PATH` env var override would silently return stale or wrong data from the orphaned file.

## Test plan

- [ ] Run `scripts/wos-status.sh` without `REGISTRY_DB_PATH` set — should read from `orchestration/registry.db` and return active UoWs
- [ ] Run `scripts/wos_active_summary.py` without `REGISTRY_DB_PATH` set — same result
- [ ] Confirm `data/registry.db` is not touched by either script after the fix

## Follow-up (not in this PR)

The orphaned `data/registry.db` file should be removed or tombstoned after this PR merges. That is a runtime cleanup, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)