### PR TITLE
hygiene: remove dead oracle frontmatter from lobster-oracle.md agent definition

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -6,9 +6,6 @@ description: >
   Writes to oracle/verdicts/pr-{number}.md and oracle/learnings.md.
   Surfaces premise-level patterns as raw observations to meta/premise-review.md.
 model: claude-opus-4-6
-oracle_status: approved
-oracle_pr: https://github.com/SiderealPress/lobster/pull/864
-oracle_date: "2026-04-23"
 ---
 
 You are a Lobster subagent. Do NOT call `wait_for_messages`. Call `send_reply` and `write_result` when complete.

--- a/docs/oracle-review-protocol.md
+++ b/docs/oracle-review-protocol.md
@@ -81,12 +81,6 @@ Do NOT apply to:
 - Short reference stubs or index files
 - Internal scaffolding files
 
-### oracle_status frontmatter on agent definitions
-
-The `oracle_status: approved` field in `.claude/agents/lobster-oracle.md` is **not a template** for other agent definitions. It is present on the oracle agent only as an exceptional self-applying test — the oracle agent definition is itself a substantial document (it was reviewed in PR #864) and carries frontmatter to record that review status, exactly as any other substantial document would.
-
-No other agent definition requires `oracle_status` frontmatter. No code reads this field from agent definitions. Adding it to other agent definitions has no behavioral effect and should not be done.
-
 ## Integration with Delivery
 
 See `sys.subagent.bootup.md` for the pre-delivery check: before calling `send_reply` to deliver a substantial document, verify that `oracle_status: approved` is present in its frontmatter. If not, use `write_task_output` with `status=pending` and stop.


### PR DESCRIPTION
## Summary

Closes #1272

The three frontmatter fields (`oracle_status`, `oracle_pr`, `oracle_date`) in `.claude/agents/lobster-oracle.md` were confirmed dead. A grep across `src/`, `.claude/`, and `scripts/` found no code that reads these fields from agent definition files. Claude Code's agent loader reads only `name`, `description`, `model`, and `tools` from frontmatter — all other fields are silently ignored at load time. The `oracle_status` field is read by `sys.subagent.bootup.md`, but only from *documents being delivered*, not from agent definitions. The subsection in `oracle-review-protocol.md` titled "oracle_status frontmatter on agent definitions" existed solely to rationalize having these fields on the oracle agent definition itself; with the fields removed, the subsection has no referent. The existing "Do NOT apply to: Bootup files and configuration files" rule already covers agent definitions.

WOS-UoW: uow_20260523_c8591e