### PR TITLE
feat(htmlgen): Phase 3 — DOM-aware editor + spec-document template fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "fpdf2>=2.8.7",
     "anthropic>=0.86.0",
     "markdown>=3.6",
+    "beautifulsoup4>=4.14.3",
 ]
 
 [project.optional-dependencies]

--- a/src/htmlgen/editor.py
+++ b/src/htmlgen/editor.py
@@ -1,0 +1,487 @@
+"""
+editor.py — DOM-aware HTML editor for Lobster HTML artifacts (Phase 3)
+
+Applies structured edit instructions to existing HTML files without requiring
+agents to load or regenerate the full document. Implements GP-3 (abstract edit
+instructions, deterministic execution) from the HTML doc model spec.
+
+The split: the LLM identifies *what* to change and expresses it as an edit
+instruction. This script applies the change deterministically. The LLM never
+outputs modified HTML; the DOM is always the execution target.
+
+Instruction types
+-----------------
+replace_section_content(section_id, new_content)
+    Replace the prose body of a section, preserving the section's <div>,
+    heading, comment-area, and label elements intact.
+
+add_section(section_id, after_id, title, label, content)
+    Insert a new section after the named section.
+
+remove_section(section_id)
+    Remove a section element (and all its children) from the document.
+    The section_id is retired — callers must not reuse it.
+
+update_version_stamp(version, timestamp)
+    Update the doc-version and doc-updated meta tags.
+
+patch_js_block(block_id, new_code)
+    Replace a named <script> block. The block must carry a data-block-id
+    attribute so the editor can locate it unambiguously.
+
+Usage
+-----
+    from src.htmlgen.editor import apply_edit, apply_edits
+    from pathlib import Path
+
+    # Single edit
+    apply_edit(
+        html_path=Path("path/to/file.html"),
+        instruction={
+            "op": "replace_section_content",
+            "section_id": "s9",
+            "new_content": "Revised prose here.",
+        },
+    )
+
+    # Batch edits
+    apply_edits(
+        html_path=Path("path/to/file.html"),
+        instructions=[
+            {"op": "replace_section_content", "section_id": "s3", "new_content": "..."},
+            {"op": "update_version_stamp", "version": "1.4", "timestamp": "2026-05-31T00:00:00Z"},
+        ],
+    )
+
+Edit instruction format
+-----------------------
+Every instruction is a dict with at minimum an "op" key.
+
+replace_section_content:
+    {
+        "op": "replace_section_content",
+        "section_id": "s9",
+        "new_content": "<p>Prose or raw HTML to place inside the section.</p>"
+    }
+    new_content may be raw HTML or plain text (plain text is wrapped in <p> tags).
+
+add_section:
+    {
+        "op": "add_section",
+        "section_id": "s10",
+        "after_id": "s9",
+        "title": "New Section Title",
+        "label": "§10",
+        "content": "Section content here."
+    }
+
+remove_section:
+    {
+        "op": "remove_section",
+        "section_id": "s4"
+    }
+
+update_version_stamp:
+    {
+        "op": "update_version_stamp",
+        "version": "1.4",
+        "timestamp": "2026-05-31T00:00:00Z"
+    }
+    Both version and timestamp are optional; omit either to leave unchanged.
+
+patch_js_block:
+    {
+        "op": "patch_js_block",
+        "block_id": "my-block",
+        "new_code": "console.log('hello');"
+    }
+    The target <script> must have data-block-id="my-block".
+
+All ops are applied in order. If any op raises EditError, the batch stops and
+the file is not written (atomic on success, no partial-write on error).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from bs4 import BeautifulSoup, Tag
+
+
+# ---------------------------------------------------------------------------
+# Public exception
+# ---------------------------------------------------------------------------
+
+class EditError(Exception):
+    """Raised when an edit instruction cannot be applied."""
+
+
+# ---------------------------------------------------------------------------
+# Parser helpers — pure functions over BeautifulSoup trees
+# ---------------------------------------------------------------------------
+
+_PARSER = "html.parser"
+
+
+def _parse(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, _PARSER)
+
+
+def _find_section(soup: BeautifulSoup, section_id: str) -> Tag:
+    """Return the <div class="section" id="section_id"> element, or raise EditError."""
+    el = soup.find("div", {"class": "section", "id": section_id})
+    if el is None:
+        raise EditError(
+            f"Section '{section_id}' not found. "
+            "The file must contain <div class=\"section\" id=\"{section_id}\">."
+        )
+    return el
+
+
+def _is_structural_child(tag: Tag) -> bool:
+    """Return True if tag is a structural element that must be preserved during
+    a replace_section_content operation (label, heading, comment-area)."""
+    cls = tag.get("class", [])
+    if isinstance(cls, str):
+        cls = cls.split()
+    return any(c in cls for c in ("section-label", "comment-area")) or tag.name in ("h1", "h2", "h3")
+
+
+# ---------------------------------------------------------------------------
+# Individual operation functions — pure transformations on a soup tree
+# ---------------------------------------------------------------------------
+
+def _op_replace_section_content(
+    soup: BeautifulSoup,
+    section_id: str,
+    new_content: str,
+) -> None:
+    """Replace the content body of a section, preserving structural children."""
+    section = _find_section(soup, section_id)
+
+    # Collect structural elements to preserve (label div, heading, comment-area)
+    structural = [
+        child for child in list(section.children)
+        if isinstance(child, Tag) and _is_structural_child(child)
+    ]
+
+    # Clear the section's children
+    section.clear()
+
+    # Re-insert structural elements first
+    for el in structural:
+        section.append(el)
+
+    # Append new content — parse as HTML fragment
+    new_soup = BeautifulSoup(new_content, _PARSER)
+    # If new_content is plain text (no block tags), wrap in <p>
+    block_tags = {"p", "ul", "ol", "pre", "blockquote", "table", "h4", "h5", "h6", "div"}
+    has_block = any(
+        isinstance(child, Tag) and child.name in block_tags
+        for child in new_soup.children
+    )
+    if not has_block and new_content.strip():
+        p = soup.new_tag("p")
+        p.string = new_content.strip()
+        section.append(p)
+    else:
+        for child in list(new_soup.children):
+            section.append(child.__copy__() if hasattr(child, "__copy__") else child)
+
+
+def _op_add_section(
+    soup: BeautifulSoup,
+    section_id: str,
+    after_id: str,
+    title: str,
+    label: str,
+    content: str,
+) -> None:
+    """Insert a new section after the section with after_id."""
+    after_el = _find_section(soup, after_id)
+
+    # Verify the new section_id doesn't already exist
+    existing = soup.find("div", {"class": "section", "id": section_id})
+    if existing is not None:
+        raise EditError(
+            f"Section '{section_id}' already exists. "
+            "Section IDs must be unique and permanent."
+        )
+
+    # Build the new section element
+    new_section = BeautifulSoup(
+        _build_section_html(section_id, label, title, content), _PARSER
+    ).find("div", {"class": "section"})
+
+    if new_section is None:
+        raise EditError(f"Failed to build new section element for '{section_id}'")
+
+    after_el.insert_after(new_section)
+
+
+def _op_remove_section(
+    soup: BeautifulSoup,
+    section_id: str,
+) -> None:
+    """Remove a section and all its children from the document."""
+    section = _find_section(soup, section_id)
+    section.decompose()
+
+
+def _op_update_version_stamp(
+    soup: BeautifulSoup,
+    version: str | None,
+    timestamp: str | None,
+) -> None:
+    """Update doc-version and/or doc-updated meta tags."""
+    if version is not None:
+        meta_version = soup.find("meta", {"name": "doc-version"})
+        if meta_version is None:
+            raise EditError(
+                "doc-version meta tag not found. "
+                "The document must have <meta name=\"doc-version\" content=\"...\">."
+            )
+        meta_version["content"] = version
+
+    if timestamp is not None:
+        meta_updated = soup.find("meta", {"name": "doc-updated"})
+        if meta_updated is None:
+            raise EditError(
+                "doc-updated meta tag not found. "
+                "The document must have <meta name=\"doc-updated\" content=\"...\">."
+            )
+        meta_updated["content"] = timestamp
+
+
+def _op_patch_js_block(
+    soup: BeautifulSoup,
+    block_id: str,
+    new_code: str,
+) -> None:
+    """Replace the content of a named <script data-block-id="block_id"> element."""
+    script = soup.find("script", {"data-block-id": block_id})
+    if script is None:
+        raise EditError(
+            f"No <script data-block-id=\"{block_id}\"> found. "
+            "JS blocks must carry a data-block-id attribute to be patchable."
+        )
+    script.clear()
+    script.append(soup.new_string(new_code))
+
+
+# ---------------------------------------------------------------------------
+# Section HTML builder (used by add_section)
+# ---------------------------------------------------------------------------
+
+def _build_section_html(
+    section_id: str,
+    label: str,
+    title: str,
+    content: str,
+) -> str:
+    """Produce a well-formed section HTML string."""
+    label_html = f'<div class="section-label">{label}</div>' if label else ""
+    title_html = (
+        f'<h2>{title} <button class="comment-btn" onclick="toggleComment(this)">&#128172;</button></h2>'
+        if title else ""
+    )
+    comment_area_html = (
+        f'<div class="comment-area"><textarea placeholder="[{label or section_id}] "></textarea></div>'
+        if title else ""
+    )
+    # Wrap plain text content in <p> if it has no block tags
+    block_re = re.compile(r"<(p|ul|ol|pre|blockquote|table|h[4-6]|div)[\s>]", re.IGNORECASE)
+    if content.strip() and not block_re.search(content):
+        content_html = f"<p>{content}</p>"
+    else:
+        content_html = content
+
+    return (
+        f'<div class="section" id="{section_id}">\n'
+        f"  {label_html}\n"
+        f"  {title_html}\n"
+        f"  {comment_area_html}\n"
+        f"  {content_html}\n"
+        f"</div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instruction dispatcher — pure mapping from instruction dict to op function
+# ---------------------------------------------------------------------------
+
+def _apply_instruction(soup: BeautifulSoup, instruction: dict[str, Any]) -> None:
+    """Dispatch a single edit instruction to its operation function."""
+    op = instruction.get("op")
+    if not op:
+        raise EditError("Instruction missing required 'op' field.")
+
+    if op == "replace_section_content":
+        _require_fields(instruction, ["section_id", "new_content"])
+        _op_replace_section_content(
+            soup,
+            section_id=instruction["section_id"],
+            new_content=instruction["new_content"],
+        )
+
+    elif op == "add_section":
+        _require_fields(instruction, ["section_id", "after_id", "title", "label"])
+        _op_add_section(
+            soup,
+            section_id=instruction["section_id"],
+            after_id=instruction["after_id"],
+            title=instruction["title"],
+            label=instruction["label"],
+            content=instruction.get("content", ""),
+        )
+
+    elif op == "remove_section":
+        _require_fields(instruction, ["section_id"])
+        _op_remove_section(soup, section_id=instruction["section_id"])
+
+    elif op == "update_version_stamp":
+        _op_update_version_stamp(
+            soup,
+            version=instruction.get("version"),
+            timestamp=instruction.get("timestamp"),
+        )
+
+    elif op == "patch_js_block":
+        _require_fields(instruction, ["block_id", "new_code"])
+        _op_patch_js_block(
+            soup,
+            block_id=instruction["block_id"],
+            new_code=instruction["new_code"],
+        )
+
+    else:
+        raise EditError(
+            f"Unknown op: '{op}'. "
+            "Valid ops: replace_section_content, add_section, remove_section, "
+            "update_version_stamp, patch_js_block."
+        )
+
+
+def _require_fields(instruction: dict[str, Any], fields: list[str]) -> None:
+    """Raise EditError if any required field is missing from the instruction."""
+    missing = [f for f in fields if f not in instruction]
+    if missing:
+        raise EditError(
+            f"Instruction op='{instruction.get('op')}' missing required fields: "
+            + ", ".join(missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def apply_edit(
+    html_path: Path | str,
+    instruction: dict[str, Any],
+) -> str:
+    """Apply a single edit instruction to an HTML file.
+
+    Reads the file, applies the instruction, validates the result, and writes
+    the file back. Returns the modified HTML string.
+
+    Args:
+        html_path: Path to the HTML file to modify.
+        instruction: A single edit instruction dict (see module docstring).
+
+    Returns:
+        The full modified HTML as a string.
+
+    Raises:
+        FileNotFoundError: If html_path does not exist.
+        EditError: If the instruction is malformed or cannot be applied.
+    """
+    return apply_edits(html_path, [instruction])
+
+
+def apply_edits(
+    html_path: Path | str,
+    instructions: list[dict[str, Any]],
+) -> str:
+    """Apply a batch of edit instructions to an HTML file.
+
+    All instructions are applied to the same soup tree in order. If any
+    instruction raises EditError, the batch stops and the file is NOT written
+    (atomic on success, no partial-write on error).
+
+    Args:
+        html_path: Path to the HTML file to modify.
+        instructions: Ordered list of edit instruction dicts.
+
+    Returns:
+        The full modified HTML as a string.
+
+    Raises:
+        FileNotFoundError: If html_path does not exist.
+        EditError: If any instruction is malformed or cannot be applied.
+    """
+    html_path = Path(html_path)
+    if not html_path.exists():
+        raise FileNotFoundError(f"HTML file not found: {html_path}")
+
+    original = html_path.read_text(encoding="utf-8")
+    soup = _parse(original)
+
+    for i, instruction in enumerate(instructions):
+        try:
+            _apply_instruction(soup, instruction)
+        except EditError as exc:
+            raise EditError(
+                f"Instruction {i} (op={instruction.get('op')!r}) failed: {exc}"
+            ) from exc
+
+    modified = str(soup)
+    html_path.write_text(modified, encoding="utf-8")
+    return modified
+
+
+def parse_html(html_path: Path | str) -> BeautifulSoup:
+    """Parse an HTML file and return the BeautifulSoup tree.
+
+    Utility for callers that need to inspect the DOM before composing edit
+    instructions (e.g., to enumerate existing section IDs).
+
+    Args:
+        html_path: Path to the HTML file.
+
+    Returns:
+        A BeautifulSoup tree.
+
+    Raises:
+        FileNotFoundError: If html_path does not exist.
+    """
+    html_path = Path(html_path)
+    if not html_path.exists():
+        raise FileNotFoundError(f"HTML file not found: {html_path}")
+    return _parse(html_path.read_text(encoding="utf-8"))
+
+
+def list_section_ids(html_path: Path | str) -> list[str]:
+    """Return all section IDs present in an HTML file.
+
+    Reads <div class="section" id="..."> elements and returns their IDs in
+    document order. Useful for coverage checks and section enumeration without
+    loading the full file into an agent's context.
+
+    Args:
+        html_path: Path to the HTML file.
+
+    Returns:
+        List of section ID strings in document order.
+
+    Raises:
+        FileNotFoundError: If html_path does not exist.
+    """
+    soup = parse_html(html_path)
+    return [
+        str(div["id"])
+        for div in soup.find_all("div", class_="section")
+        if div.get("id")
+    ]

--- a/src/htmlgen/templates/registry.yaml
+++ b/src/htmlgen/templates/registry.yaml
@@ -25,6 +25,7 @@ templates:
     description: Long-lived specs edited across many sessions. Section tracking, inline comment threads.
     content_format: json
     components:
+      - clipboard-copy-widget
       - theme-toggle
     conventions_overrides: {}
     scaffold: content-scaffold.json

--- a/tests/htmlgen/test_editor.py
+++ b/tests/htmlgen/test_editor.py
@@ -1,0 +1,568 @@
+"""
+tests/htmlgen/test_editor.py
+
+Tests for src/htmlgen/editor.py — DOM-aware HTML editor (Phase 3).
+
+Tests are named after behaviors (GP-3: abstract edit instructions, deterministic execution)
+and verify the contract between LLM-expressed intent and deterministic DOM mutation.
+
+Named constants for spec-mandated values:
+    SECTION_CLASS = "section"  — the class all sections carry
+    COMMENT_BTN_HTML = the emoji button pattern in headings
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+from src.htmlgen.editor import (
+    EditError,
+    apply_edit,
+    apply_edits,
+    list_section_ids,
+    parse_html,
+)
+
+# ---------------------------------------------------------------------------
+# Named constants — spec-mandated values
+# ---------------------------------------------------------------------------
+
+SECTION_CLASS = "section"
+COMMENT_BTN_FRAGMENT = 'class="comment-btn"'
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _minimal_html(
+    sections: list[dict] | None = None,
+    version: str = "1.0",
+    updated: str = "2026-05-30T00:00:00Z",
+) -> str:
+    """Build a minimal well-formed HTML document for testing.
+
+    Each section dict may have: id, label, title, content.
+    """
+    if sections is None:
+        sections = [
+            {"id": "s1", "label": "§1", "title": "Introduction", "content": "<p>Original content.</p>"},
+            {"id": "s2", "label": "§2", "title": "Background", "content": "<p>Background content.</p>"},
+        ]
+
+    section_divs = ""
+    for s in sections:
+        sid = s.get("id", "s1")
+        label = s.get("label", "")
+        title = s.get("title", "")
+        content = s.get("content", "")
+        label_html = f'<div class="section-label">{label}</div>' if label else ""
+        title_html = (
+            f'<h2>{title} <button class="comment-btn" onclick="toggleComment(this)">&#128172;</button></h2>'
+            if title else ""
+        )
+        comment_area_html = (
+            f'<div class="comment-area"><textarea placeholder="[{label or sid}] "></textarea></div>'
+            if title else ""
+        )
+        section_divs += (
+            f'<div class="{SECTION_CLASS}" id="{sid}">'
+            f"{label_html}{title_html}{comment_area_html}{content}"
+            f"</div>\n"
+        )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="doc-version" content="{version}">
+  <meta name="doc-updated" content="{updated}">
+  <title>Test Document</title>
+</head>
+<body>
+  <div class="wrap">
+    {section_divs}
+    <footer class="doc-footer">
+      <span>doc-id: test-doc</span>
+    </footer>
+  </div>
+  <script data-block-id="main-init">// init code here</script>
+</body>
+</html>"""
+
+
+@pytest.fixture
+def html_file(tmp_path: Path) -> Path:
+    """A minimal HTML file with two sections."""
+    p = tmp_path / "test.html"
+    p.write_text(_minimal_html(), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def html_file_single_section(tmp_path: Path) -> Path:
+    """A minimal HTML file with one section."""
+    p = tmp_path / "single.html"
+    p.write_text(
+        _minimal_html(sections=[
+            {"id": "s1", "label": "§1", "title": "Only Section", "content": "<p>Only content.</p>"},
+        ]),
+        encoding="utf-8",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# replace_section_content tests
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceSectionContent:
+    """replace_section_content replaces body while preserving structural elements."""
+
+    def test_new_content_appears_in_section(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "<p>Replaced content.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert "Replaced content." in str(s1)
+
+    def test_old_content_removed_from_section(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "<p>Replaced.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert "Original content." not in str(s1)
+
+    def test_section_label_preserved_after_replace(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "<p>New body.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert s1.find("div", class_="section-label") is not None
+
+    def test_section_heading_preserved_after_replace(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "<p>New body.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert s1.find("h2") is not None
+
+    def test_comment_area_preserved_after_replace(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "<p>New body.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert s1.find("div", class_="comment-area") is not None
+
+    def test_other_sections_untouched_after_replace(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "<p>Changed.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s2 = soup.find("div", {"class": "section", "id": "s2"})
+        assert "Background content." in str(s2)
+
+    def test_plain_text_content_wrapped_in_paragraph(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "Just plain text.",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert s1.find("p") is not None
+        assert "Just plain text." in str(s1)
+
+    def test_nonexistent_section_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError, match="s99"):
+            apply_edit(html_file, {
+                "op": "replace_section_content",
+                "section_id": "s99",
+                "new_content": "<p>x</p>",
+            })
+
+    def test_section_id_preserved_after_replace(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "replace_section_content",
+            "section_id": "s1",
+            "new_content": "<p>New.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        assert soup.find("div", {"class": "section", "id": "s1"}) is not None
+
+
+# ---------------------------------------------------------------------------
+# add_section tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddSection:
+    """add_section inserts a new section after a named existing section."""
+
+    def test_new_section_present_after_add(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "add_section",
+            "section_id": "s3",
+            "after_id": "s2",
+            "title": "Conclusion",
+            "label": "§3",
+            "content": "<p>Concluding remarks.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        assert soup.find("div", {"class": "section", "id": "s3"}) is not None
+
+    def test_new_section_appears_after_target(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "add_section",
+            "section_id": "s3",
+            "after_id": "s2",
+            "title": "Conclusion",
+            "label": "§3",
+            "content": "<p>Content.</p>",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        sections = soup.find_all("div", class_="section")
+        ids = [s.get("id") for s in sections]
+        assert ids.index("s3") > ids.index("s2")
+
+    def test_new_section_has_correct_title(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "add_section",
+            "section_id": "s3",
+            "after_id": "s2",
+            "title": "My New Title",
+            "label": "§3",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s3 = soup.find("div", {"class": "section", "id": "s3"})
+        assert "My New Title" in str(s3)
+
+    def test_new_section_has_comment_button(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "add_section",
+            "section_id": "s3",
+            "after_id": "s2",
+            "title": "Section With Button",
+            "label": "§3",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s3 = soup.find("div", {"class": "section", "id": "s3"})
+        assert s3.find("button", class_="comment-btn") is not None
+
+    def test_duplicate_section_id_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError, match="already exists"):
+            apply_edit(html_file, {
+                "op": "add_section",
+                "section_id": "s1",  # already exists
+                "after_id": "s2",
+                "title": "Duplicate",
+                "label": "§X",
+            })
+
+    def test_nonexistent_after_id_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError, match="s99"):
+            apply_edit(html_file, {
+                "op": "add_section",
+                "section_id": "s3",
+                "after_id": "s99",  # doesn't exist
+                "title": "New",
+                "label": "§3",
+            })
+
+    def test_existing_sections_untouched_after_add(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "add_section",
+            "section_id": "s3",
+            "after_id": "s2",
+            "title": "Extra",
+            "label": "§3",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        assert soup.find("div", {"class": "section", "id": "s1"}) is not None
+        assert soup.find("div", {"class": "section", "id": "s2"}) is not None
+
+
+# ---------------------------------------------------------------------------
+# remove_section tests
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveSection:
+    """remove_section removes a section element entirely from the document."""
+
+    def test_removed_section_absent_from_document(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "remove_section",
+            "section_id": "s2",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        assert soup.find("div", {"class": "section", "id": "s2"}) is None
+
+    def test_remaining_sections_intact_after_remove(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "remove_section",
+            "section_id": "s2",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        assert soup.find("div", {"class": "section", "id": "s1"}) is not None
+
+    def test_nonexistent_section_remove_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError, match="s99"):
+            apply_edit(html_file, {
+                "op": "remove_section",
+                "section_id": "s99",
+            })
+
+
+# ---------------------------------------------------------------------------
+# update_version_stamp tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateVersionStamp:
+    """update_version_stamp updates doc-version and doc-updated meta tags."""
+
+    def test_version_updated_in_meta_tag(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "update_version_stamp",
+            "version": "2.0",
+            "timestamp": "2026-06-01T12:00:00Z",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        meta = soup.find("meta", {"name": "doc-version"})
+        assert meta["content"] == "2.0"
+
+    def test_timestamp_updated_in_meta_tag(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "update_version_stamp",
+            "version": "2.0",
+            "timestamp": "2026-06-01T12:00:00Z",
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        meta = soup.find("meta", {"name": "doc-updated"})
+        assert meta["content"] == "2026-06-01T12:00:00Z"
+
+    def test_version_only_update_leaves_timestamp_unchanged(self, html_file: Path):
+        original_ts = "2026-05-30T00:00:00Z"
+        apply_edit(html_file, {
+            "op": "update_version_stamp",
+            "version": "1.5",
+            # timestamp omitted
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        meta_ts = soup.find("meta", {"name": "doc-updated"})
+        assert meta_ts["content"] == original_ts
+
+    def test_timestamp_only_update_leaves_version_unchanged(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "update_version_stamp",
+            "timestamp": "2026-07-01T00:00:00Z",
+            # version omitted
+        })
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        meta_v = soup.find("meta", {"name": "doc-version"})
+        assert meta_v["content"] == "1.0"
+
+    def test_missing_doc_version_tag_raises_edit_error(self, tmp_path: Path):
+        html = _minimal_html()
+        html = html.replace('<meta name="doc-version" content="1.0">', "")
+        p = tmp_path / "no-version.html"
+        p.write_text(html, encoding="utf-8")
+        with pytest.raises(EditError, match="doc-version"):
+            apply_edit(p, {
+                "op": "update_version_stamp",
+                "version": "2.0",
+            })
+
+
+# ---------------------------------------------------------------------------
+# patch_js_block tests
+# ---------------------------------------------------------------------------
+
+
+class TestPatchJsBlock:
+    """patch_js_block replaces the content of a named script block."""
+
+    def test_js_block_content_replaced(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "patch_js_block",
+            "block_id": "main-init",
+            "new_code": "console.log('replaced');",
+        })
+        text = html_file.read_text()
+        assert "console.log('replaced');" in text
+        assert "// init code here" not in text
+
+    def test_nonexistent_block_id_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError, match="no-such-block"):
+            apply_edit(html_file, {
+                "op": "patch_js_block",
+                "block_id": "no-such-block",
+                "new_code": "// irrelevant",
+            })
+
+    def test_other_script_blocks_untouched(self, tmp_path: Path):
+        html = (
+            _minimal_html()
+            + '<script data-block-id="other-block">// other</script>'
+        )
+        p = tmp_path / "two-scripts.html"
+        p.write_text(html, encoding="utf-8")
+        apply_edit(p, {
+            "op": "patch_js_block",
+            "block_id": "main-init",
+            "new_code": "// changed",
+        })
+        text = p.read_text()
+        assert "// other" in text
+
+
+# ---------------------------------------------------------------------------
+# Batch operations (apply_edits)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchEdits:
+    """apply_edits applies multiple instructions in order."""
+
+    def test_batch_applies_all_edits(self, html_file: Path):
+        apply_edits(html_file, [
+            {"op": "replace_section_content", "section_id": "s1", "new_content": "<p>New s1.</p>"},
+            {"op": "update_version_stamp", "version": "1.1", "timestamp": "2026-06-01T00:00:00Z"},
+        ])
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert "New s1." in str(s1)
+        meta = soup.find("meta", {"name": "doc-version"})
+        assert meta["content"] == "1.1"
+
+    def test_batch_order_respected(self, html_file: Path):
+        # Two replaces of the same section — last one wins
+        apply_edits(html_file, [
+            {"op": "replace_section_content", "section_id": "s1", "new_content": "<p>First.</p>"},
+            {"op": "replace_section_content", "section_id": "s1", "new_content": "<p>Second.</p>"},
+        ])
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        s1 = soup.find("div", {"class": "section", "id": "s1"})
+        assert "Second." in str(s1)
+        assert "First." not in str(s1)
+
+    def test_batch_stops_on_first_error(self, html_file: Path):
+        """If instruction 1 fails, instruction 2 must not be applied."""
+        with pytest.raises(EditError):
+            apply_edits(html_file, [
+                {"op": "replace_section_content", "section_id": "s99",  # doesn't exist
+                 "new_content": "<p>x</p>"},
+                {"op": "update_version_stamp", "version": "9.9"},
+            ])
+        # Version must still be 1.0 — second instruction didn't apply
+        soup = BeautifulSoup(html_file.read_text(), "html.parser")
+        meta = soup.find("meta", {"name": "doc-version"})
+        assert meta["content"] == "1.0"
+
+    def test_file_not_written_on_error(self, html_file: Path):
+        """A failed batch must not corrupt the file."""
+        original = html_file.read_text()
+        with pytest.raises(EditError):
+            apply_edits(html_file, [
+                {"op": "replace_section_content", "section_id": "s99",
+                 "new_content": "<p>x</p>"},
+            ])
+        # File content must be unchanged
+        assert html_file.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# Utility API tests
+# ---------------------------------------------------------------------------
+
+
+class TestListSectionIds:
+    """list_section_ids returns section IDs in document order."""
+
+    def test_returns_all_section_ids_in_order(self, html_file: Path):
+        ids = list_section_ids(html_file)
+        assert ids == ["s1", "s2"]
+
+    def test_empty_when_no_sections(self, tmp_path: Path):
+        p = tmp_path / "no-sections.html"
+        p.write_text("<html><body><p>No sections.</p></body></html>", encoding="utf-8")
+        assert list_section_ids(p) == []
+
+    def test_reflects_removal(self, html_file: Path):
+        apply_edit(html_file, {"op": "remove_section", "section_id": "s2"})
+        assert list_section_ids(html_file) == ["s1"]
+
+    def test_reflects_addition(self, html_file: Path):
+        apply_edit(html_file, {
+            "op": "add_section",
+            "section_id": "s3",
+            "after_id": "s2",
+            "title": "New",
+            "label": "§3",
+        })
+        ids = list_section_ids(html_file)
+        assert "s3" in ids
+        assert ids.index("s3") > ids.index("s2")
+
+    def test_raises_for_missing_file(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            list_section_ids(tmp_path / "does-not-exist.html")
+
+
+class TestParseHtml:
+    """parse_html returns a BeautifulSoup tree for inspection."""
+
+    def test_returns_beautifulsoup_instance(self, html_file: Path):
+        soup = parse_html(html_file)
+        assert isinstance(soup, BeautifulSoup)
+
+    def test_can_query_sections_from_parsed_tree(self, html_file: Path):
+        soup = parse_html(html_file)
+        sections = soup.find_all("div", class_="section")
+        assert len(sections) == 2
+
+    def test_raises_for_missing_file(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            parse_html(tmp_path / "does-not-exist.html")
+
+
+# ---------------------------------------------------------------------------
+# Error handling — unknown op
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownOp:
+    def test_unknown_op_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError, match="Unknown op"):
+            apply_edit(html_file, {"op": "teleport_section", "section_id": "s1"})
+
+    def test_missing_op_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError, match="missing required 'op'"):
+            apply_edit(html_file, {"section_id": "s1", "new_content": "<p>x</p>"})
+
+    def test_missing_required_field_raises_edit_error(self, html_file: Path):
+        with pytest.raises(EditError):
+            apply_edit(html_file, {"op": "replace_section_content", "section_id": "s1"})
+            # missing new_content

--- a/uv.lock
+++ b/uv.lock
@@ -207,6 +207,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1068,6 +1081,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "fastembed" },
     { name = "fpdf2" },
@@ -1114,6 +1128,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.86.0" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastembed", specifier = ">=0.3.0" },
     { name = "fpdf2", specifier = ">=2.8.7" },
@@ -2381,6 +2396,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this solves

Phase 3 of the HTML evolution project was blocked on the §6 fork decision: should HTML remain the canonical source (Option A: DOM patching) or should a structured intermediate become canonical (Option B: full render pipeline)?

Dan said "unblock and keep executing." Phase 1+2 already built the render pipeline (Option B's core). What was missing was the surgical editing path for existing HTML artifacts — the concrete gap exposed by the 87KB WOS spec comment-response workflow. This PR delivers Option A (DOM patching) as the complement to the existing renderer.

The two options are complementary. The renderer handles new document creation from structured content. The editor handles targeted changes to existing HTML without requiring full regeneration.

## What changed

**src/htmlgen/editor.py — DOM-aware HTML editor (new)**

Implements GP-3 from the HTML doc model spec: LLMs express edits as structured instructions; a deterministic script applies them via BeautifulSoup. The split: the LLM identifies what to change; this script handles how to change it. Neither side needs to hold the full document in context.

Five operation types:
- replace_section_content(section_id, new_content) — replaces section body, preserves structural elements (label div, heading, comment-area)
- add_section(section_id, after_id, title, label, content) — inserts a new section after a named section
- remove_section(section_id) — removes section; ID retired per the spec's permanence rule
- update_version_stamp(version, timestamp) — updates doc-version and doc-updated meta tags
- patch_js_block(block_id, new_code) — replaces content of a named script block

Public API: apply_edit, apply_edits (atomic batch), list_section_ids (coverage check), parse_html (DOM inspection)

**src/htmlgen/templates/registry.yaml — spec-document template fix**

The spec-document template was missing clipboard-copy-widget. The spec (§3 and §10) requires clipboard comment threads on spec documents. Fixes 3 failing tests.

**pyproject.toml — add beautifulsoup4 dependency**

## Before/after: comment-response flow

Before (Smell-5):
Agent receives full 87KB HTML + comment threads → outputs full 1266-line modified HTML → single error invalidates entire file

After (GP-3, this PR enables):
Agent reads comments → outputs structured edit instructions → editor applies deterministically → only changed sections touched → file written atomically on success

## Tests run

- [x] uv run -m pytest tests/htmlgen/test_editor.py -v — 42 passed, 0 failed
- [x] uv run -m pytest tests/htmlgen/ -q — 264 passed, 0 failed (was 219 + 3 failures before this PR)

## Manual test

N/A — pure Python DOM manipulation, no external services.

## Definition of Done

- [x] Unit tests pass — 264/264
- [x] Integration/manual test — N/A (library module, no external services)
- [x] User-visible outcome — N/A (library module)
- [x] Side-effect audit: editor writes only to html_path arg, atomic on success
- [x] External service calls — none