### PR TITLE
docs: add canonical WOS acronym definition to vocabulary layer

### DIFF
--- a/docs/wos/current/INDEX.md
+++ b/docs/wos/current/INDEX.md
@@ -11,6 +11,14 @@ documents.
 
 ---
 
+## Acronym Reference
+
+**WOS** — Work Orchestration System
+
+The system that classifies, routes, and executes Units of Work (UoWs) through a structured pipeline from observation to completion. All WOS-prefixed components, schemas, and configuration keys refer to this system.
+
+---
+
 ## Component Map
 
 ### Germinator (`src/orchestration/germinator.py`)


### PR DESCRIPTION
## Summary

- Adds an explicit **Acronym Reference** section to `docs/wos/current/INDEX.md` defining WOS as "Work Orchestration System"
- Resolves structural smell: 100+ uses of WOS acronym with no canonical definition in the vocabulary layer
- Closes #1270
- Sourced from UoW `uow_20260523_7cc995`

## What changed

Added a new `## Acronym Reference` section before `## Component Map` in the WOS component glossary. The expansion was already present inline in `overview.md` but not surfaced as a term-level entry any agent or reader could locate directly.

## Test plan
- [x] `docs/wos/current/INDEX.md` contains "WOS — Work Orchestration System" before the Component Map section
- [x] No existing docs broken or restructured

WOS-UoW: uow_20260523_7cc995