### PR TITLE
config: remove stray subagent_type field from lobster-auditor.md frontmatter

### DIFF
--- a/.claude/agents/lobster-auditor.md
+++ b/.claude/agents/lobster-auditor.md
@@ -2,7 +2,6 @@
 name: lobster-auditor
 description: Investigates system health, diagnosing failures in background processes, queues, hooks, and scheduled jobs across any deployment.
 model: claude-sonnet-4-6
-subagent_type: lobster-auditor
 ---
 
 > **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `write_result` when your investigation is complete (see Reporting section for protocol).


### PR DESCRIPTION
## Summary

- Removes the `subagent_type: lobster-auditor` line from `.claude/agents/lobster-auditor.md` frontmatter
- The field is not a standard Claude Code agent definition key
- Runtime dispatch reads `agent_type` from inbox message payloads (`msg["agent_type"]`), not from agent definition frontmatter
- Confirmed via `grep`: no code in `src/` reads `subagent_type` from agent definition files

## Verification

```bash
# Confirmed: no source code reads subagent_type from frontmatter
grep -r 'frontmatter\|agent_def\|\.claude/agents' ~/lobster/src/ | grep -i subagent_type
# Result: no text matches (only binary cache files)

# Confirmed: no other agent definition files carry this field in frontmatter
grep 'subagent_type' .claude/agents/*.md
# Result: only references in body text (agent call parameters), not frontmatter
```

Closes #1271

WOS-UoW: uow_20260523_18ab51