### PR TITLE
feat(wos): Stage 1 Adaptive Steward — verdict accumulator, Haiku normalization, observability rollup

### DIFF
--- a/src/orchestration/migrations/0029_adaptive_steward_verdict_accumulator.sql
+++ b/src/orchestration/migrations/0029_adaptive_steward_verdict_accumulator.sql
@@ -1,0 +1,50 @@
+-- Migration 0029: Adaptive Steward — verdict_accumulator, prescription_hypothesis_log,
+-- normalization_log tables.
+--
+-- §3-I Adaptive Steward (wos-evolution-spec.md).
+--
+-- verdict_accumulator: aggregate scored outcomes per (register, hypothesis_normalized).
+--   Each row accumulates pass/fail/partial counts across all UoWs that shared the same
+--   normalized hypothesis. The UNIQUE constraint on (register, diagnosis_hypothesis)
+--   enforces the aggregate-upsert pattern: every new scored outcome either inserts a
+--   new row or increments an existing one.
+--
+-- prescription_hypothesis_log: per-UoW record of the raw hypothesis at prescription time.
+--   The Steward writes one row here when it logs a prescription. At UoW closure, the
+--   normalization hook reads this row to find the raw hypothesis before scoring it.
+--
+-- normalization_log: audit trail for every Haiku normalization call.
+--   Records both the original and normalized form so hypothesis drift and overcollapse
+--   in normalization behavior are visible over time.
+
+CREATE TABLE IF NOT EXISTS verdict_accumulator (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    register             TEXT    NOT NULL,
+    diagnosis_hypothesis TEXT    NOT NULL,       -- normalized form
+    n_successes          INTEGER NOT NULL DEFAULT 0,
+    n_failures           INTEGER NOT NULL DEFAULT 0,
+    n_partial            INTEGER NOT NULL DEFAULT 0,
+    last_updated         TEXT    NOT NULL,
+    UNIQUE(register, diagnosis_hypothesis)
+);
+
+CREATE TABLE IF NOT EXISTS prescription_hypothesis_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    uow_id       TEXT    NOT NULL,
+    hypothesis   TEXT    NOT NULL,
+    register     TEXT    NOT NULL,
+    generated_at TEXT    NOT NULL,
+    outcome      TEXT    NULL,      -- 'pass' | 'fail' | 'partial' — written at scoring time
+    scored_at    TEXT    NULL       -- ISO timestamp — written at scoring time
+);
+
+-- normalization_log: audit of every Haiku normalization call.
+-- model: the model ID used (e.g. "claude-haiku-4-5-20251001").
+CREATE TABLE IF NOT EXISTS normalization_log (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    uow_id     TEXT    NOT NULL,
+    raw        TEXT    NOT NULL,
+    normalized TEXT    NOT NULL,
+    model      TEXT    NOT NULL,
+    ts         TEXT    NOT NULL
+);

--- a/src/orchestration/prescription_object.py
+++ b/src/orchestration/prescription_object.py
@@ -1,0 +1,142 @@
+"""
+PrescriptionObject — typed representation of a Steward prescription for scoring.
+
+§3-I Adaptive Steward (wos-evolution-spec.md).
+
+PrescriptionObject captures the machine-comparable fields of a prescription at
+dispatch time. Its primary role is to supply the `diagnosis_hypothesis` string
+to the verdict scoring pipeline — the 140-character description of what the
+Steward believes is wrong and how it plans to fix it.
+
+Design:
+- Frozen dataclass: prescriptions are immutable once written. No in-place edits.
+- Separate from PrescriptionV2: PrescriptionV2 is the full 7-section LLM output
+  consumed by the Executor. PrescriptionObject is a scoring-layer artifact that
+  extracts the scoring-relevant fields for the verdict accumulator pipeline.
+- module-level: no registry imports. Can be imported in isolation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from orchestration.registry import UoWRegister
+
+
+# Spec-mandated maximum length for diagnosis_hypothesis (machine-comparable).
+HYPOTHESIS_MAX_CHARS: int = 140
+
+
+def _truncate_hypothesis(raw: str) -> str:
+    """
+    Truncate *raw* to HYPOTHESIS_MAX_CHARS characters.
+
+    Pure function — no side effects.
+    """
+    return raw[:HYPOTHESIS_MAX_CHARS]
+
+
+@dataclass(frozen=True)
+class PrescriptionObject:
+    """
+    Typed representation of a Steward prescription for the verdict scoring pipeline.
+
+    §3-I Adaptive Steward spec (wos-evolution-spec.md).
+
+    Fields
+    ------
+    uow_id : str
+        The UoW this prescription was written for.
+    register : UoWRegister
+        Attentional register of the UoW at prescription time.
+    diagnosis_hypothesis : str
+        Max 140 characters. Machine-comparable description of what the Steward
+        believes is the root cause and how it plans to fix it. This is the
+        string passed to the Haiku normalization call at verdict scoring time.
+    proposed_steps : list[str]
+        Ordered list of steps proposed by the prescription.
+    confidence : float
+        Steward's confidence in the prescription (0.0–1.0).
+    counterfactual_question : str
+        "What would falsify this hypothesis?" — provided for human review and
+        future use as a secondary scoring signal.
+    generated_at : str
+        ISO 8601 UTC timestamp when this prescription was generated.
+    selector_priors : list[str]
+        Top-5 prior hypothesis IDs from verdict_accumulator that influenced
+        this prescription. Empty list when the accumulator has no signal yet.
+    """
+
+    uow_id: str
+    register: UoWRegister
+    diagnosis_hypothesis: str
+    proposed_steps: list[str]
+    confidence: float
+    counterfactual_question: str
+    generated_at: str
+    selector_priors: list[str]
+
+    def __post_init__(self) -> None:
+        # Enforce the 140-char limit at construction time so callers cannot
+        # accidentally store an over-long hypothesis in the log.
+        if len(self.diagnosis_hypothesis) > HYPOTHESIS_MAX_CHARS:
+            raise ValueError(
+                f"PrescriptionObject.diagnosis_hypothesis exceeds {HYPOTHESIS_MAX_CHARS} chars "
+                f"(got {len(self.diagnosis_hypothesis)}): {self.diagnosis_hypothesis!r}"
+            )
+
+
+def build_prescription_object(
+    uow_id: str,
+    register: UoWRegister,
+    hypothesis_raw: str,
+    proposed_steps: list[str],
+    confidence: float,
+    counterfactual_question: str,
+    generated_at: str,
+    selector_priors: list[str] | None = None,
+) -> PrescriptionObject:
+    """
+    Build a PrescriptionObject, truncating the hypothesis to spec max length.
+
+    Use this factory rather than the constructor directly when the hypothesis
+    comes from LLM output (which may exceed 140 chars).
+
+    Pure function — no side effects.
+
+    Args:
+        uow_id: The UoW identifier.
+        register: The attentional register.
+        hypothesis_raw: The raw hypothesis string (will be truncated to 140 chars).
+        proposed_steps: The ordered list of proposed steps.
+        confidence: Prescription confidence (0.0–1.0).
+        counterfactual_question: "What would falsify this hypothesis?"
+        generated_at: ISO 8601 UTC timestamp.
+        selector_priors: Top-5 hypothesis IDs from verdict_accumulator. Defaults to [].
+
+    Returns:
+        Frozen PrescriptionObject.
+    """
+    return PrescriptionObject(
+        uow_id=uow_id,
+        register=register,
+        diagnosis_hypothesis=_truncate_hypothesis(hypothesis_raw),
+        proposed_steps=list(proposed_steps),
+        confidence=float(confidence),
+        counterfactual_question=counterfactual_question,
+        generated_at=generated_at,
+        selector_priors=list(selector_priors or []),
+    )
+
+
+def hypothesis_from_uow_summary(summary: str) -> str:
+    """
+    Derive a machine-comparable hypothesis string from a UoW summary.
+
+    Used when no explicit PrescriptionObject is available for a UoW (e.g. UoWs
+    created before the Adaptive Steward was deployed). The summary is truncated
+    to HYPOTHESIS_MAX_CHARS.
+
+    Pure function — no side effects.
+    """
+    return _truncate_hypothesis((summary or "").strip())

--- a/src/orchestration/verdict_normalization.py
+++ b/src/orchestration/verdict_normalization.py
@@ -1,0 +1,485 @@
+"""
+verdict_normalization.py — Haiku normalization and verdict accumulator upsert.
+
+§3-I Adaptive Steward (wos-evolution-spec.md), Fork 1 — Option C (LOCKED).
+
+At UoW closure, this module:
+1. Normalizes the raw hypothesis string via a Haiku call (deduplicates phrasing,
+   enforces consistent vocabulary).
+2. Upserts the scored, normalized hypothesis into `verdict_accumulator`.
+3. Logs both the raw and normalized form to `normalization_log` for observability.
+
+Design principles:
+- Non-fatal: all methods catch and log exceptions so UoW closure is never blocked.
+- Pure normalization function: `normalize_hypothesis_text` is a pure transformation
+  (modulo network I/O) — it does not write to any DB.
+- Idempotency: verdict_accumulator upsert uses INSERT OR REPLACE with
+  n_successes/n_failures/n_partial increments so duplicate calls are safe.
+- Prompt caching: the system prompt is marked with cache_control so repeated
+  calls on the same model session benefit from cache hits.
+
+Model: claude-haiku-4-5-20251001 (HAIKU_MODEL constant).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+log = logging.getLogger("verdict_normalization")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Haiku model ID for normalization calls (spec §3-I, Fork 1 Option C).
+HAIKU_MODEL: str = "claude-haiku-4-5-20251001"
+
+#: Outcome labels accepted by the accumulator upsert.
+VerdictOutcome = Literal["pass", "fail", "partial"]
+
+#: Normalization system prompt — static text eligible for prompt caching.
+_NORMALIZATION_SYSTEM_PROMPT: str = (
+    "You are a hypothesis normalization assistant for a software engineering workflow system.\n"
+    "Given a raw hypothesis string describing what a system believes is the root cause of a problem "
+    "and how it plans to fix it, produce a canonical normalized form that:\n"
+    "1. Removes implementation-specific details that would prevent matching across similar hypotheses.\n"
+    "2. Uses consistent vocabulary (e.g. 'configuration issue' not 'config problem' or 'config bug').\n"
+    "3. Preserves the core causal claim and proposed fix.\n"
+    "4. Is at most 140 characters.\n"
+    "5. Is in present tense, third person (e.g. 'Missing X causes Y; fix by adding Z').\n\n"
+    "Respond with ONLY the normalized hypothesis string — no explanation, no quotes, no punctuation "
+    "unless part of the hypothesis itself."
+)
+
+#: Maximum characters for the normalized hypothesis (mirrors PrescriptionObject spec).
+_HYPOTHESIS_MAX_CHARS: int = 140
+
+#: Default path to the WOS metrics DB (relative to LOBSTER_WORKSPACE).
+_METRICS_DB_SUBPATH: str = "orchestration/wos-metrics.db"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _metrics_db_path() -> Path:
+    """Return the absolute path to wos-metrics.db, honouring LOBSTER_WORKSPACE."""
+    workspace = os.environ.get(
+        "LOBSTER_WORKSPACE",
+        str(Path.home() / "lobster-workspace"),
+    )
+    return Path(workspace) / _METRICS_DB_SUBPATH
+
+
+def _connect_metrics_db() -> sqlite3.Connection:
+    db_path = _metrics_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    """Create normalization_log and verdict_accumulator tables if absent."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS normalization_log (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            uow_id     TEXT    NOT NULL,
+            raw        TEXT    NOT NULL,
+            normalized TEXT    NOT NULL,
+            model      TEXT    NOT NULL,
+            ts         TEXT    NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS verdict_accumulator (
+            id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+            register             TEXT    NOT NULL,
+            diagnosis_hypothesis TEXT    NOT NULL,
+            n_successes          INTEGER NOT NULL DEFAULT 0,
+            n_failures           INTEGER NOT NULL DEFAULT 0,
+            n_partial            INTEGER NOT NULL DEFAULT 0,
+            last_updated         TEXT    NOT NULL,
+            UNIQUE(register, diagnosis_hypothesis)
+        );
+
+        CREATE TABLE IF NOT EXISTS prescription_hypothesis_log (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            uow_id       TEXT    NOT NULL,
+            hypothesis   TEXT    NOT NULL,
+            register     TEXT    NOT NULL,
+            generated_at TEXT    NOT NULL,
+            outcome      TEXT    NULL,
+            scored_at    TEXT    NULL
+        );
+    """)
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Normalization (Haiku call)
+# ---------------------------------------------------------------------------
+
+def normalize_hypothesis_text(
+    raw: str,
+    *,
+    model: str = HAIKU_MODEL,
+    anthropic_client=None,  # type: ignore[assignment]
+) -> str:
+    """
+    Normalize *raw* hypothesis string via a Haiku call.
+
+    The normalization prompt is sent with cache_control on the system prompt
+    so repeated calls on the same session benefit from cache hits.
+
+    Args:
+        raw: The raw hypothesis string (will be truncated to 140 chars if the
+             model returns something longer).
+        model: The model ID to use. Defaults to HAIKU_MODEL.
+        anthropic_client: An already-constructed `anthropic.Anthropic` instance.
+            When None, a new client is created using the ANTHROPIC_API_KEY env var.
+            Inject a mock in tests.
+
+    Returns:
+        Normalized hypothesis string (≤140 chars).
+
+    Raises:
+        RuntimeError: If the Anthropic API call fails or returns an empty response.
+    """
+    if anthropic_client is None:
+        import anthropic
+        anthropic_client = anthropic.Anthropic()
+
+    response = anthropic_client.messages.create(
+        model=model,
+        max_tokens=200,
+        system=[
+            {
+                "type": "text",
+                "text": _NORMALIZATION_SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[
+            {
+                "role": "user",
+                "content": f"Normalize this hypothesis:\n\n{raw}",
+            }
+        ],
+    )
+
+    # Extract text from the first content block
+    if not response.content:
+        raise RuntimeError(
+            f"Haiku normalization returned empty content for hypothesis: {raw!r}"
+        )
+
+    text_blocks = [
+        block.text for block in response.content
+        if hasattr(block, "text")
+    ]
+    if not text_blocks:
+        raise RuntimeError(
+            f"Haiku normalization returned no text content for hypothesis: {raw!r}"
+        )
+
+    normalized = text_blocks[0].strip()[:_HYPOTHESIS_MAX_CHARS]
+    if not normalized:
+        raise RuntimeError(
+            f"Haiku normalization returned empty string for hypothesis: {raw!r}"
+        )
+
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# DB writes
+# ---------------------------------------------------------------------------
+
+def _log_normalization(
+    conn: sqlite3.Connection,
+    uow_id: str,
+    raw: str,
+    normalized: str,
+    model: str,
+) -> None:
+    """
+    Write one row to normalization_log.
+
+    Pure side effect — no return value.
+    """
+    ts = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO normalization_log (uow_id, raw, normalized, model, ts) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (uow_id, raw, normalized, model, ts),
+    )
+
+
+def _upsert_verdict(
+    conn: sqlite3.Connection,
+    register: str,
+    hypothesis_normalized: str,
+    outcome: VerdictOutcome,
+) -> None:
+    """
+    Insert or update a verdict_accumulator row.
+
+    On INSERT: initialize the matching outcome counter to 1.
+    On conflict (same register + hypothesis): increment the matching counter.
+
+    Uses SQLite's INSERT OR IGNORE + UPDATE pattern to avoid the
+    INSERT OR REPLACE anti-pattern (which resets non-matched counters to 0).
+
+    Pure side effect — no return value.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Ensure the row exists first.
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO verdict_accumulator
+            (register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated)
+        VALUES (?, ?, 0, 0, 0, ?)
+        """,
+        (register, hypothesis_normalized, now),
+    )
+
+    # Increment the appropriate counter.
+    if outcome == "pass":
+        conn.execute(
+            "UPDATE verdict_accumulator SET n_successes = n_successes + 1, last_updated = ? "
+            "WHERE register = ? AND diagnosis_hypothesis = ?",
+            (now, register, hypothesis_normalized),
+        )
+    elif outcome == "fail":
+        conn.execute(
+            "UPDATE verdict_accumulator SET n_failures = n_failures + 1, last_updated = ? "
+            "WHERE register = ? AND diagnosis_hypothesis = ?",
+            (now, register, hypothesis_normalized),
+        )
+    else:  # "partial"
+        conn.execute(
+            "UPDATE verdict_accumulator SET n_partial = n_partial + 1, last_updated = ? "
+            "WHERE register = ? AND diagnosis_hypothesis = ?",
+            (now, register, hypothesis_normalized),
+        )
+
+
+def _mark_hypothesis_scored(
+    conn: sqlite3.Connection,
+    uow_id: str,
+    outcome: VerdictOutcome,
+) -> None:
+    """
+    Write outcome + scored_at to prescription_hypothesis_log for the given uow_id.
+
+    Idempotency guard: only updates rows where scored_at IS NULL.
+    Pure side effect — no return value.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "UPDATE prescription_hypothesis_log "
+        "SET outcome = ?, scored_at = ? "
+        "WHERE uow_id = ? AND scored_at IS NULL",
+        (outcome, now, uow_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def score_and_normalize_verdict(
+    uow_id: str,
+    register: str,
+    hypothesis_raw: str,
+    outcome: VerdictOutcome,
+    *,
+    model: str = HAIKU_MODEL,
+    anthropic_client=None,  # type: ignore[assignment]
+    db_path: Path | None = None,
+) -> None:
+    """
+    Normalize *hypothesis_raw* via Haiku and upsert the scored verdict.
+
+    Called at UoW closure by `maybe_complete_wos_uow` and the failure path.
+    Non-fatal: all exceptions are caught and logged at WARNING level so that
+    UoW closure is never blocked.
+
+    Steps:
+    1. Normalize the raw hypothesis via `normalize_hypothesis_text` (Haiku call).
+    2. Write one row to `normalization_log` (raw + normalized + model + ts).
+    3. Upsert into `verdict_accumulator` (increment appropriate counter).
+    4. Mark the `prescription_hypothesis_log` row as scored (idempotent).
+
+    Args:
+        uow_id: The UoW identifier.
+        register: The UoW's attentional register (written to verdict_accumulator).
+        hypothesis_raw: The raw hypothesis string (from UoW summary or
+            prescription_hypothesis_log).
+        outcome: One of "pass", "fail", "partial".
+        model: Haiku model ID (injectable for tests).
+        anthropic_client: Pre-constructed Anthropic client (injectable for tests).
+        db_path: Override the metrics DB path (injectable for tests).
+    """
+    if not hypothesis_raw or not hypothesis_raw.strip():
+        log.warning(
+            "score_and_normalize_verdict: empty hypothesis for UoW %r — skipping",
+            uow_id,
+        )
+        return
+
+    try:
+        normalized = normalize_hypothesis_text(
+            hypothesis_raw.strip(),
+            model=model,
+            anthropic_client=anthropic_client,
+        )
+    except Exception as exc:
+        log.warning(
+            "score_and_normalize_verdict: Haiku normalization failed for UoW %r — %s: %s",
+            uow_id,
+            type(exc).__name__,
+            exc,
+        )
+        return
+
+    effective_db_path = db_path or _metrics_db_path()
+    try:
+        conn = sqlite3.connect(str(effective_db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        try:
+            _ensure_schema(conn)
+            _log_normalization(conn, uow_id, hypothesis_raw.strip(), normalized, model)
+            _upsert_verdict(conn, register, normalized, outcome)
+            _mark_hypothesis_scored(conn, uow_id, outcome)
+            conn.commit()
+            log.info(
+                "score_and_normalize_verdict: scored UoW %r (outcome=%r, "
+                "register=%r, normalized=%r)",
+                uow_id,
+                outcome,
+                register,
+                normalized,
+            )
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning(
+            "score_and_normalize_verdict: DB write failed for UoW %r — %s: %s",
+            uow_id,
+            type(exc).__name__,
+            exc,
+        )
+
+
+def log_prescription_hypothesis(
+    uow_id: str,
+    hypothesis: str,
+    register: str,
+    generated_at: str,
+    *,
+    db_path: Path | None = None,
+) -> None:
+    """
+    Write a row to prescription_hypothesis_log at prescription time.
+
+    Called by the Steward when it generates a new prescription so the
+    verdict scoring hook can look up the hypothesis at UoW closure.
+
+    Non-fatal: all exceptions are caught and logged at WARNING level.
+
+    Args:
+        uow_id: The UoW identifier.
+        hypothesis: The raw hypothesis string (diagnosis_hypothesis from
+            PrescriptionObject, or derived from uow.summary).
+        register: The UoW's attentional register.
+        generated_at: ISO timestamp of prescription generation.
+        db_path: Override the metrics DB path (injectable for tests).
+    """
+    effective_db_path = db_path or _metrics_db_path()
+    try:
+        conn = sqlite3.connect(str(effective_db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        try:
+            _ensure_schema(conn)
+            conn.execute(
+                "INSERT INTO prescription_hypothesis_log "
+                "(uow_id, hypothesis, register, generated_at) "
+                "VALUES (?, ?, ?, ?)",
+                (uow_id, hypothesis, register, generated_at),
+            )
+            conn.commit()
+            log.debug(
+                "log_prescription_hypothesis: logged hypothesis for UoW %r (register=%r)",
+                uow_id,
+                register,
+            )
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning(
+            "log_prescription_hypothesis: DB write failed for UoW %r — %s: %s",
+            uow_id,
+            type(exc).__name__,
+            exc,
+        )
+
+
+def get_hypothesis_for_uow(
+    uow_id: str,
+    *,
+    db_path: Path | None = None,
+) -> str | None:
+    """
+    Look up the raw hypothesis for a UoW from prescription_hypothesis_log.
+
+    Returns the hypothesis from the most recent unscored row for *uow_id*,
+    or None if no such row exists.
+
+    Used by the verdict scoring hook to find the hypothesis at UoW closure
+    when it was not passed explicitly.
+
+    Non-fatal: returns None on any DB error.
+    """
+    effective_db_path = db_path or _metrics_db_path()
+    if not Path(effective_db_path).exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(effective_db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT hypothesis FROM prescription_hypothesis_log "
+                "WHERE uow_id = ? AND scored_at IS NULL "
+                "ORDER BY id DESC LIMIT 1",
+                (uow_id,),
+            ).fetchone()
+            return row["hypothesis"] if row else None
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning(
+            "get_hypothesis_for_uow: DB read failed for UoW %r — %s: %s",
+            uow_id,
+            type(exc).__name__,
+            exc,
+        )
+        return None

--- a/src/orchestration/verdict_stats.py
+++ b/src/orchestration/verdict_stats.py
@@ -1,0 +1,441 @@
+"""
+verdict_stats.py — Observability rollup for the verdict accumulator.
+
+§3-I Adaptive Steward (wos-evolution-spec.md).
+
+Provides read-path queries against the verdict_accumulator and normalization_log
+tables in wos-metrics.db. These functions feed the observability dashboard
+(normalization clustering health, hypothesis signal quality) and will be
+consumed by the Orientation Layer Governor in Stage 3.
+
+Design:
+- Pure read path: all functions are SELECT-only, no writes.
+- Non-fatal on missing DB: returns empty results when wos-metrics.db does not
+  exist so callers do not need to guard against fresh installs.
+- Named return types: typed dataclasses for all query results so callers get
+  IDE support and the dashboard generator can pattern-match on fields.
+
+Gate condition for Stage 2: accumulator_total_scored() >= GATE_SCORED_OUTCOMES_MIN.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger("verdict_stats")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Gate condition: Stage 2 requires at least this many scored outcomes.
+#: Spec §4 transition table: "verdict_accumulator has 20+ scored outcomes".
+GATE_SCORED_OUTCOMES_MIN: int = 20
+
+#: "Pearl" threshold: hypotheses with success rate ≥ this are considered pearls.
+#: Spec §5 glossary: "Pearl from Adaptive Steward = hypothesis with >0.7 success rate after 5+ observations".
+PEARL_SUCCESS_RATE_THRESHOLD: float = 0.7
+
+#: Minimum observations before a hypothesis is considered stable signal.
+#: Spec §5 glossary: "after 5+ observations".
+PEARL_MIN_OBSERVATIONS: int = 5
+
+#: Default path relative to LOBSTER_WORKSPACE.
+_METRICS_DB_SUBPATH: str = "orchestration/wos-metrics.db"
+
+
+def _metrics_db_path() -> Path:
+    workspace = os.environ.get(
+        "LOBSTER_WORKSPACE",
+        str(Path.home() / "lobster-workspace"),
+    )
+    return Path(workspace) / _METRICS_DB_SUBPATH
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Return types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class HypothesisRollup:
+    """
+    Aggregated scoring data for one normalized hypothesis across a register.
+
+    Fields
+    ------
+    register : str
+        The UoW attentional register.
+    diagnosis_hypothesis : str
+        The normalized hypothesis string.
+    n_successes : int
+        Total scored outcomes with outcome='pass'.
+    n_failures : int
+        Total scored outcomes with outcome='fail'.
+    n_partial : int
+        Total scored outcomes with outcome='partial'.
+    total : int
+        Sum of n_successes + n_failures + n_partial.
+    success_rate : float
+        n_successes / total (0.0 when total == 0).
+    last_updated : str
+        ISO timestamp of the last upsert.
+    """
+
+    register: str
+    diagnosis_hypothesis: str
+    n_successes: int
+    n_failures: int
+    n_partial: int
+    total: int
+    success_rate: float
+    last_updated: str
+
+
+@dataclass(frozen=True)
+class NormalizationClusterHealth:
+    """
+    Clustering health report for one register.
+
+    Used to detect hypothesis fragmentation (Churn Basin failure mode).
+    A healthy register has a high raw-to-normalized compression ratio.
+
+    Fields
+    ------
+    register : str
+        The UoW attentional register.
+    distinct_normalized : int
+        Count of distinct normalized hypothesis strings in verdict_accumulator.
+    distinct_raw : int
+        Count of distinct raw hypothesis strings in normalization_log.
+    mean_observations : float
+        Mean (n_successes + n_failures + n_partial) across all hypothesis rows.
+    churn_basin_risk : bool
+        True when distinct_normalized > 100 AND mean_observations < 5.
+        Spec §5.1 Churn Basin detection threshold.
+    """
+
+    register: str
+    distinct_normalized: int
+    distinct_raw: int
+    mean_observations: float
+    churn_basin_risk: bool
+
+
+@dataclass(frozen=True)
+class AccumulatorSummary:
+    """
+    High-level summary of the verdict accumulator state.
+
+    Fields
+    ------
+    total_scored : int
+        Total number of distinct (register, hypothesis) pairs with at least
+        one scored outcome.
+    gate_ready : bool
+        True when total_scored >= GATE_SCORED_OUTCOMES_MIN (Stage 2 gate).
+    pearl_count : int
+        Hypotheses with success_rate >= PEARL_SUCCESS_RATE_THRESHOLD and
+        total >= PEARL_MIN_OBSERVATIONS.
+    """
+
+    total_scored: int
+    gate_ready: bool
+    pearl_count: int
+
+
+# ---------------------------------------------------------------------------
+# Query functions
+# ---------------------------------------------------------------------------
+
+def get_hypothesis_rollup(
+    register: str | None = None,
+    *,
+    db_path: Path | None = None,
+    min_observations: int = 0,
+) -> list[HypothesisRollup]:
+    """
+    Return per-hypothesis aggregated scoring data, optionally filtered by register.
+
+    Results are ordered by success_rate descending, then total descending.
+
+    Args:
+        register: Optional register filter. None returns all registers.
+        db_path: Override metrics DB path (injectable for tests).
+        min_observations: Only return rows with total >= this value.
+
+    Returns:
+        List of HypothesisRollup objects (empty if DB absent or no data).
+    """
+    effective_db_path = db_path or _metrics_db_path()
+    if not Path(effective_db_path).exists():
+        return []
+
+    try:
+        conn = _connect(effective_db_path)
+        try:
+            base_query = """
+                SELECT
+                    register,
+                    diagnosis_hypothesis,
+                    n_successes,
+                    n_failures,
+                    n_partial,
+                    (n_successes + n_failures + n_partial) AS total,
+                    CASE
+                        WHEN (n_successes + n_failures + n_partial) = 0 THEN 0.0
+                        ELSE CAST(n_successes AS REAL) / (n_successes + n_failures + n_partial)
+                    END AS success_rate,
+                    last_updated
+                FROM verdict_accumulator
+                WHERE (n_successes + n_failures + n_partial) >= ?
+            """
+            params: list = [min_observations]
+
+            if register is not None:
+                base_query += " AND register = ?"
+                params.append(register)
+
+            base_query += " ORDER BY success_rate DESC, total DESC"
+
+            rows = conn.execute(base_query, params).fetchall()
+            return [
+                HypothesisRollup(
+                    register=r["register"],
+                    diagnosis_hypothesis=r["diagnosis_hypothesis"],
+                    n_successes=r["n_successes"],
+                    n_failures=r["n_failures"],
+                    n_partial=r["n_partial"],
+                    total=r["total"],
+                    success_rate=r["success_rate"],
+                    last_updated=r["last_updated"],
+                )
+                for r in rows
+            ]
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("get_hypothesis_rollup: query failed — %s: %s", type(exc).__name__, exc)
+        return []
+
+
+def get_normalization_cluster_health(
+    *,
+    db_path: Path | None = None,
+) -> list[NormalizationClusterHealth]:
+    """
+    Return per-register normalization clustering health.
+
+    Computes distinct_normalized (from verdict_accumulator) and distinct_raw
+    (from normalization_log) per register to detect Churn Basin risk.
+
+    Args:
+        db_path: Override metrics DB path (injectable for tests).
+
+    Returns:
+        List of NormalizationClusterHealth objects (empty if DB absent or no data).
+    """
+    effective_db_path = db_path or _metrics_db_path()
+    if not Path(effective_db_path).exists():
+        return []
+
+    try:
+        conn = _connect(effective_db_path)
+        try:
+            # Accumulator stats per register
+            accumulator_rows = conn.execute(
+                """
+                SELECT
+                    register,
+                    COUNT(DISTINCT diagnosis_hypothesis) AS distinct_normalized,
+                    AVG(n_successes + n_failures + n_partial) AS mean_obs
+                FROM verdict_accumulator
+                GROUP BY register
+                """
+            ).fetchall()
+
+            # Raw hypothesis count per register from normalization_log.
+            # Note: normalization_log joins to prescription_hypothesis_log by uow_id
+            # to get the register. We query prescription_hypothesis_log for register.
+            raw_counts: dict[str, int] = {}
+            try:
+                raw_rows = conn.execute(
+                    """
+                    SELECT p.register, COUNT(DISTINCT n.raw) AS distinct_raw
+                    FROM normalization_log n
+                    JOIN prescription_hypothesis_log p ON n.uow_id = p.uow_id
+                    GROUP BY p.register
+                    """
+                ).fetchall()
+                raw_counts = {r["register"]: r["distinct_raw"] for r in raw_rows}
+            except Exception as raw_exc:
+                # prescription_hypothesis_log may not exist on pre-migration DBs
+                log.debug(
+                    "get_normalization_cluster_health: raw count query failed — %s",
+                    raw_exc,
+                )
+
+            results = []
+            for row in accumulator_rows:
+                register = row["register"]
+                distinct_normalized = row["distinct_normalized"]
+                mean_obs = float(row["mean_obs"] or 0.0)
+                distinct_raw = raw_counts.get(register, distinct_normalized)
+
+                # Spec §5.1 Churn Basin detection:
+                # >100 distinct hypotheses per register AND mean observations <5
+                churn_basin_risk = (distinct_normalized > 100 and mean_obs < 5.0)
+
+                results.append(NormalizationClusterHealth(
+                    register=register,
+                    distinct_normalized=distinct_normalized,
+                    distinct_raw=distinct_raw,
+                    mean_observations=mean_obs,
+                    churn_basin_risk=churn_basin_risk,
+                ))
+            return results
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning(
+            "get_normalization_cluster_health: query failed — %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        return []
+
+
+def accumulator_total_scored(
+    *,
+    db_path: Path | None = None,
+) -> int:
+    """
+    Return the total number of distinct (register, hypothesis) pairs with
+    at least one scored outcome.
+
+    Gate condition check for Stage 2: when this value >= GATE_SCORED_OUTCOMES_MIN,
+    the Governor can begin operating on real signal.
+
+    Args:
+        db_path: Override metrics DB path (injectable for tests).
+
+    Returns:
+        Count of distinct scored hypothesis rows. 0 if DB absent or error.
+    """
+    effective_db_path = db_path or _metrics_db_path()
+    if not Path(effective_db_path).exists():
+        return 0
+
+    try:
+        conn = _connect(effective_db_path)
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) AS c FROM verdict_accumulator "
+                "WHERE (n_successes + n_failures + n_partial) > 0"
+            ).fetchone()
+            return int(row["c"]) if row else 0
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("accumulator_total_scored: query failed — %s: %s", type(exc).__name__, exc)
+        return 0
+
+
+def get_accumulator_summary(
+    *,
+    db_path: Path | None = None,
+) -> AccumulatorSummary:
+    """
+    Return a high-level summary of the accumulator state.
+
+    Includes gate_ready flag (Stage 2 gate condition) and pearl count.
+
+    Args:
+        db_path: Override metrics DB path (injectable for tests).
+
+    Returns:
+        AccumulatorSummary with total_scored, gate_ready, and pearl_count.
+    """
+    effective_db_path = db_path or _metrics_db_path()
+    if not Path(effective_db_path).exists():
+        return AccumulatorSummary(
+            total_scored=0,
+            gate_ready=False,
+            pearl_count=0,
+        )
+
+    try:
+        conn = _connect(effective_db_path)
+        try:
+            total_scored = int(
+                conn.execute(
+                    "SELECT COUNT(*) AS c FROM verdict_accumulator "
+                    "WHERE (n_successes + n_failures + n_partial) > 0"
+                ).fetchone()["c"]
+            )
+
+            pearl_count = int(
+                conn.execute(
+                    """
+                    SELECT COUNT(*) AS c FROM verdict_accumulator
+                    WHERE (n_successes + n_failures + n_partial) >= ?
+                    AND CAST(n_successes AS REAL) / (n_successes + n_failures + n_partial) >= ?
+                    """,
+                    (PEARL_MIN_OBSERVATIONS, PEARL_SUCCESS_RATE_THRESHOLD),
+                ).fetchone()["c"]
+            )
+
+            return AccumulatorSummary(
+                total_scored=total_scored,
+                gate_ready=total_scored >= GATE_SCORED_OUTCOMES_MIN,
+                pearl_count=pearl_count,
+            )
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("get_accumulator_summary: query failed — %s: %s", type(exc).__name__, exc)
+        return AccumulatorSummary(total_scored=0, gate_ready=False, pearl_count=0)
+
+
+def get_top_priors(
+    register: str,
+    *,
+    limit: int = 5,
+    db_path: Path | None = None,
+) -> list[str]:
+    """
+    Return the top *limit* hypothesis strings for *register* ordered by success rate.
+
+    This is the Selector query: pure SQL on verdict_accumulator, ordered by
+    success rate. Used to inject top-5 priors into the prescription prompt.
+    No LLM call required.
+
+    Spec §3-I: "Selector: Pure SQL query on verdict_accumulator ordered by success
+    rate. Injects top-5 priors into prescription prompt."
+
+    Args:
+        register: The UoW attentional register.
+        limit: Maximum number of hypotheses to return (default 5 per spec).
+        db_path: Override metrics DB path (injectable for tests).
+
+    Returns:
+        List of normalized hypothesis strings (may be shorter than *limit*
+        when insufficient data exists).
+    """
+    rollup = get_hypothesis_rollup(
+        register=register,
+        db_path=db_path,
+        min_observations=1,
+    )
+    return [r.diagnosis_hypothesis for r in rollup[:limit]]

--- a/src/orchestration/wos_completion.py
+++ b/src/orchestration/wos_completion.py
@@ -784,6 +784,68 @@ def _stamp_issue_on_completion(
 
 
 # ---------------------------------------------------------------------------
+# Adaptive Steward scoring hook — §3-I wos-evolution-spec.md
+# ---------------------------------------------------------------------------
+
+def _score_verdict_for_uow(
+    uow_id: str,
+    uow: object,
+    outcome: str,
+) -> None:
+    """
+    Normalize the UoW hypothesis and upsert a scored verdict into verdict_accumulator.
+
+    Called at UoW closure (success or failure) to feed the Adaptive Steward
+    learning layer. Non-fatal: all exceptions are caught and logged at WARNING
+    level so UoW transitions are never blocked.
+
+    Hypothesis source priority:
+    1. prescription_hypothesis_log (written by Steward at prescription time)
+    2. uow.summary (fallback for UoWs created before the Adaptive Steward)
+
+    Args:
+        uow_id: The WOS unit-of-work ID.
+        uow: The UoW object (must have .summary and .register attributes).
+        outcome: One of "pass", "fail", or "partial".
+    """
+    try:
+        from orchestration.verdict_normalization import (
+            get_hypothesis_for_uow,
+            score_and_normalize_verdict,
+        )
+        from orchestration.prescription_object import hypothesis_from_uow_summary
+
+        # Try prescription_hypothesis_log first; fall back to summary.
+        hypothesis = get_hypothesis_for_uow(uow_id)
+        if not hypothesis:
+            summary = getattr(uow, "summary", None) or ""
+            hypothesis = hypothesis_from_uow_summary(summary)
+
+        if not hypothesis:
+            log.debug(
+                "_score_verdict_for_uow: no hypothesis available for UoW %r — skipping",
+                uow_id,
+            )
+            return
+
+        register = str(getattr(uow, "register", "operational") or "operational")
+
+        score_and_normalize_verdict(
+            uow_id=uow_id,
+            register=register,
+            hypothesis_raw=hypothesis,
+            outcome=outcome,  # type: ignore[arg-type]
+        )
+    except Exception as exc:
+        log.warning(
+            "_score_verdict_for_uow: failed for UoW %r — %s: %s",
+            uow_id,
+            type(exc).__name__,
+            exc,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Main entry point — called by inbox_server.py on every write_result
 # ---------------------------------------------------------------------------
 
@@ -978,6 +1040,11 @@ def maybe_complete_wos_uow(
             gh_bin=gh_bin,
         )
 
+        # Adaptive Steward scoring hook (§3-I, wos-evolution-spec.md).
+        # Normalize the hypothesis and upsert into verdict_accumulator.
+        # Non-fatal: must never block the UoW transition.
+        _score_verdict_for_uow(uow_id=uow_id, uow=uow, outcome="pass")
+
     except Exception as exc:
         log.warning(
             "maybe_complete_wos_uow: failed to complete UoW %r — %s: %s",
@@ -1051,6 +1118,12 @@ def maybe_fail_wos_uow(task_id: str, reason: str) -> None:
             uow_id,
             reason,
         )
+
+        # Adaptive Steward scoring hook (§3-I, wos-evolution-spec.md).
+        # Record a "fail" verdict for this UoW's hypothesis.
+        # Non-fatal: must never block the hook's exit path.
+        _score_verdict_for_uow(uow_id=uow_id, uow=uow, outcome="fail")
+
     except Exception as exc:
         log.warning(
             "maybe_fail_wos_uow: failed for UoW %r — %s: %s",

--- a/tests/unit/test_orchestration/test_adaptive_steward.py
+++ b/tests/unit/test_orchestration/test_adaptive_steward.py
@@ -1,0 +1,820 @@
+"""
+Tests for WOS Evolution Stage 1: Adaptive Steward.
+
+Covers:
+- Migration 0029 idempotency: verdict_accumulator, prescription_hypothesis_log,
+  normalization_log tables exist after migration.
+- PrescriptionObject construction: hypothesis truncation, frozen immutability.
+- hypothesis_from_uow_summary: truncation at 140 chars.
+- normalize_hypothesis_text: Haiku call (mocked), returns truncated string.
+- score_and_normalize_verdict: end-to-end path (mocked Haiku), writes to
+  normalization_log and verdict_accumulator.
+- Verdict upsert idempotency: duplicate calls increment, don't reset.
+- Rollup queries: get_hypothesis_rollup, accumulator_total_scored.
+- Gate condition: GATE_SCORED_OUTCOMES_MIN constant and gate_ready flag.
+- get_top_priors: returns hypotheses ordered by success_rate DESC.
+- AccumulatorSummary: pearl_count, gate_ready.
+- log_prescription_hypothesis and get_hypothesis_for_uow round-trip.
+- _score_verdict_for_uow fallback path (no log row → uses summary).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from orchestration.migrate import run_migrations, _MIGRATIONS_DIR
+from orchestration.prescription_object import (
+    HYPOTHESIS_MAX_CHARS,
+    PrescriptionObject,
+    build_prescription_object,
+    hypothesis_from_uow_summary,
+)
+from orchestration.registry import UoWRegister
+from orchestration.verdict_normalization import (
+    HAIKU_MODEL,
+    _ensure_schema,
+    _log_normalization,
+    _mark_hypothesis_scored,
+    _upsert_verdict,
+    get_hypothesis_for_uow,
+    log_prescription_hypothesis,
+    normalize_hypothesis_text,
+    score_and_normalize_verdict,
+)
+from orchestration.verdict_stats import (
+    GATE_SCORED_OUTCOMES_MIN,
+    PEARL_MIN_OBSERVATIONS,
+    PEARL_SUCCESS_RATE_THRESHOLD,
+    AccumulatorSummary,
+    get_accumulator_summary,
+    get_hypothesis_rollup,
+    get_normalization_cluster_health,
+    get_top_priors,
+    accumulator_total_scored,
+)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _table_names(db_path: Path) -> set[str]:
+    conn = _connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        return {r["name"] for r in rows}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration 0029 idempotency
+# ---------------------------------------------------------------------------
+
+class TestMigration0029:
+    """Migration 0029 creates the three new tables idempotently."""
+
+    def test_verdict_accumulator_table_created(self, tmp_path: Path) -> None:
+        """verdict_accumulator table exists after running migrations."""
+        db_path = tmp_path / "wos.db"
+        run_migrations(db_path)
+        assert "verdict_accumulator" in _table_names(db_path)
+
+    def test_prescription_hypothesis_log_table_created(self, tmp_path: Path) -> None:
+        """prescription_hypothesis_log table exists after running migrations."""
+        db_path = tmp_path / "wos.db"
+        run_migrations(db_path)
+        assert "prescription_hypothesis_log" in _table_names(db_path)
+
+    def test_normalization_log_table_created(self, tmp_path: Path) -> None:
+        """normalization_log table exists after running migrations."""
+        db_path = tmp_path / "wos.db"
+        run_migrations(db_path)
+        assert "normalization_log" in _table_names(db_path)
+
+    def test_migration_is_idempotent(self, tmp_path: Path) -> None:
+        """Running migrations twice is safe (idempotent CREATE TABLE IF NOT EXISTS)."""
+        db_path = tmp_path / "wos.db"
+        first = run_migrations(db_path)
+        second = run_migrations(db_path)
+        assert 29 in first
+        assert 29 not in second  # already applied
+
+    def test_verdict_accumulator_unique_constraint(self, tmp_path: Path) -> None:
+        """verdict_accumulator enforces UNIQUE(register, diagnosis_hypothesis)."""
+        db_path = tmp_path / "wos.db"
+        run_migrations(db_path)
+        conn = _connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO verdict_accumulator "
+                "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+                "VALUES ('operational', 'test hypothesis', 1, 0, 0, '2026-01-01T00:00:00Z')"
+            )
+            conn.commit()
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO verdict_accumulator "
+                    "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+                    "VALUES ('operational', 'test hypothesis', 0, 1, 0, '2026-01-01T00:00:00Z')"
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# PrescriptionObject
+# ---------------------------------------------------------------------------
+
+class TestPrescriptionObject:
+    """PrescriptionObject construction and validation."""
+
+    def test_construction_with_valid_fields(self) -> None:
+        """PrescriptionObject can be constructed with all required fields."""
+        obj = PrescriptionObject(
+            uow_id="uow_test_001",
+            register=UoWRegister.OPERATIONAL,
+            diagnosis_hypothesis="Missing retry logic causes intermittent 503s",
+            proposed_steps=["Add retry with exponential backoff"],
+            confidence=0.8,
+            counterfactual_question="Would the issue persist with retries?",
+            generated_at="2026-01-01T00:00:00Z",
+            selector_priors=[],
+        )
+        assert obj.uow_id == "uow_test_001"
+        assert obj.confidence == 0.8
+
+    def test_hypothesis_max_chars_enforced(self) -> None:
+        """Hypothesis exceeding 140 chars raises ValueError at construction."""
+        with pytest.raises(ValueError, match="exceeds.*chars"):
+            PrescriptionObject(
+                uow_id="uow_test_001",
+                register=UoWRegister.OPERATIONAL,
+                diagnosis_hypothesis="x" * (HYPOTHESIS_MAX_CHARS + 1),
+                proposed_steps=[],
+                confidence=0.5,
+                counterfactual_question="",
+                generated_at="2026-01-01T00:00:00Z",
+                selector_priors=[],
+            )
+
+    def test_hypothesis_exactly_max_chars_is_valid(self) -> None:
+        """Hypothesis at exactly 140 chars is accepted."""
+        obj = PrescriptionObject(
+            uow_id="uow_test_001",
+            register=UoWRegister.OPERATIONAL,
+            diagnosis_hypothesis="x" * HYPOTHESIS_MAX_CHARS,
+            proposed_steps=[],
+            confidence=0.5,
+            counterfactual_question="",
+            generated_at="2026-01-01T00:00:00Z",
+            selector_priors=[],
+        )
+        assert len(obj.diagnosis_hypothesis) == HYPOTHESIS_MAX_CHARS
+
+    def test_frozen_immutability(self) -> None:
+        """PrescriptionObject instances are immutable (frozen dataclass)."""
+        obj = PrescriptionObject(
+            uow_id="uow_test_001",
+            register=UoWRegister.OPERATIONAL,
+            diagnosis_hypothesis="Short hypothesis",
+            proposed_steps=[],
+            confidence=0.5,
+            counterfactual_question="",
+            generated_at="2026-01-01T00:00:00Z",
+            selector_priors=[],
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            obj.uow_id = "something_else"  # type: ignore[misc]
+
+    def test_build_prescription_object_truncates_hypothesis(self) -> None:
+        """build_prescription_object truncates over-long hypotheses."""
+        long_hypothesis = "a" * 200
+        obj = build_prescription_object(
+            uow_id="uow_test_001",
+            register=UoWRegister.OPERATIONAL,
+            hypothesis_raw=long_hypothesis,
+            proposed_steps=[],
+            confidence=0.5,
+            counterfactual_question="",
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        assert len(obj.diagnosis_hypothesis) == HYPOTHESIS_MAX_CHARS
+        assert obj.diagnosis_hypothesis == "a" * HYPOTHESIS_MAX_CHARS
+
+
+class TestHypothesisFromSummary:
+    """hypothesis_from_uow_summary derivation."""
+
+    def test_truncates_to_max_chars(self) -> None:
+        """Long summary is truncated to HYPOTHESIS_MAX_CHARS."""
+        long_summary = "b" * 300
+        result = hypothesis_from_uow_summary(long_summary)
+        assert len(result) == HYPOTHESIS_MAX_CHARS
+
+    def test_short_summary_unchanged(self) -> None:
+        """Short summary is returned unchanged."""
+        short = "Fix the login bug"
+        assert hypothesis_from_uow_summary(short) == short
+
+    def test_empty_summary_returns_empty(self) -> None:
+        """Empty summary returns empty string."""
+        assert hypothesis_from_uow_summary("") == ""
+
+    def test_strips_leading_trailing_whitespace(self) -> None:
+        """Leading/trailing whitespace is stripped."""
+        padded = "  Fix the login bug  "
+        assert hypothesis_from_uow_summary(padded) == "Fix the login bug"
+
+
+# ---------------------------------------------------------------------------
+# normalize_hypothesis_text (mocked Haiku call)
+# ---------------------------------------------------------------------------
+
+class TestNormalizeHypothesisText:
+    """normalize_hypothesis_text calls Haiku and returns a normalized string."""
+
+    def _make_mock_client(self, normalized_text: str) -> MagicMock:
+        """Build a mock anthropic.Anthropic client returning *normalized_text*."""
+        content_block = MagicMock()
+        content_block.text = normalized_text
+
+        response = MagicMock()
+        response.content = [content_block]
+
+        client = MagicMock()
+        client.messages.create.return_value = response
+        return client
+
+    def test_returns_normalized_string(self) -> None:
+        """normalize_hypothesis_text returns the Haiku-normalized form."""
+        mock_client = self._make_mock_client("Missing retry logic causes 503s; add exponential backoff.")
+        result = normalize_hypothesis_text("missing retry causes 503", anthropic_client=mock_client)
+        assert result == "Missing retry logic causes 503s; add exponential backoff."
+
+    def test_truncates_to_max_chars(self) -> None:
+        """If Haiku returns >140 chars, result is truncated."""
+        mock_client = self._make_mock_client("x" * 200)
+        result = normalize_hypothesis_text("some hypothesis", anthropic_client=mock_client)
+        assert len(result) == HYPOTHESIS_MAX_CHARS
+
+    def test_calls_haiku_model(self) -> None:
+        """normalize_hypothesis_text uses the HAIKU_MODEL by default."""
+        mock_client = self._make_mock_client("normalized")
+        normalize_hypothesis_text("some hypothesis", anthropic_client=mock_client)
+        call_kwargs = mock_client.messages.create.call_args[1]
+        assert call_kwargs["model"] == HAIKU_MODEL
+
+    def test_includes_cache_control_on_system_prompt(self) -> None:
+        """System prompt is sent with cache_control for prompt caching."""
+        mock_client = self._make_mock_client("normalized")
+        normalize_hypothesis_text("some hypothesis", anthropic_client=mock_client)
+        call_kwargs = mock_client.messages.create.call_args[1]
+        system = call_kwargs["system"]
+        assert isinstance(system, list)
+        assert any("cache_control" in block for block in system)
+
+    def test_raises_on_empty_response(self) -> None:
+        """RuntimeError raised when Haiku returns empty content."""
+        response = MagicMock()
+        response.content = []
+        client = MagicMock()
+        client.messages.create.return_value = response
+        with pytest.raises(RuntimeError):
+            normalize_hypothesis_text("some hypothesis", anthropic_client=client)
+
+
+# ---------------------------------------------------------------------------
+# score_and_normalize_verdict (mocked Haiku, tmp DB)
+# ---------------------------------------------------------------------------
+
+class TestScoreAndNormalizeVerdict:
+    """score_and_normalize_verdict writes to normalization_log and verdict_accumulator."""
+
+    def _make_mock_client(self, normalized: str = "Normalized hypothesis") -> MagicMock:
+        content_block = MagicMock()
+        content_block.text = normalized
+        response = MagicMock()
+        response.content = [content_block]
+        client = MagicMock()
+        client.messages.create.return_value = response
+        return client
+
+    def test_writes_to_normalization_log(self, tmp_path: Path) -> None:
+        """After scoring, normalization_log contains one row for the UoW."""
+        db_path = tmp_path / "wos-metrics.db"
+        mock_client = self._make_mock_client("Normalized form")
+
+        score_and_normalize_verdict(
+            uow_id="uow_test_001",
+            register="operational",
+            hypothesis_raw="raw hypothesis string",
+            outcome="pass",
+            anthropic_client=mock_client,
+            db_path=db_path,
+        )
+
+        conn = _connect(db_path)
+        try:
+            rows = conn.execute("SELECT * FROM normalization_log").fetchall()
+            assert len(rows) == 1
+            assert rows[0]["uow_id"] == "uow_test_001"
+            assert rows[0]["raw"] == "raw hypothesis string"
+            assert rows[0]["normalized"] == "Normalized form"
+        finally:
+            conn.close()
+
+    def test_writes_to_verdict_accumulator(self, tmp_path: Path) -> None:
+        """After scoring, verdict_accumulator contains one row with n_successes=1."""
+        db_path = tmp_path / "wos-metrics.db"
+        mock_client = self._make_mock_client("Canonical hypothesis")
+
+        score_and_normalize_verdict(
+            uow_id="uow_test_001",
+            register="operational",
+            hypothesis_raw="raw text",
+            outcome="pass",
+            anthropic_client=mock_client,
+            db_path=db_path,
+        )
+
+        conn = _connect(db_path)
+        try:
+            rows = conn.execute("SELECT * FROM verdict_accumulator").fetchall()
+            assert len(rows) == 1
+            assert rows[0]["n_successes"] == 1
+            assert rows[0]["n_failures"] == 0
+        finally:
+            conn.close()
+
+    def test_fail_outcome_increments_n_failures(self, tmp_path: Path) -> None:
+        """outcome='fail' increments n_failures in verdict_accumulator."""
+        db_path = tmp_path / "wos-metrics.db"
+        mock_client = self._make_mock_client("Same hypothesis")
+
+        score_and_normalize_verdict(
+            uow_id="uow_test_001",
+            register="operational",
+            hypothesis_raw="raw text",
+            outcome="fail",
+            anthropic_client=mock_client,
+            db_path=db_path,
+        )
+
+        conn = _connect(db_path)
+        try:
+            rows = conn.execute("SELECT * FROM verdict_accumulator").fetchall()
+            assert rows[0]["n_failures"] == 1
+            assert rows[0]["n_successes"] == 0
+        finally:
+            conn.close()
+
+    def test_partial_outcome_increments_n_partial(self, tmp_path: Path) -> None:
+        """outcome='partial' increments n_partial in verdict_accumulator."""
+        db_path = tmp_path / "wos-metrics.db"
+        mock_client = self._make_mock_client("Same hypothesis")
+
+        score_and_normalize_verdict(
+            uow_id="uow_test_002",
+            register="iterative-convergent",
+            hypothesis_raw="raw text",
+            outcome="partial",
+            anthropic_client=mock_client,
+            db_path=db_path,
+        )
+
+        conn = _connect(db_path)
+        try:
+            rows = conn.execute("SELECT * FROM verdict_accumulator").fetchall()
+            assert rows[0]["n_partial"] == 1
+        finally:
+            conn.close()
+
+    def test_duplicate_calls_increment_not_reset(self, tmp_path: Path) -> None:
+        """Two 'pass' verdicts for the same hypothesis yield n_successes=2."""
+        db_path = tmp_path / "wos-metrics.db"
+        mock_client = self._make_mock_client("Same hypothesis")
+
+        for i in range(2):
+            score_and_normalize_verdict(
+                uow_id=f"uow_test_{i:03d}",
+                register="operational",
+                hypothesis_raw="raw text",
+                outcome="pass",
+                anthropic_client=mock_client,
+                db_path=db_path,
+            )
+
+        conn = _connect(db_path)
+        try:
+            rows = conn.execute("SELECT * FROM verdict_accumulator").fetchall()
+            assert len(rows) == 1  # same normalized hypothesis → same row
+            assert rows[0]["n_successes"] == 2
+        finally:
+            conn.close()
+
+    def test_empty_hypothesis_is_skipped(self, tmp_path: Path) -> None:
+        """Empty hypothesis string does not write to the DB."""
+        db_path = tmp_path / "wos-metrics.db"
+        mock_client = self._make_mock_client("anything")
+
+        score_and_normalize_verdict(
+            uow_id="uow_test_001",
+            register="operational",
+            hypothesis_raw="",
+            outcome="pass",
+            anthropic_client=mock_client,
+            db_path=db_path,
+        )
+
+        # DB should not have been created or have no rows
+        if db_path.exists():
+            conn = _connect(db_path)
+            try:
+                tables = conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+                table_names = {r["name"] for r in tables}
+                if "normalization_log" in table_names:
+                    rows = conn.execute("SELECT * FROM normalization_log").fetchall()
+                    assert len(rows) == 0
+            finally:
+                conn.close()
+
+    def test_haiku_failure_is_non_fatal(self, tmp_path: Path) -> None:
+        """If Haiku fails, score_and_normalize_verdict does not raise."""
+        db_path = tmp_path / "wos-metrics.db"
+        failing_client = MagicMock()
+        failing_client.messages.create.side_effect = RuntimeError("API error")
+
+        # Must not raise
+        score_and_normalize_verdict(
+            uow_id="uow_test_001",
+            register="operational",
+            hypothesis_raw="some hypothesis",
+            outcome="pass",
+            anthropic_client=failing_client,
+            db_path=db_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# log_prescription_hypothesis + get_hypothesis_for_uow round-trip
+# ---------------------------------------------------------------------------
+
+class TestPrescriptionHypothesisLogRoundTrip:
+    """log_prescription_hypothesis and get_hypothesis_for_uow work together."""
+
+    def test_round_trip_returns_stored_hypothesis(self, tmp_path: Path) -> None:
+        """Hypothesis written by log_prescription_hypothesis is retrievable."""
+        db_path = tmp_path / "wos-metrics.db"
+
+        log_prescription_hypothesis(
+            uow_id="uow_test_001",
+            hypothesis="Missing index causes slow queries on accounts table",
+            register="operational",
+            generated_at="2026-01-01T00:00:00Z",
+            db_path=db_path,
+        )
+
+        result = get_hypothesis_for_uow("uow_test_001", db_path=db_path)
+        assert result == "Missing index causes slow queries on accounts table"
+
+    def test_returns_none_for_unknown_uow(self, tmp_path: Path) -> None:
+        """get_hypothesis_for_uow returns None when no row exists."""
+        db_path = tmp_path / "wos-metrics.db"
+        result = get_hypothesis_for_uow("uow_does_not_exist", db_path=db_path)
+        assert result is None
+
+    def test_returns_most_recent_unscored_row(self, tmp_path: Path) -> None:
+        """When multiple rows exist, the most recent unscored is returned."""
+        db_path = tmp_path / "wos-metrics.db"
+
+        log_prescription_hypothesis(
+            uow_id="uow_test_001",
+            hypothesis="Old hypothesis",
+            register="operational",
+            generated_at="2026-01-01T00:00:00Z",
+            db_path=db_path,
+        )
+        log_prescription_hypothesis(
+            uow_id="uow_test_001",
+            hypothesis="New hypothesis",
+            register="operational",
+            generated_at="2026-01-02T00:00:00Z",
+            db_path=db_path,
+        )
+
+        result = get_hypothesis_for_uow("uow_test_001", db_path=db_path)
+        assert result == "New hypothesis"
+
+    def test_scored_rows_are_excluded(self, tmp_path: Path) -> None:
+        """After scoring, get_hypothesis_for_uow returns None."""
+        db_path = tmp_path / "wos-metrics.db"
+
+        # Ensure schema
+        conn = sqlite3.connect(str(db_path))
+        _ensure_schema(conn)
+        conn.commit()
+
+        log_prescription_hypothesis(
+            uow_id="uow_test_001",
+            hypothesis="Some hypothesis",
+            register="operational",
+            generated_at="2026-01-01T00:00:00Z",
+            db_path=db_path,
+        )
+
+        # Mark as scored
+        conn2 = sqlite3.connect(str(db_path))
+        conn2.row_factory = sqlite3.Row
+        _mark_hypothesis_scored(conn2, "uow_test_001", "pass")
+        conn2.commit()
+        conn2.close()
+
+        result = get_hypothesis_for_uow("uow_test_001", db_path=db_path)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Rollup queries
+# ---------------------------------------------------------------------------
+
+class TestRollupQueries:
+    """get_hypothesis_rollup, accumulator_total_scored, get_accumulator_summary."""
+
+    def _seed_db(self, db_path: Path) -> None:
+        """Seed the DB with test data for rollup queries."""
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        _ensure_schema(conn)
+
+        rows = [
+            ("operational", "Hypothesis A: missing retry logic", 7, 1, 0, "2026-01-01T00:00:00Z"),
+            ("operational", "Hypothesis B: stale cache causing reads", 3, 3, 2, "2026-01-02T00:00:00Z"),
+            ("iterative-convergent", "Hypothesis C: convergence threshold too tight", 2, 0, 1, "2026-01-03T00:00:00Z"),
+        ]
+        for register, hyp, n_s, n_f, n_p, ts in rows:
+            conn.execute(
+                "INSERT INTO verdict_accumulator "
+                "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (register, hyp, n_s, n_f, n_p, ts),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_rollup_returns_all_rows(self, tmp_path: Path) -> None:
+        """get_hypothesis_rollup with no register filter returns all rows."""
+        db_path = tmp_path / "wos-metrics.db"
+        self._seed_db(db_path)
+        results = get_hypothesis_rollup(db_path=db_path)
+        assert len(results) == 3
+
+    def test_rollup_filtered_by_register(self, tmp_path: Path) -> None:
+        """get_hypothesis_rollup filtered by register returns only that register."""
+        db_path = tmp_path / "wos-metrics.db"
+        self._seed_db(db_path)
+        results = get_hypothesis_rollup(register="operational", db_path=db_path)
+        assert len(results) == 2
+        assert all(r.register == "operational" for r in results)
+
+    def test_rollup_ordered_by_success_rate_desc(self, tmp_path: Path) -> None:
+        """Results are ordered by success_rate descending."""
+        db_path = tmp_path / "wos-metrics.db"
+        self._seed_db(db_path)
+        results = get_hypothesis_rollup(register="operational", db_path=db_path)
+        rates = [r.success_rate for r in results]
+        assert rates == sorted(rates, reverse=True)
+
+    def test_rollup_computes_total_and_rate(self, tmp_path: Path) -> None:
+        """total and success_rate are computed correctly."""
+        db_path = tmp_path / "wos-metrics.db"
+        self._seed_db(db_path)
+        results = get_hypothesis_rollup(register="operational", db_path=db_path)
+        # Find Hypothesis A: 7 successes, 1 failure, 0 partial → total=8, rate=7/8=0.875
+        hyp_a = next(r for r in results if "Hypothesis A" in r.diagnosis_hypothesis)
+        assert hyp_a.total == 8
+        assert abs(hyp_a.success_rate - 7 / 8) < 0.001
+
+    def test_rollup_returns_empty_on_missing_db(self, tmp_path: Path) -> None:
+        """Returns empty list when DB does not exist."""
+        db_path = tmp_path / "nonexistent.db"
+        results = get_hypothesis_rollup(db_path=db_path)
+        assert results == []
+
+    def test_accumulator_total_scored(self, tmp_path: Path) -> None:
+        """accumulator_total_scored counts rows with at least one observation."""
+        db_path = tmp_path / "wos-metrics.db"
+        self._seed_db(db_path)
+        total = accumulator_total_scored(db_path=db_path)
+        assert total == 3
+
+    def test_accumulator_total_scored_zero_on_missing_db(self, tmp_path: Path) -> None:
+        """Returns 0 when DB does not exist."""
+        db_path = tmp_path / "nonexistent.db"
+        assert accumulator_total_scored(db_path=db_path) == 0
+
+    def test_gate_condition_not_met_below_threshold(self, tmp_path: Path) -> None:
+        """gate_ready is False when total_scored < GATE_SCORED_OUTCOMES_MIN."""
+        db_path = tmp_path / "wos-metrics.db"
+        self._seed_db(db_path)  # seeds 3 rows, threshold is 20
+        summary = get_accumulator_summary(db_path=db_path)
+        assert summary.total_scored == 3
+        assert summary.gate_ready is False
+
+    def test_gate_condition_met_at_threshold(self, tmp_path: Path) -> None:
+        """gate_ready is True when total_scored >= GATE_SCORED_OUTCOMES_MIN."""
+        db_path = tmp_path / "wos-metrics.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        _ensure_schema(conn)
+
+        # Insert exactly GATE_SCORED_OUTCOMES_MIN rows
+        for i in range(GATE_SCORED_OUTCOMES_MIN):
+            conn.execute(
+                "INSERT INTO verdict_accumulator "
+                "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("operational", f"Hypothesis {i}", 1, 0, 0, "2026-01-01T00:00:00Z"),
+            )
+        conn.commit()
+        conn.close()
+
+        summary = get_accumulator_summary(db_path=db_path)
+        assert summary.total_scored == GATE_SCORED_OUTCOMES_MIN
+        assert summary.gate_ready is True
+
+    def test_pearl_count_computed_correctly(self, tmp_path: Path) -> None:
+        """pearl_count counts hypotheses with success_rate >= 0.7 and total >= 5."""
+        db_path = tmp_path / "wos-metrics.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        _ensure_schema(conn)
+
+        # Pearl: 7 successes, 1 failure (rate=0.875 ≥ 0.7, total=8 ≥ 5)
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("operational", "Pearl hypothesis", 7, 1, 0, "2026-01-01T00:00:00Z"),
+        )
+        # Not a pearl: 2 successes, 8 failures (rate=0.2 < 0.7)
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("operational", "Non-pearl hypothesis", 2, 8, 0, "2026-01-01T00:00:00Z"),
+        )
+        # Not a pearl: 5 successes but total=5 (≥ 5) but rate=5/5=1.0 — this IS a pearl
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("operational", "Another pearl", 5, 0, 0, "2026-01-01T00:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        summary = get_accumulator_summary(db_path=db_path)
+        assert summary.pearl_count == 2  # "Pearl hypothesis" and "Another pearl"
+
+
+# ---------------------------------------------------------------------------
+# get_top_priors (Selector query)
+# ---------------------------------------------------------------------------
+
+class TestGetTopPriors:
+    """get_top_priors returns top-5 hypotheses by success_rate."""
+
+    def test_returns_hypotheses_ordered_by_success_rate(self, tmp_path: Path) -> None:
+        """get_top_priors returns hypotheses in success_rate descending order."""
+        db_path = tmp_path / "wos-metrics.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        _ensure_schema(conn)
+
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES ('operational', 'Hypothesis A', 8, 2, 0, '2026-01-01T00:00:00Z')"
+        )
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES ('operational', 'Hypothesis B', 3, 7, 0, '2026-01-01T00:00:00Z')"
+        )
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES ('operational', 'Hypothesis C', 5, 1, 0, '2026-01-01T00:00:00Z')"
+        )
+        conn.commit()
+        conn.close()
+
+        priors = get_top_priors("operational", db_path=db_path)
+        # A: 8/10=0.8, C: 5/6=0.833, B: 3/10=0.3 → order: C, A, B
+        assert priors[0] == "Hypothesis C"
+        assert priors[1] == "Hypothesis A"
+        assert priors[2] == "Hypothesis B"
+
+    def test_respects_limit_parameter(self, tmp_path: Path) -> None:
+        """get_top_priors respects the limit parameter."""
+        db_path = tmp_path / "wos-metrics.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        _ensure_schema(conn)
+
+        for i in range(10):
+            conn.execute(
+                "INSERT INTO verdict_accumulator "
+                "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+                "VALUES ('operational', ?, 1, 0, 0, '2026-01-01T00:00:00Z')",
+                (f"Hypothesis {i}",),
+            )
+        conn.commit()
+        conn.close()
+
+        priors = get_top_priors("operational", limit=3, db_path=db_path)
+        assert len(priors) == 3
+
+    def test_returns_empty_list_when_no_data(self, tmp_path: Path) -> None:
+        """Returns empty list when no data for register."""
+        db_path = tmp_path / "nonexistent.db"
+        priors = get_top_priors("operational", db_path=db_path)
+        assert priors == []
+
+    def test_filters_by_register(self, tmp_path: Path) -> None:
+        """get_top_priors only returns hypotheses for the requested register."""
+        db_path = tmp_path / "wos-metrics.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        _ensure_schema(conn)
+
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES ('operational', 'Operational hypothesis', 5, 0, 0, '2026-01-01T00:00:00Z')"
+        )
+        conn.execute(
+            "INSERT INTO verdict_accumulator "
+            "(register, diagnosis_hypothesis, n_successes, n_failures, n_partial, last_updated) "
+            "VALUES ('iterative-convergent', 'IC hypothesis', 3, 0, 0, '2026-01-01T00:00:00Z')"
+        )
+        conn.commit()
+        conn.close()
+
+        priors = get_top_priors("operational", db_path=db_path)
+        assert len(priors) == 1
+        assert priors[0] == "Operational hypothesis"
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    """Named constants match spec requirements."""
+
+    def test_gate_scored_outcomes_min_is_20(self) -> None:
+        """GATE_SCORED_OUTCOMES_MIN must be 20 per spec §4 transition table."""
+        assert GATE_SCORED_OUTCOMES_MIN == 20
+
+    def test_hypothesis_max_chars_is_140(self) -> None:
+        """HYPOTHESIS_MAX_CHARS must be 140 per spec §3-I PrescriptionObject."""
+        assert HYPOTHESIS_MAX_CHARS == 140
+
+    def test_pearl_success_rate_threshold_is_0_7(self) -> None:
+        """PEARL_SUCCESS_RATE_THRESHOLD must be 0.7 per spec §5 glossary."""
+        assert PEARL_SUCCESS_RATE_THRESHOLD == 0.7
+
+    def test_pearl_min_observations_is_5(self) -> None:
+        """PEARL_MIN_OBSERVATIONS must be 5 per spec §5 glossary."""
+        assert PEARL_MIN_OBSERVATIONS == 5
+
+    def test_haiku_model_id(self) -> None:
+        """HAIKU_MODEL must use the claude-haiku-4-5-20251001 model."""
+        assert HAIKU_MODEL == "claude-haiku-4-5-20251001"


### PR DESCRIPTION
## What this solves

WOS had no mechanism to learn from prescription outcomes. Every cycle, the Prescriber operated on pure noise — no scored history, no signal about which hypotheses tended to succeed or fail. §3-I of the WOS evolution spec defines the Adaptive Steward as the learning layer that accumulates this signal. This PR implements it.

Gate condition for Stage 2: `verdict_accumulator` must contain ≥20 scored outcomes before the Governor can operate on real signal.

## What changed

**New DB tables (migration 0029):**
- `verdict_accumulator` — aggregate pass/fail/partial counts per `(register, diagnosis_hypothesis)`. The `UNIQUE` constraint enforces INSERT OR IGNORE + UPDATE upsert so duplicate closure calls increment, never reset.
- `prescription_hypothesis_log` — per-UoW record of the raw hypothesis at prescription time. The scoring hook reads this at closure; falls back to `uow.summary` for UoWs created before this deploy.
- `normalization_log` — audit trail of every Haiku normalization call (raw, normalized, model, ts). Required by the spec for Churn Basin detection and normalization drift visibility.

**`prescription_object.py`** — frozen `PrescriptionObject` dataclass (spec §3-I). Captures `diagnosis_hypothesis` (≤140 chars, enforced at construction), `proposed_steps`, `confidence`, `selector_priors`. `build_prescription_object()` truncates over-long hypotheses from LLM output. `hypothesis_from_uow_summary()` derives a hypothesis for UoWs with no explicit prescription log entry.

**`verdict_normalization.py`** — the closure hook. At UoW completion or failure, `score_and_normalize_verdict()`:
1. Normalizes the raw hypothesis via `claude-haiku-4-5-20251001` (system prompt has `cache_control` for prompt caching)
2. Writes to `normalization_log`
3. Upserts into `verdict_accumulator` (INSERT OR IGNORE + UPDATE per-counter)
4. Marks the `prescription_hypothesis_log` row as scored (idempotent)

All steps are non-fatal. Haiku failure or DB error logs at WARNING and returns — UoW transitions are never blocked.

**`verdict_stats.py`** — read-path rollup. Pure SELECT queries:
- `get_hypothesis_rollup()` — per-hypothesis aggregate with success_rate, ordered by rate DESC
- `get_top_priors()` — the Selector (spec §3-I): top-5 hypotheses by success rate for a register. Pure SQL, no LLM.
- `get_accumulator_summary()` — total_scored, gate_ready flag, pearl_count
- `get_normalization_cluster_health()` — distinct_normalized vs distinct_raw per register, Churn Basin risk flag
- `accumulator_total_scored()` — direct gate condition check

**`wos_completion.py`** — `_score_verdict_for_uow()` added as a non-fatal hook called from both `maybe_complete_wos_uow` (outcome="pass") and `maybe_fail_wos_uow` (outcome="fail"). Hypothesis source priority: `prescription_hypothesis_log` first, `uow.summary` fallback.

## What was not changed

- Executor dispatch logic: untouched
- `execution_enabled` state: untouched (WOS execution remains paused)
- Steward prescription cycle: the `log_prescription_hypothesis()` function is available but the Steward is not yet wired to call it at prescription time — that's a follow-on. The scoring hook uses `uow.summary` as the hypothesis until then, which is correct for bootstrap.
- Stages 2–5: not implemented

## Before/after flow

```
Before:
  UoW executing → write_result → ready-for-steward (no learning)

After:
  UoW executing → write_result → ready-for-steward
                                        │
                                        └── _score_verdict_for_uow (non-fatal)
                                                │
                                                ├── get_hypothesis_for_uow()  (from log or summary)
                                                ├── normalize_hypothesis_text()  (Haiku call)
                                                ├── normalization_log INSERT
                                                └── verdict_accumulator UPSERT
```

## Tests run

- [x] `uv run python -m pytest tests/unit/test_orchestration/test_adaptive_steward.py -v` — 49 passed, 0 failed
- [x] `uv run python -m pytest tests/unit/test_orchestration/test_wos_completion.py -v` — 89 passed, 0 failed (no regressions)
- [x] `uv run python -m pytest tests/unit/test_orchestration/test_migrations.py -v` — 21 passed, 0 failed
- [x] `uv tool run ruff check src/orchestration/prescription_object.py src/orchestration/verdict_normalization.py src/orchestration/verdict_stats.py src/orchestration/wos_completion.py` — all checks passed

## Manual test

N/A. This change does not touch systemd units, cron entries, or Telegram output. The scoring hook is non-fatal and WOS execution is paused (`execution_enabled: false`). No live UoW closures will fire the hook until WOS execution is re-enabled by a separate operator decision.

The `verdict_accumulator` tables will remain empty until at least one UoW completes after WOS execution is resumed.

## Definition of Done

- [x] Unit tests pass with proper mocking (Haiku client mocked — no production hits in automated tests)
- [x] Integration/manual test: N/A — WOS execution paused, no live closures to test against
- [x] User-visible outcome: not applicable — this is a background data accumulation layer with no UI surface
- [x] Side-effect audit: no floods (only fires at UoW closure, WOS is paused), no unscoped writes, no unintended volume
- [x] External service calls: Haiku API mocked in all tests

Closes #1350