### PR TITLE
feat: cookie-free token usage tracking via local session-file parser

### DIFF
--- a/scheduled-tasks/local-session-parser.py
+++ b/scheduled-tasks/local-session-parser.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""
+Local Session Parser — extract token usage from local Claude Code session files.
+
+Reads JSONL session files from ~/.claude/projects/-home-lobster-lobster-workspace/
+and accumulates per-day token counts without requiring a claude.ai session cookie.
+
+Writes two outputs:
+  1. ~/lobster-workspace/data/cc-usage.json — tokens_today, tokens_this_week,
+     per-day breakdown (input, output, cache_creation, cache_read).
+  2. ~/.claude/cc-budget/state.json — appends a ``token_usage`` section with the
+     same data, so the quota gate and morning briefing have a single state file to
+     consult. Does NOT overwrite ``rate_limits`` if they already exist and are fresh.
+
+Problem context: cc-usage-poller.py fetches quota percentages via a cookie that
+expired on 2026-05-17.  After expiry the poller is blind.  Session JSONL files at
+~/.claude/projects/-home-lobster-lobster-workspace/*.jsonl contain token usage in
+every ``assistant`` entry under ``message.usage``.  This script aggregates those
+counts and writes them to the cc-usage and cc-budget state files so the morning
+briefing and quota gate can surface real usage data even when the cookie is absent.
+
+Token fields extracted from each assistant entry:
+  - input_tokens
+  - output_tokens
+  - cache_creation_input_tokens
+  - cache_read_input_tokens
+
+Date attribution: uses the ``timestamp`` field (ISO 8601 UTC) on each entry.
+Falls back to the file's mtime if the entry has no timestamp.
+
+Cron schedule (every 30 minutes, offset from cc-usage-poller):
+    15,45 * * * * cd ~/lobster && uv run scheduled-tasks/local-session-parser.py >> ~/lobster-workspace/scheduled-jobs/logs/local-session-parser.log 2>&1 # LOBSTER-LOCAL-SESSION-PARSER
+
+Type B dispatch: cron calls this script directly (no inbox/ message, no
+dispatcher involvement). The jobs.json enabled gate is checked at the top
+of main() so that runtime enable/disable is respected without touching cron.
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/local-session-parser.py [--dry-run] [--verbose]
+
+Related issue: dcetlin/Lobster#740
+"""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import tempfile
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.jobs import is_job_enabled  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("local-session-parser")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Directory containing Claude Code session JSONL files for this workspace.
+SESSION_DIR: Path = (
+    Path.home() / ".claude" / "projects" / "-home-lobster-lobster-workspace"
+)
+
+# Output: token counts (independent of quota percentages)
+CC_USAGE_PATH: Path = Path.home() / "lobster-workspace" / "data" / "cc-usage.json"
+
+# Output: cc-budget state file (shared with cc-usage-poller and cc-usage-collect.sh)
+STATE_FILE_PATH: Path = Path.home() / ".claude" / "cc-budget" / "state.json"
+
+# Source tag written into state.json to identify local-parser data.
+SOURCE_TAG = "local-session-parser"
+
+# How many calendar days of history to include in the per-day breakdown.
+HISTORY_DAYS: int = 14
+
+# Seconds before state.json's rate_limits data is considered stale and
+# eligible to be cleared/replaced by local token_usage data.
+# 2 hours matches the threshold used by read_quota_state() / format_quota_message().
+POLLER_STALE_SECONDS: int = 2 * 60 * 60
+
+# 5-hour rolling window size in seconds — used for 5h token window computation.
+FIVE_HOUR_WINDOW_SECONDS: int = 5 * 60 * 60
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+def _empty_day_counts() -> dict[str, int]:
+    """Return a zeroed token count dict for one calendar day."""
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Session file discovery — pure, no side effects beyond filesystem reads
+# ---------------------------------------------------------------------------
+
+
+def discover_session_files(session_dir: Path) -> list[Path]:
+    """Return all *.jsonl session files in session_dir, sorted by name.
+
+    Returns an empty list if the directory does not exist or no files match.
+    This function never raises — missing directory is not an error.
+    """
+    if not session_dir.exists():
+        return []
+    return sorted(session_dir.glob("*.jsonl"))
+
+
+# ---------------------------------------------------------------------------
+# Single-entry extraction — pure function
+# ---------------------------------------------------------------------------
+
+
+def extract_usage_from_entry(entry: dict[str, Any]) -> tuple[str | None, dict[str, int]]:
+    """Extract date and token counts from one JSONL entry.
+
+    Returns ``(date_str, counts)`` where:
+    - ``date_str`` is a ``YYYY-MM-DD`` string (UTC) or None if the entry has
+      no date and should be skipped.
+    - ``counts`` is a token count dict (all values default to 0 for missing keys).
+
+    Only ``assistant`` entries carry usage data.  All other entry types return
+    ``(None, zeros)`` — the caller should skip these.
+
+    Pure function: no filesystem I/O, no side effects.
+    """
+    zeros = _empty_day_counts()
+
+    if entry.get("type") != "assistant":
+        return None, zeros
+
+    usage = entry.get("message", {}).get("usage", {})
+    if not usage:
+        return None, zeros
+
+    # Attribute to the UTC date from the entry's timestamp.
+    timestamp_str = entry.get("timestamp")
+    if timestamp_str:
+        try:
+            ts = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+            date_str = ts.strftime("%Y-%m-%d")
+        except ValueError:
+            return None, zeros
+    else:
+        return None, zeros
+
+    counts = {
+        "input_tokens": int(usage.get("input_tokens", 0)),
+        "output_tokens": int(usage.get("output_tokens", 0)),
+        "cache_creation": int(usage.get("cache_creation_input_tokens", 0)),
+        "cache_read": int(usage.get("cache_read_input_tokens", 0)),
+    }
+    return date_str, counts
+
+
+# ---------------------------------------------------------------------------
+# Session file parsing — reads one file, returns per-day counts
+# ---------------------------------------------------------------------------
+
+
+def parse_session_file(path: Path) -> dict[str, dict[str, int]]:
+    """Parse one JSONL session file and return per-day token counts.
+
+    Returns a dict mapping ``YYYY-MM-DD`` → token counts.  Lines that are
+    not valid JSON or not assistant entries are silently skipped.
+
+    Isolated side effect: reads one file from the filesystem.
+    """
+    daily: dict[str, dict[str, int]] = defaultdict(lambda: _empty_day_counts())
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        log.warning("Could not read session file %s: %s", path, exc)
+        return {}
+
+    for lineno, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            log.debug("Skipping malformed JSON at %s:%d", path.name, lineno)
+            continue
+
+        date_str, counts = extract_usage_from_entry(entry)
+        if date_str is None:
+            continue
+
+        day = daily[date_str]
+        for key in ("input_tokens", "output_tokens", "cache_creation", "cache_read"):
+            day[key] += counts[key]
+
+    return dict(daily)
+
+
+# ---------------------------------------------------------------------------
+# Aggregation across session files — pure transformation
+# ---------------------------------------------------------------------------
+
+
+def aggregate_daily_counts(
+    per_file: list[dict[str, dict[str, int]]],
+    cutoff_date: str,
+) -> dict[str, dict[str, int]]:
+    """Merge per-file daily counts into a single dict, filtering old dates.
+
+    Args:
+        per_file:    List of dicts from ``parse_session_file`` (one per file).
+        cutoff_date: ``YYYY-MM-DD`` string.  Dates strictly before this are dropped.
+
+    Returns a dict ``YYYY-MM-DD`` → merged token counts covering only dates
+    on or after ``cutoff_date``.
+
+    Pure function: no side effects.
+    """
+    merged: dict[str, dict[str, int]] = defaultdict(lambda: _empty_day_counts())
+
+    for file_daily in per_file:
+        for date_str, counts in file_daily.items():
+            if date_str < cutoff_date:
+                continue
+            day = merged[date_str]
+            for key in ("input_tokens", "output_tokens", "cache_creation", "cache_read"):
+                day[key] += counts[key]
+
+    return dict(merged)
+
+
+# ---------------------------------------------------------------------------
+# Summary statistics — pure computations over aggregated daily counts
+# ---------------------------------------------------------------------------
+
+
+def compute_tokens_today(daily: dict[str, dict[str, int]], today: str) -> int:
+    """Return the total token count (input + output) for today's UTC date."""
+    counts = daily.get(today, _empty_day_counts())
+    return counts["input_tokens"] + counts["output_tokens"]
+
+
+def compute_tokens_this_week(
+    daily: dict[str, dict[str, int]],
+    week_start: str,
+) -> int:
+    """Return the total token count (input + output) since ``week_start`` (inclusive).
+
+    ``week_start`` is a ``YYYY-MM-DD`` string.
+    """
+    total = 0
+    for date_str, counts in daily.items():
+        if date_str >= week_start:
+            total += counts["input_tokens"] + counts["output_tokens"]
+    return total
+
+
+def compute_five_hour_tokens(
+    session_files: list[Path],
+    cutoff_ts: datetime,
+) -> int:
+    """Return total tokens (input + output) from entries after ``cutoff_ts``.
+
+    Parses all session files and sums tokens for entries with timestamps
+    strictly after the cutoff.  This gives a rolling 5-hour window total.
+
+    Pure with respect to the filesystem: reads files but does not write.
+
+    Args:
+        session_files: List of JSONL file paths to scan.
+        cutoff_ts:     Timezone-aware datetime.  Entries before this are ignored.
+
+    Returns total int token count.
+    """
+    total = 0
+    for path in session_files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("type") != "assistant":
+                continue
+            ts_str = entry.get("timestamp")
+            if not ts_str:
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if ts <= cutoff_ts:
+                continue
+            usage = entry.get("message", {}).get("usage", {})
+            total += int(usage.get("input_tokens", 0))
+            total += int(usage.get("output_tokens", 0))
+    return total
+
+
+# ---------------------------------------------------------------------------
+# cc-usage.json writer — isolated side effect
+# ---------------------------------------------------------------------------
+
+
+def build_cc_usage(
+    daily: dict[str, dict[str, int]],
+    today: str,
+    week_start: str,
+    now_iso: str,
+) -> dict[str, Any]:
+    """Build the cc-usage.json payload from aggregated daily counts.
+
+    Pure function: all inputs are arguments; no file reads.
+    """
+    tokens_today = compute_tokens_today(daily, today)
+    tokens_this_week = compute_tokens_this_week(daily, week_start)
+
+    return {
+        "last_updated": now_iso,
+        "tokens_today": tokens_today,
+        "tokens_this_week": tokens_this_week,
+        "week_start": week_start,
+        "daily": {
+            date_str: {
+                "input_tokens": counts["input_tokens"],
+                "output_tokens": counts["output_tokens"],
+                "cache_creation": counts["cache_creation"],
+                "cache_read": counts["cache_read"],
+            }
+            for date_str, counts in sorted(daily.items())
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# state.json merger — pure function
+# ---------------------------------------------------------------------------
+
+
+def _poller_data_is_fresh(existing: dict[str, Any]) -> bool:
+    """Return True if the poller-written rate_limits data is still fresh.
+
+    Fresh means: ``last_updated`` is within ``POLLER_STALE_SECONDS`` AND
+    ``source`` is NOT ``local-session-parser`` (i.e. the poller or hook wrote it).
+
+    If last_updated is absent or unparseable, defaults to stale=True so local
+    data is surfaced rather than suppressed.
+    """
+    source = existing.get("source", "")
+    if source == SOURCE_TAG:
+        # Already our data — not "fresh poller data"
+        return False
+
+    last_updated_str = existing.get("last_updated")
+    if not last_updated_str:
+        return False
+
+    try:
+        ts = datetime.fromisoformat(last_updated_str.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - ts
+        return age.total_seconds() <= POLLER_STALE_SECONDS
+    except Exception:
+        return False
+
+
+def merge_token_usage_into_state(
+    existing: dict[str, Any],
+    daily: dict[str, dict[str, int]],
+    tokens_today: int,
+    tokens_this_week: int,
+    five_hour_tokens: int,
+    week_start: str,
+    now_iso: str,
+    now_unix: int,
+) -> dict[str, Any]:
+    """Merge local token counts into the existing state.json content.
+
+    Preserves ``rate_limits`` if poller data is still fresh (within 2 hours).
+    Always adds or replaces the ``token_usage`` section with local counts.
+    Updates ``source`` to ``local-session-parser`` only when rate_limits are stale.
+
+    Pure function: all inputs are arguments; no file reads.
+    """
+    updated = dict(existing)
+    updated["v"] = existing.get("v", 1)
+    updated["ts"] = now_unix
+
+    # Preserve fresh poller/hook rate_limits — the local parser only supplements.
+    # When poller data is stale, clear rate_limits so the quota gate knows not to
+    # use stale percentages.  (The gate is fail-open: None → proceed normally.)
+    poller_fresh = _poller_data_is_fresh(existing)
+    if not poller_fresh and existing.get("rate_limits"):
+        # Clear stale percentages — the local parser cannot supply them.
+        # Keeping stale values would mislead the quota gate.
+        updated["rate_limits"] = {
+            "five_hour": {"pct": None, "resets_at": None},
+            "seven_day": {"pct": None, "resets_at": None},
+        }
+        updated["source"] = SOURCE_TAG
+        updated["last_updated"] = now_iso
+    elif not poller_fresh:
+        updated["source"] = SOURCE_TAG
+        updated["last_updated"] = now_iso
+
+    # Always write token_usage section — supplemental to rate_limits.
+    updated["token_usage"] = {
+        "tokens_today": tokens_today,
+        "tokens_this_week": tokens_this_week,
+        "five_hour_tokens": five_hour_tokens,
+        "week_start": week_start,
+        "last_updated": now_iso,
+        "source": SOURCE_TAG,
+    }
+
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Atomic file writer — isolated side effect
+# ---------------------------------------------------------------------------
+
+
+def write_atomically(data: dict[str, Any], dest_path: Path) -> None:
+    """Write data as JSON to dest_path via an atomic temp-file rename.
+
+    Creates parent directories if needed.  Raises OSError on write failure
+    (caller owns error handling).
+    """
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=dest_path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_path, dest_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# State file loader — isolated read, returns {} on failure
+# ---------------------------------------------------------------------------
+
+
+def load_existing_state(state_path: Path) -> dict[str, Any]:
+    """Return the current state.json contents, or {} if absent or unreadable."""
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(dry_run: bool = False, verbose: bool = False) -> int:
+    """Parse local session JSONL files and write token usage data.
+
+    Returns 0 on success, 1 on hard failure.  Soft failures (no files found,
+    read errors on individual files) are logged and return 0.
+    """
+    if verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if not is_job_enabled("local-session-parser"):
+        log.info("local-session-parser is disabled in jobs.json — skipping")
+        return 0
+
+    now = datetime.now(timezone.utc)
+    today = now.strftime("%Y-%m-%d")
+    now_iso = now.isoformat()
+    now_unix = int(now.timestamp())
+
+    # Week start: Monday of the current week (ISO calendar).
+    monday = now - timedelta(days=now.weekday())
+    week_start = monday.strftime("%Y-%m-%d")
+
+    # Cutoff for per-day history: HISTORY_DAYS ago.
+    cutoff = now - timedelta(days=HISTORY_DAYS)
+    cutoff_date = cutoff.strftime("%Y-%m-%d")
+
+    # 5-hour window: entries after this timestamp.
+    five_hour_cutoff = now - timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS)
+
+    # Step 1: Discover session files.
+    session_dir = Path(os.environ.get("LOBSTER_SESSION_DIR", SESSION_DIR))
+    session_files = discover_session_files(session_dir)
+
+    if not session_files:
+        log.warning(
+            "No session JSONL files found in %s — nothing to parse", session_dir
+        )
+        return 0
+
+    log.info("Parsing %d session file(s) from %s", len(session_files), session_dir)
+
+    # Step 2: Parse all files and aggregate daily counts.
+    per_file = [parse_session_file(f) for f in session_files]
+    daily = aggregate_daily_counts(per_file, cutoff_date)
+
+    if not daily:
+        log.warning("No token usage entries found in recent session files")
+        return 0
+
+    # Step 3: Compute summary statistics.
+    tokens_today = compute_tokens_today(daily, today)
+    tokens_this_week = compute_tokens_this_week(daily, week_start)
+
+    # 5-hour rolling window — re-reads files with timestamp filter.
+    five_hour_tokens = compute_five_hour_tokens(session_files, five_hour_cutoff)
+
+    log.info(
+        "Aggregated: today=%d, this_week=%d, 5h_window=%d tokens",
+        tokens_today,
+        tokens_this_week,
+        five_hour_tokens,
+    )
+
+    if dry_run:
+        log.info("[dry-run] Would write to %s and %s", CC_USAGE_PATH, STATE_FILE_PATH)
+        log.info("[dry-run] Daily breakdown: %s", json.dumps(daily, indent=2))
+        return 0
+
+    # Step 4: Write cc-usage.json.
+    cc_usage_path = Path(os.environ.get("LOBSTER_CC_USAGE_PATH", CC_USAGE_PATH))
+    cc_usage = build_cc_usage(daily, today, week_start, now_iso)
+    try:
+        write_atomically(cc_usage, cc_usage_path)
+        log.info("Wrote cc-usage.json to %s", cc_usage_path)
+    except OSError as exc:
+        log.error("Failed to write cc-usage.json to %s: %s", cc_usage_path, exc)
+        return 1
+
+    # Step 5: Merge token_usage into state.json.
+    state_path = Path(
+        os.environ.get("LOBSTER_CC_BUDGET_STATE", STATE_FILE_PATH)
+    )
+    existing = load_existing_state(state_path)
+    new_state = merge_token_usage_into_state(
+        existing=existing,
+        daily=daily,
+        tokens_today=tokens_today,
+        tokens_this_week=tokens_this_week,
+        five_hour_tokens=five_hour_tokens,
+        week_start=week_start,
+        now_iso=now_iso,
+        now_unix=now_unix,
+    )
+    try:
+        write_atomically(new_state, state_path)
+        log.info("Updated state.json at %s (token_usage section)", state_path)
+    except OSError as exc:
+        log.error("Failed to write state.json to %s: %s", state_path, exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Parse local Claude Code session JSONL files and write token usage data"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be written without modifying any files",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG-level logging",
+    )
+    args = parser.parse_args()
+    sys.exit(main(dry_run=args.dry_run, verbose=args.verbose))

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4558,6 +4558,63 @@ PY127
         substep "Migration 127: LOBSTER-VAULT-JOURNAL-SCANNER cron entry already present — skipping"
     fi
 
+    # Migration 128: Register local-session-parser in jobs.json and add cron entry.
+    # Cookie-free token usage tracker that reads ~/.claude/projects/*.jsonl files
+    # and writes per-day token counts to cc-usage.json and a token_usage section
+    # to ~/.claude/cc-budget/state.json (issue #740).
+    local LOCAL_SESSION_PARSER_MARKER="# LOBSTER-LOCAL-SESSION-PARSER"
+    if [ -f "$_JOBS_FILE" ]; then
+        if ! uv run python3 -c "import json,sys; d=json.load(open('$_JOBS_FILE')); sys.exit(0 if 'local-session-parser' in d.get('jobs',{}) else 1)" 2>/dev/null; then
+            substep "Migration 128: adding local-session-parser to jobs.json"
+            local _m128_tmp
+            _m128_tmp=$(mktemp)
+            uv run python3 - <<'PY128' "$_JOBS_FILE" "$_m128_tmp"
+import json, sys
+from datetime import datetime, timezone
+jobs_path, tmp_path = sys.argv[1], sys.argv[2]
+with open(jobs_path) as f:
+    data = json.load(f)
+data.setdefault("jobs", {})["local-session-parser"] = {
+    "name": "local-session-parser",
+    "type": "B",
+    "dispatch": "cron-direct",
+    "schedule": "15,45 * * * *",
+    "schedule_human": "Every 30 minutes (offset)",
+    "task_file": None,
+    "created_at": datetime.now(timezone.utc).isoformat(),
+    "updated_at": datetime.now(timezone.utc).isoformat(),
+    "enabled": True,
+    "last_run": None,
+    "last_status": None,
+    "description": "Every 30 min: parse local Claude Code session JSONL files and write token usage to cc-usage.json and state.json (cookie-free fallback for cc-usage-poller)",
+}
+with open(tmp_path, "w") as f:
+    json.dump(data, f, indent=2, default=str)
+print("OK")
+PY128
+            if [ -s "$_m128_tmp" ]; then
+                mv "$_m128_tmp" "$_JOBS_FILE"
+                substep "Migration 128: local-session-parser added to jobs.json"
+                migrated=$((migrated + 1))
+            else
+                rm -f "$_m128_tmp"
+                warn "Migration 128: failed to update jobs.json — add local-session-parser manually"
+            fi
+        else
+            substep "Migration 128: local-session-parser already in jobs.json — skipping"
+        fi
+    fi
+
+    if ! crontab -l 2>/dev/null | grep -qF "$LOCAL_SESSION_PARSER_MARKER"; then
+        local LOCAL_SESSION_PARSER_ENTRY="15,45 * * * * cd $LOBSTER_DIR && uv run scheduled-tasks/local-session-parser.py >> $WORKSPACE_DIR/scheduled-jobs/logs/local-session-parser.log 2>&1 $LOCAL_SESSION_PARSER_MARKER"
+        (crontab -l 2>/dev/null; echo "$LOCAL_SESSION_PARSER_ENTRY") | crontab - && {
+            substep "Migration 128: added LOBSTER-LOCAL-SESSION-PARSER cron entry (every 30 min, offset)"
+            migrated=$((migrated + 1))
+        } || warn "Could not add LOBSTER-LOCAL-SESSION-PARSER cron entry — add manually"
+    else
+        substep "Migration 128: LOBSTER-LOCAL-SESSION-PARSER cron entry already present — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -3062,8 +3062,11 @@ def read_quota_state(state_path: Path | None = None) -> dict | None:
     try:
         text = resolved.read_text(encoding="utf-8")
         data = json.loads(text)
-        # Require the rate_limits key written by cc-usage-poller (v2 schema).
-        if "rate_limits" not in data:
+        # Accept state that has either:
+        # - ``rate_limits`` (written by cc-usage-poller / cc-usage-collect.sh — v2 schema)
+        # - ``token_usage`` (written by local-session-parser — cookie-free fallback)
+        # Require at least one to ensure we have meaningful data, not a bare empty dict.
+        if "rate_limits" not in data and "token_usage" not in data:
             return None
         return data
     except Exception:
@@ -3090,16 +3093,56 @@ def _is_quota_state_stale(state: dict) -> bool:
         return False
 
 
+def _format_token_usage_fallback(token_usage: dict) -> str:
+    """Format a CC usage string from local-session-parser token counts.
+
+    Called when rate_limits percentage data is unavailable (poller cookie
+    expired) but local token counts from the session-file parser are present.
+
+    Format:
+        CC usage (local): today 269M tokens | week 1.2B tokens | 5h 42M tokens
+        [cookie expired — no % available]
+
+    Pure function: no side effects. All inputs are arguments.
+    """
+    def _fmt_tokens(n: int) -> str:
+        """Format a raw token count as a human-readable abbreviated string."""
+        if n >= 1_000_000_000:
+            return f"{n / 1_000_000_000:.1f}B"
+        if n >= 1_000_000:
+            return f"{n / 1_000_000:.0f}M"
+        if n >= 1_000:
+            return f"{n / 1_000:.0f}K"
+        return str(n)
+
+    today = _fmt_tokens(token_usage.get("tokens_today", 0))
+    week = _fmt_tokens(token_usage.get("tokens_this_week", 0))
+    five_h = _fmt_tokens(token_usage.get("five_hour_tokens", 0))
+    return (
+        f"CC usage (local): today {today} | week {week} | 5h {five_h} tokens\n"
+        f"[cookie expired — quota % unavailable]"
+    )
+
+
 def format_quota_message(state: dict | None) -> str:
     """Format a CC usage string from the cc-budget state dict.
 
+    Data source priority:
+    1. ``rate_limits`` with non-None pct values (poller or statusLine hook) — full % format.
+    2. ``token_usage`` from local-session-parser — token counts format when % unavailable.
+    3. "unavailable" string — when neither source has fresh data.
+
     Returns the unavailable message when:
     - ``state`` is None (file missing/unreadable)
-    - ``state`` is stale (older than QUOTA_STALE_THRESHOLD_HOURS)
-    - ``rate_limits`` keys are missing or malformed
+    - ``state`` is stale (older than QUOTA_STALE_THRESHOLD_HOURS) AND has no token_usage
+    - ``rate_limits`` pct values are None and ``token_usage`` is absent or stale
 
-    Format when data is available:
+    Format when poller data is available:
         CC usage: 5h 42% | 7d 15%. Resets 5h: May 15 4:10 PM ET / 7d: May 22 11:00 AM ET.
+
+    Format when only local token counts are available (cookie expired):
+        CC usage (local): today 269M | week 1.2B | 5h 42M tokens
+        [cookie expired — quota % unavailable]
 
     Pure function: no side effects. All inputs are arguments.
     """
@@ -3108,32 +3151,58 @@ def format_quota_message(state: dict | None) -> str:
     if state is None:
         return _UNAVAILABLE
 
-    if _is_quota_state_stale(state):
-        return _UNAVAILABLE
-
+    # Try rate_limits (poller / hook data) first — requires non-None pct values.
     try:
-        rl = state["rate_limits"]
-        five_pct = rl["five_hour"]["pct"]
-        seven_pct = rl["seven_day"]["pct"]
-        five_resets_at = rl["five_hour"]["resets_at"]
-        seven_resets_at = rl["seven_day"]["resets_at"]
-    except (KeyError, TypeError):
-        return _UNAVAILABLE
+        rl = state.get("rate_limits", {})
+        five_pct = rl.get("five_hour", {}).get("pct")
+        seven_pct = rl.get("seven_day", {}).get("pct")
+        five_resets_at = rl.get("five_hour", {}).get("resets_at")
+        seven_resets_at = rl.get("seven_day", {}).get("resets_at")
+        has_pct = five_pct is not None and seven_pct is not None
+    except (KeyError, TypeError, AttributeError):
+        has_pct = False
 
-    def _fmt_reset(iso: str) -> str:
-        """Format an ISO reset timestamp in the owner's configured timezone."""
-        try:
-            return _format_iso_for_user(iso, fmt="%b %-d %-I:%M %p %Z")
-        except Exception:
-            return iso[:16]  # fallback: truncated ISO
+    if has_pct:
+        # Staleness check only applies to the percentage-based path.
+        if _is_quota_state_stale(state):
+            has_pct = False  # fall through to token_usage check below
+        else:
+            def _fmt_reset(iso: str | None) -> str:
+                """Format an ISO reset timestamp in the owner's configured timezone."""
+                if not iso:
+                    return "unknown"
+                try:
+                    return _format_iso_for_user(iso, fmt="%b %-d %-I:%M %p %Z")
+                except Exception:
+                    return iso[:16]  # fallback: truncated ISO
 
-    five_reset_str = _fmt_reset(five_resets_at)
-    seven_reset_str = _fmt_reset(seven_resets_at)
+            five_reset_str = _fmt_reset(five_resets_at)
+            seven_reset_str = _fmt_reset(seven_resets_at)
+            return (
+                f"CC usage: 5h {five_pct:.0f}% | 7d {seven_pct:.0f}%. "
+                f"Resets — 5h: {five_reset_str} / 7d: {seven_reset_str}."
+            )
 
-    return (
-        f"CC usage: 5h {five_pct:.0f}% | 7d {seven_pct:.0f}%. "
-        f"Resets — 5h: {five_reset_str} / 7d: {seven_reset_str}."
-    )
+    # Fallback: local token counts from session-file parser.
+    # These use their own last_updated timestamp inside token_usage, independent
+    # of the top-level state last_updated (which may be stale from the poller).
+    token_usage = state.get("token_usage")
+    if token_usage:
+        token_last_updated = token_usage.get("last_updated")
+        token_fresh = False
+        if token_last_updated:
+            try:
+                from datetime import datetime as _dt, timezone as _tz, timedelta as _td
+                ts = _dt.fromisoformat(token_last_updated.replace("Z", "+00:00"))
+                age = _dt.now(_tz.utc) - ts
+                token_fresh = age <= _td(hours=QUOTA_STALE_THRESHOLD_HOURS)
+            except Exception:
+                token_fresh = True  # unparseable → assume fresh
+
+        if token_fresh:
+            return _format_token_usage_fallback(token_usage)
+
+    return _UNAVAILABLE
 
 
 def format_status_message(

--- a/tests/unit/test_orchestration/test_dispatcher_commands.py
+++ b/tests/unit/test_orchestration/test_dispatcher_commands.py
@@ -114,12 +114,36 @@ class TestReadQuotaState:
         result = read_quota_state(state_path=p)
         assert result is None
 
-    def test_returns_none_for_missing_rate_limits_key(self, tmp_path: Path) -> None:
-        """Returns None when 'rate_limits' key is absent from state.json."""
+    def test_returns_none_when_neither_rate_limits_nor_token_usage(self, tmp_path: Path) -> None:
+        """Returns None when neither 'rate_limits' nor 'token_usage' key is present."""
         p = tmp_path / "state.json"
         p.write_text(json.dumps({"v": 1, "ts": 1234567890}))
         result = read_quota_state(state_path=p)
         assert result is None
+
+    def test_returns_dict_when_only_token_usage_present(self, tmp_path: Path) -> None:
+        """Returns the dict when 'token_usage' is present even without 'rate_limits'.
+
+        This supports the local-session-parser cookie-free fallback path where
+        the parser writes token counts but no quota percentages.
+        """
+        state = {
+            "v": 1,
+            "ts": int(datetime.now(timezone.utc).timestamp()),
+            "token_usage": {
+                "tokens_today": 100_000,
+                "tokens_this_week": 500_000,
+                "five_hour_tokens": 20_000,
+                "week_start": "2026-05-19",
+                "last_updated": datetime.now(timezone.utc).isoformat(),
+                "source": "local-session-parser",
+            },
+        }
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps(state))
+        result = read_quota_state(state_path=p)
+        assert result is not None
+        assert result["token_usage"]["tokens_today"] == 100_000
 
 
 # ---------------------------------------------------------------------------
@@ -168,6 +192,57 @@ class TestFormatQuotaMessage:
         state = read_quota_state(state_path=fresh_state)
         msg = format_quota_message(state)
         assert "CC usage" in msg or "cc usage" in msg.lower()
+
+    def test_token_usage_fallback_when_pct_none(self, tmp_path: Path) -> None:
+        """When rate_limits.pct is None but token_usage is present, show token counts."""
+        from datetime import timedelta
+        state = {
+            "v": 1,
+            "ts": int(datetime.now(timezone.utc).timestamp()),
+            "rate_limits": {
+                "five_hour": {"pct": None, "resets_at": None},
+                "seven_day": {"pct": None, "resets_at": None},
+            },
+            "token_usage": {
+                "tokens_today": 269_000_000,
+                "tokens_this_week": 1_200_000_000,
+                "five_hour_tokens": 42_000_000,
+                "week_start": "2026-05-19",
+                "last_updated": datetime.now(timezone.utc).isoformat(),
+                "source": "local-session-parser",
+            },
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "source": "local-session-parser",
+        }
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps(state))
+        loaded = read_quota_state(state_path=p)
+        msg = format_quota_message(loaded)
+        # Must show token counts in the local fallback format — not the generic
+        # "unavailable" string that indicates no data at all.
+        assert "token" in msg.lower() or "today" in msg.lower()
+        # The local format includes "quota % unavailable" within a context note,
+        # but must NOT be the bare "CC usage data unavailable" no-data message.
+        assert "CC usage data unavailable" not in msg
+        assert "CC usage (local)" in msg
+
+    def test_unavailable_when_pct_none_and_no_token_usage(self, tmp_path: Path) -> None:
+        """When rate_limits.pct is None and no token_usage, return unavailable."""
+        state = {
+            "v": 1,
+            "ts": int(datetime.now(timezone.utc).timestamp()),
+            "rate_limits": {
+                "five_hour": {"pct": None, "resets_at": None},
+                "seven_day": {"pct": None, "resets_at": None},
+            },
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "source": "local-session-parser",
+        }
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps(state))
+        loaded = read_quota_state(state_path=p)
+        msg = format_quota_message(loaded)
+        assert "unavailable" in msg.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scheduled_tasks/test_local_session_parser.py
+++ b/tests/unit/test_scheduled_tasks/test_local_session_parser.py
@@ -1,0 +1,484 @@
+"""
+Unit tests for scheduled-tasks/local-session-parser.py.
+
+Tests verify behavior, not implementation details.  All filesystem I/O is
+replaced by in-memory fakes.  Named after the behaviors they verify:
+
+  - test_skips_non_assistant_entries
+  - test_extracts_token_counts_from_assistant_entry
+  - test_missing_timestamp_yields_no_date
+  - test_malformed_timestamp_yields_no_date
+  - test_aggregates_counts_across_files
+  - test_drops_dates_before_cutoff
+  - test_tokens_today_sums_input_and_output_for_given_date
+  - test_tokens_this_week_sums_since_week_start
+  - test_build_cc_usage_shape
+  - test_merge_preserves_fresh_poller_rate_limits
+  - test_merge_clears_stale_rate_limits
+  - test_merge_always_writes_token_usage_section
+  - test_merge_sets_source_to_local_parser_when_stale
+  - test_poller_data_is_fresh_when_recent
+  - test_poller_data_is_stale_when_old
+  - test_poller_data_is_stale_when_source_is_local_parser
+  - test_discover_returns_empty_list_for_missing_directory
+  - test_parse_session_file_handles_read_error_gracefully
+  - test_disabled_job_exits_without_parsing
+  - test_dry_run_does_not_write_files
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import textwrap
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the module under test via importlib (lives in scheduled-tasks/, not a package)
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "scheduled-tasks"
+    / "local-session-parser.py"
+)
+
+spec = importlib.util.spec_from_file_location("local_session_parser", SCRIPT_PATH)
+_mod: ModuleType = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+# Pull names into local scope.
+extract_usage_from_entry = _mod.extract_usage_from_entry
+parse_session_file = _mod.parse_session_file
+aggregate_daily_counts = _mod.aggregate_daily_counts
+compute_tokens_today = _mod.compute_tokens_today
+compute_tokens_this_week = _mod.compute_tokens_this_week
+build_cc_usage = _mod.build_cc_usage
+merge_token_usage_into_state = _mod.merge_token_usage_into_state
+discover_session_files = _mod.discover_session_files
+_poller_data_is_fresh = _mod._poller_data_is_fresh
+main = _mod.main
+SOURCE_TAG = _mod.SOURCE_TAG
+POLLER_STALE_SECONDS = _mod.POLLER_STALE_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts(dt: datetime) -> str:
+    """Format a datetime as a Claude JSONL timestamp string."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _assistant_entry(
+    ts: str,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_creation: int = 200,
+    cache_read: int = 1000,
+) -> dict:
+    """Build a minimal assistant JSONL entry with the given usage fields."""
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": cache_creation,
+                "cache_read_input_tokens": cache_read,
+            }
+        },
+    }
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# extract_usage_from_entry
+# ---------------------------------------------------------------------------
+
+
+def test_skips_non_assistant_entries():
+    for entry_type in ("user", "system", "attachment", "queue-operation"):
+        entry = {"type": entry_type, "timestamp": "2026-05-20T12:00:00.000Z"}
+        date_str, counts = extract_usage_from_entry(entry)
+        assert date_str is None, f"Expected None for type={entry_type}"
+        assert all(v == 0 for v in counts.values())
+
+
+def test_extracts_token_counts_from_assistant_entry():
+    now = _now_utc()
+    entry = _assistant_entry(
+        ts=_ts(now),
+        input_tokens=300,
+        output_tokens=150,
+        cache_creation=400,
+        cache_read=2000,
+    )
+    date_str, counts = extract_usage_from_entry(entry)
+    assert date_str == now.strftime("%Y-%m-%d")
+    assert counts["input_tokens"] == 300
+    assert counts["output_tokens"] == 150
+    assert counts["cache_creation"] == 400
+    assert counts["cache_read"] == 2000
+
+
+def test_missing_timestamp_yields_no_date():
+    entry = {
+        "type": "assistant",
+        "message": {"usage": {"input_tokens": 10, "output_tokens": 5}},
+    }
+    date_str, counts = extract_usage_from_entry(entry)
+    assert date_str is None
+
+
+def test_malformed_timestamp_yields_no_date():
+    entry = {
+        "type": "assistant",
+        "timestamp": "not-a-date",
+        "message": {"usage": {"input_tokens": 10, "output_tokens": 5}},
+    }
+    date_str, counts = extract_usage_from_entry(entry)
+    assert date_str is None
+
+
+# ---------------------------------------------------------------------------
+# aggregate_daily_counts
+# ---------------------------------------------------------------------------
+
+
+def test_aggregates_counts_across_files():
+    file1 = {"2026-05-20": {"input_tokens": 100, "output_tokens": 50, "cache_creation": 0, "cache_read": 0}}
+    file2 = {"2026-05-20": {"input_tokens": 200, "output_tokens": 100, "cache_creation": 10, "cache_read": 500}}
+    result = aggregate_daily_counts([file1, file2], cutoff_date="2026-05-01")
+    assert result["2026-05-20"]["input_tokens"] == 300
+    assert result["2026-05-20"]["output_tokens"] == 150
+    assert result["2026-05-20"]["cache_creation"] == 10
+    assert result["2026-05-20"]["cache_read"] == 500
+
+
+def test_drops_dates_before_cutoff():
+    data = {
+        "2026-05-10": {"input_tokens": 100, "output_tokens": 50, "cache_creation": 0, "cache_read": 0},
+        "2026-05-20": {"input_tokens": 200, "output_tokens": 100, "cache_creation": 0, "cache_read": 0},
+    }
+    result = aggregate_daily_counts([data], cutoff_date="2026-05-15")
+    assert "2026-05-10" not in result
+    assert "2026-05-20" in result
+
+
+# ---------------------------------------------------------------------------
+# compute_tokens_today / compute_tokens_this_week
+# ---------------------------------------------------------------------------
+
+
+def test_tokens_today_sums_input_and_output_for_given_date():
+    daily = {
+        "2026-05-20": {"input_tokens": 300, "output_tokens": 150, "cache_creation": 999, "cache_read": 9999},
+    }
+    assert compute_tokens_today(daily, "2026-05-20") == 450
+    assert compute_tokens_today(daily, "2026-05-21") == 0
+
+
+def test_tokens_this_week_sums_since_week_start():
+    daily = {
+        "2026-05-18": {"input_tokens": 100, "output_tokens": 50, "cache_creation": 0, "cache_read": 0},  # Sunday (before)
+        "2026-05-19": {"input_tokens": 200, "output_tokens": 100, "cache_creation": 0, "cache_read": 0},  # Monday (week start)
+        "2026-05-20": {"input_tokens": 300, "output_tokens": 150, "cache_creation": 0, "cache_read": 0},  # Tuesday
+    }
+    total = compute_tokens_this_week(daily, week_start="2026-05-19")
+    assert total == (200 + 100) + (300 + 150)  # 750, excludes Sunday
+
+
+# ---------------------------------------------------------------------------
+# build_cc_usage
+# ---------------------------------------------------------------------------
+
+
+def test_build_cc_usage_shape():
+    daily = {
+        "2026-05-20": {"input_tokens": 100, "output_tokens": 50, "cache_creation": 200, "cache_read": 1000},
+    }
+    result = build_cc_usage(
+        daily=daily,
+        today="2026-05-20",
+        week_start="2026-05-19",
+        now_iso="2026-05-20T12:00:00+00:00",
+    )
+    assert result["tokens_today"] == 150  # 100 + 50
+    assert result["tokens_this_week"] == 150
+    assert "week_start" in result
+    assert "daily" in result
+    assert "last_updated" in result
+
+
+# ---------------------------------------------------------------------------
+# _poller_data_is_fresh
+# ---------------------------------------------------------------------------
+
+
+def test_poller_data_is_fresh_when_recent():
+    recent_ts = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+    state = {
+        "source": "cc-usage-poller",
+        "last_updated": recent_ts,
+        "rate_limits": {"five_hour": {"pct": 20.0}},
+    }
+    assert _poller_data_is_fresh(state) is True
+
+
+def test_poller_data_is_stale_when_old():
+    old_ts = (
+        datetime.now(timezone.utc) - timedelta(seconds=POLLER_STALE_SECONDS + 600)
+    ).isoformat()
+    state = {
+        "source": "cc-usage-poller",
+        "last_updated": old_ts,
+    }
+    assert _poller_data_is_fresh(state) is False
+
+
+def test_poller_data_is_stale_when_source_is_local_parser():
+    # If state was already written by this parser, it's not "fresh poller data"
+    recent_ts = datetime.now(timezone.utc).isoformat()
+    state = {
+        "source": SOURCE_TAG,
+        "last_updated": recent_ts,
+    }
+    assert _poller_data_is_fresh(state) is False
+
+
+def test_poller_data_is_stale_when_last_updated_absent():
+    state = {"source": "cc-usage-poller"}
+    assert _poller_data_is_fresh(state) is False
+
+
+# ---------------------------------------------------------------------------
+# merge_token_usage_into_state
+# ---------------------------------------------------------------------------
+
+FRESH_TS = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+STALE_TS = (
+    datetime.now(timezone.utc) - timedelta(seconds=POLLER_STALE_SECONDS + 7200)
+).isoformat()
+
+DAILY_SAMPLE = {
+    "2026-05-20": {"input_tokens": 100, "output_tokens": 50, "cache_creation": 0, "cache_read": 0},
+}
+
+
+def test_merge_preserves_fresh_poller_rate_limits():
+    existing = {
+        "source": "cc-usage-poller",
+        "last_updated": FRESH_TS,
+        "rate_limits": {
+            "five_hour": {"pct": 42.0, "resets_at": "2026-05-20T18:00:00Z"},
+            "seven_day": {"pct": 28.0, "resets_at": "2026-05-25T12:00:00Z"},
+        },
+    }
+    result = merge_token_usage_into_state(
+        existing=existing,
+        daily=DAILY_SAMPLE,
+        tokens_today=150,
+        tokens_this_week=150,
+        five_hour_tokens=50,
+        week_start="2026-05-19",
+        now_iso="2026-05-20T12:00:00+00:00",
+        now_unix=1716206400,
+    )
+    # Poller data must be preserved
+    assert result["rate_limits"]["five_hour"]["pct"] == 42.0
+    assert result["rate_limits"]["seven_day"]["pct"] == 28.0
+    # Local token usage is still added
+    assert "token_usage" in result
+    assert result["token_usage"]["tokens_today"] == 150
+
+
+def test_merge_clears_stale_rate_limits():
+    existing = {
+        "source": "cc-usage-poller",
+        "last_updated": STALE_TS,
+        "rate_limits": {
+            "five_hour": {"pct": 42.0, "resets_at": "2026-05-10T18:00:00Z"},
+            "seven_day": {"pct": 28.0, "resets_at": "2026-05-17T12:00:00Z"},
+        },
+    }
+    result = merge_token_usage_into_state(
+        existing=existing,
+        daily=DAILY_SAMPLE,
+        tokens_today=150,
+        tokens_this_week=150,
+        five_hour_tokens=50,
+        week_start="2026-05-19",
+        now_iso="2026-05-20T12:00:00+00:00",
+        now_unix=1716206400,
+    )
+    # Stale pct values must be cleared to None so the quota gate treats them as unavailable
+    assert result["rate_limits"]["five_hour"]["pct"] is None
+    assert result["rate_limits"]["seven_day"]["pct"] is None
+
+
+def test_merge_always_writes_token_usage_section():
+    for existing in [{}, {"source": "cc-usage-poller", "last_updated": FRESH_TS}]:
+        result = merge_token_usage_into_state(
+            existing=existing,
+            daily=DAILY_SAMPLE,
+            tokens_today=100,
+            tokens_this_week=200,
+            five_hour_tokens=30,
+            week_start="2026-05-19",
+            now_iso="2026-05-20T12:00:00+00:00",
+            now_unix=1716206400,
+        )
+        assert "token_usage" in result, f"token_usage absent for existing={existing!r}"
+        assert result["token_usage"]["five_hour_tokens"] == 30
+
+
+def test_merge_sets_source_to_local_parser_when_stale():
+    existing = {
+        "source": "cc-usage-poller",
+        "last_updated": STALE_TS,
+    }
+    result = merge_token_usage_into_state(
+        existing=existing,
+        daily=DAILY_SAMPLE,
+        tokens_today=100,
+        tokens_this_week=200,
+        five_hour_tokens=30,
+        week_start="2026-05-19",
+        now_iso="2026-05-20T12:00:00+00:00",
+        now_unix=1716206400,
+    )
+    assert result["source"] == SOURCE_TAG
+
+
+# ---------------------------------------------------------------------------
+# discover_session_files
+# ---------------------------------------------------------------------------
+
+
+def test_discover_returns_empty_list_for_missing_directory():
+    result = discover_session_files(Path("/does/not/exist/anywhere"))
+    assert result == []
+
+
+def test_discover_finds_jsonl_files(tmp_path):
+    (tmp_path / "abc.jsonl").write_text("")
+    (tmp_path / "def.jsonl").write_text("")
+    (tmp_path / "ignored.txt").write_text("")
+    result = discover_session_files(tmp_path)
+    assert len(result) == 2
+    assert all(p.suffix == ".jsonl" for p in result)
+
+
+# ---------------------------------------------------------------------------
+# parse_session_file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_session_file_handles_read_error_gracefully(tmp_path):
+    # File does not exist — should return {} without raising
+    result = parse_session_file(tmp_path / "nonexistent.jsonl")
+    assert result == {}
+
+
+def test_parse_session_file_aggregates_assistant_entries(tmp_path):
+    now = _now_utc()
+    today = now.strftime("%Y-%m-%d")
+    lines = [
+        json.dumps(_assistant_entry(_ts(now), input_tokens=100, output_tokens=50)),
+        json.dumps(_assistant_entry(_ts(now), input_tokens=200, output_tokens=100)),
+        json.dumps({"type": "user", "timestamp": _ts(now)}),  # non-assistant, skip
+        "NOT VALID JSON",  # malformed, skip
+    ]
+    f = tmp_path / "session.jsonl"
+    f.write_text("\n".join(lines) + "\n")
+    result = parse_session_file(f)
+    assert result[today]["input_tokens"] == 300
+    assert result[today]["output_tokens"] == 150
+
+
+# ---------------------------------------------------------------------------
+# main() — integration-level behavior tests
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_job_exits_without_parsing(tmp_path):
+    with patch.object(_mod, "is_job_enabled", return_value=False):
+        with patch.object(_mod, "discover_session_files") as mock_discover:
+            ret = main(dry_run=False)
+    assert ret == 0
+    mock_discover.assert_not_called()
+
+
+def test_dry_run_does_not_write_files(tmp_path):
+    """Dry-run must log intent but not create or modify any files."""
+    now = _now_utc()
+    session_file = tmp_path / "session.jsonl"
+    session_file.write_text(
+        json.dumps(_assistant_entry(_ts(now), input_tokens=100, output_tokens=50)) + "\n"
+    )
+
+    cc_usage_out = tmp_path / "cc-usage.json"
+    state_out = tmp_path / "state.json"
+
+    with patch.object(_mod, "is_job_enabled", return_value=True):
+        with patch.dict(
+            os.environ,
+            {
+                "LOBSTER_SESSION_DIR": str(tmp_path),
+                "LOBSTER_CC_USAGE_PATH": str(cc_usage_out),
+                "LOBSTER_CC_BUDGET_STATE": str(state_out),
+            },
+        ):
+            ret = main(dry_run=True)
+
+    assert ret == 0
+    assert not cc_usage_out.exists(), "dry-run must not write cc-usage.json"
+    assert not state_out.exists(), "dry-run must not write state.json"
+
+
+def test_main_writes_cc_usage_and_state_files(tmp_path):
+    """Full run with valid session files produces both output files."""
+    now = _now_utc()
+    session_file = tmp_path / "session.jsonl"
+    session_file.write_text(
+        json.dumps(_assistant_entry(_ts(now), input_tokens=100, output_tokens=50)) + "\n"
+    )
+
+    cc_usage_out = tmp_path / "cc-usage.json"
+    state_dir = tmp_path / "state_dir"
+    state_out = state_dir / "state.json"
+
+    with patch.object(_mod, "is_job_enabled", return_value=True):
+        with patch.dict(
+            os.environ,
+            {
+                "LOBSTER_SESSION_DIR": str(tmp_path),
+                "LOBSTER_CC_USAGE_PATH": str(cc_usage_out),
+                "LOBSTER_CC_BUDGET_STATE": str(state_out),
+            },
+        ):
+            ret = main(dry_run=False)
+
+    assert ret == 0
+    assert cc_usage_out.exists(), "cc-usage.json must be written"
+    assert state_out.exists(), "state.json must be written"
+
+    cc_usage = json.loads(cc_usage_out.read_text())
+    assert cc_usage["tokens_today"] == 150  # 100 + 50
+    assert "daily" in cc_usage
+
+    state = json.loads(state_out.read_text())
+    assert "token_usage" in state
+    assert state["token_usage"]["tokens_today"] == 150


### PR DESCRIPTION
## Problem

The cc-usage-poller.py cookie expired 2026-05-17 — quota tracking has been blind for 9+ days. The morning briefing shows stale/unavailable quota data, and the UoW dispatch quota gate cannot see current usage. The cookie mechanism cannot be fixed without manual action from Dan.

This PR adds a parallel, cookie-free path that reads token usage directly from local Claude Code session JSONL files. It does not fix the cookie problem — it provides a fallback so the system stops being blind while the cookie is expired.

## What changed

### New: `scheduled-tasks/local-session-parser.py`

Type B cron script (runs at :15 and :45 past each hour) that:
1. Discovers all `*.jsonl` files in `~/.claude/projects/-home-lobster-lobster-workspace/`
2. Extracts `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` from each `assistant` entry's `message.usage`
3. Aggregates per UTC date, computes today/week/5h-window totals
4. Writes to two outputs:
   - `~/lobster-workspace/data/cc-usage.json` — `tokens_today`, `tokens_this_week`, per-day breakdown (same schema the morning briefing already reads)
   - `~/.claude/cc-budget/state.json` — adds `token_usage` section; when poller rate_limits are stale (>2h), clears `pct` values to `None` so the quota gate treats them as unavailable rather than trusting stale percentages

The `cc-usage-poller.py` is not touched. When the cookie is valid and poller data is fresh, the poller's `rate_limits` section takes precedence.

### Updated: `src/orchestration/dispatcher_handlers.py`

**`read_quota_state()`** — previously returned `None` if `rate_limits` key was absent. Now also accepts state with a `token_usage` key, so the local parser's output is readable even if it hasn't written `rate_limits` yet.

**`format_quota_message()`** — new fallback path:
- Priority 1 (unchanged): `rate_limits.pct` with non-None values → existing "5h N% | 7d N%" format
- Priority 2 (new): `token_usage` when pct is None → "CC usage (local): today 269M | week 1.2B | 5h 42M tokens / [cookie expired — quota % unavailable]"
- Priority 3 (unchanged): "unavailable" when neither source is fresh

New helper: `_format_token_usage_fallback()` — pure function, handles human-readable token abbreviation (K/M/B).

### Updated: `scripts/upgrade.sh`

Migration 128: registers `local-session-parser` in jobs.json (Type B, `cron-direct`) and adds the cron entry `15,45 * * * *`.

### Updated: `~/lobster-workspace/scheduled-jobs/tasks/morning-briefing.md`

Section 3b updated to document both data sources (poller pct vs. token_usage) and provide formatting guidance for both. This is a runtime workspace file, not version-controlled — the update is applied directly.

## Flow: before vs. after

**Before (cookie expired):**
```
cc-usage-poller → 401 auth error → state.json rate_limits stale (>2h)
format_quota_message → "CC usage data unavailable — poller may not have run yet."
Morning briefing: [stale]
Quota gate (executor-heartbeat): None → fail-open (proceeds)
```

**After (cookie still expired, local parser running):**
```
local-session-parser → reads 202 JSONL files → writes token_usage to state.json
format_quota_message → "CC usage (local): today 269M | week 1.2B | 5h 42M tokens [cookie expired]"
Morning briefing: shows real token counts with cookie-expired note
Quota gate (executor-heartbeat): unchanged — still fail-open on None pct (correct)
cc-usage.json: updated with fresh tokens_today for morning briefing
```

## Functional patterns

- All business logic is in pure functions (`extract_usage_from_entry`, `aggregate_daily_counts`, `merge_token_usage_into_state`, `_format_token_usage_fallback`, etc.)
- Side effects are isolated to `write_atomically()`, `parse_session_file()`, and `main()`
- Fail-open at every layer: missing dir → skip; read error → skip file; missing job entry → enabled by default

## Tests run

- [x] `uv run pytest tests/unit/test_scheduled_tasks/test_local_session_parser.py tests/unit/test_orchestration/test_dispatcher_commands.py tests/unit/test_scheduled_tasks/test_cc_usage_poller.py -v` — 76 passed, 0 failed
- [x] `uv run scheduled-tasks/local-session-parser.py --dry-run` — correctly identified 202 session files, computed 513K tokens today, 1.68M this week, 965K in 5h window
- [x] Live run with `LOBSTER_CC_USAGE_PATH=/tmp/test-cc-usage.json LOBSTER_CC_BUDGET_STATE=/tmp/test-state.json` — wrote both files correctly with expected structure

## Manual test

This change touches file I/O (reads JSONL, writes JSON). Tested against real production session files in dry-run mode and live against temp files:

- Dry-run: parsed 202 session files in ~3s, computed correct token counts, confirmed no files written
- Live (temp files): confirmed `cc-usage.json` and `state.json` written with correct schema and fresh timestamps
- User-visible outcome: not applicable to this PR directly — the output surfaces through `format_quota_message` (covered by unit tests) and the morning briefing (task file updated, will surface on next 7am run)

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see Manual test above
- [x] User-visible outcome: `/usage` and `/quota` commands will show token counts instead of "unavailable" when cookie is expired
- [x] Side-effect audit: reads local files only; writes are atomic; no network calls; no Telegram messages sent
- [x] External service calls: none in this PR

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)