### PR TITLE
fix(vault-processor): call journal scanner after annotation sync

### DIFF
--- a/scheduled-tasks/vault-processor.py
+++ b/scheduled-tasks/vault-processor.py
@@ -527,6 +527,25 @@ def run_processor(config: dict, db_path: Path = DB_PATH_DEFAULT) -> bool:
         except Exception as e:
             log.error("Error processing annotations in %s: %s", scan_file, e)
 
+    # Step 5b: journal checkbox scan — extract - [ ] items from new/changed journal files
+    log.info("Step 5b: journal checkbox scan")
+    try:
+        from src.utils.jobs import is_job_enabled as _is_job_enabled
+        if _is_job_enabled("vault-journal-scanner"):
+            import importlib.util as _ilu
+            _scanner_path = _TASKS_DIR / "vault-journal-scanner.py"
+            _spec = _ilu.spec_from_file_location("vault_journal_scanner", _scanner_path)
+            _scanner = _ilu.module_from_spec(_spec)
+            _spec.loader.exec_module(_scanner)
+            _j_state = _scanner.load_scanner_state(_scanner.STATE_FILE_PATH)
+            _, _, _j_updated = _scanner.scan_vault(vault_path, db_path, _j_state)
+            _scanner.save_scanner_state(_scanner.STATE_FILE_PATH, _j_updated)
+            log.info("Step 5b: journal scan complete")
+        else:
+            log.debug("Step 5b: vault-journal-scanner disabled in jobs.json — skipping")
+    except Exception as _exc:
+        log.warning("Step 5b: journal scan failed (non-fatal): %s", _exc)
+
     # Step 6: git add annotation-cleared files
     if staging_files:
         log.info("Step 6: git add %d annotation-cleared files", len(staging_files))


### PR DESCRIPTION
## Summary

- Wires vault-processor to call vault-journal-scanner after each annotation scan step (Step 5b)
- Provides immediate checkbox extraction on vault push (rather than waiting up to 1 hour for the cron)
- Gated on `is_job_enabled("vault-journal-scanner")` so jobs.json toggle controls both paths
- Uses `importlib` to load `vault-journal-scanner.py` by path (hyphenated filename is not a valid Python module name for direct import)

## Context

PR #1287 delivered the vault-journal-scanner script and migrations. This PR closes the remaining success criterion from uow_20260524_599c97: the vault-processor wiring step that runs the scanner synchronously on each vault sync cycle.

Machine-local migrations (jobs.json registration + crontab entry) were applied directly on this machine during the same UoW execution.

## Test plan
- [x] `uv run pytest tests/unit/los/test_vault_journal_scanner.py` passes (30/30)
- [x] vault-processor.py imports cleanly with the new wiring
- [ ] Confirm Step 5b log line appears in vault-processor output during a dry-run

WOS-UoW: uow_20260524_599c97

🤖 Generated with [Claude Code](https://claude.com/claude-code)