### PR TITLE
docs: add staged dispatch complexity gates for HTML document production

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1619,6 +1619,20 @@ pr_ref = parts[1].strip() if len(parts) > 1 else ""
 # send_reply: "On it — reviewing {pr_url}."
 ```
 
+### HTML document complexity gate
+
+**Applies before dispatching any HTML generation task.**
+
+When a task will produce a document-class HTML artifact AND either (a) draws from 3+ source files, OR (b) is described as a "canon document", "synthesis document", or spans multiple workstreams, dispatch THREE agents in sequence, not one:
+
+1. `task_id: <slug>-synthesis` — reads all sources, produces `~/lobster-workspace/workstreams/<slug>/synthesis.md`. Instruction to agent: "Do NOT render HTML. Output is structured markdown only."
+2. `task_id: <slug>-htmlgen` — takes `synthesis.md` as sole input, renders with `html-generation` skill context loaded, uploads to bisque. Include in prompt: "Skill context required: html-generation. Call get_skill_context(skill_name='html-generation') before rendering."
+3. `task_id: <slug>-polish` — reads rendered HTML, applies canon-standard review, patches via `apply_edits()`. Delivers final bisque URL to user.
+
+**Single-pass is appropriate for:** dashboard updates, section additions to existing docs, short reports under 800 words, edits where the content is already fully specified.
+
+**Single-pass is a defect for:** any document the user will reference repeatedly, any document that defines or structures a vocabulary or taxonomy, any document drawing from multiple source workstreams.
+
 ---
 
 ## Agent Council — "council: [topic]" Trigger

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1619,20 +1619,6 @@ pr_ref = parts[1].strip() if len(parts) > 1 else ""
 # send_reply: "On it — reviewing {pr_url}."
 ```
 
-### HTML document complexity gate
-
-**Applies before dispatching any HTML generation task.**
-
-When a task will produce a document-class HTML artifact AND either (a) draws from 3+ source files, OR (b) is described as a "canon document", "synthesis document", or spans multiple workstreams, dispatch THREE agents in sequence, not one:
-
-1. `task_id: <slug>-synthesis` — reads all sources, produces `~/lobster-workspace/workstreams/<slug>/synthesis.md`. Instruction to agent: "Do NOT render HTML. Output is structured markdown only."
-2. `task_id: <slug>-htmlgen` — takes `synthesis.md` as sole input, renders with `html-generation` skill context loaded, uploads to bisque. Include in prompt: "Skill context required: html-generation. Call get_skill_context(skill_name='html-generation') before rendering."
-3. `task_id: <slug>-polish` — reads rendered HTML, applies canon-standard review, patches via `apply_edits()`. Delivers final bisque URL to user.
-
-**Single-pass is appropriate for:** dashboard updates, section additions to existing docs, short reports under 800 words, edits where the content is already fully specified.
-
-**Single-pass is a defect for:** any document the user will reference repeatedly, any document that defines or structures a vocabulary or taxonomy, any document drawing from multiple source workstreams.
-
 ---
 
 ## Agent Council — "council: [topic]" Trigger
@@ -1867,6 +1853,22 @@ Do NOT call `list_tasks(status="pending")` separately — the `status="all"` cal
 4. Spawn subagent with task_id in prompt header
 5. mark_processed(message_id)
 ```
+
+### HTML document staging gate
+
+**Applies before dispatching any HTML generation task.**
+
+The default pattern for producing a document-class HTML artifact is **always three agents in sequence** (md synthesis → HTML gen → polish). Single-pass "render only" is the explicit exception, not the default.
+
+Dispatch THREE agents in sequence unless the dispatch prompt is explicitly labeled "render only":
+
+1. `task_id: <slug>-synthesis` — reads all sources, produces `~/lobster-workspace/workstreams/<slug>/synthesis.md`. Instruction to agent: "Do NOT render HTML. Output is structured markdown only."
+2. `task_id: <slug>-htmlgen` — takes `synthesis.md` as sole input, renders with `html-generation` skill context loaded, uploads to bisque. Include in prompt: "Skill context required: html-generation. Call get_skill_context(skill_name='html-generation') before rendering."
+3. `task_id: <slug>-polish` — reads rendered HTML, applies canon-standard review, patches via `apply_edits()`. Delivers final bisque URL to user.
+
+**Single-pass ("render only") is appropriate when:** the dispatch prompt is explicitly labeled "render only" — e.g., dashboard updates, section additions to existing docs, short reports where content is already fully specified.
+
+**Staging is a hard default for:** any document-class HTML artifact where the dispatch prompt does not say "render only". Never synthesize and render in the same cognitive pass — the rendering constraints crowd out synthesis quality.
 
 ### When subagent completes
 

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -505,6 +505,28 @@ Before declaring any integration or manual test PASS:
   The `patch.multiple` module target for inbox_server tests is always
   `"src.mcp.inbox_server"` (not `"inbox_server"` or `"mcp.inbox_server"`).
 
+## HTML Generation Layer
+
+When working with HTML documents (WOS spec, design docs, bisque artifacts):
+- **Edit existing docs** via `src/htmlgen/editor.py` — never rewrite from scratch; use `list_section_ids` first, then `apply_edit` or `apply_edits`
+- **Generate new docs** via `src/htmlgen/renderer.py` with conventions loaded from `src/htmlgen/conventions.py`
+- **Load conventions first** — `load_conventions()` before any render or edit call
+- Source of truth: `~/lobster-workspace/workstreams/html-interface/`
+
+**Explicit skill loading (required for complex document tasks):** If your task prompt includes `Skill context required: html-generation`, call `get_skill_context(skill_name="html-generation")` before any render or edit call. Do not assume skill context is loaded automatically.
+
+**Document production complexity gate:**
+
+- **Simple task** (narrow scope, one source domain, short content): synthesize and render in one pass. Use `render_document()` with conventions loaded.
+- **Complex task** (3+ source domains, multi-section synthesis, >1,500 words body prose, OR canon document): you should have been dispatched as Agent 2 of 3 with a `synthesis.md` input file. If you were dispatched as a single-pass agent for a complex task, stop, write `synthesis.md` to the workstream directory first, then render from it. Never synthesize and render in the same cognitive pass for complex tasks — the rendering constraints crowd out synthesis quality.
+
+**Checklist before delivering any HTML artifact:**
+- [ ] Conventions loaded before renderer call
+- [ ] All canon standards applied (dark-first palette, taxonomic section IDs, comment widget, version metadata)
+- [ ] Document uploaded to bisque; bisque URL in reply (never a filesystem path)
+- [ ] Version metadata present (`doc-version`, `doc-updated`)
+- [ ] For document-class with taxonomy: D3.js force-directed network included (not a static diagram)
+
 ## WOS Subagent Contract
 
 When you are dispatched to execute a **Unit of Work (UoW)** by the WOS Executor, your task prompt will contain an `output_ref` path and a `uow_id`. Before you exit — success or failure — you **must** write a result.json file at that path. The Steward reads this file on its next heartbeat cycle to determine whether the UoW is complete, failed, or needs re-diagnosis. Without it, the Steward cannot distinguish a successful silent exit from a crash and will eventually mark the UoW failed via TTL expiry.

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -515,10 +515,12 @@ When working with HTML documents (WOS spec, design docs, bisque artifacts):
 
 **Explicit skill loading (required for complex document tasks):** If your task prompt includes `Skill context required: html-generation`, call `get_skill_context(skill_name="html-generation")` before any render or edit call. Do not assume skill context is loaded automatically.
 
-**Document production complexity gate:**
+**Document production staging gate:**
 
-- **Simple task** (narrow scope, one source domain, short content): synthesize and render in one pass. Use `render_document()` with conventions loaded.
-- **Complex task** (3+ source domains, multi-section synthesis, >1,500 words body prose, OR canon document): you should have been dispatched as Agent 2 of 3 with a `synthesis.md` input file. If you were dispatched as a single-pass agent for a complex task, stop, write `synthesis.md` to the workstream directory first, then render from it. Never synthesize and render in the same cognitive pass for complex tasks — the rendering constraints crowd out synthesis quality.
+The default pattern for producing a document-class HTML artifact is **always staged** (md synthesis → HTML gen → polish). Single-pass "render only" is the explicit exception.
+
+- **Staged (default):** you should have been dispatched as one of three agents in sequence, with a `synthesis.md` input file already written by the previous agent. If you are the synthesis agent (Agent 1), produce only structured markdown — do NOT render HTML. If you are the htmlgen agent (Agent 2), take `synthesis.md` as sole input and render. If you are the polish agent (Agent 3), apply canon-standard review and deliver the final bisque URL.
+- **Single-pass ("render only"):** only when the dispatch prompt is explicitly labeled "render only". If you were dispatched as a single-pass agent without that label for any document-class HTML task, stop — write `synthesis.md` to the workstream directory first, then render from it. Never synthesize and render in the same cognitive pass — the rendering constraints crowd out synthesis quality.
 
 **Checklist before delivering any HTML artifact:**
 - [ ] Conventions loaded before renderer call


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this solves

The Sensibility Stack v3 session failed because the dispatcher had no criteria to distinguish a simple HTML task from a complex multi-source synthesis task. A generalist agent was dispatched with all three responsibilities — read sources, synthesize markdown, render HTML — in a single pass. The staged workflow (synthesis → HTML gen → polish) was never triggered, and the html-generation skill was not explicitly loaded.

The root cause was upstream of the skill: neither the dispatcher bootup nor the subagent bootup encoded a decision rule for when to stage vs. single-pass. This PR adds that rule to both files.

## What changed

sys.subagent.bootup.md — The 5-bullet HTML Generation Layer is replaced with an expanded section containing:
- An explicit skill-loading instruction: if the task prompt includes Skill context required: html-generation, call get_skill_context before any render/edit call. Removes the false confidence from the previous "loads when triggered" wording, which implied automatic loading that does not happen in subagent sessions.
- A complexity gate with a concrete decision rule: simple task (one source domain, short content) → synthesize and render in one pass; complex task (3+ source domains, >1500 words body prose, or canon document) → stop and write synthesis.md first, then render from it.
- A pre-delivery checklist for HTML artifacts (conventions, bisque URL, version metadata, D3 graph if taxonomy present).

sys.dispatcher.bootup.md — A new HTML document complexity gate subsection added under Working on GitHub Issues. Encodes the 3-agent sequence for document-class tasks drawing from 3+ sources or described as canon/synthesis documents:
1. slug-synthesis — reads sources, writes synthesis.md, explicitly told not to render HTML
2. slug-htmlgen — takes synthesis.md only, loads html-generation skill context
3. slug-polish — canon-standard review, targeted edits via apply_edits() only

Also states when single-pass is correct so agents have both sides of the gate.

## Scope

Bootup file changes only. Companion changes applied directly (user-config, no PR needed): skill behavior/system.md complexity tiers section added, skill.toml trigger keywords expanded, IFTTT rule added via MCP.

No WOS code, HTML generation source code, or runtime data was modified.

## Manual test

N/A — doc-only changes to bootup instruction files.

## Tests run
- No automated tests apply — doc-only changes
- Proposed text from the process audit used verbatim for both sections