### PR TITLE
feat(htmlgen): vocab tooltips, §2 visual fix, remove Section Comments panel

### DIFF
--- a/src/htmlgen/components/__init__.py
+++ b/src/htmlgen/components/__init__.py
@@ -11,11 +11,13 @@ Each component module exports:
 from . import clipboard_copy_widget
 from . import d3_vocabulary_network
 from . import theme_toggle
+from . import vocab_tooltip
 
 COMPONENTS: dict = {
     "theme-toggle": theme_toggle,
     "clipboard-copy-widget": clipboard_copy_widget,
     "d3-vocabulary-network": d3_vocabulary_network,
+    "vocab-tooltip": vocab_tooltip,
 }
 
 
@@ -38,4 +40,5 @@ __all__ = [
     "theme_toggle",
     "clipboard_copy_widget",
     "d3_vocabulary_network",
+    "vocab_tooltip",
 ]

--- a/src/htmlgen/components/vocab_tooltip.py
+++ b/src/htmlgen/components/vocab_tooltip.py
@@ -189,16 +189,22 @@ _JS_TEMPLATE = r"""
       var html = text;
       var matched = false;
       terms.forEach(function(term) {
-        // Match whole word only, case-sensitive.
+        // Match case-sensitive (no word-boundary anchors — terms may appear mid-word).
         var re = new RegExp('(' + escapeRegex(term) + ')', 'g');
-        if (re.test(html)) {
+        var def = vocab[term]
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/\$/g, '$$$$');  // escape $ to prevent .replace() backreference interpretation
+        var newHtml = html.replace(re,
+          '<span class="vocab-term" tabindex="0">' +
+          '<span class="vocab-tip"><span class="vocab-tip-term">' + term + '</span>' + def + '</span>' +
+          '$1</span>'
+        );
+        if (newHtml !== html) {
           matched = true;
-          var def = vocab[term].replace(/"/g, '&quot;');
-          html = html.replace(re,
-            '<span class="vocab-term" tabindex="0">' +
-            '<span class="vocab-tip"><span class="vocab-tip-term">' + term + '</span>' + vocab[term] + '</span>' +
-            '$1</span>'
-          );
+          html = newHtml;
         }
       });
       if (matched) {

--- a/src/htmlgen/components/vocab_tooltip.py
+++ b/src/htmlgen/components/vocab_tooltip.py
@@ -1,0 +1,297 @@
+"""
+vocab_tooltip.py — Vocabulary tooltip index component.
+
+Renders two interleaved artifacts:
+  1. A <style> + <script> block that wraps every occurrence of each vocab
+     term in the document body with a <span class="vocab-term"> that shows
+     a hover tooltip card.
+  2. A collapsible <div class="vocab-index"> panel listing all terms
+     alphabetically with their full definitions.
+
+The component is activated by including a ``vocab`` dict in the content
+manifest (term → definition strings).  When the manifest has no ``vocab``
+field the renderer skips this component entirely.
+
+Usage in manifest JSON:
+    {
+      "vocab": {
+        "Stiffness": "Resistance to deformation; preserves geometry under load.",
+        "Elasticity": "Deformation with return; ...",
+        ...
+      }
+    }
+
+The renderer auto-injects this component when the manifest carries a
+``vocab`` key — callers do not need to list it in ``components``.
+
+Design constraints:
+- Matches the document's dark/light CSS variable palette.
+- Tooltip card appears above the term (flips below near viewport top).
+- The vocab index panel is collapsible (open by default).
+- Term matching is case-sensitive to avoid false positives on common words.
+- Terms containing regex special characters are escaped before matching.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+COMPONENT_ID = "vocab-tooltip"
+COMPONENT_VERSION = "1.0.0"
+
+CONFIG_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "vocab": {
+            "type": "object",
+            "description": "Mapping of term strings to definition strings.",
+            "additionalProperties": {"type": "string"},
+        }
+    },
+    "required": ["vocab"],
+}
+
+# ---------------------------------------------------------------------------
+# CSS
+# ---------------------------------------------------------------------------
+
+_CSS = """
+/* ── Vocab tooltip inline terms ── */
+.vocab-term {
+  border-bottom: 1px dotted var(--accent);
+  cursor: help;
+  position: relative;
+  display: inline-block;
+}
+.vocab-term .vocab-tip {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 900;
+  background: var(--surface3);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
+  padding: 10px 14px;
+  width: 260px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text);
+  box-shadow: 0 4px 16px rgba(0,0,0,.35);
+  transition: opacity .15s ease, visibility .15s ease;
+  white-space: normal;
+  text-align: left;
+}
+.vocab-term .vocab-tip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--border2);
+}
+.vocab-term:hover .vocab-tip,
+.vocab-term:focus .vocab-tip {
+  visibility: visible;
+  opacity: 1;
+}
+.vocab-tip-term {
+  font-weight: 700;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 5px;
+}
+
+/* ── Vocab index panel ── */
+.vocab-index {
+  margin: 2.5rem 0 1rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  overflow: hidden;
+}
+.vocab-index-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  cursor: pointer;
+  user-select: none;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface2);
+}
+.vocab-index-header:hover { background: var(--surface3); }
+.vocab-index-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .09em;
+  color: var(--text3);
+}
+.vocab-index-chevron {
+  font-size: 10px;
+  color: var(--text3);
+  transition: transform .2s ease;
+}
+.vocab-index.collapsed .vocab-index-chevron { transform: rotate(-90deg); }
+.vocab-index-body {
+  padding: 16px 20px 20px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+.vocab-index.collapsed .vocab-index-body { display: none; }
+.vocab-entry {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+.vocab-entry:last-child { border-bottom: none; }
+.vocab-entry-term {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 4px;
+}
+.vocab-entry-def {
+  font-size: 13px;
+  color: var(--text2);
+  line-height: 1.6;
+}
+"""
+
+# ---------------------------------------------------------------------------
+# JS — term highlighting injected at runtime (safe: runs after DOM is built)
+# ---------------------------------------------------------------------------
+
+_JS_TEMPLATE = r"""
+(function() {
+  var vocab = {vocab_json};
+
+  // Sort terms longest-first to avoid partial matches swallowing longer terms.
+  var terms = Object.keys(vocab).sort(function(a, b) { return b.length - a.length; });
+
+  function escapeRegex(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function wrapTermsInNode(node) {
+    if (!node) return;
+    if (node.nodeType === Node.TEXT_NODE) {
+      var text = node.textContent;
+      var html = text;
+      var matched = false;
+      terms.forEach(function(term) {
+        // Match whole word only, case-sensitive.
+        var re = new RegExp('(' + escapeRegex(term) + ')', 'g');
+        if (re.test(html)) {
+          matched = true;
+          var def = vocab[term].replace(/"/g, '&quot;');
+          html = html.replace(re,
+            '<span class="vocab-term" tabindex="0">' +
+            '<span class="vocab-tip"><span class="vocab-tip-term">' + term + '</span>' + vocab[term] + '</span>' +
+            '$1</span>'
+          );
+        }
+      });
+      if (matched) {
+        var span = document.createElement('span');
+        span.innerHTML = html;
+        node.parentNode.replaceChild(span, node);
+      }
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      !/^(SCRIPT|STYLE|CODE|PRE|TEXTAREA|INPUT|BUTTON|A)$/.test(node.tagName) &&
+      !node.classList.contains('vocab-tip') &&
+      !node.classList.contains('vocab-index')
+    ) {
+      // Walk child nodes (snapshot to avoid live-NodeList mutation issues)
+      Array.from(node.childNodes).forEach(wrapTermsInNode);
+    }
+  }
+
+  // Run after DOM is ready (we're deferred to end of body)
+  var sections = document.querySelectorAll('.section');
+  sections.forEach(function(el) { wrapTermsInNode(el); });
+})();
+
+function toggleVocabIndex() {
+  var panel = document.getElementById('vocab-index-panel');
+  if (panel) panel.classList.toggle('collapsed');
+}
+"""
+
+# ---------------------------------------------------------------------------
+# HTML panel template
+# ---------------------------------------------------------------------------
+
+_PANEL_TEMPLATE = """<div class="vocab-index" id="vocab-index-panel">
+  <div class="vocab-index-header" onclick="toggleVocabIndex()">
+    <span class="vocab-index-label">Vocabulary Index</span>
+    <span class="vocab-index-chevron">&#9660;</span>
+  </div>
+  <div class="vocab-index-body">
+{entries}
+  </div>
+</div>"""
+
+_ENTRY_TEMPLATE = """    <div class="vocab-entry">
+      <div class="vocab-entry-term">{term}</div>
+      <div class="vocab-entry-def">{definition}</div>
+    </div>"""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def render(config: dict) -> str:
+    """Return HTML+CSS+JS fragment for the vocab tooltip + index panel.
+
+    Args:
+        config: Dict with key ``vocab`` mapping term strings to definition strings.
+
+    Returns:
+        A self-contained HTML fragment: <style>, panel HTML, and <script>.
+    """
+    vocab: dict[str, str] = config.get("vocab", {})
+    if not vocab:
+        return ""
+
+    # Build alphabetically sorted entries for the panel
+    sorted_terms = sorted(vocab.keys())
+    entries_html = "\n".join(
+        _ENTRY_TEMPLATE.format(
+            term=_escape_html(term),
+            definition=_escape_html(vocab[term]),
+        )
+        for term in sorted_terms
+    )
+    panel_html = _PANEL_TEMPLATE.format(entries=entries_html)
+
+    # Build JS with the vocab data embedded
+    vocab_json = json.dumps(vocab, ensure_ascii=False)
+    js = _JS_TEMPLATE.replace("{vocab_json}", vocab_json)
+
+    return (
+        f"<style>{_CSS}</style>\n"
+        f"{panel_html}\n"
+        f"<script>{js}</script>"
+    )
+
+
+def _escape_html(s: str) -> str:
+    """Minimal HTML escaping for safe injection into HTML attributes and text."""
+    return (
+        s.replace("&", "&amp;")
+         .replace("<", "&lt;")
+         .replace(">", "&gt;")
+         .replace('"', "&quot;")
+    )

--- a/src/htmlgen/renderer.py
+++ b/src/htmlgen/renderer.py
@@ -269,7 +269,8 @@ code, pre, kbd {{
 .section-label {{ font-size: 11px; font-weight: 700; color: var(--text3); text-transform: uppercase;
   letter-spacing: .08em; margin-bottom: 6px; }}
 .section h2 {{ font-size: 19px; font-weight: 700; color: var(--text); margin: 0 0 16px; }}
-.section h3 {{ font-size: 16px; font-weight: 600; color: var(--text); margin: 20px 0 12px; }}
+.section h3 {{ font-size: 16px; font-weight: 700; color: var(--text); margin: 32px 0 6px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }}
+.section h3:first-of-type {{ margin-top: 20px; }}
 .section p {{ color: var(--text2); margin: 0 0 14px; }}
 .section ul, .section ol {{ color: var(--text2); padding-left: 24px; }}
 .section li {{ margin-bottom: 6px; }}
@@ -357,17 +358,6 @@ _MERMAID_CDN_SCRIPT = '<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist
 # ---------------------------------------------------------------------------
 
 _SECTION_CONTENT_CSS = """
-  /* ── Material quality entries (§2-style h3 sections) ── */
-  .section h3 {
-    font-size: 16px;
-    font-weight: 700;
-    color: var(--text);
-    margin: 32px 0 6px;
-    padding-bottom: 6px;
-    border-bottom: 1px solid var(--border);
-  }
-  /* First h3 in a section — no top margin to avoid double gap after section h2 */
-  .section h3:first-of-type { margin-top: 20px; }
   .section > hr {
     border: none;
     border-top: 1px solid var(--border);

--- a/src/htmlgen/renderer.py
+++ b/src/htmlgen/renderer.py
@@ -353,6 +353,38 @@ _MERMAID_CDN_SCRIPT = '<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist
 
 
 # ---------------------------------------------------------------------------
+# Section content visual improvements (§2 typographic hierarchy)
+# ---------------------------------------------------------------------------
+
+_SECTION_CONTENT_CSS = """
+  /* ── Material quality entries (§2-style h3 sections) ── */
+  .section h3 {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text);
+    margin: 32px 0 6px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border);
+  }
+  /* First h3 in a section — no top margin to avoid double gap after section h2 */
+  .section h3:first-of-type { margin-top: 20px; }
+  .section > hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 28px 0;
+    opacity: 0.5;
+  }
+  /* Register mapping lists — tighter and visually distinct */
+  .section ul li {
+    margin-bottom: 4px;
+    padding-left: 4px;
+  }
+  /* Good/Bad/Heuristic runs — keep them visually grouped */
+  .section p + ul { margin-top: -6px; }
+"""
+
+
+# ---------------------------------------------------------------------------
 # Three-level comment system (v1.3 feature parity)
 # ---------------------------------------------------------------------------
 
@@ -706,6 +738,20 @@ def _assemble_html(
     comment_system_global_html = _COMMENT_SYSTEM_GLOBAL_HTML if enable_comment_system else ""
     comment_system_js = f"<script>{_COMMENT_SYSTEM_JS}</script>" if enable_comment_system else ""
 
+    # --- Vocab tooltip auto-injection ---
+    # When the manifest includes a "vocab" dict, the vocab-tooltip component is
+    # auto-injected regardless of the template's component list.  This keeps the
+    # vocab feature fully data-driven: drop a "vocab" key into any manifest and
+    # the tooltip + index panel appear automatically.
+    vocab_fragment = ""
+    vocab = manifest.get("vocab", {})
+    if vocab and isinstance(vocab, dict):
+        try:
+            vocab_mod = get_component("vocab-tooltip")
+            vocab_fragment = vocab_mod.render({"vocab": vocab})
+        except ValueError:
+            pass  # vocab-tooltip not registered — skip silently
+
     # --- Mermaid CSS injection ---
     mermaid_extra_css = _MERMAID_CSS if needs_mermaid else ""
 
@@ -746,6 +792,7 @@ def _assemble_html(
   {mermaid_script_tag}
   <style>
 {global_css}
+{_SECTION_CONTENT_CSS}
 {comment_system_extra_css}
 {mermaid_extra_css}
   </style>
@@ -759,6 +806,7 @@ def _assemble_html(
   {doc_header}
   {sections_html}
   {comment_system_global_html}
+  {vocab_fragment}
   {other_fragments_html}
   {footer}
 </div>

--- a/src/htmlgen/templates/document-class/template.yaml
+++ b/src/htmlgen/templates/document-class/template.yaml
@@ -3,8 +3,6 @@ name: Document (narrative)
 description: Design docs, proposals, audits, synthesis. Narrative-primary.
 content_format: markdown
 components:
-  - id: clipboard-copy-widget
-    config: {}  # auto-populated from section list at render time
   - id: theme-toggle
     config:
       mode: js-toggle
@@ -45,6 +43,6 @@ optional_sections:
 # Rendering parameters
 render_params:
   inject_section_labels: true
-  auto_populate_clipboard_sections: true  # derive sections list from manifest
+  auto_populate_clipboard_sections: false  # clipboard-copy-widget removed
   header_pattern: doc-header  # doc-header with doc-title + doc-subtitle
   footer: true

--- a/src/htmlgen/templates/registry.yaml
+++ b/src/htmlgen/templates/registry.yaml
@@ -4,7 +4,6 @@ templates:
     description: Design docs, proposals, audits, synthesis. Narrative-primary.
     content_format: markdown
     components:
-      - clipboard-copy-widget
       - theme-toggle
     conventions_overrides: {}
     scaffold: content-scaffold.md
@@ -25,7 +24,6 @@ templates:
     description: Long-lived specs edited across many sessions. Section tracking, inline comment threads.
     content_format: json
     components:
-      - clipboard-copy-widget
       - theme-toggle
     conventions_overrides: {}
     scaffold: content-scaffold.json

--- a/src/htmlgen/templates/spec-document/template.yaml
+++ b/src/htmlgen/templates/spec-document/template.yaml
@@ -3,8 +3,6 @@ name: Spec (structured, versioned)
 description: Long-lived specs edited across many sessions. Section tracking, comment threads.
 content_format: json
 components:
-  - id: clipboard-copy-widget
-    config: {}  # auto-populated from section list at render time
   - id: theme-toggle
     config:
       mode: js-toggle
@@ -34,7 +32,7 @@ required_sections:
 # Rendering parameters
 render_params:
   inject_section_labels: true
-  auto_populate_clipboard_sections: true  # derive sections list from manifest
+  auto_populate_clipboard_sections: false  # clipboard-copy-widget removed
   header_pattern: doc-header  # doc-header with doc-title + doc-subtitle
   footer: true
   # Section ID stability: IDs in the manifest are permanent. Never renumber.

--- a/tests/htmlgen/test_integration.py
+++ b/tests/htmlgen/test_integration.py
@@ -121,8 +121,9 @@ class TestLayerImports:
 
     def test_components_importable(self):
         assert "theme-toggle" in COMPONENTS
-        assert "clipboard-copy-widget" in COMPONENTS
+        assert "clipboard-copy-widget" in COMPONENTS  # still in registry; not in templates
         assert "d3-vocabulary-network" in COMPONENTS
+        assert "vocab-tooltip" in COMPONENTS
 
     def test_renderer_importable(self):
         # Just confirm the key functions are callable
@@ -209,22 +210,16 @@ class TestEndToEndRender:
         result = render(smoke_manifest_file, "spec-document", out)
         assert 'id="theme-toggle"' in result
 
-    def test_render_includes_clipboard_widget(self, smoke_manifest_file: Path, tmp_path: Path):
-        out = tmp_path / "spec.html"
-        result = render(smoke_manifest_file, "spec-document", out)
-        assert 'id="comment-widget"' in result
+    def test_render_section_comments_absent(self, smoke_manifest_file: Path, tmp_path: Path):
+        """Section Comments widget (clipboard-copy-widget) must not appear in spec-document output.
 
-    def test_render_clipboard_sections_match_manifest(
-        self, smoke_manifest_file: Path, tmp_path: Path
-    ):
-        """Clipboard widget sections must match manifest sections."""
+        Dan confirmed this panel is redundant — the inline comment buttons and
+        'Copy all comments' button already provide this functionality.
+        """
         out = tmp_path / "spec.html"
         result = render(smoke_manifest_file, "spec-document", out)
-        # All section IDs should appear in the clipboard widget JS
-        for sid in ["s1", "s2", "s2-1", "s2-2"]:
-            assert f'"id": "{sid}"' in result or f'"id":"{sid}"' in result.replace(" ", ""), (
-                f"Section {sid} missing from clipboard widget"
-            )
+        assert 'id="comment-widget"' not in result
+        assert "Section Comments" not in result
 
     def test_render_passes_post_render_validation(
         self, smoke_manifest_file: Path, tmp_path: Path

--- a/tests/htmlgen/test_renderer.py
+++ b/tests/htmlgen/test_renderer.py
@@ -263,18 +263,16 @@ class TestRender:
         result = render(manifest_file, "document-class", output_file)
         assert 'id="theme-toggle"' in result
 
-    def test_render_has_clipboard_widget_component(self, manifest_file: Path, output_file: Path):
-        """document-class template requires clipboard-copy-widget component."""
-        result = render(manifest_file, "document-class", output_file)
-        assert 'id="comment-widget"' in result
+    def test_render_section_comments_widget_absent(self, manifest_file: Path, output_file: Path):
+        """Section Comments widget (clipboard-copy-widget) must NOT appear in document-class output.
 
-    def test_render_clipboard_widget_has_all_section_inputs(
-        self, manifest_file: Path, output_file: Path
-    ):
-        """Clipboard widget must reference all sections from the manifest."""
+        Dan confirmed this panel is redundant — inline comment buttons and the
+        'Copy all comments' button already provide this functionality.
+        """
         result = render(manifest_file, "document-class", output_file)
-        assert '"id": "s1"' in result or '"id":"s1"' in result.replace(" ", "")
-        assert '"id": "s2"' in result or '"id":"s2"' in result.replace(" ", "")
+        assert 'id="comment-widget"' not in result
+        assert "Section Comments" not in result
+        assert "comment-widget-title" not in result
 
     def test_render_title_in_output(self, manifest_file: Path, output_file: Path):
         result = render(manifest_file, "document-class", output_file)
@@ -622,3 +620,104 @@ class TestD3ComponentInjection:
         assert "d3js.org" not in result, (
             "D3 CDN script must not be present when d3 component is not used"
         )
+
+
+# ---------------------------------------------------------------------------
+# Vocab tooltip component tests
+# ---------------------------------------------------------------------------
+
+
+VOCAB_MANIFEST_TERMS = {
+    "Stiffness": "Resistance to deformation; preserves geometry under load.",
+    "Elasticity": "Deformation with return; receives perturbation without losing yourself.",
+    "Damping": "Absorbs vibration; prevents irrelevant oscillation from propagating.",
+}
+
+
+class TestVocabTooltipComponent:
+    """Tests for the vocab tooltip system (Task 3 — vocab index).
+
+    The vocab field in the manifest drives both:
+    1. Inline hover tooltips on term occurrences in section text.
+    2. A collapsible vocab index panel listing all terms alphabetically with definitions.
+    """
+
+    def _make_vocab_manifest(self, tmp_path: Path) -> Path:
+        manifest = dict(MINIMAL_MANIFEST)
+        manifest["sections"] = [
+            {
+                "id": "s1",
+                "label": "§1",
+                "title": "Concepts",
+                "content": "Stiffness is key. Elasticity enables return. Damping prevents noise.",
+            }
+        ]
+        manifest["vocab"] = VOCAB_MANIFEST_TERMS
+        p = tmp_path / "vocab-manifest.json"
+        p.write_text(json.dumps(manifest), encoding="utf-8")
+        return p
+
+    def test_vocab_panel_present_when_vocab_field_in_manifest(self, tmp_path: Path):
+        """When manifest includes vocab field, a vocab index panel must appear in the output."""
+        manifest_path = self._make_vocab_manifest(tmp_path)
+        out = tmp_path / "vocab-out.html"
+        result = render(manifest_path, "document-class", out)
+        assert "vocab-index" in result or "vocab-panel" in result, (
+            "Vocab index panel must appear when manifest has vocab field"
+        )
+
+    def test_vocab_terms_appear_in_panel(self, tmp_path: Path):
+        """Each vocab term must appear in the vocab index panel."""
+        manifest_path = self._make_vocab_manifest(tmp_path)
+        out = tmp_path / "vocab-out.html"
+        result = render(manifest_path, "document-class", out)
+        for term in VOCAB_MANIFEST_TERMS:
+            assert term in result, f"Vocab term '{term}' missing from rendered output"
+
+    def test_vocab_definitions_appear_in_panel(self, tmp_path: Path):
+        """Each vocab definition must appear in the rendered output."""
+        manifest_path = self._make_vocab_manifest(tmp_path)
+        out = tmp_path / "vocab-out.html"
+        result = render(manifest_path, "document-class", out)
+        for _term, defn in VOCAB_MANIFEST_TERMS.items():
+            # Definition text must be present somewhere in the output
+            assert defn[:40] in result, f"Definition '{defn[:40]}...' missing from rendered output"
+
+    def test_vocab_tooltip_markup_present(self, tmp_path: Path):
+        """Tooltip markup (vocab-term class or data-def attribute) must be present."""
+        manifest_path = self._make_vocab_manifest(tmp_path)
+        out = tmp_path / "vocab-out.html"
+        result = render(manifest_path, "document-class", out)
+        assert "vocab-term" in result, (
+            "vocab-term CSS class must be used to mark tooltip-enhanced terms"
+        )
+
+    def test_no_vocab_panel_without_vocab_field(self, manifest_file: Path, output_file: Path):
+        """When manifest has no vocab field, no vocab panel must appear."""
+        result = render(manifest_file, "document-class", output_file)
+        assert "vocab-index" not in result and "vocab-panel" not in result, (
+            "Vocab panel must not appear when manifest has no vocab field"
+        )
+
+    def test_vocab_panel_alphabetically_sorted(self, tmp_path: Path):
+        """Terms in the vocab index panel must appear in alphabetical order."""
+        manifest_path = self._make_vocab_manifest(tmp_path)
+        out = tmp_path / "vocab-out.html"
+        result = render(manifest_path, "document-class", out)
+        # Find positions of each term in the output
+        positions = {
+            term: result.find(f'class="vocab-entry"') for term in VOCAB_MANIFEST_TERMS
+        }
+        # Find where each term appears in the vocab panel section
+        vocab_panel_start = result.find("vocab-index")
+        if vocab_panel_start == -1:
+            vocab_panel_start = result.find("vocab-panel")
+        panel_section = result[vocab_panel_start:] if vocab_panel_start != -1 else result
+        sorted_terms = sorted(VOCAB_MANIFEST_TERMS.keys())
+        prev_pos = 0
+        for term in sorted_terms:
+            pos = panel_section.find(term, prev_pos)
+            assert pos >= prev_pos, (
+                f"Term '{term}' is out of alphabetical order in vocab panel"
+            )
+            prev_pos = pos

--- a/tests/htmlgen/test_renderer.py
+++ b/tests/htmlgen/test_renderer.py
@@ -704,10 +704,6 @@ class TestVocabTooltipComponent:
         manifest_path = self._make_vocab_manifest(tmp_path)
         out = tmp_path / "vocab-out.html"
         result = render(manifest_path, "document-class", out)
-        # Find positions of each term in the output
-        positions = {
-            term: result.find(f'class="vocab-entry"') for term in VOCAB_MANIFEST_TERMS
-        }
         # Find where each term appears in the vocab panel section
         vocab_panel_start = result.find("vocab-index")
         if vocab_panel_start == -1:

--- a/tests/htmlgen/test_template_registry.py
+++ b/tests/htmlgen/test_template_registry.py
@@ -55,21 +55,23 @@ class TestLoadRegistry:
         spec = next(t for t in templates if t["id"] == "spec-document")
         assert spec["content_format"] == "json"
 
-    def test_document_class_has_clipboard_widget(self):
+    def test_document_class_does_not_have_clipboard_widget(self):
+        """clipboard-copy-widget was removed — Section Comments panel is redundant."""
         templates = load_registry()
         doc_class = next(t for t in templates if t["id"] == "document-class")
         component_ids = [c if isinstance(c, str) else c for c in doc_class["components"]]
-        assert "clipboard-copy-widget" in component_ids
+        assert "clipboard-copy-widget" not in component_ids
 
     def test_document_class_has_theme_toggle(self):
         templates = load_registry()
         doc_class = next(t for t in templates if t["id"] == "document-class")
         assert "theme-toggle" in doc_class["components"]
 
-    def test_spec_document_has_clipboard_widget(self):
+    def test_spec_document_does_not_have_clipboard_widget(self):
+        """clipboard-copy-widget was removed — Section Comments panel is redundant."""
         templates = load_registry()
         spec = next(t for t in templates if t["id"] == "spec-document")
-        assert "clipboard-copy-widget" in spec["components"]
+        assert "clipboard-copy-widget" not in spec["components"]
 
     def test_dashboard_class_has_theme_toggle(self):
         templates = load_registry()


### PR DESCRIPTION
## What this changes

The Section Comments widget — a panel labeled "Section Comments" with per-section text inputs — has been removed from all HTML document templates. Dan confirmed it is redundant: inline 💬 comment buttons (per-heading) and the global "Copy all comments" button already cover this workflow. Before this PR, every rendered document had both systems active simultaneously. After this PR, only the inline comment system remains.

Two additions accompany the removal:

**Vocab tooltip index (Task 3 — golden):** A new \`vocab-tooltip\` component that activates automatically when a manifest includes a \`"vocab"\` dict. It injects hover tooltip cards on every occurrence of each defined term in the document body, and adds a collapsible Vocabulary Index panel at the bottom listing all terms alphabetically with definitions. The design follows the existing dark/light CSS variable palette. The component is fully data-driven — no template changes required for any document. The sensibility-stack v3.1 manifest (in \`workstreams/sensibility-stack-v3/\`) uses it with 34 terms extracted from the document.

**§2 visual hierarchy (Task 2):** h3 entries now have a border-bottom separator, 32px top-margin between quality entries, and tighter list spacing for register mapping bullets. Applied via \`_SECTION_CONTENT_CSS\` in the renderer so all spec-document sections benefit, not just §2.

## What is out of scope

- The clipboard-copy-widget module is retained in the component registry for backwards compatibility — it is simply not listed in any template's component list.
- \`~/messages/bisque-uploads/\` rendered artifacts were not modified (those are generated, not source).
- WOS code was not touched.

## Functional patterns used

Pure CSS custom property inheritance ensures both dark and light themes work without JS branching. Component injection is declarative and data-driven: dropping \`"vocab": {...}\` into any manifest activates the system. Term wrapping defers to runtime DOM traversal rather than preprocessing rendered HTML strings, which avoids fragility with markdown-to-HTML output. The \`_SECTION_CONTENT_CSS\` constant is a pure function of conventions, injected once per document head.

## Tests run

- [x] \`uv run pytest tests/htmlgen/ -v\` — **306 passed, 0 failed**
- [x] Re-rendered \`sensibility-stack-v3.1.html\` via CLI — validated: 0 "Section Comments", 15 \`vocab-index\` occurrences, 6 \`vocab-term\` occurrences, Vocabulary Index panel present, §2 h3 border styling present

## Manual test

The rendered \`~/messages/bisque-uploads/sensibility-stack-v3.1.html\` was produced directly during development and inspected via grep for the key structural markers. The file is not committed to the repo (it's a generated artifact). The test of user-visible outcome requires Dan to view the Bisque-hosted v3.1 doc — the CI pipeline above is the automated verification.

N/A for systemd, cron, DB schema, or external service changes — this is purely a Python + HTML/CSS/JS renderer change.

## Definition of Done

- [x] Unit tests pass (306/306)
- [x] Manual check of rendered HTML artifact for all three features
- [x] Side-effect audit: no floods, no unscoped writes; clipboard-copy-widget module retained for compat
- [x] External service calls: none