### PR TITLE
fix(htmlgen): remove dead TRACE_LOG_PATH mirror and deduplicate sections_accessed

### DIFF
--- a/src/htmlgen/editor.py
+++ b/src/htmlgen/editor.py
@@ -361,7 +361,8 @@ def _apply_instruction(
     if op == "replace_section_content":
         _require_fields(instruction, ["section_id", "new_content"])
         sid = instruction["section_id"]
-        sections_accessed.append(sid)
+        if sid not in sections_accessed:
+            sections_accessed.append(sid)
         _op_replace_section_content(
             soup,
             section_id=sid,
@@ -388,7 +389,8 @@ def _apply_instruction(
     elif op == "remove_section":
         _require_fields(instruction, ["section_id"])
         sid = instruction["section_id"]
-        sections_accessed.append(sid)
+        if sid not in sections_accessed:
+            sections_accessed.append(sid)
         _op_remove_section(soup, section_id=sid)
 
     elif op == "update_version_stamp":

--- a/tests/htmlgen/test_editor.py
+++ b/tests/htmlgen/test_editor.py
@@ -23,15 +23,13 @@ from bs4 import BeautifulSoup
 from src.htmlgen.editor import (
     EditError,
     EditTrace,
+    TRACE_LOG_PATH,
     apply_edit,
     apply_edits,
     find_sections_by_content,
     list_section_ids,
     parse_html,
 )
-
-# Spec-mandated constant: the path where edit traces are appended
-TRACE_LOG_PATH = Path.home() / "lobster-workspace" / "data" / "html-edit-traces.jsonl"
 
 # ---------------------------------------------------------------------------
 # Named constants — spec-mandated values
@@ -763,6 +761,16 @@ class TestEditTraceOnBatchEdit:
         ])
         assert "replace_section_content" in trace.operation_types
         assert "update_version_stamp" in trace.operation_types
+
+    def test_sections_accessed_deduplicated_across_repeated_ops_on_same_section(
+        self, html_file: Path
+    ):
+        # Two replace ops on the same section must not produce ["s1", "s1"]
+        _, trace = apply_edits(html_file, [
+            {"op": "replace_section_content", "section_id": "s1", "new_content": "<p>First.</p>"},
+            {"op": "replace_section_content", "section_id": "s1", "new_content": "<p>Second.</p>"},
+        ])
+        assert trace.sections_accessed.count("s1") == 1
 
 
 class TestEditTraceOnFailedEdit:


### PR DESCRIPTION
## What this fixes

Two advisory issues from the PR #1357 oracle review, combined into one change.

**Issue #1358 — Dead constant in test file:** `tests/htmlgen/test_editor.py` re-declared `TRACE_LOG_PATH` with an identical value to the production constant. It was never referenced in any test assertion (all JSONL tests monkeypatch `src.htmlgen.editor.TRACE_LOG_PATH` directly via `monkeypatch.setattr`). The declaration was dead weight that could mislead a reader into thinking the test was validating the path. Now imports `TRACE_LOG_PATH` from `src.htmlgen.editor` — one source of truth.

**Issue #1359 — Inconsistent dedup in sections_accessed:** `_apply_instruction` in `editor.py` had an asymmetry: `add_section` applied a `if sid not in sections_accessed` guard before appending to `sections_accessed`, but `replace_section_content` and `remove_section` appended unconditionally. Two replace ops on the same section produced `["s1", "s1"]` in `EditTrace.sections_accessed`, which misleads any consumer counting distinct sections touched. Applied the same dedup guard to both ops to make all three consistent.

No edit operation semantics changed — this only affects the bookkeeping list, not the DOM mutations.

## Functional patterns

Pure-function invariant maintained throughout: `_apply_instruction` mutates only the `sections_accessed` accumulator passed in by the caller, and the dedup check is a simple set-membership test with no hidden state.

## Tests run

- [x] `uv run pytest tests/htmlgen/test_editor.py -v` — 72 passed, 0 failed (includes new `test_sections_accessed_deduplicated_across_repeated_ops_on_same_section`)

## Manual test

N/A — change is entirely internal to in-memory trace bookkeeping and test imports. No external services, file I/O beyond existing test fixtures, or user-visible output affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, no external services touched
- [x] User-visible outcome — N/A, internal bookkeeping fix only
- [x] Side-effect audit: no floods, no shared-state writes, no volume impact
- [x] External service calls: none

Closes #1358
Closes #1359