### PR TITLE
docs(bootup): require subagents to read golden-patterns.md before code work

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -31,6 +31,17 @@ Do NOT call `wait_for_messages` — that is only for the main loop.
 
 These files are private and not in the git repo. They extend and override the defaults here.
 
+## Golden Patterns (Required Read Before Any Code Work)
+
+**You MUST read `~/lobster/oracle/golden-patterns.md` before writing or modifying any code.** This is mandatory, not advisory — load it before any code work begins, not as a reference to consult if something breaks.
+
+The patterns cover three structural areas that have caused latent bugs in this codebase:
+- **StrEnum usage** — no raw string literals in SQL or discriminators; always import and use the canonical StrEnum.
+- **Dead-code analysis scope** — a full-repo grep across `src/`, `.claude/`, `scripts/`, `tests/`, `scheduled-tasks/`, and `hooks/` is required before removing any code.
+- **Canonicality / anti-staleness** — every file and module must live in one unambiguous home; stale canonical placements are active misdirection.
+
+These are structural lessons that must survive context compaction. Reading the file once per session, before any code work, is the load-bearing behavior.
+
 ## Identity: Are You a Subagent?
 
 **You are a subagent if:**


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What changed

Added a "Golden Patterns" section to `.claude/sys.subagent.bootup.md` that instructs all subagents to read `~/lobster/oracle/golden-patterns.md` before writing or modifying any code.

The section:
- Phrases the read as mandatory, not advisory ("You MUST read…")
- Names the three pattern areas (StrEnum usage, dead-code analysis scope, canonicality/anti-staleness) so subagents understand why the read matters
- States explicitly that these lessons must survive context compaction and that reading once per session before code work is the load-bearing behavior
- Is positioned early in the startup sequence — immediately after the user-context files block — so it loads before any code work begins

Single file changed: `.claude/sys.subagent.bootup.md`. The `golden-patterns.md` file itself is not modified.

## Why

Patterns only help if they are structurally present in agent context. `oracle/golden-patterns.md` contains hard-won structural lessons (StrEnum discipline, full-repo dead-code grep scope, canonical placement) that have caused latent bugs when ignored. Without a read directive in the bootup file, subagents have no reliable path to the file across session boundaries and context compactions — it exists in a file that was never referenced in the startup sequence.

The fix is minimal: a read directive so the patterns are guaranteed to load before any code work begins.

## Long-term direction

As these patterns mature and get tested against real code changes, the goal is for them to become self-documenting at the structural level — embedded in types, conventions, and tests rather than requiring a separate required-read file. Until that point, this bootup directive is the lowest-friction way to ensure structural lessons survive context boundaries.

---

uow: uow_20260522_5a1984