### PR TITLE
feat(startup-sweep): checkpoint-aware orphan classification (#1324)

### DIFF
--- a/scheduled-tasks/startup_sweep.py
+++ b/scheduled-tasks/startup_sweep.py
@@ -19,6 +19,7 @@ Phase 2 dependency: requires schema migration to have been applied:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -128,10 +129,29 @@ class StartupSweepResult:
 # Phase 1: Startup sweep — crash recovery (#307)
 # ---------------------------------------------------------------------------
 
+def _read_checkpoint(checkpoint_ref: str | None) -> dict | None:
+    """
+    Read and parse checkpoint.json at the given path.
+
+    Returns the parsed dict, or None if checkpoint_ref is None, the file does
+    not exist, or the file is not valid JSON. Pure function: no side effects.
+    """
+    if not checkpoint_ref:
+        return None
+    p = Path(checkpoint_ref)
+    try:
+        if not p.exists():
+            return None
+        return json.loads(p.read_text())
+    except Exception:
+        return None
+
+
 def _classify_executing_orphan_kill_type(
     dispatch_ts: str | None,
     heartbeat_at: str | None,
-) -> str:
+    checkpoint_ref: str | None = None,
+) -> tuple[str, dict | None]:
     """
     Classify the kill type of an `executing` orphan UoW using the heartbeat signal.
 
@@ -143,8 +163,17 @@ def _classify_executing_orphan_kill_type(
             the inbox-dispatch path was added).
         heartbeat_at: ISO timestamp of the most recent heartbeat_at value on the
             UoW, or None if heartbeat_at was never written.
+        checkpoint_ref: Optional path to a checkpoint.json file written by the
+            agent during execution. When present and valid with next_step_index > 0,
+            the classification is upgraded to 'orphan_kill_during_execution_with_checkpoint'
+            and the checkpoint dict is returned as the second element.
+            Defensive: read via getattr since this field is inert until issue #1322
+            merges the DB schema migration.
 
     Returns:
+        A tuple (classification, checkpoint_data) where:
+
+        classification is one of:
         'orphan_kill_before_start': No evidence of agent working after dispatch.
             Either heartbeat_at is None, or it does not exceed
             dispatch_ts + DISPATCH_WINDOW_SECONDS.
@@ -152,22 +181,31 @@ def _classify_executing_orphan_kill_type(
 
         'orphan_kill_during_execution': Agent wrote a heartbeat after the
             dispatch window, confirming it had started processing before being
-            killed.
+            killed, but no valid checkpoint exists with progress.
             Re-entry strategy: note partial execution evidence for diagnosis.
 
-    Safe default: returns 'orphan_kill_before_start' whenever the classification
-    cannot be determined (None inputs, unparseable timestamps, missing dispatch
-    audit). This is conservative — treating an ambiguous kill as kill-before-start
-    avoids over-claiming partial execution evidence that may not exist.
+        'orphan_kill_during_execution_with_checkpoint': Agent wrote a heartbeat
+            after the dispatch window AND a valid checkpoint file exists with
+            next_step_index > 0, providing resume context.
+            Re-entry strategy: use checkpoint_data to resume from last known step.
+
+        checkpoint_data is the parsed checkpoint dict when classification is
+        'orphan_kill_during_execution_with_checkpoint', None otherwise.
+
+    Safe default: returns ('orphan_kill_before_start', None) whenever the
+    classification cannot be determined (None inputs, unparseable timestamps,
+    missing dispatch audit). This is conservative — treating an ambiguous kill
+    as kill-before-start avoids over-claiming partial execution evidence that
+    may not exist.
     """
     # No dispatch timestamp → cannot determine if heartbeat was post-dispatch.
     # Safe default: kill_before_start.
     if dispatch_ts is None:
-        return "orphan_kill_before_start"
+        return "orphan_kill_before_start", None
 
     # No heartbeat → agent never wrote one → kill-before-start.
     if heartbeat_at is None:
-        return "orphan_kill_before_start"
+        return "orphan_kill_before_start", None
 
     # Parse both timestamps for comparison.
     try:
@@ -175,14 +213,14 @@ def _classify_executing_orphan_kill_type(
         if dispatch_dt.tzinfo is None:
             dispatch_dt = dispatch_dt.replace(tzinfo=timezone.utc)
     except (ValueError, TypeError, AttributeError):
-        return "orphan_kill_before_start"
+        return "orphan_kill_before_start", None
 
     try:
         heartbeat_dt = datetime.fromisoformat(heartbeat_at.replace("Z", "+00:00"))
         if heartbeat_dt.tzinfo is None:
             heartbeat_dt = heartbeat_dt.replace(tzinfo=timezone.utc)
     except (ValueError, TypeError, AttributeError):
-        return "orphan_kill_before_start"
+        return "orphan_kill_before_start", None
 
     # heartbeat_at must be strictly after dispatch_ts + DISPATCH_WINDOW_SECONDS.
     # This absorbs startup jitter: even if the agent wrote a heartbeat quickly,
@@ -190,9 +228,15 @@ def _classify_executing_orphan_kill_type(
     from datetime import timedelta
     threshold_dt = dispatch_dt + timedelta(seconds=DISPATCH_WINDOW_SECONDS)
     if heartbeat_dt > threshold_dt:
-        return "orphan_kill_during_execution"
+        # Checkpoint detection (issue #1324): if a valid checkpoint exists with
+        # progress past step 0, surface richer classification so the Steward can
+        # use resume context.
+        checkpoint = _read_checkpoint(checkpoint_ref)
+        if checkpoint and checkpoint.get("next_step_index", 0) > 0:
+            return "orphan_kill_during_execution_with_checkpoint", checkpoint
+        return "orphan_kill_during_execution", None
 
-    return "orphan_kill_before_start"
+    return "orphan_kill_before_start", None
 
 
 def _is_heartbeat_recent(
@@ -714,10 +758,46 @@ def run_startup_sweep(
                 "(defaulting to orphan_kill_before_start)",
                 uow_id, _exc,
             )
-        kill_classification = _classify_executing_orphan_kill_type(
+        checkpoint_ref: str | None = getattr(uow, "checkpoint_ref", None)
+        kill_classification, checkpoint_data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=heartbeat_at,
+            checkpoint_ref=checkpoint_ref,
         )
+
+        # Shallow artifact verification: check that artifacts mentioned in the
+        # checkpoint actually exist on disk.
+        verified_artifacts: list = []
+        missing_artifacts: list = []
+        if checkpoint_data:
+            from pathlib import Path as _Path
+            for step in checkpoint_data.get("steps", []):
+                if step.get("status") != "complete":
+                    continue
+                for key, val in step.get("artifacts", {}).items():
+                    if key == "worktree_path":
+                        exists = _Path(val).exists()
+                        (verified_artifacts if exists else missing_artifacts).append(
+                            (step["name"], key, val)
+                        )
+                    elif key == "files_modified":
+                        targets = [val] if isinstance(val, str) else val
+                        for f in targets:
+                            exists = _Path(f).exists()
+                            (verified_artifacts if exists else missing_artifacts).append(
+                                (step["name"], key, f)
+                            )
+                    elif key == "branch":
+                        import subprocess
+                        result = subprocess.run(
+                            ["git", "-C", str(_Path.home() / "lobster-workspace/projects"),
+                             "branch", "--list", val],
+                            capture_output=True, text=True,
+                        )
+                        exists = bool(result.stdout.strip())
+                        (verified_artifacts if exists else missing_artifacts).append(
+                            (step["name"], key, val)
+                        )
 
         if dry_run:
             log.info(
@@ -734,6 +814,9 @@ def run_startup_sweep(
             age_seconds=age_seconds,
             threshold_seconds=executing_orphan_threshold_seconds,
             kill_classification=kill_classification,
+            checkpoint_data=checkpoint_data,
+            verified_artifacts=verified_artifacts,
+            missing_artifacts=missing_artifacts,
         )
 
         if rows == 1:

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -2037,6 +2037,9 @@ class Registry:
         age_seconds: float,
         threshold_seconds: int,
         kill_classification: str = "orphan_kill_before_start",
+        checkpoint_data: dict | None = None,
+        verified_artifacts: list | None = None,
+        missing_artifacts: list | None = None,
     ) -> int:
         """
         Atomically write a startup_sweep audit entry and transition an
@@ -2063,12 +2066,24 @@ class Registry:
                     — agent killed before establishing working state.
                 'orphan_kill_during_execution': heartbeat written after dispatch
                     — agent was actively working when killed.
+                'orphan_kill_during_execution_with_checkpoint': agent was actively
+                    working when killed AND a valid checkpoint exists with progress
+                    past step 0 — resume context is available in checkpoint_data.
                 Defaults to 'orphan_kill_before_start' (safe default when
                 heartbeat evidence is absent or the registry method is not
                 available).
+            checkpoint_data: Parsed checkpoint dict when classification is
+                'orphan_kill_during_execution_with_checkpoint', None otherwise.
+                Key fields included in the audit note when present:
+                next_step_index, next_step_name, completion_fraction, notes,
+                written_at.
+            verified_artifacts: List of (step_name, artifact_key, path) tuples
+                for checkpoint artifacts that were verified to exist on disk.
+            missing_artifacts: List of (step_name, artifact_key, path) tuples
+                for checkpoint artifacts that were NOT found on disk.
         """
         now = _now_iso()
-        note_json = json.dumps({
+        note = {
             "event": "startup_sweep",
             "actor": "steward",
             "classification": kill_classification,
@@ -2080,7 +2095,18 @@ class Registry:
             "started_at": started_at,
             "age_seconds": age_seconds,
             "threshold_seconds": threshold_seconds,
-        })
+        }
+        if checkpoint_data is not None:
+            note["checkpoint_next_step_index"] = checkpoint_data.get("next_step_index")
+            note["checkpoint_next_step_name"] = checkpoint_data.get("next_step_name")
+            note["checkpoint_completion_fraction"] = checkpoint_data.get("completion_fraction")
+            note["checkpoint_notes"] = checkpoint_data.get("notes")
+            note["checkpoint_written_at"] = checkpoint_data.get("written_at")
+        if verified_artifacts is not None:
+            note["verified_artifacts"] = verified_artifacts
+        if missing_artifacts is not None:
+            note["missing_artifacts"] = missing_artifacts
+        note_json = json.dumps(note)
 
         conn = self._connect()
         try:

--- a/tests/unit/test_orchestration/test_kill_classification.py
+++ b/tests/unit/test_orchestration/test_kill_classification.py
@@ -8,6 +8,10 @@ heartbeat signal to distinguish two kill scenarios:
   - orphan_kill_during_execution: agent wrote heartbeats after dispatch
     (was actively working before being killed)
 
+Issue #1324: Add checkpoint-aware classification:
+  - orphan_kill_during_execution_with_checkpoint: agent was working when killed
+    AND a valid checkpoint exists with next_step_index > 0 (resume context available)
+
 Coverage:
 - DISPATCH_WINDOW_SECONDS constant: positive integer
 - classify_executing_orphan_kill_type:
@@ -16,6 +20,9 @@ Coverage:
     heartbeat exists after dispatch + DISPATCH_WINDOW_SECONDS → orphan_kill_during_execution
     heartbeat is non-parseable → orphan_kill_before_start (safe default)
     dispatch timestamp is None (no executor_dispatch audit) → orphan_kill_before_start
+    checkpoint with next_step_index > 0 → orphan_kill_during_execution_with_checkpoint
+    checkpoint with next_step_index == 0 → orphan_kill_during_execution (no upgrade)
+    checkpoint file missing → orphan_kill_during_execution (no upgrade)
 - registry.get_executor_dispatch_timestamp:
     returns None when no audit_log entries exist
     returns None when no executor_dispatch entry exists
@@ -35,8 +42,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sqlite3
 import sys
+import tempfile
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
@@ -115,6 +124,8 @@ CREATE TABLE IF NOT EXISTS uow_registry (
     estimated_runtime   INTEGER NULL,
     steward_agenda      TEXT    NULL,
     steward_log         TEXT    NULL,
+    heartbeat_at        TEXT    NULL,
+    heartbeat_ttl       INTEGER NULL,
     UNIQUE(source_issue_number, sweep_date)
 );
 
@@ -268,37 +279,43 @@ class TestClassifyExecutingOrphanKillType:
     """
     Pure function tests for kill classification.
 
-    classify_executing_orphan_kill_type(dispatch_ts, heartbeat_at) -> str
+    classify_executing_orphan_kill_type(dispatch_ts, heartbeat_at, checkpoint_ref=None)
+        -> tuple[str, dict | None]
 
     Returns:
-    - 'orphan_kill_before_start': no evidence of heartbeat after dispatch
-    - 'orphan_kill_during_execution': heartbeat exists after dispatch window
+    - ('orphan_kill_before_start', None): no evidence of heartbeat after dispatch
+    - ('orphan_kill_during_execution', None): heartbeat exists after dispatch window, no valid checkpoint
+    - ('orphan_kill_during_execution_with_checkpoint', dict): heartbeat exists after dispatch window
+      AND checkpoint with next_step_index > 0
     """
 
     def test_no_heartbeat_null_is_kill_before_start(self) -> None:
         """NULL heartbeat_at → agent never wrote a heartbeat → kill-before-start."""
         dispatch_ts = _iso_ago(1800)
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=None,
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
     def test_no_dispatch_timestamp_is_kill_before_start(self) -> None:
         """No executor_dispatch audit entry → cannot confirm work started → kill-before-start."""
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=None,
             heartbeat_at=_iso_ago(1200),
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
     def test_both_none_is_kill_before_start(self) -> None:
         """Both None → kill-before-start (safe default)."""
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=None,
             heartbeat_at=None,
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
     def test_heartbeat_before_dispatch_is_kill_before_start(self) -> None:
         """
@@ -310,20 +327,22 @@ class TestClassifyExecutingOrphanKillType:
         dispatch_ts = _iso_ago(1800)
         # Heartbeat written 10 seconds BEFORE dispatch (initial set_heartbeat_ttl)
         heartbeat_before_dispatch = _iso_ago(1810)
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=heartbeat_before_dispatch,
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
     def test_heartbeat_at_exact_dispatch_time_is_kill_before_start(self) -> None:
         """Heartbeat at exactly dispatch time → within window → kill-before-start."""
         dispatch_ts = _iso_ago(1800)
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=dispatch_ts,  # Same timestamp
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
     def test_heartbeat_within_dispatch_window_is_kill_before_start(self) -> None:
         """
@@ -333,11 +352,12 @@ class TestClassifyExecutingOrphanKillType:
         dispatch_ts = _iso_ago(1800)
         # Heartbeat written 30 seconds after dispatch (within window)
         heartbeat_just_after = _iso_ago(1800 - 30)
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=heartbeat_just_after,
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
     def test_heartbeat_after_dispatch_window_is_kill_during_execution(self) -> None:
         """
@@ -347,38 +367,42 @@ class TestClassifyExecutingOrphanKillType:
         dispatch_ts = _iso_ago(1800)
         # Heartbeat written DISPATCH_WINDOW_SECONDS + 60 after dispatch (clearly working)
         heartbeat_after_window = _iso_ago(1800 - _sweep_mod.DISPATCH_WINDOW_SECONDS - 60)
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=heartbeat_after_window,
         )
-        assert result == "orphan_kill_during_execution"
+        assert clf == "orphan_kill_during_execution"
+        assert data is None
 
     def test_recent_heartbeat_is_kill_during_execution(self) -> None:
         """A very recent heartbeat (agent was actively working) → kill-during-execution."""
         dispatch_ts = _iso_ago(600)
         heartbeat_recent = _iso_ago(30)  # 30 seconds ago — agent was running
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at=heartbeat_recent,
         )
-        assert result == "orphan_kill_during_execution"
+        assert clf == "orphan_kill_during_execution"
+        assert data is None
 
     def test_unparseable_heartbeat_is_kill_before_start(self) -> None:
         """Unparseable heartbeat_at → cannot confirm work started → kill-before-start (safe default)."""
         dispatch_ts = _iso_ago(1800)
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts=dispatch_ts,
             heartbeat_at="not-a-timestamp",
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
     def test_unparseable_dispatch_ts_is_kill_before_start(self) -> None:
         """Unparseable dispatch_ts → cannot compare → kill-before-start (safe default)."""
-        result = _classify_executing_orphan_kill_type(
+        clf, data = _classify_executing_orphan_kill_type(
             dispatch_ts="not-a-timestamp",
             heartbeat_at=_iso_ago(600),
         )
-        assert result == "orphan_kill_before_start"
+        assert clf == "orphan_kill_before_start"
+        assert data is None
 
 
 # ---------------------------------------------------------------------------
@@ -722,3 +746,125 @@ class TestReentryPostureForNewClassifications:
             "produce reentry posture 'trace_gate_dwell', not 'diagnosing_orphan' or "
             "'first_execution'. Gap 1 from oracle verdict pr-1305.md."
         )
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint helpers
+# ---------------------------------------------------------------------------
+
+def _write_checkpoint(tmp_dir: str, data: dict) -> str:
+    """Write a checkpoint.json file to tmp_dir and return its path."""
+    p = os.path.join(tmp_dir, "checkpoint.json")
+    with open(p, "w") as f:
+        json.dump(data, f)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# TestCheckpointClassification — issue #1324
+# ---------------------------------------------------------------------------
+
+class TestCheckpointClassification:
+    """
+    Tests for checkpoint-aware orphan kill classification (issue #1324).
+
+    When a valid checkpoint.json exists with next_step_index > 0, the
+    classification is upgraded to 'orphan_kill_during_execution_with_checkpoint'
+    and the checkpoint dict is returned as the second element of the tuple.
+    """
+
+    def test_checkpoint_next_step_gt_0_returns_with_checkpoint(self, tmp_path: Path) -> None:
+        """Checkpoint with next_step_index > 0 → orphan_kill_during_execution_with_checkpoint."""
+        cp_path = _write_checkpoint(str(tmp_path), {"next_step_index": 2, "next_step_name": "implement"})
+        dispatch_ts = "2026-01-01T12:00:00Z"
+        # heartbeat > dispatch + window → orphan_kill_during_execution base
+        heartbeat_ts = "2026-01-01T12:10:00Z"
+        clf, data = _classify_executing_orphan_kill_type(dispatch_ts, heartbeat_ts, cp_path)
+        assert clf == "orphan_kill_during_execution_with_checkpoint"
+        assert data is not None
+        assert data["next_step_index"] == 2
+
+    def test_checkpoint_next_step_0_returns_standard_during_execution(self, tmp_path: Path) -> None:
+        """Checkpoint with next_step_index == 0 → no upgrade, returns orphan_kill_during_execution."""
+        cp_path = _write_checkpoint(str(tmp_path), {"next_step_index": 0})
+        dispatch_ts = "2026-01-01T12:00:00Z"
+        heartbeat_ts = "2026-01-01T12:10:00Z"
+        clf, data = _classify_executing_orphan_kill_type(dispatch_ts, heartbeat_ts, cp_path)
+        assert clf == "orphan_kill_during_execution"
+        assert data is None
+
+    def test_checkpoint_file_missing_returns_standard_during_execution(self) -> None:
+        """Missing checkpoint file → no upgrade, returns orphan_kill_during_execution."""
+        dispatch_ts = "2026-01-01T12:00:00Z"
+        heartbeat_ts = "2026-01-01T12:10:00Z"
+        clf, data = _classify_executing_orphan_kill_type(
+            dispatch_ts, heartbeat_ts, "/nonexistent/checkpoint.json"
+        )
+        assert clf == "orphan_kill_during_execution"
+        assert data is None
+
+    def test_no_checkpoint_ref_no_change(self) -> None:
+        """No checkpoint_ref → standard orphan_kill_during_execution."""
+        dispatch_ts = "2026-01-01T12:00:00Z"
+        heartbeat_ts = "2026-01-01T12:10:00Z"
+        clf, data = _classify_executing_orphan_kill_type(dispatch_ts, heartbeat_ts)
+        assert clf == "orphan_kill_during_execution"
+        assert data is None
+
+    def test_kill_before_start_returns_none_data(self) -> None:
+        """kill-before-start always returns None checkpoint data."""
+        clf, data = _classify_executing_orphan_kill_type(None, None)
+        assert clf == "orphan_kill_before_start"
+        assert data is None
+
+    def test_checkpoint_data_in_registry_audit_note(self, tmp_path: Path) -> None:
+        """
+        When a checkpoint is detected, record_startup_sweep_executing writes
+        checkpoint_next_step_index and related fields into the audit note JSON.
+        """
+        import sqlite3 as _sqlite3
+
+        # Build a DB using the full _SCHEMA (which includes heartbeat_at via
+        # the _make_executing_uow helper fixture)
+        db_path = tmp_path / "cp_test.db"
+        conn = _sqlite3.connect(str(db_path))
+        conn.executescript(_SCHEMA)
+        started_at = _iso_ago(1800)
+        _make_executing_uow(conn, uow_id="uow-cp-audit-001", started_at=started_at)
+        conn.close()
+
+        from src.orchestration.registry import Registry
+        reg = Registry(db_path)
+
+        checkpoint_data = {
+            "next_step_index": 3,
+            "next_step_name": "open_pr",
+            "completion_fraction": 0.75,
+            "notes": "implemented changes",
+            "written_at": _iso_ago(30),
+        }
+        reg.record_startup_sweep_executing(
+            uow_id="uow-cp-audit-001",
+            started_at=started_at,
+            age_seconds=1800,
+            threshold_seconds=600,
+            kill_classification="orphan_kill_during_execution_with_checkpoint",
+            checkpoint_data=checkpoint_data,
+            verified_artifacts=[("impl", "branch", "fix/foo")],
+            missing_artifacts=[],
+        )
+
+        conn2 = _sqlite3.connect(str(db_path))
+        row = conn2.execute(
+            "SELECT note FROM audit_log WHERE uow_id = ? AND event = 'startup_sweep'",
+            ("uow-cp-audit-001",),
+        ).fetchone()
+        conn2.close()
+
+        assert row is not None
+        note = json.loads(row[0])
+        assert note["checkpoint_next_step_index"] == 3
+        assert note["checkpoint_next_step_name"] == "open_pr"
+        assert note["checkpoint_completion_fraction"] == 0.75
+        assert note["verified_artifacts"] == [["impl", "branch", "fix/foo"]]
+        assert note["missing_artifacts"] == []


### PR DESCRIPTION
## Summary

- Extends `_classify_executing_orphan_kill_type()` to return `tuple[str, dict | None]` with checkpoint context
- Adds `_read_checkpoint()` helper (specified in issue #1322, included here since #1322 is unmerged)
- New classification: `orphan_kill_during_execution_with_checkpoint` when heartbeat confirms execution AND checkpoint has `next_step_index > 0`
- Shallow artifact verification (worktree_path, files_modified, branch) for completed checkpoint steps
- Enriched `record_startup_sweep_executing()` audit note with `checkpoint_next_step_index`, `checkpoint_next_step_name`, `checkpoint_completion_fraction`, `verified_artifacts`, `missing_artifacts`

## Dependency note

`checkpoint_ref` is read defensively via `getattr(uow, 'checkpoint_ref', None)` — the classification is inert until issues #1322 (checkpoint DB schema) and #1323 (executor preamble checkpoint writes) merge. No behavior change for UoWs without checkpoints.

Closes #1324

## Test plan

- [x] All 35 tests pass (updated existing tests for tuple return from `_classify_executing_orphan_kill_type`)
- [x] `TestCheckpointClassification` — 6 new tests covering: checkpoint with progress, checkpoint at step 0, missing file, no checkpoint_ref, kill-before-start, checkpoint fields in audit note
- [x] Test schema updated to include `heartbeat_at` and `heartbeat_ttl` columns