### PR TITLE
fix(sweep): add required Pings section to sweep output format template

### DIFF
--- a/memory/canonical-templates/sweep-instruction.template.md
+++ b/memory/canonical-templates/sweep-instruction.template.md
@@ -144,6 +144,31 @@ Required sections in output:
 - Detection pass findings (dissonance / golden patterns)
 - Prescription pass (actions / escalations)
 - Refactor pass (autonomous actions taken, with rationale)
+- Pings (two-ping protocol compliance record — see below)
+
+**Pings section (required):** After the two-ping protocol fires (see sweep-context.md), append a `## Pings` section to the sweep output file recording compliance:
+
+```markdown
+## Pings
+
+ping_1_sent: true
+ping_1_content: [one-sentence summary of what was included: domain, counts, pressure point]
+
+ping_2_sent: true
+ping_2_content: [one-sentence summary of the process-reflection theme]
+```
+
+If either ping was not sent, document why:
+
+```markdown
+ping_1_sent: false
+ping_1_reason: [why it was skipped, e.g., gh auth failure caused early abort]
+
+ping_2_sent: false
+ping_2_reason: [why it was skipped]
+```
+
+Both fields are required on every run. An absent `## Pings` section is a sweep protocol violation (issue #1335).
 
 ---
 


### PR DESCRIPTION
## Problem

The negentropic sweep's two-ping protocol (Ping 1: completion summary, Ping 2: meta-reflection on sweep process) has been silently unverifiable for at least 7 consecutive sweep cycles. The sweep output format specified in `sweep-instruction.template.md` required four sections but had no field for recording whether either ping was sent.

Without an audit trail in the sweep file, Ping 2 specifically — the process-improvement feedback loop — could be skipped indefinitely without detection. Issue #1335 confirmed that recent sweep files (Nights 2–7) show no evidence of either ping being documented.

## What this PR does

Adds a required `## Pings` section to the sweep output format in `sweep-instruction.template.md`. The section requires:

- `ping_1_sent: true/false` — with a one-sentence content summary when true, or a reason when false
- `ping_2_sent: true/false` — same pattern

Both fields are required on every run. The template explicitly states that an absent `## Pings` section is a protocol violation (traceable to issue #1335).

The section is self-documenting: sweeps that abort early (e.g., gh auth failure) can record `ping_1_sent: false` with the reason, which is more useful than no record at all.

## Functional patterns

Declarative constraint — adds a required section to the output template. No code changes, no logic changes. The enforcement mechanism is the template requirement itself, which future sweep runs will follow.

## What is NOT changed

- `sweep-context.md` — the two-ping protocol definition is already correct and complete there
- Any existing sweep output files — historical files are not retroactively amended
- The sweep invocation or scheduling logic

## Tests run

- [x] Template file parses cleanly as Markdown
- [x] Diff reviewed — only `sweep-instruction.template.md` modified, 25 lines added
- [ ] Sweep run with new template — not run; this is a template documentation change

## Manual test

N/A — this is a template change. No external service calls, no runtime state affected. The change takes effect on the next sweep run that references this template.

## Definition of Done

- [x] Template addition is accurate and consistent with the protocol defined in sweep-context.md
- [x] User-visible outcome: next sweep run will produce a verifiable ping audit trail
- [x] Side-effect audit: no side effects — template file only

Closes #1335.