### PR TITLE
feat(wos): add is_still_needed() pre-flight protocol to WOS executor dispatch

### DIFF
--- a/src/orchestration/executor.py
+++ b/src/orchestration/executor.py
@@ -800,24 +800,71 @@ class Executor:
         register: str = "operational",
     ) -> ExecutorResult:
         """
-        Inner execution: activate skills, dispatch subagent, write results.
+        Inner execution: activate skills, run pre-flight check, dispatch subagent, write results.
         Returns ExecutorResult. Callers must catch exceptions.
 
         Chain primitives: when artifact["chain_type"] is set, routes to the
         appropriate chain dispatch function instead of the single-subagent path.
         Fallback (chain_type absent/None/unrecognized) uses the existing path.
+
+        Pre-flight protocol (issue #929):
+        ``is_still_needed(uow)`` is called after skill activation and before any
+        subagent is spawned (both single-subagent and chain paths).  When the hook
+        returns ``False`` the UoW is marked complete with outcome_category="heat"
+        and the method returns without dispatching a subagent.
         """
         # Step 1: Activate prescribed skills
         prescribed_skills: list[str] = artifact.get("prescribed_skills") or []
         for skill_id in prescribed_skills:
             self._skill_activator(skill_id)
 
-        # Step 2: Check for chain primitives — route before single-dispatch path.
+        # Step 2: Pre-flight check — is this work still needed?
+        # Reads the current UoW from the registry so the check function receives
+        # a fully-hydrated object with all fields (type, status, source, etc.).
+        # Falls back to fail-open (True) when the UoW cannot be read.
+        from orchestration.wos_preflight import is_still_needed as _is_still_needed
+        uow_for_preflight = None
+        try:
+            uow_for_preflight = self.registry.get(uow_id)
+        except Exception as _preflight_read_err:
+            log.warning(
+                "Executor: could not read UoW %s for pre-flight check — %s (proceeding with dispatch)",
+                uow_id, _preflight_read_err,
+            )
+        if uow_for_preflight is not None and not _is_still_needed(uow_for_preflight):
+            log.info(
+                "Executor: pre-flight short-circuit for UoW %s — is_still_needed() returned False; "
+                "marking complete with outcome_category=heat (no subagent spawned)",
+                uow_id,
+            )
+            heat_result = ExecutorResult(
+                uow_id=uow_id,
+                outcome=ExecutorOutcome.COMPLETE,
+                success=True,
+                reason="pre-flight: is_still_needed() returned False",
+            )
+            _write_output_ref_content(output_ref, "pre-flight short-circuit: work no longer needed")
+            _write_result_json(output_ref, heat_result)
+            _validate_result_json_written(uow_id, output_ref)
+            trace = _build_trace(
+                uow_id=uow_id,
+                register=register,
+                outcome=ExecutorOutcome.COMPLETE,
+                execution_summary="pre-flight short-circuit: is_still_needed() returned False",
+                surprises=[],
+                prescription_delta="pre-flight: work determined no longer needed at dispatch time",
+            )
+            _write_trace_json(output_ref, trace)
+            _insert_corrective_trace(self.registry.db_path, trace)
+            self.registry.complete_uow(uow_id, output_ref, outcome_category="heat")
+            return heat_result
+
+        # Step 3: Check for chain primitives — route before single-dispatch path.
         chain_type = artifact.get("chain_type")
         if chain_type:
             return self._run_chain_execution(uow_id, output_ref, artifact, register, chain_type)
 
-        # Step 3: Dispatch LLM subagent via register-appropriate dispatcher.
+        # Step 4: Dispatch LLM subagent via register-appropriate dispatcher.
         # Build the WOS context block (UoW ID + artifact stamping instructions, issue #868)
         # and inject it into every dispatched prompt regardless of dispatcher path.
         #
@@ -837,10 +884,10 @@ class Executor:
             dispatcher = _resolve_dispatcher(executor_type)
             executor_id = dispatcher(instructions, uow_id)
 
-        # Step 4: Write output_ref content (signal that execution produced output)
+        # Step 5: Write output_ref content (signal that execution produced output)
         _write_output_ref_content(output_ref, f"execution dispatched: task_id={executor_id}")
 
-        # Step 5: Build result
+        # Step 6: Build result
         result = ExecutorResult(
             uow_id=uow_id,
             outcome=ExecutorOutcome.COMPLETE,
@@ -848,11 +895,11 @@ class Executor:
             executor_id=executor_id or None,
         )
 
-        # Step 6: Write result.json (executor-contract.md: required at every intentional exit)
+        # Step 7: Write result.json (executor-contract.md: required at every intentional exit)
         _write_result_json(output_ref, result)
         _validate_result_json_written(uow_id, output_ref)
 
-        # Step 6b: Write trace.json (V3 corrective trace contract — required alongside result.json)
+        # Step 7b: Write trace.json (V3 corrective trace contract — required alongside result.json)
         trace = _build_trace(
             uow_id=uow_id,
             register=register,
@@ -865,7 +912,7 @@ class Executor:
         _write_trace_json(output_ref, trace)
         _insert_corrective_trace(self.registry.db_path, trace)
 
-        # Step 7: Status transition — depends on dispatch path.
+        # Step 8: Status transition — depends on dispatch path.
         #
         # Async (inbox) dispatchers: write wos_execute to inbox and return immediately.
         # The subagent has NOT yet done any work — calling complete_uow here would produce

--- a/src/orchestration/wos_preflight.py
+++ b/src/orchestration/wos_preflight.py
@@ -1,0 +1,193 @@
+"""
+WOS Pre-flight Protocol — is_still_needed() hook.
+
+This module defines the shared "is this work still needed?" pre-flight check
+called by the WOS executor immediately before dispatching a subagent for any
+UoW in ready-for-executor state.
+
+Design motivation
+-----------------
+~40% of heat outcomes (already-done re-dispatches, merge-pr retries, scorer
+re-runs) trace to a single architectural gap: the executor dispatches based on
+"work exists in queue" but has no shared protocol for "work is still needed."
+Each UoW type currently reinvents or forgets this check, leading to recurring
+heat that requires case-by-case debugging.
+
+The hook
+--------
+``is_still_needed(uow) -> bool``
+
+Called once per UoW, immediately before the subagent is spawned.  If it returns
+``False``, the executor short-circuits:
+  - The subagent is NOT spawned.
+  - The UoW is marked complete with ``outcome_category="heat"`` via the
+    existing ``registry.complete_uow`` path.
+  - A one-line log entry records the short-circuit.
+
+If it returns ``True`` (the default), dispatch proceeds unchanged.
+
+Extension point
+---------------
+Per-type implementations are registered via ``register_preflight_check``:
+
+    from orchestration.wos_preflight import register_preflight_check
+
+    def my_check(uow) -> bool:
+        ...  # return False if work is no longer needed
+
+    register_preflight_check("merge-pr", my_check)
+
+Adding a check for a new UoW type does NOT require editing this file or the
+executor dispatch core.
+
+Intended first consumers
+------------------------
+- **Issue #927**: merge-pr idempotency gate — check whether the PR is already
+  merged before dispatching a merge-pr subagent.
+- **Issue #928**: scorer staleness gate — check whether the scored issue/PR is
+  still open and needs scoring before dispatching a scorer subagent.
+
+These issues are absorbed as sub-tasks of this architectural interface; their
+implementations will register checks here rather than adding per-type logic to
+the dispatch core.
+
+Public API
+----------
+``is_still_needed(uow: UoW) -> bool``
+    Call this before dispatching a subagent.  Returns True by default.
+
+``register_preflight_check(uow_type: str, check_fn: PreflightCheck) -> None``
+    Register a type-specific check.  Idempotent: re-registering the same type
+    overwrites the previous entry (useful for tests and hot-reloading).
+
+``PreflightCheck``
+    Protocol type: ``(uow: UoW) -> bool``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+log = logging.getLogger("wos_preflight")
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class PreflightCheck(Protocol):
+    """
+    Protocol for a UoW pre-flight check function.
+
+    Implementors receive the full UoW object and return True when the work is
+    still needed (dispatch should proceed) or False when it is not (short-circuit).
+    """
+
+    def __call__(self, uow: object) -> bool:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+#: Type-keyed registry mapping uow_type → check function.
+#: Populated by ``register_preflight_check`` at import time or at runtime.
+#: Issue #927 (merge-pr) and issue #928 (scorer) are the intended first entries.
+_REGISTRY: dict[str, PreflightCheck] = {}
+
+
+def register_preflight_check(uow_type: str, check_fn: PreflightCheck) -> None:
+    """
+    Register a pre-flight check for a given UoW type.
+
+    Idempotent: re-registering the same type overwrites the previous entry.
+    This is intentional — it simplifies testing (register a stub, test, restore)
+    and supports hot-reloading in long-running environments.
+
+    Args:
+        uow_type: The UoW type string (e.g. "merge-pr", "scorer").
+                  Must match the ``type`` field stored in uow_registry.
+        check_fn: Callable conforming to ``PreflightCheck`` — takes a UoW
+                  object and returns True (still needed) or False (short-circuit).
+
+    Intended consumers:
+        - Issue #927: ``register_preflight_check("merge-pr", <check_fn>)``
+        - Issue #928: ``register_preflight_check("scorer", <check_fn>)``
+
+    Raises:
+        TypeError: If ``check_fn`` is not callable.
+    """
+    if not callable(check_fn):
+        raise TypeError(
+            f"register_preflight_check: check_fn for type {uow_type!r} "
+            f"must be callable, got {type(check_fn)!r}"
+        )
+    _REGISTRY[uow_type] = check_fn
+    log.debug(
+        "wos_preflight: registered check for uow_type=%r (fn=%s)",
+        uow_type,
+        getattr(check_fn, "__qualname__", repr(check_fn)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default implementation
+# ---------------------------------------------------------------------------
+
+def _default_check(uow: object) -> bool:
+    """
+    Default pre-flight check — always returns True.
+
+    Used for any UoW type that has not registered a type-specific check.
+    Guarantees no regression: all existing UoW types dispatch normally until
+    an explicit check is registered for their type.
+    """
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def is_still_needed(uow: object) -> bool:
+    """
+    Run the pre-flight check for a UoW and return whether dispatch should proceed.
+
+    Looks up the check function for the UoW's ``type`` field in the registry.
+    Falls back to the default implementation (returns ``True``) when no
+    type-specific check is registered.
+
+    Args:
+        uow: A UoW object (any object with a ``type`` attribute, e.g. the
+             ``UoW`` namedtuple/dataclass returned by ``registry.get()``).
+
+    Returns:
+        True  — work is still needed; dispatch should proceed normally.
+        False — work is no longer needed; executor must short-circuit:
+                mark the UoW complete with outcome_category="heat" and skip
+                subagent dispatch.
+
+    Failure mode (check raises):
+        If the registered check function raises an exception, the exception is
+        caught, logged at WARNING level, and ``True`` is returned (fail-open).
+        A failing check must not block dispatch — the executor must proceed
+        unless explicitly told the work is not needed.
+    """
+    uow_type: str = getattr(uow, "type", "") or ""
+    check_fn = _REGISTRY.get(uow_type, _default_check)
+
+    try:
+        result = check_fn(uow)
+    except Exception as exc:
+        log.warning(
+            "wos_preflight: check for uow_type=%r raised %s: %s — defaulting to True (fail-open)",
+            uow_type,
+            type(exc).__name__,
+            exc,
+        )
+        return True
+
+    return bool(result)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1049,3 +1049,112 @@ class TestDispatchBoundaryLog:
             )
         finally:
             executor_mod._DISPATCH_BOUNDARY_LOG_TEMPLATE = orig
+
+
+# ---------------------------------------------------------------------------
+# Tests: pre-flight protocol (issue #929)
+# ---------------------------------------------------------------------------
+
+class TestPreflightProtocol:
+    """
+    Executor integration tests for the is_still_needed() pre-flight hook.
+
+    These tests verify that the executor correctly calls the hook and honours
+    its return value — specifically the three required paths from issue #929:
+
+      - Default path: UoW type with no registered check dispatches normally.
+      - False path: registered check returning False → no subagent spawned,
+        UoW marked complete with outcome_category="heat".
+      - True path: registered check returning True → dispatch proceeds normally.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_preflight_registry(self):
+        """Save and restore the preflight registry around each test."""
+        from orchestration.wos_preflight import _REGISTRY
+        saved = dict(_REGISTRY)
+        _REGISTRY.clear()
+        yield
+        _REGISTRY.clear()
+        _REGISTRY.update(saved)
+
+    def test_default_path_dispatches_normally(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Default path: no registered check → UoW dispatches normally (regression guard)."""
+        uow_id = "uow_preflight_default"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id))
+
+        dispatched: list[str] = []
+
+        def fake_dispatcher(instructions: str, uid: str) -> str:
+            dispatched.append(uid)
+            return "task-default"
+
+        executor = Executor(registry, dispatcher=fake_dispatcher)
+        executor.execute_uow(uow_id)
+
+        assert dispatched == [uow_id], "Subagent must be dispatched when no check is registered"
+
+    def test_false_path_no_subagent_spawned(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """False path: registered check returning False → no subagent spawned."""
+        from orchestration.wos_preflight import register_preflight_check
+        register_preflight_check("executable", lambda _: False)
+
+        uow_id = "uow_preflight_false"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id))
+
+        dispatched: list[str] = []
+
+        def fake_dispatcher(instructions: str, uid: str) -> str:
+            dispatched.append(uid)
+            return "task-should-not-run"
+
+        executor = Executor(registry, dispatcher=fake_dispatcher)
+        executor.execute_uow(uow_id)
+
+        assert dispatched == [], "No subagent must be spawned when pre-flight returns False"
+
+    def test_false_path_marks_complete_with_heat(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """False path: UoW is marked complete with outcome_category='heat'."""
+        from orchestration.wos_preflight import register_preflight_check
+        register_preflight_check("executable", lambda _: False)
+
+        uow_id = "uow_preflight_heat"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id))
+
+        executor = Executor(registry, dispatcher=_noop_dispatcher)
+        result = executor.execute_uow(uow_id)
+
+        assert result.outcome == ExecutorOutcome.COMPLETE
+        assert result.success is True
+        assert _get_uow_status(db_path, uow_id) == "ready-for-steward"
+        outcome_cat = _get_uow_field(db_path, uow_id, "outcome_category")
+        assert outcome_cat == "heat", (
+            f"outcome_category must be 'heat' after pre-flight short-circuit, got {outcome_cat!r}"
+        )
+
+    def test_true_path_dispatches_normally(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """True path: registered check returning True → subagent dispatched normally."""
+        from orchestration.wos_preflight import register_preflight_check
+        register_preflight_check("executable", lambda _: True)
+
+        uow_id = "uow_preflight_true"
+        _insert_uow(db_path, uow_id, workflow_artifact=_make_artifact(uow_id))
+
+        dispatched: list[str] = []
+
+        def fake_dispatcher(instructions: str, uid: str) -> str:
+            dispatched.append(uid)
+            return "task-true"
+
+        executor = Executor(registry, dispatcher=fake_dispatcher)
+        executor.execute_uow(uow_id)
+
+        assert dispatched == [uow_id], "Subagent must be dispatched when pre-flight returns True"

--- a/tests/unit/test_orchestration/test_wos_preflight.py
+++ b/tests/unit/test_orchestration/test_wos_preflight.py
@@ -1,0 +1,429 @@
+"""
+Tests for the WOS pre-flight protocol (issue #929).
+
+Coverage:
+- wos_preflight.is_still_needed: default-True path (no registered check)
+- wos_preflight.is_still_needed: registered check returning True
+- wos_preflight.is_still_needed: registered check returning False
+- wos_preflight.is_still_needed: check raises — fail-open (returns True)
+- wos_preflight.register_preflight_check: callable enforcement
+- wos_preflight.register_preflight_check: idempotent re-registration
+- Executor._run_execution: default-True path dispatches normally (regression guard)
+- Executor._run_execution: False-path short-circuits — no subagent spawned
+- Executor._run_execution: False-path marks UoW complete with outcome_category=heat
+- Executor._run_execution: True-path proceeds to dispatch
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestration.registry import Registry
+from orchestration.workflow_artifact import WorkflowArtifact, to_json
+from orchestration.executor import (
+    Executor,
+    ExecutorOutcome,
+    _result_json_path,
+)
+import orchestration.wos_preflight as preflight_mod
+from orchestration.wos_preflight import (
+    is_still_needed,
+    register_preflight_check,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubUoW:
+    """Minimal stub for a UoW object — just needs a type attribute."""
+
+    def __init__(self, uow_type: str = "executable") -> None:
+        self.type = uow_type
+        self.id = "stub-uow-id"
+
+
+def _make_artifact(
+    uow_id: str,
+    executor_type: str = "functional-engineer",
+    instructions: str = "Do the thing",
+) -> str:
+    artifact: WorkflowArtifact = {
+        "uow_id": uow_id,
+        "executor_type": executor_type,
+        "constraints": [],
+        "prescribed_skills": [],
+        "instructions": instructions,
+    }
+    return to_json(artifact)
+
+
+def _insert_uow(
+    db_path: Path,
+    uow_id: str,
+    uow_type: str = "executable",
+    executor_type: str = "functional-engineer",
+    register: str = "operational",
+    status: str = "ready-for-executor",
+) -> None:
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute(
+            """
+            INSERT INTO uow_registry (
+                id, type, source, status, posture, created_at, updated_at,
+                summary, success_criteria, workflow_artifact, estimated_runtime,
+                register
+            ) VALUES (?, ?, 'test', ?, 'solo', ?, ?, 'Test UoW', 'done', ?, NULL, ?)
+            """,
+            (uow_id, uow_type, status, now, now, _make_artifact(uow_id, executor_type=executor_type), register),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _get_outcome_category(db_path: Path, uow_id: str) -> str | None:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT outcome_category FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return row["outcome_category"] if row else None
+    finally:
+        conn.close()
+
+
+def _get_status(db_path: Path, uow_id: str) -> str | None:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT status FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return row["status"] if row else None
+    finally:
+        conn.close()
+
+
+def _get_output_ref(db_path: Path, uow_id: str) -> str | None:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT output_ref FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return row["output_ref"] if row else None
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "test_registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path) -> Registry:
+    return Registry(db_path)
+
+
+@pytest.fixture(autouse=True)
+def _clean_preflight_registry() -> "Generator[None, None, None]":
+    """
+    Restore the preflight registry to its original state after each test.
+
+    Tests that register type-specific checks must not pollute the global
+    registry for subsequent tests. This fixture saves and restores the
+    _REGISTRY dict around each test.
+    """
+    import copy
+    from typing import Generator
+    saved = copy.copy(preflight_mod._REGISTRY)
+    yield
+    preflight_mod._REGISTRY.clear()
+    preflight_mod._REGISTRY.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: wos_preflight module
+# ---------------------------------------------------------------------------
+
+
+class TestIsStillNeededDefault:
+    """Default path: no registered check → always returns True."""
+
+    def test_no_check_registered_returns_true(self) -> None:
+        uow = _StubUoW(uow_type="executable")
+        assert is_still_needed(uow) is True
+
+    def test_unknown_type_returns_true(self) -> None:
+        uow = _StubUoW(uow_type="an-unregistered-type")
+        assert is_still_needed(uow) is True
+
+    def test_empty_type_returns_true(self) -> None:
+        uow = _StubUoW(uow_type="")
+        assert is_still_needed(uow) is True
+
+    def test_no_type_attribute_returns_true(self) -> None:
+        """Object without .type attribute — is_still_needed must not raise."""
+        class NoType:
+            pass
+        assert is_still_needed(NoType()) is True
+
+
+class TestIsStillNeededRegistered:
+    """Registered check paths."""
+
+    def test_registered_check_returning_true_allows_dispatch(self) -> None:
+        register_preflight_check("my-type", lambda uow: True)
+        uow = _StubUoW(uow_type="my-type")
+        assert is_still_needed(uow) is True
+
+    def test_registered_check_returning_false_blocks_dispatch(self) -> None:
+        register_preflight_check("my-type", lambda uow: False)
+        uow = _StubUoW(uow_type="my-type")
+        assert is_still_needed(uow) is False
+
+    def test_registered_check_receives_uow_object(self) -> None:
+        received: list[Any] = []
+        def capturing_check(uow: Any) -> bool:
+            received.append(uow)
+            return True
+        register_preflight_check("capture-type", capturing_check)
+        uow = _StubUoW(uow_type="capture-type")
+        is_still_needed(uow)
+        assert len(received) == 1
+        assert received[0] is uow
+
+    def test_check_for_other_type_not_called(self) -> None:
+        other_called: list[bool] = []
+        register_preflight_check("other-type", lambda uow: other_called.append(True) or False)
+        uow = _StubUoW(uow_type="different-type")
+        result = is_still_needed(uow)
+        assert result is True, "Different type should use default (True), not the registered check"
+        assert len(other_called) == 0
+
+
+class TestIsStillNeededFailOpen:
+    """When check raises an exception, is_still_needed must return True (fail-open)."""
+
+    def test_raising_check_returns_true(self) -> None:
+        def bad_check(uow: Any) -> bool:
+            raise RuntimeError("simulated check failure")
+        register_preflight_check("bad-type", bad_check)
+        uow = _StubUoW(uow_type="bad-type")
+        # Must not raise; must return True
+        result = is_still_needed(uow)
+        assert result is True
+
+
+class TestRegisterPreflightCheck:
+    """register_preflight_check contract."""
+
+    def test_register_callable(self) -> None:
+        register_preflight_check("reg-type", lambda uow: True)
+        uow = _StubUoW(uow_type="reg-type")
+        assert is_still_needed(uow) is True
+
+    def test_re_register_overwrites(self) -> None:
+        """Idempotent: re-registering the same type overwrites the previous check."""
+        register_preflight_check("overwrite-type", lambda uow: True)
+        register_preflight_check("overwrite-type", lambda uow: False)
+        uow = _StubUoW(uow_type="overwrite-type")
+        assert is_still_needed(uow) is False
+
+    def test_non_callable_raises_type_error(self) -> None:
+        with pytest.raises(TypeError):
+            register_preflight_check("bad", "not-a-function")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: Executor wires is_still_needed into dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorPreflightDefaultPath:
+    """
+    Default path: no type-specific check registered → dispatch proceeds normally.
+
+    This is the regression guard: existing UoW types must not be affected.
+    """
+
+    def test_default_true_dispatches_normally(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        uow_id = "preflight_default_001"
+        _insert_uow(db_path, uow_id, uow_type="executable")
+
+        dispatch_called: list[str] = []
+
+        def capture(instructions: str, uid: str) -> str:
+            dispatch_called.append(uid)
+            return "inbox-msg-id"
+
+        import orchestration.executor as executor_mod
+        monkeypatch.setattr(executor_mod, "_dispatch_via_inbox_functional_engineer", capture)
+
+        executor = Executor(registry)
+        result = executor.execute_uow(uow_id)
+
+        assert len(dispatch_called) == 1, "Dispatcher must be called when pre-flight returns True"
+        assert dispatch_called[0] == uow_id
+        assert result.outcome == ExecutorOutcome.COMPLETE
+        assert result.success is True
+
+    def test_registered_true_check_dispatches_normally(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Registered check returning True must not block dispatch."""
+        uow_id = "preflight_true_001"
+        # Use "executable" (valid UoWType); always-True check should dispatch.
+        register_preflight_check("executable", lambda uow: True)
+        _insert_uow(db_path, uow_id, uow_type="executable")
+
+        dispatch_called: list[str] = []
+
+        def capture(instructions: str, uid: str) -> str:
+            dispatch_called.append(uid)
+            return "inbox-msg-id"
+
+        import orchestration.executor as executor_mod
+        monkeypatch.setattr(executor_mod, "_dispatch_via_inbox_functional_engineer", capture)
+
+        executor = Executor(registry)
+        result = executor.execute_uow(uow_id)
+
+        assert len(dispatch_called) == 1
+        assert result.outcome == ExecutorOutcome.COMPLETE
+        assert result.success is True
+
+
+class TestExecutorPreflightFalsePath:
+    """
+    False path: registered check returns False → no subagent spawned,
+    UoW marked complete with outcome_category=heat.
+
+    Tests use "executable" as the UoW type (a valid UoWType enum value) and
+    distinguish UoWs by filtering on uow_id inside the check function, since
+    the registry.get() call in the executor requires a valid type.
+    """
+
+    def test_false_check_does_not_spawn_subagent(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        uow_id = "preflight_false_no_dispatch_001"
+        # Use "executable" — a valid UoWType; check identifies UoW by its id.
+        register_preflight_check("executable", lambda uow: uow.id != uow_id)
+        _insert_uow(db_path, uow_id, uow_type="executable")
+
+        dispatch_called: list[str] = []
+
+        def capture(instructions: str, uid: str) -> str:
+            dispatch_called.append(uid)
+            return "should-not-be-called"
+
+        import orchestration.executor as executor_mod
+        monkeypatch.setattr(executor_mod, "_dispatch_via_inbox_functional_engineer", capture)
+        monkeypatch.setenv("WOS_OUTPUTS_DIR", str(tmp_path))
+
+        executor = Executor(registry)
+        result = executor.execute_uow(uow_id)
+
+        assert len(dispatch_called) == 0, "Dispatcher must NOT be called when pre-flight returns False"
+        assert result.outcome == ExecutorOutcome.COMPLETE
+        assert result.success is True
+        assert "pre-flight" in (result.reason or "").lower()
+
+    def test_false_check_marks_uow_complete_with_heat(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        uow_id = "preflight_heat_outcome_001"
+        register_preflight_check("executable", lambda uow: uow.id != uow_id)
+        _insert_uow(db_path, uow_id, uow_type="executable")
+
+        import orchestration.executor as executor_mod
+        monkeypatch.setattr(executor_mod, "_dispatch_via_inbox_functional_engineer", lambda i, u: "noop")
+        monkeypatch.setenv("WOS_OUTPUTS_DIR", str(tmp_path))
+
+        executor = Executor(registry)
+        executor.execute_uow(uow_id)
+
+        # Status must be ready-for-steward (complete_uow was called)
+        status = _get_status(db_path, uow_id)
+        assert status == "ready-for-steward", (
+            f"UoW must be in ready-for-steward after pre-flight short-circuit, got {status!r}"
+        )
+
+        # outcome_category must be heat
+        outcome_cat = _get_outcome_category(db_path, uow_id)
+        assert outcome_cat == "heat", (
+            f"outcome_category must be 'heat' after pre-flight short-circuit, got {outcome_cat!r}"
+        )
+
+    def test_false_check_writes_result_json(
+        self, registry: Registry, db_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        uow_id = "preflight_result_json_001"
+        register_preflight_check("executable", lambda uow: uow.id != uow_id)
+        _insert_uow(db_path, uow_id, uow_type="executable")
+
+        import orchestration.executor as executor_mod
+        monkeypatch.setattr(executor_mod, "_dispatch_via_inbox_functional_engineer", lambda i, u: "noop")
+        monkeypatch.setenv("WOS_OUTPUTS_DIR", str(tmp_path))
+
+        executor = Executor(registry)
+        executor.execute_uow(uow_id)
+
+        output_ref = _get_output_ref(db_path, uow_id)
+        assert output_ref is not None
+        result_data = json.loads(_result_json_path(output_ref).read_text())
+        assert result_data["outcome"] == "complete"
+        assert result_data["success"] is True
+        assert result_data["uow_id"] == uow_id
+
+    def test_injected_dispatcher_not_called_on_false(
+        self, registry: Registry, db_path: Path, tmp_path: Path
+    ) -> None:
+        """
+        Even with an injected dispatcher (test/CI path), False short-circuits
+        without calling the dispatcher.
+        """
+        uow_id = "preflight_injected_false_001"
+        register_preflight_check("executable", lambda uow: uow.id != uow_id)
+        _insert_uow(db_path, uow_id, uow_type="executable")
+
+        injected_called: list[str] = []
+
+        def injected(instructions: str, uid: str) -> str:
+            injected_called.append(uid)
+            return "injected-run"
+
+        import os
+        os.environ["WOS_OUTPUTS_DIR"] = str(tmp_path)
+        try:
+            executor = Executor(registry, dispatcher=injected)
+            executor.execute_uow(uow_id)
+        finally:
+            del os.environ["WOS_OUTPUTS_DIR"]
+
+        assert len(injected_called) == 0, (
+            "Injected dispatcher must NOT be called when pre-flight returns False"
+        )


### PR DESCRIPTION
## Summary

Adds a shared architectural pre-flight protocol that fires before any subagent is spawned in the WOS executor. Addresses the root cause of ~40% of heat outcomes: the executor dispatches based on "work exists in queue" with no shared protocol for "work is still needed."

**Interface:**
- New module `src/orchestration/wos_preflight.py` exports:
  - `is_still_needed(uow) -> bool`: default-True, fail-open, registry-dispatched
  - `register_preflight_check(uow_type, fn)`: idempotent per-type registration
- Wired into `Executor._run_execution` as Step 2, before both single-subagent and chain dispatch paths
- False return: marks UoW complete with `outcome_category="heat"`, no subagent spawned
- True return (default): dispatch proceeds unchanged — **no regression for existing UoW types**

**Extension point (absorbs #927 and #928):**
```python
from orchestration.wos_preflight import register_preflight_check

def check_merge_pr(uow) -> bool:
    # return False if PR is already merged
    ...

register_preflight_check("merge-pr", check_merge_pr)
```
Adding a type-specific check does not require editing the dispatch core.

**Tests:**
- 18 new tests in `tests/unit/test_orchestration/test_wos_preflight.py`
- Covers: default-True (regression guard), registered-True, False short-circuit, fail-open (check raises), heat outcome_category, result.json written, injected-dispatcher path
- 106 existing executor regression tests continue to pass

WOS-UoW: uow_20260522_6b3a1c

## Test plan

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_preflight.py` — 18/18 pass
- [x] `uv run pytest tests/unit/test_orchestration/test_executor_register_routing.py tests/unit/test_orchestration/test_executor_trace.py tests/unit/test_orchestration/test_executor_false_complete_fix.py tests/unit/test_orchestration/test_executor_heartbeat.py` — 106/106 pass
- [ ] Oracle review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)