### PR TITLE
refactor(wos): promote _WOS_UOW_EXECUTOR_PREFIX to module scope

### DIFF
--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -66,6 +66,11 @@ def _import_lifecycle() -> None:
 #: Prefix used by route_wos_message to form the task_id for wos_execute dispatches.
 WOS_TASK_ID_PREFIX = "wos-"
 
+#: Narrower prefix identifying executor-dispatched UoWs specifically (excludes
+#: wos-diagnose-*, wos-surface-*, and other non-executor wos- prefixed tasks).
+#: Used by maybe_fail_wos_uow to guard against failing non-executor UoWs.
+_WOS_UOW_EXECUTOR_PREFIX = "wos-uow_"
+
 #: write_result status value that signals successful subagent completion.
 WRITE_RESULT_SUCCESS_STATUS = "success"
 
@@ -1005,7 +1010,6 @@ def maybe_fail_wos_uow(task_id: str, reason: str) -> None:
         task_id: The task_id extracted from the transcript (format: "wos-uow_<id>").
         reason:  Short failure reason string written to the audit log (e.g. "orphan_exit").
     """
-    _WOS_UOW_EXECUTOR_PREFIX = "wos-uow_"
     if not task_id.startswith(_WOS_UOW_EXECUTOR_PREFIX):
         return
 


### PR DESCRIPTION
## Summary

The `_WOS_UOW_EXECUTOR_PREFIX` constant was defined inside `maybe_fail_wos_uow`'s function body, re-allocating on every call. This mirrors the pattern flagged in learnings.md PR #967 (gate frozenset defined inside a function body).

Promoted to module scope alongside `WOS_TASK_ID_PREFIX` for consistency. No behavioral change — the constant value ("wos-uow_") and all call sites remain identical.

**Out of scope:** This PR touches only the constant's location within wos_completion.py. No logic changes, no new functionality.

**Functional patterns:** Module-scope constant replaces per-call allocation — a pure structural improvement.

Relates to oracle verdict on PR #1331 (minor finding: promote constant to module scope).

WOS-UoW: uow_20260522_cf8707

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_completion.py -v -k "maybe_fail"` — 4 passed, 0 failed

## Manual test
N/A — pure refactor moving a constant definition from function scope to module scope. No systemd, cron, external services, file I/O, or DB schema changes.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, refactor only
- [x] User-visible outcome verified OR not applicable — N/A, internal constant relocation
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)