### PR TITLE
feat(scheduled-jobs): add reusable staleness gate to file-scanning scorers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,31 @@ Never use cron for user-space jobs. Never use systemd tools for system-level inf
 
   **Decision rule:** If the job would run identically regardless of which LLM model responds, and it runs more frequently than every 15 minutes, prefer Type B.
 
+### Staleness gate for file-scanning scorers
+
+Type A jobs that scan a file on a schedule (e.g. philosophy-discovery-scorer) must
+call the staleness gate at the top of their run, before any LLM/inference call. If
+the target file has not changed since the last scan, the job should exit immediately
+with `write_task_output(..., status="success")` — no LLM call.
+
+```python
+# Reference pattern — add to the task prompt as Step 0, before any scoring:
+from src.utils.staleness_gate import file_changed, record_scan
+
+if not file_changed(target_file, job_name="my-scorer"):
+    write_task_output(job_name="my-scorer", output="<file> unchanged — skipped (heat).", status="success")
+    return  # exit without any LLM call
+
+# ... run scoring ...
+
+record_scan(target_file, job_name="my-scorer")  # update baseline after successful scan
+```
+
+The gate uses SHA-256 content hashes (not mtime) and persists records in
+`~/lobster-workspace/data/staleness-records.json`. See `src/utils/staleness_gate.py`
+for the full API. The record store is created on first use and tolerates a missing or
+corrupt file (treats as "no record" → proceed with scoring).
+
 - **Long-running services** (dispatcher, MCP servers, Telegram bot, health daemons): These are processes, not jobs. Systemd is the right tool here when/if Lobster moves to fully-automated operation. Not part of the job type taxonomy.
 
 ## Key Directories

--- a/scheduled-jobs/tasks/philosophy-discovery-scorer.md
+++ b/scheduled-jobs/tasks/philosophy-discovery-scorer.md
@@ -1,0 +1,197 @@
+# Philosophy Discovery Scorer
+
+**Job**: philosophy-discovery-scorer
+**Schedule**: Daily at 23:30 local time (`30 23 * * *`)
+
+## Context
+
+You are a Lobster generalist subagent running the philosophy discovery scorer job.
+Your role is to score the most recent philosophy-explore session as genuine discovery
+vs. reconstruction, then log the result to the discovery JSONL file.
+
+Read the scoring heuristic at:
+`~/lobster-workspace/assessments/discovery-scoring.md`
+
+## Instructions
+
+### Step 0: Staleness gate — skip if file unchanged
+
+Before doing any scoring work, check whether the most recent philosophy-explore
+session file has changed since the last time this job ran. If it has not changed,
+exit immediately without making any LLM calls.
+
+**Find the most recent session file** (same logic as Step 1):
+
+```bash
+ls -t ~/lobster-workspace/philosophy-explore/*-philosophy-explore.md 2>/dev/null | head -1
+```
+
+Save the result as `LATEST_FILE`.
+
+**Run the staleness check** using the reusable helper:
+
+```bash
+uv run -c "
+import sys
+sys.path.insert(0, '/home/lobster/lobster')
+from src.utils.staleness_gate import file_changed
+target = '$LATEST_FILE'
+changed = file_changed(target, job_name='philosophy-discovery-scorer')
+print('changed' if changed else 'unchanged')
+"
+```
+
+- If the output is `unchanged`: call `write_task_output` with the message below and stop — do not proceed to Step 1.
+
+  ```
+  write_task_output(
+      job_name="philosophy-discovery-scorer",
+      output="Session file unchanged since last scan — skipped scoring (heat).",
+      status="success"
+  )
+  ```
+
+- If the output is `changed` (or if `LATEST_FILE` is empty): proceed to Step 1.
+
+> **Pattern note:** This staleness gate is the canonical pattern for all
+> schedule-driven file-scanning scorers. Any job that scans a file on a schedule
+> should call `file_changed` at the top of its run, before any inference. See
+> `src/utils/staleness_gate.py` for the helper's API and design rationale.
+
+---
+
+### Step 1: Find the most recent philosophy-explore session file
+
+List files in `~/lobster-workspace/philosophy-explore/` sorted by modification time.
+Identify the most recently written `*-philosophy-explore.md` file.
+
+If no file exists, or if the most recent file was written more than 48 hours ago, write:
+
+```
+write_task_output(job_name="philosophy-discovery-scorer", output="No recent philosophy-explore session found (threshold: 48h). Nothing scored.", status="success")
+```
+
+Then stop.
+
+### Step 2: Read the session file and apply the 5-signal heuristic
+
+Read the full text of the session .md file. For each of the five signals defined in
+`~/lobster-workspace/assessments/discovery-scoring.md`, determine if the signal is present (1)
+or absent (0):
+
+1. **Surprise Marker** — Did the session end with a conclusion the user explicitly marked
+   as surprising or unexpected? Look for: "I hadn't thought of that", "that's surprising",
+   "I didn't expect this", "huh", or similar meta-comments.
+
+2. **Positional Reversal** — Did the session produce a reversal — a position held at the
+   start that was abandoned or significantly modified by the end?
+
+3. **Open Starting Thread** — Did the session begin with a genuine question (open) rather
+   than a thesis or framework to apply (closed)? Score 1 if open, 0 if closed.
+
+4. **Novel Frame or Term** — Did the session coin or arrive at a new term, analogy, or
+   conceptual frame not present in the starting materials?
+
+5. **Explicit Perspective Shift** — Did Dan (or the session transcript) signal "I hadn't
+   thought of it that way" or equivalent — surprise about a framing, not just a conclusion?
+
+If Dan's session file includes a frontmatter block `discovery_signals: [1, 0, 1, 0, 1]`,
+use those values directly instead of inferring.
+
+Compute: `discovery_score = (sum of present signals) / 5.0`
+
+### Step 3: Collect condition metadata
+
+From the session file and context:
+
+- `session_start_time`: Extract from the file's date/time header (ISO8601, local timezone).
+  The filename format `YYYY-MM-DD-HH00-philosophy-explore.md` encodes this.
+- `time_of_day_bucket`: Derive from hour:
+  - 06:00–11:59 → `morning`
+  - 12:00–17:59 → `afternoon`
+  - 18:00–21:59 → `evening`
+  - 22:00–05:59 → `night`
+- `initiation_source`: If the session was written by the scheduled `philosophy-explore-1`
+  job (check if filename hour aligns with its schedule, every 4 hours), classify as
+  `scheduled`. Otherwise classify as `user-initiated`.
+- `starting_thread_type`: Read the opening of the "Today's Thread" section. Classify as:
+  `question` (starts with a question), `thesis` (starts with a claim), `observation`
+  (starts with noting something), or `continuation` (explicitly continues a prior thread).
+- `session_length_turns`: Estimate from the number of `##` section headers and paragraphs.
+  For a scheduled solo-subagent session, this is typically 1 (single agent pass). Use 1
+  unless the transcript shows explicit multi-turn structure.
+- `days_since_last_dan_interaction`: Use get_conversation_history to find the most recent
+  message from a human (non-system) sender. Compute days between that message and today.
+  If unavailable, use null.
+
+### Step 4: Write the JSONL log entry
+
+Append a single JSON line to `~/lobster-workspace/data/philosophy-discovery-log.jsonl`:
+
+```python
+import json, datetime
+
+entry = {
+    "session_start_time": "<ISO8601>",
+    "time_of_day_bucket": "<morning|afternoon|evening|night>",
+    "initiation_source": "<user-initiated|scheduled|lobster-suggested>",
+    "starting_thread_type": "<question|thesis|observation|continuation>",
+    "session_length_turns": <integer>,
+    "days_since_last_dan_interaction": <integer or null>,
+    "discovery_score": <float 0.0-1.0>,
+    "signals": {
+        "surprise_marker": <true|false>,
+        "positional_reversal": <true|false>,
+        "open_starting_thread": <true|false>,
+        "novel_frame_or_term": <true|false>,
+        "explicit_perspective_shift": <true|false>
+    },
+    "session_file": "<absolute path to source .md file>",
+    "scored_at": "<ISO8601 now>"
+}
+```
+
+Use `uv run` to execute a Python snippet that appends this entry. Example:
+
+```bash
+uv run -c "
+import json
+entry = { ... }
+with open('/home/lobster/lobster-workspace/data/philosophy-discovery-log.jsonl', 'a') as f:
+    f.write(json.dumps(entry) + '\n')
+print('Logged:', json.dumps(entry, indent=2))
+"
+```
+
+### Step 5: Record the scan and write task output
+
+**Record the scan** so the next run sees the updated baseline:
+
+```bash
+uv run -c "
+import sys
+sys.path.insert(0, '/home/lobster/lobster')
+from src.utils.staleness_gate import record_scan
+record_scan('$LATEST_FILE', job_name='philosophy-discovery-scorer')
+print('Staleness record updated.')
+"
+```
+
+Then call:
+
+```
+write_task_output(
+    job_name="philosophy-discovery-scorer",
+    output="Scored session: <session_file_basename>. discovery_score=<score> (signals: <list of present signal names>). Entry appended to philosophy-discovery-log.jsonl.",
+    status="success"
+)
+```
+
+If any step fails, write status="failed" with a description of what went wrong.
+
+## Output
+
+When you complete your task, call `write_task_output` with:
+- job_name: "philosophy-discovery-scorer"
+- output: Your results/summary
+- status: "success" or "failed"

--- a/src/utils/staleness_gate.py
+++ b/src/utils/staleness_gate.py
@@ -1,0 +1,173 @@
+"""
+src/utils/staleness_gate.py — Reusable staleness gate for file-scanning scorers.
+
+Schedule-driven file-scanning jobs (e.g. philosophy-discovery-scorer) should
+call ``file_changed(file_path, job_name)`` at the top of their run, before
+any LLM/inference call. If the file has not changed since the last scan,
+the job should short-circuit immediately:
+
+    from src.utils.staleness_gate import file_changed, record_scan
+
+    if not file_changed(file_path, job_name="my-scorer"):
+        write_result(... outcome_category="heat", text="<file> unchanged — skipped")
+        return
+
+    # ... run scoring ...
+
+    record_scan(file_path, job_name="my-scorer")
+
+Design decisions:
+- Content hash (SHA-256 of file bytes) is used rather than mtime. mtime is
+  fragile: it changes whenever a file is touched or re-written with identical
+  content (e.g. git checkout, rsync, backup restore). Content hash detects
+  actual changes reliably regardless of how the file was written.
+- Records are persisted in ``~/lobster-workspace/data/staleness-records.json``
+  keyed by ``{job_name}::{file_path}``. This small JSON store is created on
+  first use and tolerates a missing or corrupt file (treats as "no record" →
+  proceed).
+- The store is written atomically (write-to-tmp, rename) via the existing
+  ``src/utils/fs.atomic_write_json`` helper.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def _default_record_path() -> Path:
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    return workspace / "data" / "staleness-records.json"
+
+
+def _record_key(file_path: str | Path, job_name: str) -> str:
+    """Composite key uniquely identifying a (job, file) pair in the store."""
+    return f"{job_name}::{Path(file_path).resolve()}"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _compute_hash(file_path: str | Path) -> Optional[str]:
+    """Return the SHA-256 hex digest of the file's bytes, or None on read error."""
+    try:
+        data = Path(file_path).read_bytes()
+        return hashlib.sha256(data).hexdigest()
+    except (OSError, PermissionError):
+        return None
+
+
+def _load_store(record_path: Path) -> dict:
+    """
+    Load the staleness record store from disk.
+
+    Returns an empty dict when the file is absent, unreadable, or malformed.
+    Callers treat an empty dict as "no prior records" — all files are considered
+    changed and proceed through scoring.
+    """
+    try:
+        return json.loads(record_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_store(store: dict, record_path: Path) -> None:
+    """Atomically write the staleness record store to disk."""
+    # Import here to avoid circular imports at module load time.
+    from src.utils.fs import atomic_write_json
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(record_path, store)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def file_changed(
+    file_path: str | Path,
+    job_name: str,
+    record_path: Optional[Path] = None,
+) -> bool:
+    """
+    Return True if the file has changed since the last recorded scan, False if unchanged.
+
+    Callers should proceed with scoring only when this returns True. When it
+    returns False, the job should short-circuit to a "heat" outcome:
+
+        if not file_changed(path, job_name="my-scorer"):
+            write_result(... outcome_category="heat", text="unchanged — skipped")
+            return
+
+    Behaviour at the edges:
+    - File absent or unreadable → returns True (treat as changed; let the scorer
+      handle the missing file error itself).
+    - Store absent or corrupt → returns True (safe default: no prior record means
+      proceed).
+    - No prior record for this (job, file) pair → returns True.
+
+    Args:
+        file_path:   Absolute or relative path to the file being scanned.
+        job_name:    The job's canonical name (matches jobs.json / write_result).
+        record_path: Override path for the staleness store (used in tests).
+    """
+    rp = record_path or _default_record_path()
+    store = _load_store(rp)
+    key = _record_key(file_path, job_name)
+    prior_hash = store.get(key)
+
+    if prior_hash is None:
+        # No prior record — treat as changed so the first scan always runs.
+        return True
+
+    current_hash = _compute_hash(file_path)
+    if current_hash is None:
+        # Unreadable file — treat as changed; let the scorer report the error.
+        return True
+
+    return current_hash != prior_hash
+
+
+def record_scan(
+    file_path: str | Path,
+    job_name: str,
+    record_path: Optional[Path] = None,
+) -> None:
+    """
+    Record the current content hash of the file as the baseline for future comparisons.
+
+    Call this after a successful scan/score run, not before. Writing the record
+    before the scan completes would cause the next run to skip a file that was
+    changed between scan start and record write.
+
+    If the file is unreadable or the store cannot be written, the error is
+    swallowed silently — a missing record is always safe (it causes the next run
+    to treat the file as changed and proceed, which is the correct conservative
+    fallback).
+
+    Args:
+        file_path:   Absolute or relative path to the file that was scanned.
+        job_name:    The job's canonical name.
+        record_path: Override path for the staleness store (used in tests).
+    """
+    rp = record_path or _default_record_path()
+    current_hash = _compute_hash(file_path)
+    if current_hash is None:
+        # If we can't hash it, don't record anything — next run will retry.
+        return
+
+    store = _load_store(rp)
+    key = _record_key(file_path, job_name)
+    store[key] = current_hash
+    try:
+        _save_store(store, rp)
+    except OSError:
+        # Non-fatal: failure to persist the record means the next run re-scores.
+        pass

--- a/tests/unit/test_staleness_gate.py
+++ b/tests/unit/test_staleness_gate.py
@@ -1,0 +1,163 @@
+"""
+Tests for src/utils/staleness_gate.py.
+
+Covers:
+- No prior record → file_changed returns True (first scan always runs)
+- Identical content on second call → file_changed returns False (skip)
+- Modified content → file_changed returns True (re-scan)
+- Missing/corrupt store file → file_changed returns True (safe default)
+- record_scan persists the hash so the next file_changed call sees it
+- Unreadable target file → file_changed returns True (conservative fallback)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the repo root is on sys.path for all test environments.
+_REPO_ROOT = Path(__file__).parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.staleness_gate import file_changed, record_scan
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+# ---------------------------------------------------------------------------
+# Tests — file_changed
+# ---------------------------------------------------------------------------
+
+class TestFileChanged:
+    def test_no_prior_record_returns_true(self, tmp_path: Path) -> None:
+        """First call with no store entry must return True so the first scan runs."""
+        target = tmp_path / "file.md"
+        _write(target, b"hello world")
+        store = tmp_path / "staleness-records.json"
+
+        assert file_changed(target, job_name="test-job", record_path=store) is True
+
+    def test_identical_content_returns_false(self, tmp_path: Path) -> None:
+        """After recording a scan, calling file_changed on unchanged content returns False."""
+        target = tmp_path / "file.md"
+        _write(target, b"content that doesn't change")
+        store = tmp_path / "staleness-records.json"
+
+        # Record the first scan
+        record_scan(target, job_name="test-job", record_path=store)
+
+        # Same bytes — should report unchanged
+        assert file_changed(target, job_name="test-job", record_path=store) is False
+
+    def test_modified_content_returns_true(self, tmp_path: Path) -> None:
+        """After recording a scan, modifying the file makes file_changed return True."""
+        target = tmp_path / "file.md"
+        _write(target, b"original content")
+        store = tmp_path / "staleness-records.json"
+
+        record_scan(target, job_name="test-job", record_path=store)
+
+        # Modify the file
+        _write(target, b"changed content")
+
+        assert file_changed(target, job_name="test-job", record_path=store) is True
+
+    def test_missing_store_returns_true(self, tmp_path: Path) -> None:
+        """When the store file does not exist, treat as 'no record' → changed."""
+        target = tmp_path / "file.md"
+        _write(target, b"some content")
+        store = tmp_path / "nonexistent" / "store.json"  # parent dir doesn't exist
+
+        assert file_changed(target, job_name="test-job", record_path=store) is True
+
+    def test_corrupt_store_returns_true(self, tmp_path: Path) -> None:
+        """A store file containing invalid JSON is treated as empty → changed."""
+        target = tmp_path / "file.md"
+        _write(target, b"some content")
+        store = tmp_path / "staleness-records.json"
+        store.write_text("NOT VALID JSON }{][")
+
+        assert file_changed(target, job_name="test-job", record_path=store) is True
+
+    def test_missing_target_file_returns_true(self, tmp_path: Path) -> None:
+        """When the target file does not exist, return True (let the scorer handle it)."""
+        target = tmp_path / "does-not-exist.md"
+        store = tmp_path / "staleness-records.json"
+
+        assert file_changed(target, job_name="test-job", record_path=store) is True
+
+    def test_different_jobs_are_independent(self, tmp_path: Path) -> None:
+        """Records for one job do not affect another job scanning the same file."""
+        target = tmp_path / "file.md"
+        _write(target, b"shared content")
+        store = tmp_path / "staleness-records.json"
+
+        record_scan(target, job_name="job-a", record_path=store)
+
+        # job-b has no record yet — must see the file as changed
+        assert file_changed(target, job_name="job-b", record_path=store) is True
+        # job-a has a record — must see the file as unchanged
+        assert file_changed(target, job_name="job-a", record_path=store) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests — record_scan
+# ---------------------------------------------------------------------------
+
+class TestRecordScan:
+    def test_record_scan_creates_store(self, tmp_path: Path) -> None:
+        """record_scan creates the store file when it does not exist."""
+        target = tmp_path / "file.md"
+        _write(target, b"data")
+        store = tmp_path / "staleness-records.json"
+
+        assert not store.exists()
+        record_scan(target, job_name="test-job", record_path=store)
+        assert store.exists()
+
+    def test_record_scan_persists_correct_hash(self, tmp_path: Path) -> None:
+        """The stored hash matches SHA-256 of the file bytes."""
+        target = tmp_path / "file.md"
+        content = b"precise content"
+        _write(target, content)
+        store = tmp_path / "staleness-records.json"
+
+        record_scan(target, job_name="test-job", record_path=store)
+
+        data = json.loads(store.read_text())
+        key = f"test-job::{target.resolve()}"
+        expected = hashlib.sha256(content).hexdigest()
+        assert data[key] == expected
+
+    def test_record_scan_updates_existing_record(self, tmp_path: Path) -> None:
+        """record_scan overwrites an existing hash with the new one."""
+        target = tmp_path / "file.md"
+        _write(target, b"v1")
+        store = tmp_path / "staleness-records.json"
+
+        record_scan(target, job_name="test-job", record_path=store)
+        _write(target, b"v2")
+        record_scan(target, job_name="test-job", record_path=store)
+
+        data = json.loads(store.read_text())
+        key = f"test-job::{target.resolve()}"
+        expected = hashlib.sha256(b"v2").hexdigest()
+        assert data[key] == expected
+
+    def test_record_scan_on_missing_file_is_silent(self, tmp_path: Path) -> None:
+        """record_scan on a non-existent file does not raise — swallows silently."""
+        store = tmp_path / "staleness-records.json"
+        # Should not raise
+        record_scan(tmp_path / "missing.md", job_name="test-job", record_path=store)


### PR DESCRIPTION
## Summary

- Adds `src/utils/staleness_gate.py`: a reusable SHA-256 content-hash gate for schedule-driven file-scanning jobs. Exposes `file_changed(file_path, job_name)` and `record_scan(file_path, job_name)`. Records persist in `~/lobster-workspace/data/staleness-records.json`.
- Wires `philosophy-discovery-scorer` (the initial adopter) to call the gate at Step 0, before any LLM scoring. If the target file is unchanged, the job exits immediately with `write_task_output(status="success")` — no LLM call.
- Documents the pattern in CLAUDE.md under the job type guidance so future scorers adopt it.

## Design decisions

**Hash vs. mtime:** SHA-256 content hash is used rather than mtime. mtime is fragile across re-writes with identical content (git checkout, rsync, backup restore). Content hash detects actual changes reliably regardless of write mechanism.

**Store location:** `~/lobster-workspace/data/staleness-records.json`, keyed by `{job_name}::{resolved_file_path}`. Created on first use; tolerates missing/corrupt file (treats as "no record" → proceed).

**Conservative fallback:** Every error condition (no record, unreadable file, corrupt store) returns `True` (changed → proceed). The gate only blocks work when it has positive evidence the file is unchanged.

## Jobs wired

Only `philosophy-discovery-scorer` is wired in this UoW, per the boundary constraint. The helper is reusable — other file-scanners adopt the same three-line pattern documented in CLAUDE.md.

## Test coverage

11 unit tests in `tests/unit/test_staleness_gate.py`:
- No prior record → changed
- Identical content → unchanged
- Modified content → changed
- Missing store → changed (safe default)
- Corrupt store → changed (safe default)
- Unreadable target file → changed (conservative fallback)
- Different jobs scanning the same file are independent
- `record_scan` creates store, persists correct SHA-256, updates on re-scan, silent on missing file

All 11 pass: `uv run -m pytest tests/unit/test_staleness_gate.py -v`

## Test plan
- [ ] Run `uv run -m pytest tests/unit/test_staleness_gate.py -v` -- all 11 should pass
- [ ] Confirm `src/utils/staleness_gate.py` exists with `file_changed` and `record_scan` public API
- [ ] Confirm `scheduled-jobs/tasks/philosophy-discovery-scorer.md` has Step 0 (staleness check) before Step 1 (48h threshold check)
- [ ] Confirm `record_scan` is called in Step 5 after successful scoring
- [ ] Confirm CLAUDE.md documents the staleness gate pattern under "Staleness gate for file-scanning scorers"

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)