### PR TITLE
fix(wos): add 'operational' to UoWPosture enum

### DIFF
--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -125,6 +125,7 @@ class UoWPosture(StrEnum):
     SEQUENTIAL = "sequential"
     REVIEW_LOOP = "review-loop"
     FAN_OUT = "fan-out"
+    OPERATIONAL = "operational"
 
 
 class UoWRegister(StrEnum):

--- a/tests/unit/test_orchestration/test_registry.py
+++ b/tests/unit/test_orchestration/test_registry.py
@@ -1721,3 +1721,65 @@ class TestClosedStatus:
         assert isinstance(result, UpsertInserted), (
             f"Expected UpsertInserted (re-proposal after closed), got {type(result).__name__}: {result!r}"
         )
+
+
+class TestOperationalPosture:
+    """
+    'operational' is a DB posture value present on existing UoWs that was missing
+    from the UoWPosture enum. Before the fix, any code path that called _row_to_uow()
+    on a row with posture='operational' raised ValueError.
+    """
+
+    def _insert_operational_posture_row(self, db_path: Path, issue_number: int = 7777) -> str:
+        """Insert a row with posture='operational' directly via SQL, bypassing enum validation."""
+        import uuid
+        uow_id = str(uuid.uuid4())
+        conn = _open_db(db_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO uow_registry
+                    (id, status, summary, source, created_at, updated_at,
+                     type, posture, register, steward_cycles, lifetime_cycles,
+                     heartbeat_ttl, retry_count, execution_attempts, orphan_retry_count,
+                     source_issue_number)
+                VALUES
+                    (?, 'proposed', 'UoW with operational posture', 'test', datetime('now'), datetime('now'),
+                     'executable', 'operational', 'operational', 0, 0,
+                     300, 0, 0, 0,
+                     ?)
+                """,
+                (uow_id, issue_number),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return uow_id
+
+    def test_operational_is_valid_uow_posture(self):
+        """UoWPosture('operational') must not raise ValueError."""
+        from src.orchestration.registry import UoWPosture
+        posture = UoWPosture("operational")
+        assert posture == UoWPosture.OPERATIONAL
+
+    def test_registry_list_does_not_raise_on_operational_posture_row(self, registry, db_path):
+        """
+        Registry.list() must not raise ValueError when the DB contains a
+        row with posture='operational'. This was the root cause reported in the
+        fix-uow-posture-enum issue.
+        """
+        self._insert_operational_posture_row(db_path)
+        # Must not raise ValueError
+        results = registry.list()
+        operational_uows = [u for u in results if u.posture == "operational"]
+        assert len(operational_uows) == 1
+
+    def test_registry_get_does_not_raise_on_operational_posture_row(self, registry, db_path):
+        """
+        Registry.get(uow_id) must not raise ValueError for a row with posture='operational'.
+        """
+        uow_id = self._insert_operational_posture_row(db_path)
+        uow = registry.get(uow_id)
+        assert uow is not None
+        from src.orchestration.registry import UoWPosture
+        assert uow.posture == UoWPosture.OPERATIONAL


### PR DESCRIPTION
## Problem

UoWs stored in the registry DB with `posture='operational'` caused `ValueError: 'operational' is not a valid UoWPosture` whenever the Python API deserialized them via `_row_to_uow()`. Jobs were routing around this with raw SQL queries instead of using the typed API — a fragile workaround that would break on any new caller.

## Change

Adds `OPERATIONAL = "operational"` to `UoWPosture` in `src/orchestration/registry.py`. No schema migration is needed — the `posture` column already stores string values; adding an enum member is backwards-compatible with all existing rows.

No handler or routing logic switches on `UoWPosture` values, so no downstream coverage changes are required.

## Functional pattern

Pure enum extension — purely additive, no mutation of existing values or behavior. The existing `_row_to_uow` deserialization boundary already handles this correctly once the enum member exists.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py::TestOperationalPosture -v` — 3 passed (new regression tests covering the exact failure path)
- [x] `uv run pytest tests/unit/test_orchestration/test_registry.py -q` — 100 passed, 0 failed

The new `TestOperationalPosture` class follows the `TestClosedStatus` pattern: it inserts a row with the previously-invalid value directly via SQL (bypassing enum validation), then verifies that `Registry.list()` and `Registry.get()` no longer raise `ValueError`.

## Manual test

N/A — this change is entirely internal to the Python deserialization layer. No external service calls, no file system side effects, no Telegram output.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, see above
- [x] User-visible outcome verified — not applicable; this is a deserialization fix, no user-facing output
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none