### PR TITLE
fix(wos): SubagentStop hook fails WOS UoWs immediately on orphan exit

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -569,6 +569,18 @@ def main():
         content = _extract_pre_hook_text(transcript, first_fire_ts, _FALLBACK_TURNS)
         _write_synthetic_inbox_message(data, content, task_id_hint)
 
+        # If this is a WOS executor task, mark the UoW as explicitly failed now
+        # rather than waiting for the TTL orphan sweep (issue: executing_orphan gap).
+        if task_id_hint and task_id_hint.startswith("wos-uow_"):
+            try:
+                hooks_dir = Path(__file__).parent
+                repo_src = hooks_dir.parent / "src"
+                sys.path.insert(0, str(repo_src))
+                from orchestration.wos_completion import maybe_fail_wos_uow  # noqa: PLC0415
+                maybe_fail_wos_uow(task_id_hint, reason="orphan_exit")
+            except Exception:
+                pass  # Never block the hook's exit path
+
         # Clean up the fire-count temp file.
         key = _agent_key(data)
         _cleanup_fire_state(_fire_count_path(key))

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -980,3 +980,75 @@ def maybe_complete_wos_uow(
             type(exc).__name__,
             exc,
         )
+
+
+def maybe_fail_wos_uow(task_id: str, reason: str) -> None:
+    """
+    Transition a WOS UoW from 'executing' to 'failed' when its subagent exits
+    without calling write_result.
+
+    Called by the SubagentStop hook (require-write-result.py) after MAX_HOOK_FIRES
+    exhaustion to convert a silent orphan into an explicit failure the steward can
+    handle immediately, rather than waiting for TTL orphan sweep (10–600 min).
+
+    Conditions required to fire:
+    - task_id starts with "wos-uow_" (executor dispatch task_ids only; excludes
+      wos-diagnose-*, wos-surface-*, and other non-executor wos- prefixed tasks)
+    - UoW exists in the registry with status == "executing"
+
+    A UoW not in 'executing' status is skipped silently (already recovered or
+    the TTL sweep fired first).
+
+    Errors are logged and swallowed — must never block the hook's exit path.
+
+    Args:
+        task_id: The task_id extracted from the transcript (format: "wos-uow_<id>").
+        reason:  Short failure reason string written to the audit log (e.g. "orphan_exit").
+    """
+    _WOS_UOW_EXECUTOR_PREFIX = "wos-uow_"
+    if not task_id.startswith(_WOS_UOW_EXECUTOR_PREFIX):
+        return
+
+    uow_id = task_id[len(WOS_TASK_ID_PREFIX):]  # strips "wos-", leaving "uow_<id>"
+    try:
+        from orchestration.registry import Registry, UoWStatus
+        from orchestration.paths import REGISTRY_DB
+
+        db_path = REGISTRY_DB
+        if not db_path.exists():
+            log.debug(
+                "maybe_fail_wos_uow: registry DB not found at %s — skipping",
+                db_path,
+            )
+            return
+
+        registry = Registry()
+        uow = registry.get(uow_id)
+        if uow is None:
+            log.debug(
+                "maybe_fail_wos_uow: UoW %r not found in registry — skipping",
+                uow_id,
+            )
+            return
+
+        if uow.status != UoWStatus.EXECUTING:
+            log.debug(
+                "maybe_fail_wos_uow: UoW %r is in status %r (expected 'executing') — "
+                "skipping (already recovered by TTL sweep or duplicate call)",
+                uow_id,
+                uow.status,
+            )
+            return
+
+        registry.fail_uow(uow_id, reason=reason)
+        log.info(
+            "maybe_fail_wos_uow: UoW %r transitioned executing → failed "
+            "(orphan exit detected by SubagentStop hook, reason=%r)",
+            uow_id,
+            reason,
+        )
+    except Exception as exc:
+        log.warning(
+            "maybe_fail_wos_uow: failed for UoW %r — %s: %s",
+            uow_id, type(exc).__name__, exc,
+        )

--- a/tests/unit/test_orchestration/test_wos_completion.py
+++ b/tests/unit/test_orchestration/test_wos_completion.py
@@ -45,6 +45,7 @@ from orchestration.wos_completion import (
     _write_steward_trigger,
     classify_uow_output,
     maybe_complete_wos_uow,
+    maybe_fail_wos_uow,
 )
 from orchestration.registry import Registry, UoWStatus, UpsertInserted
 
@@ -1776,3 +1777,94 @@ class TestTokenUsageInResultJson:
             f"Pre-existing token_usage=5000 must not be overwritten. "
             f"Got {payload.get(TOKEN_USAGE_FIELD)!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# maybe_fail_wos_uow — orphan exit explicit failure path
+# ---------------------------------------------------------------------------
+
+class TestMaybeFailWosUow:
+    """Behavioral tests for maybe_fail_wos_uow."""
+
+    def test_maybe_fail_wos_uow_transitions_executing_to_failed(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Core behavior: a UoW in 'executing' status is transitioned to 'failed'
+        when maybe_fail_wos_uow is called with the matching task_id.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id = _seed_uow_at_status(registry, "executing", output_dir)
+        task_id = f"wos-{uow_id}"  # "wos-uow_<id>" format
+
+        with patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            maybe_fail_wos_uow(task_id, reason="orphan_exit")
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.status == UoWStatus.FAILED, (
+            f"Executing UoW must be transitioned to 'failed' by maybe_fail_wos_uow, "
+            f"got {uow.status}"
+        )
+
+    def test_maybe_fail_wos_uow_skips_non_executor_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        task_id "wos-diagnose-abc123" does not start with "wos-uow_" so
+        fail_uow must not be called.
+        """
+        db_path = tmp_path / "registry.db"
+        Registry(db_path)  # Initialize schema only
+
+        with patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            # Must not raise and must not touch any UoW
+            maybe_fail_wos_uow("wos-diagnose-abc123", reason="orphan_exit")
+
+        import sqlite3
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM uow_registry").fetchone()[0]
+        conn.close()
+        assert count == 0, "Non-executor task_id prefix must not create or modify any UoW records"
+
+    def test_maybe_fail_wos_uow_skips_non_executing_status(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A UoW already in 'failed' status must not be re-transitioned.
+        """
+        db_path = tmp_path / "registry.db"
+        output_dir = tmp_path / "outputs"
+        output_dir.mkdir()
+        registry = Registry(db_path)
+
+        uow_id = _seed_uow_at_status(registry, "executing", output_dir)
+        registry.set_status_direct(uow_id, "failed")
+
+        task_id = f"wos-{uow_id}"
+
+        with patch.dict(os.environ, {"REGISTRY_DB_PATH": str(db_path)}):
+            # Must not raise, status must remain 'failed'
+            maybe_fail_wos_uow(task_id, reason="orphan_exit")
+
+        uow = registry.get(uow_id)
+        assert uow is not None
+        assert uow.status == UoWStatus.FAILED, (
+            f"A UoW in 'failed' status must not be retransitioned; got {uow.status}"
+        )
+
+    def test_maybe_fail_wos_uow_skips_missing_db(self, tmp_path: Path) -> None:
+        """
+        When REGISTRY_DB does not exist, maybe_fail_wos_uow must return silently
+        without raising an exception.
+        """
+        nonexistent_db = tmp_path / "no_such.db"
+        task_id = "wos-uow_20260522_cf8707"
+
+        with patch.dict(os.environ, {"REGISTRY_DB_PATH": str(nonexistent_db)}):
+            # Must not raise
+            maybe_fail_wos_uow(task_id, reason="orphan_exit")


### PR DESCRIPTION
## Problem

93.4% of WOS UoW failures are `executing_orphan` — subagents exit without calling `write_result` and the UoW sits in `executing` status waiting for the TTL orphan sweep (up to 10–600 minutes) to reclassify it. The `require-write-result.py` SubagentStop hook already has a give-up fallback path after `MAX_HOOK_FIRES` (5) retries, where it writes a synthetic inbox message and exits. That fallback path did not notify the WOS registry, leaving UoWs as silent orphans.

## Solution

- **Added `maybe_fail_wos_uow(task_id, reason)`** to `src/orchestration/wos_completion.py` — explicitly transitions a UoW from `executing` → `failed` when called. Scoped to executor dispatch task_ids only (`wos-uow_` prefix), skipping `wos-diagnose-*`, `wos-surface-*`, and other WOS prefixes. Errors are logged and swallowed so they never block the hook's exit path.

- **Wired into `hooks/require-write-result.py`** in the `fire_count > MAX_HOOK_FIRES` branch, after `_write_synthetic_inbox_message` and before `_cleanup_fire_state`. When the extracted `task_id_hint` starts with `wos-uow_`, the hook calls `maybe_fail_wos_uow` to fail the UoW immediately rather than waiting for TTL recovery.

- **Verified regex coverage**: the existing task_id extraction regex `task[_\s-]?id\s*(?:is\s*)?[:\-]?\s*([A-Za-z0-9_-]+)` already matches YAML frontmatter (`task_id: wos-uow_...`) and legacy inline format (`Your task_id is: wos-uow_...`). No regex change needed.

## Tests

4 new unit tests added to `tests/unit/test_orchestration/test_wos_completion.py`:

1. `test_maybe_fail_wos_uow_transitions_executing_to_failed` — executing UoW → failed
2. `test_maybe_fail_wos_uow_skips_non_executor_prefix` — `wos-diagnose-abc123` → no-op
3. `test_maybe_fail_wos_uow_skips_non_executing_status` — already-failed UoW → no-op
4. `test_maybe_fail_wos_uow_skips_missing_db` — absent DB → no exception

All 89 tests in the file pass.

WOS-UoW: uow_20260522_cf8707