### PR TITLE
fix(wos): cap concurrent prescription dispatch at MAX_CONCURRENT_PRESCRIPTIONS=5

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -508,7 +508,22 @@ class PrescribingQueued:
     cycles: int
 
 
-StewardOutcome = Prescribed | Done | Surfaced | RaceSkipped | WaitForTrace | PrescribingQueued
+@dataclass
+class PrescriptionDeferred:
+    """
+    Returned when prescription is skipped because ``MAX_CONCURRENT_PRESCRIPTIONS``
+    is already reached.
+
+    The UoW is transitioned back to ``ready-for-steward`` so that the next
+    heartbeat cycle can attempt prescription once in-flight slots free up.
+    """
+    uow_id: str
+
+
+StewardOutcome = (
+    Prescribed | Done | Surfaced | RaceSkipped | WaitForTrace
+    | PrescribingQueued | PrescriptionDeferred
+)
 
 
 # ---------------------------------------------------------------------------
@@ -3068,6 +3083,20 @@ def _dynamic_burst_batch_size(queue_depth: int) -> int:
 # Source: oracle/patterns.md §burst — hard lower bound comment
 BURST_BASELINE_QUEUE_DEPTH: int = 6
 
+# Prescription concurrency cap: maximum number of UoWs that may be in the
+# ``prescribing`` state simultaneously (across all cycles, not just the current
+# one).  When the cap is reached, new prescription dispatches are deferred to
+# the next heartbeat cycle rather than flooding the API with concurrent
+# ``claude -p`` calls that will all hit the 600 s LLM timeout.
+#
+# Root cause context: ``_dynamic_burst_batch_size`` returns 15 when queue_depth
+# > 50.  With 60+ UoWs in ``ready-for-steward``, each heartbeat dispatches 15
+# wos_prescribe inbox messages → 15 concurrent claude -p calls.  All time out
+# at 600 s; startup_sweep resets them at 660 s; next heartbeat repeats.
+# A cap of 5 means at most 5 prescription subagents run concurrently, so
+# completions can keep up with the rate.
+MAX_CONCURRENT_PRESCRIPTIONS: int = 5
+
 
 def _count_oracle_passes(audit_entries: list[dict]) -> int:
     """Count oracle_approved events in the audit log for a UoW.
@@ -4823,11 +4852,13 @@ def _process_uow(
     llm_prescriber: Callable[..., LLMPrescription | None] | None = _llm_prescribe,
     inline_executor: Callable[[str], Any] | None = None,
     escalation_notifier: Callable[[UoW], None] | None = None,
+    prescription_slots_available: int = MAX_CONCURRENT_PRESCRIPTIONS,
 ) -> StewardOutcome:
     """
     Process a single UoW through the full diagnosis + prescribe/close/surface cycle.
 
-    Returns a StewardOutcome: Prescribed | Done | Surfaced | RaceSkipped | WaitForTrace.
+    Returns a StewardOutcome: Prescribed | Done | Surfaced | RaceSkipped | WaitForTrace
+    | PrescribingQueued | PrescriptionDeferred.
 
     Args:
         issue_info: Typed IssueInfo from GitHub API (or None if no issue).
@@ -4843,6 +4874,13 @@ def _process_uow(
             Defaults to _send_escalation_notification (immediate individual notification).
             run_steward_cycle injects a collector that accumulates escalations for
             end-of-cycle consolidation. Tests may inject a no-op or a recorder.
+        prescription_slots_available: Number of prescription dispatch slots remaining
+            this cycle (MAX_CONCURRENT_PRESCRIPTIONS - already_in_flight -
+            dispatched_this_cycle).  When 0, the async prescription path is skipped and
+            PrescriptionDeferred is returned; the UoW is transitioned back to
+            ready-for-steward for the next heartbeat.  Defaults to
+            MAX_CONCURRENT_PRESCRIPTIONS (uncapped — backward-compat for tests that
+            do not pass this argument).
     """
     uow_id = uow.id
     cycles = uow.steward_cycles
@@ -5674,6 +5712,22 @@ def _process_uow(
     # deterministic prescription path below (backward compat for tests).
     # ---------------------------------------------------------------------------
     if llm_prescriber is _llm_prescribe and not dry_run:
+        # Prescription concurrency gate: defer if no slots are available.
+        # prescription_slots_available is passed by run_steward_cycle and reflects
+        # MAX_CONCURRENT_PRESCRIPTIONS - already_in_flight - dispatched_this_cycle.
+        # When 0, we undo the diagnosing transition and return PrescriptionDeferred
+        # so the UoW is retried on the next heartbeat (once in-flight slots free up).
+        if prescription_slots_available <= 0:
+            log.info(
+                "_process_uow: prescription cap reached — deferring %s "
+                "(MAX_CONCURRENT_PRESCRIPTIONS=%d)",
+                uow_id, MAX_CONCURRENT_PRESCRIPTIONS,
+            )
+            if not dry_run:
+                # Transition back: diagnosing → ready-for-steward
+                registry.transition(uow_id, _STATUS_READY_FOR_STEWARD, _STATUS_DIAGNOSING)
+            return PrescriptionDeferred(uow_id=uow_id)
+
         # Build diagnosis_section for the prescription subagent (mirrors generate_v2_prescription).
         _executor_outcome_value = diagnosis.executor_outcome
         _async_diagnosis_section: dict[str, Any] = {
@@ -6055,6 +6109,30 @@ def _process_uow(
 
 
 # ---------------------------------------------------------------------------
+# Prescription in-flight count
+# ---------------------------------------------------------------------------
+
+def _count_prescribing_in_flight(registry) -> int:
+    """Return the number of UoWs currently in ``prescribing`` state.
+
+    Pure read — no side effects.  Used by ``run_steward_cycle`` to enforce
+    ``MAX_CONCURRENT_PRESCRIPTIONS`` before dispatching new wos_prescribe
+    inbox messages.
+
+    ``prescribing`` UoWs represent active (or recently timed-out) prescription
+    subagent invocations.  Counting them before each new dispatch prevents
+    flooding the API with more concurrent ``claude -p`` calls than can complete
+    within the 600 s LLM timeout.
+    """
+    try:
+        in_flight = registry.list(status=str(_STATUS_PRESCRIBING))
+        return len(in_flight)
+    except Exception:
+        # If the query fails, return 0 — better to allow dispatch than deadlock.
+        return 0
+
+
+# ---------------------------------------------------------------------------
 # Main steward cycle (entry point for tests and heartbeat script)
 # ---------------------------------------------------------------------------
 
@@ -6157,6 +6235,20 @@ def run_steward_cycle(
             "Steward cycle: dynamic burst batch size=%d (queue_depth=%d, default=%d)",
             _effective_burst_batch_size, _queue_depth, BURST_BATCH_SIZE,
         )
+
+    # Prescription concurrency gate: count UoWs already in 'prescribing' state.
+    # This snapshot is taken once before the loop.  The per-UoW prescription
+    # path increments _prescribing_dispatched_this_cycle for every new
+    # wos_prescribe message written this cycle so that later UoWs in the same
+    # cycle see the updated count.  Together they enforce MAX_CONCURRENT_PRESCRIPTIONS.
+    _prescribing_in_flight = _count_prescribing_in_flight(registry)
+    if _prescribing_in_flight > 0:
+        log.info(
+            "Steward cycle: prescription gate: %d UoWs already in prescribing state "
+            "(cap=%d)",
+            _prescribing_in_flight, MAX_CONCURRENT_PRESCRIPTIONS,
+        )
+    _prescribing_dispatched_this_cycle = 0
 
     evaluated = 0
     prescribed = 0
@@ -6457,6 +6549,10 @@ def run_steward_cycle(
             )
 
         evaluated += 1
+        _prescription_slots = max(
+            0,
+            MAX_CONCURRENT_PRESCRIPTIONS - _prescribing_in_flight - _prescribing_dispatched_this_cycle,
+        )
         try:
             result = _process_uow(
                 uow=uow,
@@ -6470,6 +6566,7 @@ def run_steward_cycle(
                 llm_prescriber=llm_prescriber,
                 inline_executor=inline_executor,
                 escalation_notifier=None if dry_run else _collect_escalation,
+                prescription_slots_available=_prescription_slots,
             )
         except Exception:
             log.exception("Steward: unhandled error processing UoW %s — skipping", uow_id)
@@ -6501,6 +6598,14 @@ def run_steward_cycle(
                 # The prescription subagent will complete the WorkflowArtifact
                 # and transition to ready-for-executor.
                 prescribing_queued += 1
+                # Increment cycle-local counter so subsequent UoWs see the
+                # updated in-flight total when their prescription_slots_available
+                # is computed.
+                _prescribing_dispatched_this_cycle += 1
+            case PrescriptionDeferred():
+                # Prescription cap hit — UoW transitioned back to ready-for-steward.
+                # Will be retried on the next heartbeat cycle.
+                skipped += 1
             case _:
                 skipped += 1
 

--- a/tests/unit/test_orchestration/test_steward_prescription_cap.py
+++ b/tests/unit/test_orchestration/test_steward_prescription_cap.py
@@ -1,0 +1,326 @@
+"""
+Tests for the prescription concurrency cap introduced in Issue #1390.
+
+Root cause: _dynamic_burst_batch_size returns 15 when queue_depth > 50, which
+allows 15 concurrent wos_prescribe inbox messages per heartbeat cycle. Under high
+queue depth, all 15 hit the 600s LLM timeout, startup_sweep resets them to
+ready-for-steward, and the cycle repeats — 299 attempts, 0 completions.
+
+Fix: MAX_CONCURRENT_PRESCRIPTIONS caps how many UoWs may be in the 'prescribing'
+state simultaneously. _process_uow checks prescription_slots_available and returns
+PrescriptionDeferred (with the UoW transitioned back to ready-for-steward) when no
+slots remain.
+
+Tests are named after the behavior they verify, not the mechanism.
+All threshold values are referenced from named constants, not magic literals.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.orchestration.steward import (
+    MAX_CONCURRENT_PRESCRIPTIONS,
+    PrescriptionDeferred,
+    PrescribingQueued,
+    Diagnosis,
+    IssueInfo,
+    _count_prescribing_in_flight,
+    _process_uow,
+    _llm_prescribe,
+    _dynamic_burst_batch_size,
+    BURST_BATCH_SIZE,
+)
+from src.orchestration.registry import UoW
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_uow(**kwargs) -> UoW:
+    """Build a minimal UoW with sensible defaults for prescription cap tests."""
+    defaults = dict(
+        id="uow_20260522_testcap",
+        status="ready-for-steward",
+        summary="Test UoW for prescription cap",
+        source="telegram",
+        source_issue_number=42,
+        created_at="2026-05-22T00:00:00+00:00",
+        updated_at="2026-05-22T00:00:00+00:00",
+        steward_cycles=0,
+        lifetime_cycles=0,
+        register="operational",
+    )
+    defaults.update(kwargs)
+    return UoW(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: MAX_CONCURRENT_PRESCRIPTIONS constant
+# ---------------------------------------------------------------------------
+
+class TestMaxConcurrentPrescriptionsConstant:
+    """The cap constant must be set to a value that prevents API flooding."""
+
+    def test_cap_is_below_burst_batch_ceiling(self):
+        """MAX_CONCURRENT_PRESCRIPTIONS must be below the burst batch ceiling (15).
+
+        At queue_depth > 50, _dynamic_burst_batch_size returns 15. The cap
+        must be strictly less than that ceiling or the flood is not prevented.
+        """
+        burst_ceiling = _dynamic_burst_batch_size(51)
+        assert MAX_CONCURRENT_PRESCRIPTIONS < burst_ceiling, (
+            f"Cap ({MAX_CONCURRENT_PRESCRIPTIONS}) must be below burst ceiling "
+            f"({burst_ceiling}) to prevent flooding under high queue depth"
+        )
+
+    def test_cap_is_positive(self):
+        """Cap must allow at least one concurrent prescription."""
+        assert MAX_CONCURRENT_PRESCRIPTIONS >= 1
+
+    def test_cap_constant_value(self):
+        """Named constant MAX_CONCURRENT_PRESCRIPTIONS is 5."""
+        assert MAX_CONCURRENT_PRESCRIPTIONS == 5
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _count_prescribing_in_flight
+# ---------------------------------------------------------------------------
+
+class TestCountPrescribingInFlight:
+    """_count_prescribing_in_flight queries the prescribing state count safely."""
+
+    def test_returns_count_of_prescribing_uows(self):
+        """Returns the number of UoWs the registry reports in prescribing state."""
+        registry = MagicMock()
+        registry.list.return_value = [MagicMock(), MagicMock(), MagicMock()]
+        assert _count_prescribing_in_flight(registry) == 3
+
+    def test_returns_zero_when_none_prescribing(self):
+        """Returns 0 when no UoWs are in prescribing state."""
+        registry = MagicMock()
+        registry.list.return_value = []
+        assert _count_prescribing_in_flight(registry) == 0
+
+    def test_returns_zero_on_registry_error(self):
+        """Registry errors are swallowed — returns 0 rather than raising.
+
+        A failed prescribing-count query should not block dispatch entirely;
+        better to allow dispatch than to deadlock the heartbeat.
+        """
+        registry = MagicMock()
+        registry.list.side_effect = RuntimeError("DB unavailable")
+        assert _count_prescribing_in_flight(registry) == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _process_uow defers when prescription_slots_available = 0
+# ---------------------------------------------------------------------------
+
+def _make_first_execution_diagnosis() -> Diagnosis:
+    """Return a Diagnosis representing a brand-new UoW (never executed)."""
+    return Diagnosis(
+        reentry_posture="first_execution",
+        return_reason=None,
+        return_reason_classification="no_prior_execution",
+        output_content="",
+        output_valid=False,
+        is_complete=False,
+        completion_rationale="No prior execution.",
+        stuck_condition=None,
+        executor_outcome=None,
+        success_criteria_missing=False,
+    )
+
+
+def _make_minimal_issue_info() -> IssueInfo:
+    """Return a minimal IssueInfo for tests."""
+    return IssueInfo(
+        status_code=200,
+        state="open",
+        labels=[],
+        body="Test issue body",
+        title="Test issue",
+    )
+
+
+class TestProcessUowPrescriptionCapEnforcement:
+    """_process_uow returns PrescriptionDeferred when no slots are available."""
+
+    def _make_registry_mock(self):
+        """Return a registry mock that handles the diagnosing optimistic lock."""
+        registry = MagicMock()
+        registry.transition.return_value = 1  # Successful optimistic lock
+        registry.append_audit_log.return_value = None
+        registry.update.return_value = None
+        return registry
+
+    def test_prescription_deferred_when_no_slots(self):
+        """When prescription_slots_available=0, _process_uow returns PrescriptionDeferred.
+
+        The UoW must not be transitioned to prescribing state when the cap is reached.
+        """
+        from src.orchestration import steward as _steward_mod
+
+        uow = _make_uow(steward_cycles=0)
+        registry = self._make_registry_mock()
+        issue_info = _make_minimal_issue_info()
+
+        # Patch _write_prescription_request to verify it is NOT called.
+        # Patch _diagnose_uow to return a first-execution diagnosis (needs prescription).
+        with patch.object(
+            _steward_mod, "_write_prescription_request",
+            return_value="mock-msg-id",
+        ) as mock_write, patch.object(
+            _steward_mod, "_diagnose_uow",
+            return_value=_make_first_execution_diagnosis(),
+        ):
+            result = _process_uow(
+                uow=uow,
+                registry=registry,
+                audit_entries=[],
+                issue_info=issue_info,
+                dry_run=False,
+                artifact_dir=None,
+                notify_dan=None,
+                llm_prescriber=_llm_prescribe,  # production sentinel triggers async path
+                prescription_slots_available=0,  # cap reached
+            )
+
+        # wos_prescribe message must NOT have been written
+        mock_write.assert_not_called()
+        assert isinstance(result, PrescriptionDeferred), (
+            f"Expected PrescriptionDeferred, got {type(result).__name__}"
+        )
+        assert result.uow_id == uow.id
+
+    def test_prescription_proceeds_when_slot_available(self):
+        """When prescription_slots_available > 0, the wos_prescribe message is written.
+
+        This verifies the cap only blocks when slots=0, not at positive values.
+        """
+        from src.orchestration import steward as _steward_mod
+
+        uow = _make_uow(steward_cycles=0)
+        registry = self._make_registry_mock()
+        issue_info = _make_minimal_issue_info()
+
+        with patch.object(
+            _steward_mod, "_write_prescription_request",
+            return_value="mock-msg-id",
+        ) as mock_write, patch.object(
+            _steward_mod, "_diagnose_uow",
+            return_value=_make_first_execution_diagnosis(),
+        ), patch.object(
+            _steward_mod, "_write_steward_fields",
+        ), patch.object(
+            _steward_mod, "_append_steward_log_entry",
+            return_value="{}",
+        ), patch.object(
+            _steward_mod, "_mark_current_agenda_node_prescribed",
+            return_value=[],
+        ):
+            registry.transition.side_effect = [1, 1]  # claim + prescribing transition
+
+            result = _process_uow(
+                uow=uow,
+                registry=registry,
+                audit_entries=[],
+                issue_info=issue_info,
+                dry_run=False,
+                artifact_dir=None,
+                notify_dan=None,
+                llm_prescriber=_llm_prescribe,
+                prescription_slots_available=1,  # one slot available
+            )
+
+        # wos_prescribe message should have been written (prescription proceeded)
+        mock_write.assert_called_once()
+        assert isinstance(result, PrescribingQueued), (
+            f"Expected PrescribingQueued, got {type(result).__name__}"
+        )
+
+    def test_undo_diagnosing_transition_on_deferred(self):
+        """When prescription is deferred, the UoW is transitioned back to ready-for-steward.
+
+        Without the undo transition, the UoW stays in 'diagnosing' and requires
+        startup_sweep to rescue it — adding an unnecessary heartbeat delay.
+        """
+        from src.orchestration import steward as _steward_mod
+        from src.orchestration.registry import UoWStatus
+
+        uow = _make_uow(steward_cycles=0)
+        registry = self._make_registry_mock()
+        issue_info = _make_minimal_issue_info()
+
+        with patch.object(
+            _steward_mod, "_diagnose_uow",
+            return_value=_make_first_execution_diagnosis(),
+        ):
+            _process_uow(
+                uow=uow,
+                registry=registry,
+                audit_entries=[],
+                issue_info=issue_info,
+                dry_run=False,
+                artifact_dir=None,
+                notify_dan=None,
+                llm_prescriber=_llm_prescribe,
+                prescription_slots_available=0,
+            )
+
+        # First transition: claim (ready-for-steward → diagnosing)
+        # Last transition: undo (diagnosing → ready-for-steward)
+        transition_calls = registry.transition.call_args_list
+        assert len(transition_calls) >= 2, (
+            "Expected at least 2 transition calls (claim + undo)"
+        )
+        undo_call = transition_calls[-1]
+        args = undo_call[0]
+        # registry.transition(uow_id, to_status, from_status)
+        assert args[1] == UoWStatus.READY_FOR_STEWARD, (
+            f"Undo transition should target ready-for-steward, got {args[1]}"
+        )
+        assert args[2] == UoWStatus.DIAGNOSING, (
+            f"Undo transition should come from diagnosing, got {args[2]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: run_steward_cycle prescription cap integration
+# ---------------------------------------------------------------------------
+
+class TestStewardCyclePrescriptionCapIntegration:
+    """run_steward_cycle enforces MAX_CONCURRENT_PRESCRIPTIONS across the full cycle."""
+
+    def test_cap_constant_is_below_burst_ceiling_for_queue_over_50(self):
+        """Regression: at queue_depth=60, burst_batch_size=15 but cap is 5.
+
+        This is the exact scenario that caused the flood (299 attempts, 0 completions).
+        The cap must prevent 15 concurrent prescriptions from being dispatched.
+        """
+        flood_queue_depth = 60
+        burst_size_at_flood = _dynamic_burst_batch_size(flood_queue_depth)
+        assert burst_size_at_flood == 15, (
+            f"Expected burst size 15 at queue_depth=60, got {burst_size_at_flood}"
+        )
+        assert MAX_CONCURRENT_PRESCRIPTIONS < burst_size_at_flood, (
+            f"Cap ({MAX_CONCURRENT_PRESCRIPTIONS}) must be < burst ceiling "
+            f"({burst_size_at_flood}) at the flood queue depth ({flood_queue_depth})"
+        )


### PR DESCRIPTION
## Summary

Prescription subagents were flooding the API at 15 concurrent `claude -p` calls per heartbeat cycle under high queue depth, with zero completions.

**Root cause:** `_dynamic_burst_batch_size` returns 15 when `queue_depth > 50`. With 60+ UoWs in `ready-for-steward`, each heartbeat dispatches 15 `wos_prescribe` inbox messages — 15 concurrent prescription subagents. All 15 hit the 600s LLM timeout. `startup_sweep` resets them to `ready-for-steward` at 660s. The next heartbeat sees queue_depth=60 again and dispatches another 15. Observed: 299 attempts, 0 completions.

The existing `_effective_burst_batch_size` throttle gates *new UoWs per cycle* from `ready-for-steward`, but had no visibility into how many were *already* in `prescribing` state from prior cycles.

## What changed

- Added `MAX_CONCURRENT_PRESCRIPTIONS = 5` constant (well below the burst ceiling of 15 at queue_depth > 50)
- Added `_count_prescribing_in_flight(registry)` pure function — reads the count of UoWs in `prescribing` state once before the loop
- Added `PrescriptionDeferred` result type — returned when slots are exhausted; UoW transitions back to `ready-for-steward` for retry next cycle
- Added `prescription_slots_available` parameter to `_process_uow` — defaults to `MAX_CONCURRENT_PRESCRIPTIONS` (backward-compat for existing tests)
- In `run_steward_cycle`, tracks `_prescribing_dispatched_this_cycle` so later UoWs in the same cycle see the updated budget

**What is out of scope:** execution dispatch logic is entirely unchanged. The cap applies only to the async prescription path (`llm_prescriber is _llm_prescribe and not dry_run`). Synchronous/test paths are unaffected.

## Before/after flow

**Before (flood):**
```
ready-for-steward (60 UoWs)
  → steward heartbeat: queue_depth=60, burst_batch=15
  → 15 wos_prescribe messages dispatched
  → 15 prescription subagents start → all hit 600s LLM timeout
  → startup_sweep resets 15 "prescribing" UoWs → ready-for-steward
  → repeat (299 attempts, 0 completions)
```

**After (capped):**
```
ready-for-steward (60 UoWs)
  → steward heartbeat: queue_depth=60, burst_batch=15
  → _prescribing_in_flight query: N already in prescribing
  → at most (5 - N) new prescriptions dispatched this cycle
  → remaining UoWs: PrescriptionDeferred → back to ready-for-steward
  → next heartbeat: N shrinks as completions arrive, more slots open
```

## Functional patterns used

- `_count_prescribing_in_flight`: pure function, no side effects
- `MAX_CONCURRENT_PRESCRIPTIONS`: named constant — no magic literals
- `PrescriptionDeferred`: explicit result type in the match statement, no silent drops
- Immutable slot budget (`_prescription_slots`) computed per-UoW from two immutable inputs

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_steward_prescription_cap.py -v` — 10 passed, 0 failed (new tests, all green)
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_dispatch_eligibility.py -v` — 50 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_prescription_v2.py tests/unit/test_orchestration/test_steward_prescription_confidence.py -v` — 26 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_return_reason_exhaustiveness.py tests/unit/test_orchestration/test_steward_wos_escalate_write_path.py -v` — 30 passed, 0 failed
- [ ] `tests/unit/test_orchestration/test_steward_execution_gate.py` — 4 pre-existing failures (unrelated, fail on main too, `_is_job_enabled` attribute missing from heartbeat module)

## Manual test

N/A — this change is entirely internal to the steward cycle logic. No external service calls, no Telegram output, no file I/O outside the registry DB (which is only written in production).

The fix affects prescription rate under high queue depth. Manual verification requires a live run with 60+ UoWs in `ready-for-steward`, which would require production WOS execution enabled. Not running in this PR — the behavioral change is: at most 5 prescriptions in-flight at any time, measurable from `registry.db` (count of `status='prescribing'` rows).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal logic only, no external service calls)
- [x] User-visible outcome — N/A (this is WOS internal machinery, not user-facing output)
- [x] Side-effect audit: no floods (this IS the anti-flood fix), no unscoped writes, no unintended volume
- [x] External service calls: none in this change

Closes #1390