### PR TITLE
feat: WOS Stage 2 — Event-Native Nervous System

### DIFF
--- a/scheduled-tasks/wos-event-poller.py
+++ b/scheduled-tasks/wos-event-poller.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env -S uv run
+"""
+WOS Event Poller — 30-second delta poller for the Event-Native Nervous System (Stage 2).
+
+Runs every 30 seconds (via cron at */1 * * * * with a 30-second sleep). On each invocation:
+
+1. Checks is_job_enabled("wos-event-poller") — exits immediately if disabled.
+2. Reads the since-cursor from ~/.lobster-workspace/data/wos-event-poller-cursor.json.
+3. Queries GitHub for new issues with label wos:uow created after the cursor.
+4. Queries registry.db for UoWs that transitioned to done/failed after the cursor.
+5. Emits typed inbox events for each new item:
+   - wos_issue_created  → for each new GitHub issue found
+   - wos_uow_completed  → for each newly terminal UoW
+   - wos_capacity_available → when active UoW count < max_parallel
+6. Writes event_log rows (via wos_events.py emit functions).
+7. Advances the since-cursor to now.
+
+Deduplication is enforced at the DB layer via event_log UNIQUE(event_type, dedup_key).
+Re-running with the same cursor window is safe — duplicate events are silently dropped.
+
+Type B (cron-direct): cron calls this script directly. No inbox message, no LLM round-trip.
+The jobs.json enabled gate is checked at the top of main() before any DB work.
+
+Cron entry (every 30 seconds via two staggered per-minute entries):
+    * * * * * cd ~/lobster && uv run scheduled-tasks/wos-event-poller.py >> ~/lobster-workspace/scheduled-jobs/logs/wos-event-poller.log 2>&1 # LOBSTER-WOS-EVENT-POLLER
+    * * * * * sleep 30 && cd ~/lobster && uv run scheduled-tasks/wos-event-poller.py >> ~/lobster-workspace/scheduled-jobs/logs/wos-event-poller.log 2>&1 # LOBSTER-WOS-EVENT-POLLER-30S
+
+Run standalone:
+    uv run ~/lobster/scheduled-tasks/wos-event-poller.py [--dry-run]
+
+Design reference: wos-evolution-spec.md §3-II Event-Native Nervous System
+Issue: https://github.com/dcetlin/Lobster/issues/1351
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running as a script or via importlib (tests)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+_SRC_ROOT = _REPO_ROOT / "src"
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
+from src.utils.jobs import is_job_enabled
+from src.orchestration.paths import REGISTRY_DB, WOS_CONFIG
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+log = logging.getLogger("wos-event-poller")
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+#: Job name registered in jobs.json — must match the entry there exactly.
+JOB_NAME: str = "wos-event-poller"
+
+#: GitHub repo to scan for new wos:uow issues.
+WOS_REPO: str = "dcetlin/Lobster"
+
+#: Label that marks an issue as a WOS Unit of Work.
+WOS_UOW_LABEL: str = "wos:uow"
+
+#: Maximum number of issues to retrieve per gh CLI call.
+GH_ISSUE_LIMIT: int = 50
+
+#: Default since-cursor lookback when no cursor file exists (seconds).
+#: First run scans the last 60 seconds to avoid emitting events for old issues.
+DEFAULT_CURSOR_LOOKBACK_SECONDS: int = 60
+
+#: Terminal UoW statuses that trigger wos_uow_completed events.
+TERMINAL_UOW_STATUSES: frozenset[str] = frozenset({"done", "failed", "expired"})
+
+# ---------------------------------------------------------------------------
+# Cursor persistence — tracks the "since" timestamp across invocations
+# ---------------------------------------------------------------------------
+
+
+def _cursor_path() -> Path:
+    """Return the path to the since-cursor JSON file."""
+    workspace = Path(
+        os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+    )
+    return workspace / "data" / "wos-event-poller-cursor.json"
+
+
+def _read_cursor() -> str:
+    """
+    Read the since-cursor from disk.
+
+    Returns the ISO-8601 timestamp of the last successful poll, or a timestamp
+    DEFAULT_CURSOR_LOOKBACK_SECONDS in the past if no cursor exists.
+    """
+    path = _cursor_path()
+    try:
+        data = json.loads(path.read_text())
+        return data["since"]
+    except (OSError, KeyError, json.JSONDecodeError):
+        fallback = datetime.now(timezone.utc) - timedelta(seconds=DEFAULT_CURSOR_LOOKBACK_SECONDS)
+        return fallback.isoformat()
+
+
+def _write_cursor(since: str) -> None:
+    """Write the since-cursor to disk atomically."""
+    path = _cursor_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps({"since": since, "updated_at": datetime.now(timezone.utc).isoformat()}))
+    tmp.rename(path)
+
+
+# ---------------------------------------------------------------------------
+# WOS config reader — reads max_parallel for capacity events
+# ---------------------------------------------------------------------------
+
+
+def _read_max_parallel() -> int:
+    """Return max_parallel from wos-config.json, defaulting to 2."""
+    try:
+        with WOS_CONFIG.open() as fh:
+            return int(json.load(fh).get("max_parallel", 2))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return 2
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue delta query
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NewIssue:
+    """A new GitHub issue detected since the cursor timestamp."""
+    issue_number: int
+    issue_url: str
+    title: str
+    labels: list[str]
+    created_at: str
+
+
+def _fetch_new_wos_issues(since: str, repo: str = WOS_REPO) -> list[NewIssue]:
+    """
+    Return new GitHub issues with label ``wos:uow`` created after ``since``.
+
+    Uses the gh CLI with ``--search`` filter. Returns an empty list on any
+    subprocess or parse error (non-fatal; delta poller continues).
+
+    Args:
+        since: ISO-8601 timestamp cutoff. Only issues created after this time.
+        repo: GitHub repo slug (owner/repo).
+
+    Returns:
+        List of NewIssue value objects, sorted ascending by issue number.
+    """
+    # gh supports `created:>YYYY-MM-DD` in --search but not full ISO-8601 timestamps.
+    # We use --json and filter in Python to get sub-minute precision.
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "open",
+                "--label", WOS_UOW_LABEL,
+                "--json", "number,title,labels,url,createdAt",
+                "--limit", str(GH_ISSUE_LIMIT),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=True,
+            env={**os.environ, "GH_TOKEN": "", "GITHUB_TOKEN": ""},
+        )
+    except subprocess.CalledProcessError as exc:
+        log.warning("_fetch_new_wos_issues: gh CLI returned %d: %s", exc.returncode, exc.stderr.strip())
+        return []
+    except subprocess.TimeoutExpired:
+        log.warning("_fetch_new_wos_issues: gh CLI timed out")
+        return []
+    except FileNotFoundError:
+        log.warning("_fetch_new_wos_issues: gh CLI not found")
+        return []
+
+    try:
+        issues = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        log.warning("_fetch_new_wos_issues: JSON parse error: %s", exc)
+        return []
+
+    since_dt = _parse_iso(since)
+    new_issues: list[NewIssue] = []
+    for issue in issues:
+        created_dt = _parse_iso(issue.get("createdAt", ""))
+        if created_dt is None or created_dt <= since_dt:
+            continue
+        label_names = [lbl.get("name", "") for lbl in issue.get("labels", [])]
+        new_issues.append(NewIssue(
+            issue_number=issue["number"],
+            issue_url=issue.get("url", ""),
+            title=issue.get("title", ""),
+            labels=label_names,
+            created_at=issue.get("createdAt", ""),
+        ))
+
+    new_issues.sort(key=lambda i: i.issue_number)
+    return new_issues
+
+
+# ---------------------------------------------------------------------------
+# Registry delta query — UoW terminal transitions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CompletedUoW:
+    """A UoW that transitioned to a terminal state since the cursor timestamp."""
+    uow_id: str
+    outcome: str       # done | failed | expired
+    register: str
+    output_ref: str | None
+    completed_at: str
+
+
+def _fetch_newly_completed_uows(since: str, db_path: Path | None = None) -> list[CompletedUoW]:
+    """
+    Return UoWs that transitioned to a terminal status after ``since``.
+
+    Queries registry.db for rows where ``completed_at > since``. Returns an
+    empty list if the DB is absent or unreadable (non-fatal).
+
+    Args:
+        since: ISO-8601 timestamp cutoff.
+        db_path: Override DB path (tests).
+
+    Returns:
+        List of CompletedUoW value objects, sorted ascending by completed_at.
+    """
+    path = db_path or REGISTRY_DB
+    if not path.exists():
+        log.debug("_fetch_newly_completed_uows: registry DB not found at %s", path)
+        return []
+
+    placeholders = ",".join("?" * len(TERMINAL_UOW_STATUSES))
+    query = f"""
+        SELECT id, status, route_reason AS register, output_ref, completed_at
+          FROM uow_registry
+         WHERE status IN ({placeholders})
+           AND completed_at > ?
+         ORDER BY completed_at ASC
+    """
+
+    try:
+        conn = sqlite3.connect(str(path), timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        rows = conn.execute(query, (*TERMINAL_UOW_STATUSES, since)).fetchall()
+        conn.close()
+    except Exception as exc:
+        log.warning("_fetch_newly_completed_uows: DB query failed: %s", exc)
+        return []
+
+    return [
+        CompletedUoW(
+            uow_id=row["id"],
+            outcome=row["status"],
+            register=row["register"] or "unknown",
+            output_ref=row["output_ref"],
+            completed_at=row["completed_at"],
+        )
+        for row in rows
+    ]
+
+
+def _count_active_uows(db_path: Path | None = None) -> int:
+    """Return the count of UoWs currently in 'executing' state."""
+    path = db_path or REGISTRY_DB
+    if not path.exists():
+        return 0
+    try:
+        conn = sqlite3.connect(str(path), timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        count = conn.execute(
+            "SELECT COUNT(*) FROM uow_registry WHERE status = 'executing'"
+        ).fetchone()[0]
+        conn.close()
+        return count
+    except Exception as exc:
+        log.warning("_count_active_uows: DB query failed: %s", exc)
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# ISO-8601 parsing helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(ts: str) -> datetime | None:
+    """
+    Parse an ISO-8601 timestamp to a timezone-aware datetime.
+
+    Returns None if the string is empty or unparseable. Handles both Z-suffix
+    (GitHub API format) and +00:00 offset (Python isoformat).
+    """
+    if not ts:
+        return None
+    try:
+        normalized = ts.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+    except (ValueError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Poll cycle
+# ---------------------------------------------------------------------------
+
+
+def run_poll_cycle(
+    *,
+    since: str,
+    dry_run: bool = False,
+    db_path: Path | None = None,
+) -> tuple[int, int, int]:
+    """
+    Execute one poll cycle and emit typed events for new items found.
+
+    Pure side-effectful function: queries GitHub + registry, emits inbox events,
+    records to event_log. Returns counts of events emitted for each type.
+
+    Args:
+        since: ISO-8601 since-cursor timestamp.
+        dry_run: If True, log what would be emitted but do not write anything.
+        db_path: Override registry DB path (tests).
+
+    Returns:
+        Tuple of (issue_events_emitted, uow_events_emitted, capacity_events_emitted).
+    """
+    from src.orchestration.wos_events import (  # noqa: PLC0415
+        emit_issue_created,
+        emit_uow_completed,
+        emit_capacity_available,
+    )
+
+    issue_count = 0
+    uow_count = 0
+    capacity_count = 0
+
+    # --- New GitHub issues ---
+    new_issues = _fetch_new_wos_issues(since)
+    for issue in new_issues:
+        log.info(
+            "run_poll_cycle: new wos:uow issue #%d %r (created=%s)",
+            issue.issue_number, issue.title, issue.created_at,
+        )
+        if not dry_run:
+            event_id = emit_issue_created(
+                issue_number=issue.issue_number,
+                issue_url=issue.issue_url,
+                title=issue.title,
+                labels=issue.labels,
+                triggered_at=issue.created_at,
+                db_path=db_path,
+            )
+            if event_id:
+                issue_count += 1
+
+    # --- Newly terminal UoWs ---
+    completed = _fetch_newly_completed_uows(since, db_path=db_path)
+    max_parallel = _read_max_parallel()
+    active_count = _count_active_uows(db_path=db_path)
+
+    for uow in completed:
+        log.info(
+            "run_poll_cycle: UoW %r completed outcome=%s (completed_at=%s)",
+            uow.uow_id, uow.outcome, uow.completed_at,
+        )
+        if not dry_run:
+            event_id = emit_uow_completed(
+                uow_id=uow.uow_id,
+                outcome=uow.outcome,
+                register=uow.register,
+                output_ref=uow.output_ref,
+                triggered_at=uow.completed_at,
+                db_path=db_path,
+            )
+            if event_id:
+                uow_count += 1
+
+            # Emit capacity event if this completion freed a slot
+            if active_count < max_parallel:
+                cap_event_id = emit_capacity_available(
+                    freed_uow_id=uow.uow_id,
+                    freed_at=uow.completed_at,
+                    current_active_count=active_count,
+                    max_parallel=max_parallel,
+                    db_path=db_path,
+                )
+                if cap_event_id:
+                    capacity_count += 1
+
+    if dry_run:
+        log.info(
+            "run_poll_cycle [dry-run]: would emit %d issue / %d uow / %d capacity events",
+            len(new_issues), len(completed), sum(1 for u in completed if active_count < max_parallel),
+        )
+
+    return issue_count, uow_count, capacity_count
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="WOS 30s event delta poller")
+    parser.add_argument("--dry-run", action="store_true", help="Log without writing events")
+    args = parser.parse_args()
+
+    # jobs.json gate — respect runtime enable/disable via wos start/stop
+    if not is_job_enabled(JOB_NAME):
+        log.debug("wos-event-poller: disabled in jobs.json — exiting")
+        return
+
+    since = _read_cursor()
+    poll_start = datetime.now(timezone.utc)
+
+    log.info("wos-event-poller: poll cycle starting (since=%s, dry_run=%s)", since, args.dry_run)
+
+    try:
+        issue_count, uow_count, capacity_count = run_poll_cycle(
+            since=since,
+            dry_run=args.dry_run,
+        )
+        log.info(
+            "wos-event-poller: cycle complete — emitted issue=%d uow=%d capacity=%d",
+            issue_count, uow_count, capacity_count,
+        )
+    except Exception as exc:
+        log.error("wos-event-poller: poll cycle failed: %s: %s", type(exc).__name__, exc)
+        # Do NOT advance the cursor on failure — next run will re-scan the same window
+        raise
+
+    # Advance cursor to poll start (not now) so any events that happened during
+    # this poll window are captured on the next run rather than silently skipped.
+    if not args.dry_run:
+        _write_cursor(poll_start.isoformat())
+        log.debug("wos-event-poller: cursor advanced to %s", poll_start.isoformat())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4707,6 +4707,79 @@ except Exception:
         migrated=$((migrated + m130_count))
     fi
 
+    # Migration 131: Register wos-event-poller in jobs.json and add two cron entries
+    # for 30-second polling (one per-minute entry + one with 30s sleep offset).
+    # wos-event-poller.py is the Stage 2 Event-Native delta poller (issue #1351).
+    # It starts disabled so it does not fire until explicitly enabled with `wos start`.
+    local WOS_EVENT_POLLER_MARKER="# LOBSTER-WOS-EVENT-POLLER"
+    local WOS_EVENT_POLLER_30S_MARKER="# LOBSTER-WOS-EVENT-POLLER-30S"
+    if [ -f "$_JOBS_FILE" ]; then
+        if ! uv run python3 -c "import json,sys; d=json.load(open('$_JOBS_FILE')); sys.exit(0 if 'wos-event-poller' in d.get('jobs',{}) else 1)" 2>/dev/null; then
+            substep "Migration 131: adding wos-event-poller to jobs.json"
+            local _m131_tmp
+            _m131_tmp=$(mktemp)
+            uv run python3 - <<'PY131' "$_JOBS_FILE" "$_m131_tmp"
+import json, sys
+from datetime import datetime, timezone
+jobs_path, tmp_path = sys.argv[1], sys.argv[2]
+with open(jobs_path) as f:
+    data = json.load(f)
+data.setdefault("jobs", {})["wos-event-poller"] = {
+    "name": "wos-event-poller",
+    "type": "B",
+    "dispatch": "cron-direct",
+    "schedule": "* * * * *",
+    "schedule_human": "Every 30 seconds (two cron entries)",
+    "task_file": None,
+    "created_at": datetime.now(timezone.utc).isoformat(),
+    "updated_at": datetime.now(timezone.utc).isoformat(),
+    "enabled": False,
+    "last_run": None,
+    "last_status": None,
+    "wos_core": True,
+    "description": "Every 30s: detect new wos:uow GitHub issues and terminal UoW transitions; emit typed inbox events for Event-Native pipeline (Stage 2, issue #1351). Starts disabled.",
+}
+with open(tmp_path, "w") as f:
+    json.dump(data, f, indent=2, default=str)
+print("OK")
+PY131
+            if [ -s "$_m131_tmp" ]; then
+                mv "$_m131_tmp" "$_JOBS_FILE"
+                substep "Migration 131: wos-event-poller added to jobs.json (disabled)"
+                migrated=$((migrated + 1))
+            else
+                rm -f "$_m131_tmp"
+                warn "Migration 131: failed to update jobs.json — add wos-event-poller manually"
+            fi
+        else
+            substep "Migration 131: wos-event-poller already in jobs.json — skipping"
+        fi
+    fi
+
+    local WOS_EVENT_POLLER_SCRIPT="$LOBSTER_DIR/scheduled-tasks/wos-event-poller.py"
+    if [ -f "$WOS_EVENT_POLLER_SCRIPT" ]; then
+        if ! crontab -l 2>/dev/null | grep -qF "$WOS_EVENT_POLLER_MARKER"; then
+            local WOS_EVENT_POLLER_ENTRY="* * * * * cd $LOBSTER_DIR && uv run scheduled-tasks/wos-event-poller.py >> $WORKSPACE_DIR/scheduled-jobs/logs/wos-event-poller.log 2>&1 $WOS_EVENT_POLLER_MARKER"
+            (crontab -l 2>/dev/null; echo "$WOS_EVENT_POLLER_ENTRY") | crontab - && {
+                substep "Migration 131: added LOBSTER-WOS-EVENT-POLLER cron entry (every minute)"
+                migrated=$((migrated + 1))
+            } || warn "Could not add LOBSTER-WOS-EVENT-POLLER cron entry — add manually"
+        else
+            substep "Migration 131: LOBSTER-WOS-EVENT-POLLER cron entry already present — skipping"
+        fi
+        if ! crontab -l 2>/dev/null | grep -qF "$WOS_EVENT_POLLER_30S_MARKER"; then
+            local WOS_EVENT_POLLER_30S_ENTRY="* * * * * sleep 30 && cd $LOBSTER_DIR && uv run scheduled-tasks/wos-event-poller.py >> $WORKSPACE_DIR/scheduled-jobs/logs/wos-event-poller.log 2>&1 $WOS_EVENT_POLLER_30S_MARKER"
+            (crontab -l 2>/dev/null; echo "$WOS_EVENT_POLLER_30S_ENTRY") | crontab - && {
+                substep "Migration 131: added LOBSTER-WOS-EVENT-POLLER-30S cron entry (30s offset)"
+                migrated=$((migrated + 1))
+            } || warn "Could not add LOBSTER-WOS-EVENT-POLLER-30S cron entry — add manually"
+        else
+            substep "Migration 131: LOBSTER-WOS-EVENT-POLLER-30S cron entry already present — skipping"
+        fi
+    else
+        warn "wos-event-poller.py not found at $WOS_EVENT_POLLER_SCRIPT — skipping Migration 131 cron entries"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -1249,6 +1249,23 @@ WOS_MESSAGE_TYPE_DISPATCH: dict[str, str] = {
     # executing → ready-for-steward, eliminating the 24h claimed_until expiry
     # cycle that previously bypassed the steward's orphan retry logic.
     "agent_failed": "handle_agent_failed",
+    # Stage 2 Event-Native Nervous System (issue #1351): three typed event message types
+    # emitted by wos-event-poller.py (30s Type B cron). All three are fast-path handlers
+    # (dispatched before the spawn-gate) that return action="mark_processed" — they update
+    # event_log.consumed_at and log the event; no subagent spawn is required.
+    #
+    # wos_issue_created: emitted by delta poller when a GitHub issue with wos:uow label
+    # is detected. Handler logs the event and marks it consumed. Germination is still
+    # handled by the existing issue-sweeper job; this event is observability + future hook.
+    "wos_issue_created": "handle_wos_issue_created",
+    # wos_uow_completed: emitted by delta poller when a UoW transitions to done/failed.
+    # Handler marks the event consumed and logs it. Downstream capacity signaling is
+    # carried by wos_capacity_available (separate event per slot freed).
+    "wos_uow_completed": "handle_wos_uow_completed",
+    # wos_capacity_available: emitted by delta poller when executor has free slots
+    # (running < max_parallel). Handler marks the event consumed and logs it.
+    # Future use: signal the germinator to promote pending UoWs faster.
+    "wos_capacity_available": "handle_wos_capacity_available",
 }
 
 
@@ -2325,6 +2342,161 @@ def handle_agent_failed(
     return {"action": "mark_processed", "message_type": "agent_failed"}
 
 
+# ---------------------------------------------------------------------------
+# Stage 2 Event-Native Nervous System handlers (issue #1351)
+#
+# Three typed event message types emitted by wos-event-poller.py (30s Type B
+# cron). All three are fast-path handlers: they mark the event consumed in
+# event_log and return action="mark_processed". No subagent spawn required.
+#
+# route_wos_message dispatches these before the spawn-gate because they
+# legitimately return action="mark_processed" rather than "spawn_subagent".
+# ---------------------------------------------------------------------------
+
+
+def handle_wos_issue_created(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle a ``wos_issue_created`` typed inbox event (Stage 2, issue #1351).
+
+    Emitted by wos-event-poller.py when a new GitHub issue with label ``wos:uow``
+    is detected via the 30s delta poller. Records the event in event_log as
+    consumed and logs it for observability.
+
+    Germination is still handled by the existing issue-sweeper job; this handler
+    is primarily an observability hook and a foundation for future Stage 2 routing.
+
+    Pure function — no blocking I/O beyond the event_log update.
+
+    Args:
+        msg: The raw inbox message dict. Expected fields:
+            ``event_id`` (str): UUID of the event_log row.
+            ``issue_number`` (int): GitHub issue number.
+            ``issue_url`` (str): Full GitHub issue URL.
+            ``title`` (str): Issue title.
+            ``labels`` (list[str]): Label names on the issue.
+            ``triggered_at`` (str): ISO-8601 timestamp of detection.
+
+    Returns:
+        ``{"action": "mark_processed", "message_type": "wos_issue_created"}``
+    """
+    event_id: str = msg.get("event_id", "")
+    issue_number: int = msg.get("issue_number", 0)
+    issue_url: str = msg.get("issue_url", "")
+    title: str = msg.get("title", "")
+
+    _log.info(
+        "handle_wos_issue_created: issue #%d %r (%s) event_id=%s",
+        issue_number, title, issue_url, event_id,
+    )
+
+    if event_id:
+        try:
+            from .wos_events import mark_event_consumed as _mark_consumed  # noqa: PLC0415
+            _mark_consumed(event_id, consumer_task_id="dispatcher-wos_issue_created")
+        except Exception as exc:
+            _log.warning(
+                "handle_wos_issue_created: mark_event_consumed failed for %s: %s",
+                event_id, exc,
+            )
+
+    return {"action": "mark_processed", "message_type": "wos_issue_created"}
+
+
+def handle_wos_uow_completed(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle a ``wos_uow_completed`` typed inbox event (Stage 2, issue #1351).
+
+    Emitted by wos-event-poller.py when it detects a UoW that has transitioned
+    to ``done`` or ``failed`` state since the last poll. Records the event as
+    consumed in event_log.
+
+    Downstream capacity signaling is carried by ``wos_capacity_available``
+    (a separate event emitted alongside this one when a slot is freed).
+
+    Pure function — no blocking I/O beyond the event_log update.
+
+    Args:
+        msg: The raw inbox message dict. Expected fields:
+            ``event_id`` (str): UUID of the event_log row.
+            ``uow_id`` (str): The completed UoW identifier.
+            ``outcome`` (str): Terminal outcome — ``"done"`` or ``"failed"``.
+            ``register`` (str): Register the UoW was assigned to.
+            ``output_ref`` (str | None): Path to the output artifact.
+            ``triggered_at`` (str): ISO-8601 timestamp of the transition.
+
+    Returns:
+        ``{"action": "mark_processed", "message_type": "wos_uow_completed"}``
+    """
+    event_id: str = msg.get("event_id", "")
+    uow_id: str = msg.get("uow_id", "")
+    outcome: str = msg.get("outcome", "")
+
+    _log.info(
+        "handle_wos_uow_completed: UoW %r outcome=%s event_id=%s",
+        uow_id, outcome, event_id,
+    )
+
+    if event_id:
+        try:
+            from .wos_events import mark_event_consumed as _mark_consumed  # noqa: PLC0415
+            _mark_consumed(event_id, consumer_task_id="dispatcher-wos_uow_completed")
+        except Exception as exc:
+            _log.warning(
+                "handle_wos_uow_completed: mark_event_consumed failed for %s: %s",
+                event_id, exc,
+            )
+
+    return {"action": "mark_processed", "message_type": "wos_uow_completed"}
+
+
+def handle_wos_capacity_available(msg: dict[str, Any]) -> dict[str, Any]:
+    """
+    Handle a ``wos_capacity_available`` typed inbox event (Stage 2, issue #1351).
+
+    Emitted by wos-event-poller.py when the executor has free slots
+    (running < max_parallel). Signals that the germinator can promote pending
+    UoWs to ready-for-executor state without violating the parallel cap.
+
+    Records the event as consumed in event_log and logs capacity state for
+    observability. Future use: trigger germination without waiting for the
+    next steward-heartbeat cron tick.
+
+    Pure function — no blocking I/O beyond the event_log update.
+
+    Args:
+        msg: The raw inbox message dict. Expected fields:
+            ``event_id`` (str): UUID of the event_log row.
+            ``freed_uow_id`` (str): UoW whose completion freed the slot.
+            ``freed_at`` (str): ISO-8601 timestamp when the slot was freed.
+            ``current_active_count`` (int): Active UoWs after the slot freed.
+            ``max_parallel`` (int): Maximum allowed concurrent UoWs.
+
+    Returns:
+        ``{"action": "mark_processed", "message_type": "wos_capacity_available"}``
+    """
+    event_id: str = msg.get("event_id", "")
+    freed_uow_id: str = msg.get("freed_uow_id", "")
+    current_active_count: int = msg.get("current_active_count", -1)
+    max_parallel: int = msg.get("max_parallel", -1)
+
+    _log.info(
+        "handle_wos_capacity_available: freed_uow_id=%r active=%d/%d event_id=%s",
+        freed_uow_id, current_active_count, max_parallel, event_id,
+    )
+
+    if event_id:
+        try:
+            from .wos_events import mark_event_consumed as _mark_consumed  # noqa: PLC0415
+            _mark_consumed(event_id, consumer_task_id="dispatcher-wos_capacity_available")
+        except Exception as exc:
+            _log.warning(
+                "handle_wos_capacity_available: mark_event_consumed failed for %s: %s",
+                event_id, exc,
+            )
+
+    return {"action": "mark_processed", "message_type": "wos_capacity_available"}
+
+
 def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
     """
     Route an inbox message whose `type` is listed in WOS_MESSAGE_TYPE_DISPATCH.
@@ -2548,6 +2720,53 @@ def route_wos_message(msg: dict[str, Any]) -> dict[str, Any]:
             _logging.getLogger(__name__).error(
                 "route_wos_message: handle_agent_failed raised %s: %s — "
                 "marking processed without state transition",
+                type(exc).__name__, exc,
+            )
+            return {"action": "mark_processed", "message_type": msg_type}
+
+    # ---------------------------------------------------------------------------
+    # Stage 2 Event-Native fast-paths (issue #1351): all three event types return
+    # action="mark_processed" — they record event_log consumption and log the event.
+    # Dispatched before the spawn-gate because they legitimately do not spawn subagents.
+    # ---------------------------------------------------------------------------
+    if msg_type == "wos_issue_created":
+        try:
+            result = handle_wos_issue_created(msg)
+            result["message_type"] = msg_type
+            return result
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).error(
+                "route_wos_message: handle_wos_issue_created raised %s: %s — "
+                "marking processed",
+                type(exc).__name__, exc,
+            )
+            return {"action": "mark_processed", "message_type": msg_type}
+
+    if msg_type == "wos_uow_completed":
+        try:
+            result = handle_wos_uow_completed(msg)
+            result["message_type"] = msg_type
+            return result
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).error(
+                "route_wos_message: handle_wos_uow_completed raised %s: %s — "
+                "marking processed",
+                type(exc).__name__, exc,
+            )
+            return {"action": "mark_processed", "message_type": msg_type}
+
+    if msg_type == "wos_capacity_available":
+        try:
+            result = handle_wos_capacity_available(msg)
+            result["message_type"] = msg_type
+            return result
+        except Exception as exc:
+            import logging as _logging
+            _logging.getLogger(__name__).error(
+                "route_wos_message: handle_wos_capacity_available raised %s: %s — "
+                "marking processed",
                 type(exc).__name__, exc,
             )
             return {"action": "mark_processed", "message_type": msg_type}

--- a/src/orchestration/migrations/0029_event_log.sql
+++ b/src/orchestration/migrations/0029_event_log.sql
@@ -1,0 +1,38 @@
+-- Migration 0029: Create event_log table for WOS Event-Native Nervous System.
+--
+-- The event_log records typed events emitted by the WOS event pipeline:
+--   wos_issue_created    — emitted when a GitHub issue with label wos:uow is created
+--   wos_uow_completed    — emitted when a UoW transitions to completed/failed state
+--   wos_capacity_available — emitted when executor has slots free (running < max_parallel)
+--
+-- Events are written on emission and marked consumed (consumed_at non-null)
+-- after the dispatcher processes the corresponding inbox message.
+--
+-- Deduplication: (event_type, dedup_key) is UNIQUE so the delta poller can
+-- re-run safely without flooding the inbox with duplicate events.
+-- dedup_key is event-type-specific (e.g. issue number for wos_issue_created,
+-- uow_id for wos_uow_completed, freed_uow_id for wos_capacity_available).
+--
+-- Retention: consumed events older than 30 days may be pruned.
+-- The poller reads max(emitted_at) as a since-cursor to find the next delta.
+
+CREATE TABLE IF NOT EXISTS event_log (
+    event_id          TEXT    PRIMARY KEY,           -- UUID
+    event_type        TEXT    NOT NULL,               -- wos_issue_created | wos_uow_completed | wos_capacity_available
+    payload           TEXT    NOT NULL DEFAULT '{}',  -- JSON
+    emitted_at        TEXT    NOT NULL,               -- ISO-8601 UTC
+    consumed_at       TEXT    DEFAULT NULL,           -- ISO-8601 UTC; NULL = not yet consumed
+    consumer_task_id  TEXT    DEFAULT NULL,           -- task_id of the consuming dispatcher job
+    dedup_key         TEXT    DEFAULT NULL            -- type-specific dedup handle; see UNIQUE constraint below
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_event_log_dedup
+    ON event_log (event_type, dedup_key)
+    WHERE dedup_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_event_log_emitted_at
+    ON event_log (emitted_at);
+
+CREATE INDEX IF NOT EXISTS idx_event_log_unconsumed
+    ON event_log (event_type, emitted_at)
+    WHERE consumed_at IS NULL;

--- a/src/orchestration/migrations/0030_event_log.sql
+++ b/src/orchestration/migrations/0030_event_log.sql
@@ -1,4 +1,4 @@
--- Migration 0029: Create event_log table for WOS Event-Native Nervous System.
+-- Migration 0030: Create event_log table for WOS Event-Native Nervous System.
 --
 -- The event_log records typed events emitted by the WOS event pipeline:
 --   wos_issue_created    — emitted when a GitHub issue with label wos:uow is created

--- a/src/orchestration/wos_events.py
+++ b/src/orchestration/wos_events.py
@@ -1,0 +1,448 @@
+"""
+WOS Event-Native Nervous System — typed event emission (Stage 2).
+
+Provides three pure emit functions that write typed inbox messages and record
+events in the event_log DB table. The dispatcher's WOS_MESSAGE_TYPE_DISPATCH
+table routes these message types to the corresponding handlers.
+
+**Event types emitted:**
+
+  wos_issue_created       — GitHub issue with label wos:uow was created
+  wos_uow_completed       — UoW transitioned to done/failed state
+  wos_capacity_available  — Executor has free slots (running < max_parallel)
+
+**Design principles:**
+
+- All emit functions are pure side-effectful functions: they write to disk
+  (inbox/ and event_log) and return the event_id on success.
+- Deduplication is enforced at the DB layer via the UNIQUE(event_type, dedup_key)
+  index. Callers can safely call emit_* on every poll cycle without flooding
+  the inbox — duplicate events are silently skipped.
+- Non-fatal pattern: inbox write failures are logged and swallowed so that
+  event emission never blocks the caller's critical path.
+- event_log writes use atomic tmp-then-rename for the inbox file; the DB write
+  uses a short-timeout connection consistent with Registry._connect().
+
+**Consuming events:**
+
+  After the dispatcher processes a typed event message, it should call
+  mark_event_consumed(event_id, consumer_task_id) to record the consumed_at
+  timestamp. This is advisory — unconsumed events do not block future emission.
+
+References:
+  spec: ~/lobster-workspace/workstreams/wos/spec/wos-evolution-spec.md §3-II
+  issue: https://github.com/dcetlin/Lobster/issues/1351
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Path helpers — read from env at call time so tests can override via
+# patch.dict(os.environ, {...}) without re-importing the module.
+# ---------------------------------------------------------------------------
+
+_INBOX_DIR_DEFAULT: str = "~/messages/inbox"
+_ADMIN_CHAT_ID_DEFAULT: str = "8075091586"
+
+
+def _inbox_dir() -> Path:
+    """Return the inbox directory path, creating it if absent."""
+    base = os.environ.get("LOBSTER_INBOX_DIR", _INBOX_DIR_DEFAULT)
+    path = Path(os.path.expanduser(base))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _admin_chat_id() -> str:
+    """Return the admin chat_id from the environment."""
+    return os.environ.get("LOBSTER_ADMIN_CHAT_ID", _ADMIN_CHAT_ID_DEFAULT)
+
+
+def _registry_db_path() -> Path:
+    """Return the registry.db path from the environment."""
+    if env_path := os.environ.get("REGISTRY_DB_PATH"):
+        return Path(env_path)
+    workspace = Path(
+        os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+    )
+    return workspace / "orchestration" / "registry.db"
+
+
+# ---------------------------------------------------------------------------
+# event_log DB helpers
+# ---------------------------------------------------------------------------
+
+def _db_connect(db_path: Path) -> sqlite3.Connection:
+    """Open a short-timeout WAL connection to registry.db."""
+    conn = sqlite3.connect(str(db_path), timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def _record_event(
+    *,
+    event_id: str,
+    event_type: str,
+    payload: dict[str, Any],
+    dedup_key: str | None,
+    db_path: Path | None = None,
+) -> bool:
+    """
+    Insert a row into event_log; return True on success, False on duplicate.
+
+    Uses INSERT OR IGNORE so callers can safely call this on every poll cycle
+    without raising on duplicate dedup_key values. Returns False when the
+    insert was a no-op (duplicate), True when a new row was written.
+
+    Non-fatal: DB errors are logged and return False so inbox emission can
+    proceed independently of whether the DB write succeeded.
+    """
+    path = db_path or _registry_db_path()
+    if not path.exists():
+        log.debug("_record_event: registry DB not found at %s — skipping", path)
+        return False
+    try:
+        conn = _db_connect(path)
+        cursor = conn.execute(
+            """
+            INSERT OR IGNORE INTO event_log
+                (event_id, event_type, payload, emitted_at, dedup_key)
+            VALUES
+                (?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                event_type,
+                json.dumps(payload),
+                datetime.now(timezone.utc).isoformat(),
+                dedup_key,
+            ),
+        )
+        conn.commit()
+        conn.close()
+        return cursor.rowcount > 0
+    except Exception as exc:
+        log.warning("_record_event: DB write failed for %s/%s: %s", event_type, dedup_key, exc)
+        return False
+
+
+def mark_event_consumed(
+    event_id: str,
+    consumer_task_id: str | None = None,
+    *,
+    db_path: Path | None = None,
+) -> None:
+    """
+    Mark an event as consumed by recording consumed_at and consumer_task_id.
+
+    Called by the dispatcher after it finishes processing a typed WOS event.
+    Non-fatal — failures are logged and swallowed.
+    """
+    path = db_path or _registry_db_path()
+    if not path.exists():
+        return
+    try:
+        conn = _db_connect(path)
+        conn.execute(
+            """
+            UPDATE event_log
+               SET consumed_at = ?, consumer_task_id = ?
+             WHERE event_id = ? AND consumed_at IS NULL
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(),
+                consumer_task_id,
+                event_id,
+            ),
+        )
+        conn.commit()
+        conn.close()
+    except Exception as exc:
+        log.warning("mark_event_consumed: failed for event %s: %s", event_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Inbox message writer
+# ---------------------------------------------------------------------------
+
+def _write_inbox_message(msg: dict[str, Any]) -> None:
+    """
+    Atomically write a typed WOS event message to the inbox.
+
+    Uses tmp-then-rename so the dispatcher never reads a partial file.
+    Non-fatal: failures are logged and re-raised so callers can decide.
+    """
+    msg_id: str = msg["id"]
+    inbox = _inbox_dir()
+    dest = inbox / f"{msg_id}.json"
+    tmp = inbox / f"{msg_id}.json.tmp"
+    try:
+        tmp.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+        tmp.rename(dest)
+        log.info("_write_inbox_message: wrote %s → %s", msg["type"], dest.name)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Public emit functions
+# ---------------------------------------------------------------------------
+
+def emit_issue_created(
+    *,
+    issue_number: int,
+    issue_url: str,
+    title: str,
+    labels: list[str],
+    triggered_at: str | None = None,
+    db_path: Path | None = None,
+) -> str | None:
+    """
+    Emit a ``wos_issue_created`` typed inbox event.
+
+    Called by the delta poller when it detects a new GitHub issue with the
+    ``wos:uow`` label that has not yet been seen (i.e. not in event_log).
+
+    Deduplication key: ``str(issue_number)`` — one emission per issue.
+    A second call for the same issue_number is a no-op (returns None).
+
+    Args:
+        issue_number: GitHub issue number.
+        issue_url: Full GitHub issue URL.
+        title: Issue title.
+        labels: List of label names on the issue.
+        triggered_at: ISO-8601 timestamp of when the issue was detected.
+                      Defaults to now.
+        db_path: Override registry DB path (tests).
+
+    Returns:
+        event_id (str) on first emission, None if the event is a duplicate.
+    """
+    dedup_key = str(issue_number)
+    triggered_at = triggered_at or datetime.now(timezone.utc).isoformat()
+
+    event_id = str(uuid.uuid4())
+    payload: dict[str, Any] = {
+        "issue_number": issue_number,
+        "issue_url": issue_url,
+        "title": title,
+        "labels": labels,
+        "triggered_at": triggered_at,
+    }
+
+    inserted = _record_event(
+        event_id=event_id,
+        event_type="wos_issue_created",
+        payload=payload,
+        dedup_key=dedup_key,
+        db_path=db_path,
+    )
+
+    if not inserted:
+        log.debug("emit_issue_created: duplicate issue #%d — skipping inbox write", issue_number)
+        return None
+
+    msg: dict[str, Any] = {
+        "id": event_id,
+        "source": "system",
+        "type": "wos_issue_created",
+        "chat_id": _admin_chat_id(),
+        "event_id": event_id,
+        "issue_number": issue_number,
+        "issue_url": issue_url,
+        "title": title,
+        "labels": labels,
+        "triggered_at": triggered_at,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        _write_inbox_message(msg)
+    except Exception as exc:
+        log.warning(
+            "emit_issue_created: inbox write failed for issue #%d: %s",
+            issue_number, exc,
+        )
+        return None
+
+    log.info("emit_issue_created: emitted event %s for issue #%d", event_id, issue_number)
+    return event_id
+
+
+def emit_uow_completed(
+    *,
+    uow_id: str,
+    outcome: str,
+    register: str,
+    output_ref: str | None = None,
+    triggered_at: str | None = None,
+    db_path: Path | None = None,
+) -> str | None:
+    """
+    Emit a ``wos_uow_completed`` typed inbox event.
+
+    Called when a UoW transitions to done or failed state. Signals downstream
+    components (capacity tracker, germinator, etc.) that a slot has freed.
+
+    Deduplication key: ``uow_id`` — one emission per UoW terminal transition.
+
+    Args:
+        uow_id: The UoW identifier.
+        outcome: Terminal outcome — ``"done"`` or ``"failed"``.
+        register: Register the UoW was assigned to.
+        output_ref: Path to the UoW output artifact (optional).
+        triggered_at: ISO-8601 timestamp of the transition. Defaults to now.
+        db_path: Override registry DB path (tests).
+
+    Returns:
+        event_id (str) on first emission, None if duplicate.
+    """
+    dedup_key = uow_id
+    triggered_at = triggered_at or datetime.now(timezone.utc).isoformat()
+
+    event_id = str(uuid.uuid4())
+    payload: dict[str, Any] = {
+        "uow_id": uow_id,
+        "outcome": outcome,
+        "register": register,
+        "output_ref": output_ref,
+        "triggered_at": triggered_at,
+    }
+
+    inserted = _record_event(
+        event_id=event_id,
+        event_type="wos_uow_completed",
+        payload=payload,
+        dedup_key=dedup_key,
+        db_path=db_path,
+    )
+
+    if not inserted:
+        log.debug("emit_uow_completed: duplicate UoW %r — skipping inbox write", uow_id)
+        return None
+
+    msg: dict[str, Any] = {
+        "id": event_id,
+        "source": "system",
+        "type": "wos_uow_completed",
+        "chat_id": _admin_chat_id(),
+        "event_id": event_id,
+        "uow_id": uow_id,
+        "outcome": outcome,
+        "register": register,
+        "output_ref": output_ref,
+        "triggered_at": triggered_at,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        _write_inbox_message(msg)
+    except Exception as exc:
+        log.warning(
+            "emit_uow_completed: inbox write failed for UoW %r: %s",
+            uow_id, exc,
+        )
+        return None
+
+    log.info("emit_uow_completed: emitted event %s for UoW %r (outcome=%s)", event_id, uow_id, outcome)
+    return event_id
+
+
+def emit_capacity_available(
+    *,
+    freed_uow_id: str,
+    freed_at: str | None = None,
+    current_active_count: int,
+    max_parallel: int,
+    db_path: Path | None = None,
+) -> str | None:
+    """
+    Emit a ``wos_capacity_available`` typed inbox event.
+
+    Called when executor capacity becomes available (active UoWs < max_parallel).
+    Signals the germinator that it can promote pending UoWs to ready-for-executor.
+
+    Deduplication key: ``freed_uow_id`` — one capacity event per UoW that freed
+    a slot. This prevents duplicate capacity signals when the same UoW finishes
+    and the poller runs multiple times before the dispatcher processes the event.
+
+    Args:
+        freed_uow_id: The UoW whose completion freed the slot.
+        freed_at: ISO-8601 timestamp when capacity became available. Defaults to now.
+        current_active_count: Number of active UoWs after the slot was freed.
+        max_parallel: Maximum parallel UoWs allowed by wos-config.json.
+        db_path: Override registry DB path (tests).
+
+    Returns:
+        event_id (str) on first emission, None if duplicate.
+    """
+    dedup_key = freed_uow_id
+    freed_at = freed_at or datetime.now(timezone.utc).isoformat()
+
+    event_id = str(uuid.uuid4())
+    payload: dict[str, Any] = {
+        "freed_uow_id": freed_uow_id,
+        "freed_at": freed_at,
+        "current_active_count": current_active_count,
+        "max_parallel": max_parallel,
+    }
+
+    inserted = _record_event(
+        event_id=event_id,
+        event_type="wos_capacity_available",
+        payload=payload,
+        dedup_key=dedup_key,
+        db_path=db_path,
+    )
+
+    if not inserted:
+        log.debug(
+            "emit_capacity_available: duplicate freed_uow_id %r — skipping inbox write",
+            freed_uow_id,
+        )
+        return None
+
+    msg: dict[str, Any] = {
+        "id": event_id,
+        "source": "system",
+        "type": "wos_capacity_available",
+        "chat_id": _admin_chat_id(),
+        "event_id": event_id,
+        "freed_uow_id": freed_uow_id,
+        "freed_at": freed_at,
+        "current_active_count": current_active_count,
+        "max_parallel": max_parallel,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        _write_inbox_message(msg)
+    except Exception as exc:
+        log.warning(
+            "emit_capacity_available: inbox write failed for freed_uow_id %r: %s",
+            freed_uow_id, exc,
+        )
+        return None
+
+    log.info(
+        "emit_capacity_available: emitted event %s (freed=%r active=%d/%d)",
+        event_id, freed_uow_id, current_active_count, max_parallel,
+    )
+    return event_id

--- a/tests/test_wos_stage2_event_native.py
+++ b/tests/test_wos_stage2_event_native.py
@@ -70,7 +70,7 @@ if str(_REPO_ROOT / "src") not in sys.path:
 
 def _make_event_log_schema() -> str:
     """Return the event_log migration SQL."""
-    migration_path = _REPO_ROOT / "src" / "orchestration" / "migrations" / "0029_event_log.sql"
+    migration_path = _REPO_ROOT / "src" / "orchestration" / "migrations" / "0030_event_log.sql"
     return migration_path.read_text()
 
 

--- a/tests/test_wos_stage2_event_native.py
+++ b/tests/test_wos_stage2_event_native.py
@@ -1,0 +1,783 @@
+"""
+Tests for WOS Stage 2 Event-Native Nervous System (issue #1351).
+
+Coverage:
+  event_log schema
+  - test_event_log_migration_creates_table: migration SQL creates table with required columns
+  - test_event_log_dedup_index: unique (event_type, dedup_key) constraint prevents duplicates
+  - test_event_log_allows_null_dedup_key: NULL dedup_key rows are not deduped
+
+  wos_events.py — emit functions
+  - test_emit_issue_created_writes_inbox_message: emit_issue_created writes inbox file
+  - test_emit_issue_created_records_event_log: emit_issue_created inserts event_log row
+  - test_emit_issue_created_deduplication: second call with same issue_number is no-op
+  - test_emit_issue_created_returns_none_on_duplicate: returns None for duplicate
+  - test_emit_uow_completed_writes_inbox_message: emit_uow_completed writes inbox file
+  - test_emit_uow_completed_records_event_log: inserts event_log row
+  - test_emit_uow_completed_deduplication: second call with same uow_id is no-op
+  - test_emit_capacity_available_writes_inbox_message: emit_capacity_available writes inbox file
+  - test_emit_capacity_available_deduplication: second call with same freed_uow_id is no-op
+  - test_mark_event_consumed_sets_timestamps: mark_event_consumed updates consumed_at
+
+  dispatcher_handlers.py — handler functions
+  - test_handle_wos_issue_created_returns_mark_processed: handler returns action=mark_processed
+  - test_handle_wos_uow_completed_returns_mark_processed: handler returns action=mark_processed
+  - test_handle_wos_capacity_available_returns_mark_processed: handler returns action=mark_processed
+  - test_handle_wos_issue_created_calls_mark_event_consumed: handler calls mark_event_consumed
+  - test_handle_wos_uow_completed_calls_mark_event_consumed: handler calls mark_event_consumed
+
+  route_wos_message routing
+  - test_route_wos_message_routes_wos_issue_created: routes to handle_wos_issue_created
+  - test_route_wos_message_routes_wos_uow_completed: routes to handle_wos_uow_completed
+  - test_route_wos_message_routes_wos_capacity_available: routes to handle_wos_capacity_available
+  - test_route_wos_message_handles_handler_exception: exception in handler returns mark_processed
+
+  wos-event-poller.py
+  - test_poller_exits_when_disabled: is_job_enabled=False causes immediate return
+  - test_poller_run_cycle_emits_issue_events: new issues trigger emit_issue_created
+  - test_poller_run_cycle_emits_uow_events: terminal UoWs trigger emit_uow_completed
+  - test_poller_run_cycle_emits_capacity_events: UoW completion with free slots triggers capacity
+  - test_poller_advances_cursor_on_success: cursor is written after successful cycle
+  - test_poller_does_not_advance_cursor_on_failure: cursor not written on exception
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event_log_schema() -> str:
+    """Return the event_log migration SQL."""
+    migration_path = _REPO_ROOT / "src" / "orchestration" / "migrations" / "0029_event_log.sql"
+    return migration_path.read_text()
+
+
+def _create_event_log_db(path: Path) -> sqlite3.Connection:
+    """Create a minimal SQLite DB with the event_log table applied."""
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_make_event_log_schema())
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# event_log schema tests
+# ---------------------------------------------------------------------------
+
+class TestEventLogSchema:
+    def test_event_log_migration_creates_table(self, tmp_path):
+        """Migration SQL creates the event_log table with all required columns."""
+        db_path = tmp_path / "registry.db"
+        conn = _create_event_log_db(db_path)
+        # Check table exists by querying it
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='event_log'").fetchall()
+        assert len(rows) == 1, "event_log table should exist after migration"
+        # Check column names
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(event_log)").fetchall()}
+        required_cols = {"event_id", "event_type", "payload", "emitted_at", "consumed_at", "consumer_task_id", "dedup_key"}
+        assert required_cols == cols, f"Missing columns: {required_cols - cols}"
+        conn.close()
+
+    def test_event_log_dedup_index_prevents_duplicates(self, tmp_path):
+        """UNIQUE(event_type, dedup_key) prevents inserting duplicate events."""
+        db_path = tmp_path / "registry.db"
+        conn = _create_event_log_db(db_path)
+
+        conn.execute(
+            "INSERT INTO event_log (event_id, event_type, payload, emitted_at, dedup_key) VALUES (?, ?, '{}', datetime('now'), ?)",
+            ("id-1", "wos_issue_created", "42"),
+        )
+        conn.commit()
+
+        # INSERT OR IGNORE should silently skip the duplicate
+        conn.execute(
+            "INSERT OR IGNORE INTO event_log (event_id, event_type, payload, emitted_at, dedup_key) VALUES (?, ?, '{}', datetime('now'), ?)",
+            ("id-2", "wos_issue_created", "42"),
+        )
+        conn.commit()
+
+        rows = conn.execute("SELECT COUNT(*) FROM event_log WHERE event_type='wos_issue_created' AND dedup_key='42'").fetchone()
+        assert rows[0] == 1, "Duplicate (event_type, dedup_key) should be ignored"
+        conn.close()
+
+    def test_event_log_allows_null_dedup_key(self, tmp_path):
+        """NULL dedup_key rows are not subject to the unique constraint."""
+        db_path = tmp_path / "registry.db"
+        conn = _create_event_log_db(db_path)
+
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO event_log (event_id, event_type, payload, emitted_at, dedup_key) VALUES (?, ?, '{}', datetime('now'), NULL)",
+                (str(uuid.uuid4()), "wos_issue_created"),
+            )
+        conn.commit()
+
+        count = conn.execute("SELECT COUNT(*) FROM event_log").fetchone()[0]
+        assert count == 3, "NULL dedup_key rows should all be inserted"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# wos_events.py tests
+# ---------------------------------------------------------------------------
+
+class TestEmitIssueCreated:
+    def test_emit_issue_created_writes_inbox_message(self, tmp_path):
+        """emit_issue_created writes a JSON file to the inbox directory."""
+        from src.orchestration.wos_events import emit_issue_created
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            event_id = emit_issue_created(
+                issue_number=100,
+                issue_url="https://github.com/dcetlin/Lobster/issues/100",
+                title="test issue",
+                labels=["wos:uow"],
+                db_path=db_path,
+            )
+
+        assert event_id is not None, "event_id should be returned on first emission"
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1, "Exactly one inbox file should be written"
+
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["type"] == "wos_issue_created"
+        assert msg["issue_number"] == 100
+        assert msg["labels"] == ["wos:uow"]
+
+    def test_emit_issue_created_records_event_log(self, tmp_path):
+        """emit_issue_created inserts a row into event_log."""
+        from src.orchestration.wos_events import emit_issue_created
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            event_id = emit_issue_created(
+                issue_number=200,
+                issue_url="https://github.com/dcetlin/Lobster/issues/200",
+                title="another issue",
+                labels=["wos:uow"],
+                db_path=db_path,
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT * FROM event_log WHERE event_id=?", (event_id,)).fetchone()
+        conn.close()
+
+        assert row is not None, "event_log row should be written"
+        assert row[1] == "wos_issue_created"  # event_type
+        assert row[6] == "200"                # dedup_key = str(issue_number)
+
+    def test_emit_issue_created_deduplication(self, tmp_path):
+        """Second call with the same issue_number skips inbox write (dedup)."""
+        from src.orchestration.wos_events import emit_issue_created
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            first_id = emit_issue_created(
+                issue_number=300,
+                issue_url="https://github.com/dcetlin/Lobster/issues/300",
+                title="dupe issue",
+                labels=["wos:uow"],
+                db_path=db_path,
+            )
+            second_id = emit_issue_created(
+                issue_number=300,  # same issue_number
+                issue_url="https://github.com/dcetlin/Lobster/issues/300",
+                title="dupe issue",
+                labels=["wos:uow"],
+                db_path=db_path,
+            )
+
+        assert first_id is not None
+        assert second_id is None, "Duplicate emission should return None"
+        # Only one inbox file should have been written
+        assert len(list(inbox_dir.glob("*.json"))) == 1
+
+    def test_emit_issue_created_returns_none_on_duplicate(self, tmp_path):
+        """emit_issue_created returns None rather than raising on duplicate dedup_key."""
+        from src.orchestration.wos_events import emit_issue_created
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            emit_issue_created(
+                issue_number=400,
+                issue_url="https://github.com/dcetlin/Lobster/issues/400",
+                title="dup test",
+                labels=[],
+                db_path=db_path,
+            )
+            result = emit_issue_created(
+                issue_number=400,
+                issue_url="https://github.com/dcetlin/Lobster/issues/400",
+                title="dup test",
+                labels=[],
+                db_path=db_path,
+            )
+
+        assert result is None
+
+
+class TestEmitUowCompleted:
+    def test_emit_uow_completed_writes_inbox_message(self, tmp_path):
+        """emit_uow_completed writes a JSON inbox message with correct fields."""
+        from src.orchestration.wos_events import emit_uow_completed
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        uow_id = "uow_20260531_abc123"
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            event_id = emit_uow_completed(
+                uow_id=uow_id,
+                outcome="done",
+                register="code",
+                output_ref="/some/output.json",
+                db_path=db_path,
+            )
+
+        assert event_id is not None
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["type"] == "wos_uow_completed"
+        assert msg["uow_id"] == uow_id
+        assert msg["outcome"] == "done"
+        assert msg["register"] == "code"
+
+    def test_emit_uow_completed_records_event_log(self, tmp_path):
+        """emit_uow_completed inserts a row with dedup_key=uow_id."""
+        from src.orchestration.wos_events import emit_uow_completed
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        uow_id = "uow_test_1"
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            event_id = emit_uow_completed(
+                uow_id=uow_id,
+                outcome="failed",
+                register="research",
+                db_path=db_path,
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT dedup_key FROM event_log WHERE event_id=?", (event_id,)).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == uow_id  # dedup_key should be uow_id
+
+    def test_emit_uow_completed_deduplication(self, tmp_path):
+        """Second emit_uow_completed for same uow_id is silently dropped."""
+        from src.orchestration.wos_events import emit_uow_completed
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        uow_id = "uow_dedup_test"
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            first = emit_uow_completed(uow_id=uow_id, outcome="done", register="code", db_path=db_path)
+            second = emit_uow_completed(uow_id=uow_id, outcome="done", register="code", db_path=db_path)
+
+        assert first is not None
+        assert second is None
+        assert len(list(inbox_dir.glob("*.json"))) == 1
+
+
+class TestEmitCapacityAvailable:
+    def test_emit_capacity_available_writes_inbox_message(self, tmp_path):
+        """emit_capacity_available writes a JSON inbox message with correct fields."""
+        from src.orchestration.wos_events import emit_capacity_available
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        freed_uow_id = "uow_freed_1"
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            event_id = emit_capacity_available(
+                freed_uow_id=freed_uow_id,
+                current_active_count=1,
+                max_parallel=2,
+                db_path=db_path,
+            )
+
+        assert event_id is not None
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["type"] == "wos_capacity_available"
+        assert msg["freed_uow_id"] == freed_uow_id
+        assert msg["current_active_count"] == 1
+        assert msg["max_parallel"] == 2
+
+    def test_emit_capacity_available_deduplication(self, tmp_path):
+        """Second emit_capacity_available for same freed_uow_id is silently dropped."""
+        from src.orchestration.wos_events import emit_capacity_available
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        freed_uow_id = "uow_freed_dedup"
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            first = emit_capacity_available(freed_uow_id=freed_uow_id, current_active_count=0, max_parallel=2, db_path=db_path)
+            second = emit_capacity_available(freed_uow_id=freed_uow_id, current_active_count=0, max_parallel=2, db_path=db_path)
+
+        assert first is not None
+        assert second is None
+
+
+class TestMarkEventConsumed:
+    def test_mark_event_consumed_sets_consumed_at(self, tmp_path):
+        """mark_event_consumed sets consumed_at on an unconsumed event."""
+        from src.orchestration.wos_events import emit_issue_created, mark_event_consumed
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+            event_id = emit_issue_created(
+                issue_number=999,
+                issue_url="https://github.com/dcetlin/Lobster/issues/999",
+                title="consume test",
+                labels=[],
+                db_path=db_path,
+            )
+
+        assert event_id is not None
+
+        # Verify consumed_at is NULL before calling mark_event_consumed
+        conn = sqlite3.connect(str(db_path))
+        row_before = conn.execute(
+            "SELECT consumed_at, consumer_task_id FROM event_log WHERE event_id=?",
+            (event_id,),
+        ).fetchone()
+        conn.close()
+        assert row_before[0] is None, "consumed_at should be NULL before mark_event_consumed"
+
+        mark_event_consumed(event_id, "test-consumer", db_path=db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        row_after = conn.execute(
+            "SELECT consumed_at, consumer_task_id FROM event_log WHERE event_id=?",
+            (event_id,),
+        ).fetchone()
+        conn.close()
+        assert row_after[0] is not None, "consumed_at should be set after mark_event_consumed"
+        assert row_after[1] == "test-consumer"
+
+
+# ---------------------------------------------------------------------------
+# dispatcher_handlers.py handler tests
+# ---------------------------------------------------------------------------
+
+class TestDispatcherEventHandlers:
+    """Tests for the three new Stage 2 event handlers in dispatcher_handlers.py."""
+
+    def _load_handlers(self):
+        """Import dispatcher_handlers with minimal env patching."""
+        # Ensure the module can be imported without a live DB
+        import importlib
+        import src.orchestration.dispatcher_handlers as dh
+        # Re-import to get fresh state
+        importlib.reload(dh)
+        return dh
+
+    def test_handle_wos_issue_created_returns_mark_processed(self):
+        """handle_wos_issue_created always returns action=mark_processed."""
+        from src.orchestration.dispatcher_handlers import handle_wos_issue_created
+
+        msg = {
+            "type": "wos_issue_created",
+            "event_id": str(uuid.uuid4()),
+            "issue_number": 42,
+            "issue_url": "https://github.com/dcetlin/Lobster/issues/42",
+            "title": "test issue",
+            "labels": ["wos:uow"],
+            "triggered_at": "2026-05-31T00:00:00+00:00",
+        }
+
+        with patch("src.orchestration.dispatcher_handlers.handle_wos_issue_created.__module__"):
+            pass  # just import
+
+        with patch("src.orchestration.wos_events.mark_event_consumed"):
+            result = handle_wos_issue_created(msg)
+
+        assert result["action"] == "mark_processed"
+        assert result["message_type"] == "wos_issue_created"
+
+    def test_handle_wos_uow_completed_returns_mark_processed(self):
+        """handle_wos_uow_completed always returns action=mark_processed."""
+        from src.orchestration.dispatcher_handlers import handle_wos_uow_completed
+
+        msg = {
+            "type": "wos_uow_completed",
+            "event_id": str(uuid.uuid4()),
+            "uow_id": "uow_20260531_abc",
+            "outcome": "done",
+            "register": "code",
+            "triggered_at": "2026-05-31T00:00:00+00:00",
+        }
+
+        with patch("src.orchestration.wos_events.mark_event_consumed"):
+            result = handle_wos_uow_completed(msg)
+
+        assert result["action"] == "mark_processed"
+        assert result["message_type"] == "wos_uow_completed"
+
+    def test_handle_wos_capacity_available_returns_mark_processed(self):
+        """handle_wos_capacity_available always returns action=mark_processed."""
+        from src.orchestration.dispatcher_handlers import handle_wos_capacity_available
+
+        msg = {
+            "type": "wos_capacity_available",
+            "event_id": str(uuid.uuid4()),
+            "freed_uow_id": "uow_freed_123",
+            "freed_at": "2026-05-31T00:00:00+00:00",
+            "current_active_count": 1,
+            "max_parallel": 2,
+        }
+
+        with patch("src.orchestration.wos_events.mark_event_consumed"):
+            result = handle_wos_capacity_available(msg)
+
+        assert result["action"] == "mark_processed"
+        assert result["message_type"] == "wos_capacity_available"
+
+    def test_handle_wos_issue_created_calls_mark_event_consumed(self):
+        """handle_wos_issue_created calls mark_event_consumed with the event_id."""
+        from src.orchestration.dispatcher_handlers import handle_wos_issue_created
+
+        event_id = str(uuid.uuid4())
+        msg = {
+            "type": "wos_issue_created",
+            "event_id": event_id,
+            "issue_number": 55,
+            "title": "check consumed call",
+        }
+
+        with patch("src.orchestration.wos_events.mark_event_consumed") as mock_consume:
+            handle_wos_issue_created(msg)
+
+        mock_consume.assert_called_once_with(event_id, consumer_task_id="dispatcher-wos_issue_created")
+
+    def test_handle_wos_uow_completed_calls_mark_event_consumed(self):
+        """handle_wos_uow_completed calls mark_event_consumed with the event_id."""
+        from src.orchestration.dispatcher_handlers import handle_wos_uow_completed
+
+        event_id = str(uuid.uuid4())
+        msg = {
+            "type": "wos_uow_completed",
+            "event_id": event_id,
+            "uow_id": "uow_test_consume",
+            "outcome": "done",
+        }
+
+        with patch("src.orchestration.wos_events.mark_event_consumed") as mock_consume:
+            handle_wos_uow_completed(msg)
+
+        mock_consume.assert_called_once_with(event_id, consumer_task_id="dispatcher-wos_uow_completed")
+
+
+# ---------------------------------------------------------------------------
+# route_wos_message routing tests
+# ---------------------------------------------------------------------------
+
+class TestRouteWosMessageStage2:
+    """Tests for route_wos_message routing of Stage 2 event types."""
+
+    def test_route_wos_message_routes_wos_issue_created(self):
+        """route_wos_message dispatches wos_issue_created to handle_wos_issue_created."""
+        from src.orchestration.dispatcher_handlers import route_wos_message
+
+        msg = {
+            "type": "wos_issue_created",
+            "event_id": str(uuid.uuid4()),
+            "issue_number": 100,
+            "issue_url": "https://github.com/dcetlin/Lobster/issues/100",
+            "title": "routed issue",
+            "labels": ["wos:uow"],
+        }
+
+        with patch("src.orchestration.wos_events.mark_event_consumed"):
+            result = route_wos_message(msg)
+
+        assert result["action"] == "mark_processed"
+        assert result["message_type"] == "wos_issue_created"
+
+    def test_route_wos_message_routes_wos_uow_completed(self):
+        """route_wos_message dispatches wos_uow_completed to handle_wos_uow_completed."""
+        from src.orchestration.dispatcher_handlers import route_wos_message
+
+        msg = {
+            "type": "wos_uow_completed",
+            "event_id": str(uuid.uuid4()),
+            "uow_id": "uow_route_test",
+            "outcome": "failed",
+            "register": "research",
+        }
+
+        with patch("src.orchestration.wos_events.mark_event_consumed"):
+            result = route_wos_message(msg)
+
+        assert result["action"] == "mark_processed"
+        assert result["message_type"] == "wos_uow_completed"
+
+    def test_route_wos_message_routes_wos_capacity_available(self):
+        """route_wos_message dispatches wos_capacity_available to handle_wos_capacity_available."""
+        from src.orchestration.dispatcher_handlers import route_wos_message
+
+        msg = {
+            "type": "wos_capacity_available",
+            "event_id": str(uuid.uuid4()),
+            "freed_uow_id": "uow_cap_route",
+            "current_active_count": 0,
+            "max_parallel": 2,
+        }
+
+        with patch("src.orchestration.wos_events.mark_event_consumed"):
+            result = route_wos_message(msg)
+
+        assert result["action"] == "mark_processed"
+        assert result["message_type"] == "wos_capacity_available"
+
+    def test_route_wos_message_handler_exception_returns_mark_processed(self):
+        """route_wos_message catches handler exceptions for Stage 2 types and returns mark_processed."""
+        from src.orchestration.dispatcher_handlers import route_wos_message
+
+        msg = {
+            "type": "wos_issue_created",
+            "event_id": str(uuid.uuid4()),
+            "issue_number": 0,  # valid msg; we mock the handler to raise
+        }
+
+        with patch("src.orchestration.dispatcher_handlers.handle_wos_issue_created", side_effect=RuntimeError("boom")):
+            result = route_wos_message(msg)
+
+        assert result["action"] == "mark_processed"
+        assert result["message_type"] == "wos_issue_created"
+
+
+# ---------------------------------------------------------------------------
+# wos-event-poller.py tests
+# ---------------------------------------------------------------------------
+
+def _load_poller_module():
+    """Import wos-event-poller with patched heavy dependencies."""
+    import importlib
+    import importlib.util
+
+    mocks_paths = MagicMock()
+    mocks_paths.REGISTRY_DB = Path("/nonexistent/registry.db")
+    mocks_paths.WOS_CONFIG = Path("/nonexistent/wos-config.json")
+
+    mocks = {
+        "src.utils.jobs": MagicMock(),
+        "src.orchestration.paths": mocks_paths,
+    }
+
+    mod_name = "wos_event_poller"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+
+    spec = importlib.util.spec_from_file_location(
+        mod_name,
+        _REPO_ROOT / "scheduled-tasks" / "wos-event-poller.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec_module so dataclass type resolution works
+    sys.modules[mod_name] = mod
+
+    with patch.dict("sys.modules", mocks):
+        spec.loader.exec_module(mod)
+
+    return mod
+
+
+class TestWosEventPoller:
+    """Tests for wos-event-poller.py poll logic."""
+
+    def test_poller_exits_when_disabled(self, tmp_path, capsys):
+        """main() returns immediately when is_job_enabled returns False."""
+        mod = _load_poller_module()
+        mod.is_job_enabled = MagicMock(return_value=False)
+        mod._read_cursor = MagicMock()
+        mod.run_poll_cycle = MagicMock()
+
+        mod.main.__globals__["is_job_enabled"] = MagicMock(return_value=False)
+        # Patch sys.argv to avoid argparse picking up pytest args
+        with patch("sys.argv", ["wos-event-poller.py"]):
+            mod.main()
+
+        mod.run_poll_cycle.assert_not_called()
+
+    def test_poller_run_cycle_emits_issue_events(self, tmp_path):
+        """run_poll_cycle emits wos_issue_created for new GitHub issues found."""
+        mod = _load_poller_module()
+
+        from dataclasses import dataclass
+
+        new_issue = mod.NewIssue(
+            issue_number=1000,
+            issue_url="https://github.com/dcetlin/Lobster/issues/1000",
+            title="new wos issue",
+            labels=["wos:uow"],
+            created_at="2026-05-31T12:00:00+00:00",
+        )
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.object(mod, "_fetch_new_wos_issues", return_value=[new_issue]), \
+             patch.object(mod, "_fetch_newly_completed_uows", return_value=[]), \
+             patch.object(mod, "_count_active_uows", return_value=0), \
+             patch.object(mod, "_read_max_parallel", return_value=2), \
+             patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+
+            issue_count, uow_count, capacity_count = mod.run_poll_cycle(
+                since="2026-05-31T11:00:00+00:00",
+                db_path=db_path,
+            )
+
+        assert issue_count == 1
+        assert uow_count == 0
+        assert capacity_count == 0
+
+    def test_poller_run_cycle_emits_uow_events(self, tmp_path):
+        """run_poll_cycle emits wos_uow_completed for newly terminal UoWs."""
+        mod = _load_poller_module()
+
+        completed_uow = mod.CompletedUoW(
+            uow_id="uow_20260531_poller1",
+            outcome="done",
+            register="code",
+            output_ref=None,
+            completed_at="2026-05-31T12:00:00+00:00",
+        )
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.object(mod, "_fetch_new_wos_issues", return_value=[]), \
+             patch.object(mod, "_fetch_newly_completed_uows", return_value=[completed_uow]), \
+             patch.object(mod, "_count_active_uows", return_value=2), \
+             patch.object(mod, "_read_max_parallel", return_value=2), \
+             patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+
+            issue_count, uow_count, capacity_count = mod.run_poll_cycle(
+                since="2026-05-31T11:00:00+00:00",
+                db_path=db_path,
+            )
+
+        assert issue_count == 0
+        assert uow_count == 1
+        # active_count == max_parallel so no capacity event
+        assert capacity_count == 0
+
+    def test_poller_run_cycle_emits_capacity_events(self, tmp_path):
+        """run_poll_cycle emits wos_capacity_available when active < max_parallel."""
+        mod = _load_poller_module()
+
+        completed_uow = mod.CompletedUoW(
+            uow_id="uow_20260531_cap1",
+            outcome="done",
+            register="code",
+            output_ref=None,
+            completed_at="2026-05-31T12:00:00+00:00",
+        )
+
+        db_path = tmp_path / "registry.db"
+        _create_event_log_db(db_path)
+        inbox_dir = tmp_path / "inbox"
+
+        with patch.object(mod, "_fetch_new_wos_issues", return_value=[]), \
+             patch.object(mod, "_fetch_newly_completed_uows", return_value=[completed_uow]), \
+             patch.object(mod, "_count_active_uows", return_value=1), \
+             patch.object(mod, "_read_max_parallel", return_value=2), \
+             patch.dict("os.environ", {"LOBSTER_INBOX_DIR": str(inbox_dir)}):
+
+            issue_count, uow_count, capacity_count = mod.run_poll_cycle(
+                since="2026-05-31T11:00:00+00:00",
+                db_path=db_path,
+            )
+
+        assert uow_count == 1
+        # active_count (1) < max_parallel (2) → capacity event emitted
+        assert capacity_count == 1
+
+    def test_poller_advances_cursor_on_success(self, tmp_path):
+        """main() writes a new since-cursor after a successful poll cycle."""
+        mod = _load_poller_module()
+
+        cursor_path = tmp_path / "wos-event-poller-cursor.json"
+        mod._cursor_path = MagicMock(return_value=cursor_path)
+        mod._read_cursor = MagicMock(return_value="2026-05-31T10:00:00+00:00")
+        mock_write = MagicMock()
+        mod._write_cursor = mock_write
+        mod.run_poll_cycle = MagicMock(return_value=(0, 0, 0))
+        mod.is_job_enabled = MagicMock(return_value=True)
+
+        with patch("sys.argv", ["wos-event-poller.py"]):
+            mod.main()
+
+        mock_write.assert_called_once()
+        written_cursor = mock_write.call_args[0][0]
+        assert written_cursor, "Cursor should be advanced after successful run"
+
+    def test_poller_does_not_advance_cursor_on_failure(self, tmp_path):
+        """main() does not write a cursor when run_poll_cycle raises."""
+        mod = _load_poller_module()
+
+        mock_write = MagicMock()
+        mod._write_cursor = mock_write
+        mod._read_cursor = MagicMock(return_value="2026-05-31T10:00:00+00:00")
+        mod.run_poll_cycle = MagicMock(side_effect=RuntimeError("db error"))
+        mod.is_job_enabled = MagicMock(return_value=True)
+
+        with patch("sys.argv", ["wos-event-poller.py"]):
+            with pytest.raises(RuntimeError):
+                mod.main()
+
+        mock_write.assert_not_called()


### PR DESCRIPTION
Closes #1351

## What this solves

WOS germination currently depends on polling loops running every ~15 minutes to detect new GitHub issues with `wos:uow` and UoW terminal transitions. This means a new issue can sit undetected for up to 15 minutes before the pipeline reacts.

Stage 2 replaces that with a 30-second delta poller that emits typed inbox events immediately when changes are detected. Mean detection latency drops from ~15 min to ~30s.

## What changed

**event_log table** (`0029_event_log.sql`): New registry.db table with `UNIQUE(event_type, dedup_key)` constraint. Dedup is enforced at the DB layer — the poller can re-run safely on overlapping windows without flooding the inbox.

**Three typed emit functions** (`src/orchestration/wos_events.py`):
- `emit_issue_created(issue_number, ...)` — emitted when a new `wos:uow` issue is detected; dedup_key = issue number
- `emit_uow_completed(uow_id, outcome, ...)` — emitted when a UoW reaches done/failed; dedup_key = uow_id
- `emit_capacity_available(freed_uow_id, ...)` — emitted when active UoWs < max_parallel; dedup_key = freed_uow_id

Each emit function: writes atomic inbox JSON, records event_log row, returns event_id or None on duplicate. All are pure side-effectful functions — no blocking I/O except disk writes.

**Three typed handlers** (`dispatcher_handlers.py`): `handle_wos_issue_created`, `handle_wos_uow_completed`, `handle_wos_capacity_available`. All return `action=mark_processed` — they log the event and call `mark_event_consumed` on the event_log row. No subagent spawn. Dispatched via fast-path in `route_wos_message` before the spawn-gate. All three are registered in `WOS_MESSAGE_TYPE_DISPATCH`.

**Delta poller** (`scheduled-tasks/wos-event-poller.py`): Type B cron job (no LLM). Runs every 30 seconds via two staggered cron entries. On each invocation: reads since-cursor → queries GitHub for new `wos:uow` issues → queries registry for newly terminal UoWs → emits typed events → advances cursor. Starts **disabled** so it has no effect until `wos start` is called.

**upgrade.sh Migration 130**: Registers `wos-event-poller` in jobs.json (disabled, `wos_core: true`) and installs the two 30-second cron entries.

## What is NOT changed

- Executor dispatch logic (unchanged)
- `execution_enabled` state (unchanged — stays false)
- Steward heartbeat cadence (heartbeat demotion is a future step behind `event_native_active` feature flag)
- GardenCaretaker (retained as reconciliation backstop)
- Any UoW state transitions
- Stages 1, 3, 4, 5

## Functional patterns used

Pure functions for emit and handlers; immutable dataclasses for poller value objects; all I/O isolated to boundaries; handlers are side-effect-free from the perspective of WOS state (they only log + mark consumed).

## Before / after flow

```
Before:
  New issue → waits ≤15 min → issue-sweeper cron → germinator → UoW

After (once wos-event-poller is enabled):
  New issue → ≤30s → wos_issue_created inbox event → dispatcher logs it
  (germination still via issue-sweeper — this adds observability + foundation)
  
  UoW done → ≤30s → wos_uow_completed + wos_capacity_available inbox events
              → dispatcher logs and marks consumed
```

The event pipeline is now present and routable; the germinator acceleration hook (using capacity events to trigger faster UoW promotion) is a future Stage 2 extension behind the `event_native_active` feature flag.

## Tests run

- [x] `uv run pytest tests/test_wos_stage2_event_native.py -v` — 28 passed, 0 failed
- [x] `uv run pytest tests/test_wos_execute_router.py tests/test_wos_execute_gate.py tests/orchestration/ -q` — 72 passed, 0 failed (WOS-adjacent tests; no regressions)

## Manual test

N/A — this change is entirely internal. The poller starts disabled and writes no cron entries until `upgrade.sh` is run with Migration 130. No Telegram output, no external service calls during tests. The inbox write path is the same atomic tmp-then-rename pattern used by all other WOS event writers (wos_completion.py, executor.py).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (poller starts disabled; no live DB access in tests)
- [x] User-visible outcome — not applicable for this PR (internal event pipeline; no user-facing output)
- [x] Side-effect audit: poller starts disabled; no writes to production DB or inbox until enabled; dedup prevents event floods even when enabled
- [x] External service calls: GitHub CLI mocked in poller tests; registry DB replaced with tmp SQLite in all tests