### PR TITLE
fix: use source_ref guard in tend() and requalify_proposed() to stop repeated ValueError

### DIFF
--- a/src/orchestration/garden_caretaker.py
+++ b/src/orchestration/garden_caretaker.py
@@ -250,12 +250,12 @@ class GardenCaretaker:
             )
 
         for uow in proposed_uows:
-            if not uow.source:
+            if not uow.source_ref:
                 logger.debug("requalify_proposed: skipping UoW %s — no source_ref", uow.id)
                 continue
 
             try:
-                snapshot = self.source.get_issue(uow.source)
+                snapshot = self.source.get_issue(uow.source_ref)
             except Exception as exc:
                 logger.warning(
                     "requalify_proposed: error fetching source for UoW %s: %s — skipping",
@@ -287,13 +287,13 @@ class GardenCaretaker:
                     "actor": "garden_caretaker",
                     "from_status": "proposed",
                     "to_status": "ready-for-steward",
-                    "source_ref": uow.source,
+                    "source_ref": uow.source_ref,
                     "timestamp": _now_iso(),
                 })
                 requalified += 1
                 logger.info(
                     "requalify_proposed: auto-qualified UoW %s → ready-for-steward (source_ref=%s)",
-                    uow.id, uow.source,
+                    uow.id, uow.source_ref,
                 )
 
         return {"requalified": requalified}
@@ -386,13 +386,13 @@ class GardenCaretaker:
         active_uows = self._fetch_active_uows()
 
         for uow in active_uows:
-            if not uow.source:
+            if not uow.source_ref:
                 logger.debug("tend: skipping UoW %s — no source_ref", uow.id)
                 no_change += 1
                 continue
 
             try:
-                snapshot = self.source.get_issue(uow.source)
+                snapshot = self.source.get_issue(uow.source_ref)
             except Exception as exc:
                 logger.warning("tend: error fetching source for UoW %s: %s — no state change", uow.id, exc)
                 no_change += 1
@@ -419,8 +419,8 @@ class GardenCaretaker:
 
             elif action == "warn":
                 logger.warning(
-                    "tend: unknown/error source state for UoW %s (source=%s) — no state change",
-                    uow.id, uow.source,
+                    "tend: unknown/error source state for UoW %s (source_ref=%s) — no state change",
+                    uow.id, uow.source_ref,
                 )
                 no_change += 1
 
@@ -518,7 +518,7 @@ class GardenCaretaker:
                 "classification": reason,
                 "from_status": str(uow.status),
                 "to_status": "expired",
-                "source_ref": uow.source,
+                "source_ref": uow.source_ref,
                 "timestamp": _now_iso(),
             })
             logger.info("tend: archived UoW %s (was %s) — %s", uow.id, uow.status, reason)
@@ -547,7 +547,7 @@ class GardenCaretaker:
                 "classification": classification,
                 "from_status": str(uow.status),
                 "to_status": "ready-for-steward",
-                "source_ref": uow.source,
+                "source_ref": uow.source_ref,
                 "timestamp": _now_iso(),
             })
             logger.info(
@@ -565,7 +565,7 @@ class GardenCaretaker:
         the TOCTOU race where a concurrent intake could insert a new proposed row
         between the check and the write.
         """
-        issue_number = self._extract_issue_number(uow.source or "")
+        issue_number = self._extract_issue_number(uow.source_ref or "")
         if issue_number is None:
             # Cannot extract issue number — fall back to direct reactivation.
             # This path is rare (only UoWs with malformed source_ref).
@@ -577,7 +577,7 @@ class GardenCaretaker:
                     "classification": "source_reopened",
                     "from_status": str(uow.status),
                     "to_status": "proposed",
-                    "source_ref": uow.source,
+                    "source_ref": uow.source_ref,
                     "timestamp": _now_iso(),
                 })
                 logger.info("tend: reactivated UoW %s → proposed (source reopened, no issue_number)", uow.id)
@@ -614,7 +614,7 @@ class GardenCaretaker:
             "classification": "source_reopened",
             "from_status": str(uow.status),
             "to_status": "proposed",
-            "source_ref": uow.source,
+            "source_ref": uow.source_ref,
             "timestamp": _now_iso(),
         })
         logger.info("tend: reactivated UoW %s → proposed (source reopened)", uow.id)

--- a/tests/unit/test_orchestration/test_garden_caretaker.py
+++ b/tests/unit/test_orchestration/test_garden_caretaker.py
@@ -367,7 +367,7 @@ class TestTend:
         assert len(proposed) == 1
 
     def test_tend_archives_proposed_uow_when_source_closed(self, registry: Registry) -> None:
-        registry.upsert(issue_number=10, title="Will close", success_criteria="Test completion.")
+        registry.upsert(issue_number=10, title="Will close", success_criteria="Test completion.", source_ref="github:issue/10")
 
         snap = _snapshot(source_ref="github:issue/10", state="closed")
         source = _make_source(issue_map={"github:issue/10": snap})
@@ -388,7 +388,7 @@ class TestTend:
         A UoW that has been approved (ready-for-steward) and whose source closes is
         surfaced to the Steward (not archived) because in-flight work is involved.
         """
-        upsert_result = registry.upsert(issue_number=11, title="Pending issue", success_criteria="Test completion.")
+        upsert_result = registry.upsert(issue_number=11, title="Pending issue", success_criteria="Test completion.", source_ref="github:issue/11")
         # approve() now lands on ready-for-steward, not pending
         registry.approve(upsert_result.id)
         uow = registry.get(upsert_result.id)
@@ -410,7 +410,7 @@ class TestTend:
 
     def test_tend_archives_pending_uow_set_directly_when_source_closed(self, registry: Registry) -> None:
         """Legacy: a UoW manually set to pending (pre-auto-advance) is archived when source closes."""
-        upsert_result = registry.upsert(issue_number=111, title="Legacy pending issue", success_criteria="Test completion.")
+        upsert_result = registry.upsert(issue_number=111, title="Legacy pending issue", success_criteria="Test completion.", source_ref="github:issue/111")
         # Bypass approve() to simulate a legacy pending UoW
         registry.set_status_direct(upsert_result.id, "pending")
 
@@ -477,7 +477,7 @@ class TestTend:
     def test_tend_reactivates_archived_uow_when_source_reopens(
         self, registry: Registry
     ) -> None:
-        upsert_result = registry.upsert(issue_number=50, title="Was expired", success_criteria="Test completion.")
+        upsert_result = registry.upsert(issue_number=50, title="Was expired", success_criteria="Test completion.", source_ref="github:issue/50")
         # Simulate archived (expired) UoW
         registry.set_status_direct(upsert_result.id, "expired")
 
@@ -524,7 +524,7 @@ class TestTend:
 
     def test_tend_audit_log_written_on_archive(self, registry: Registry) -> None:
         import sqlite3
-        upsert_result = registry.upsert(issue_number=80, title="Audit check", success_criteria="Test completion.")
+        upsert_result = registry.upsert(issue_number=80, title="Audit check", success_criteria="Test completion.", source_ref="github:issue/80")
 
         snap = _snapshot(source_ref="github:issue/80", state="closed")
         source = _make_source(issue_map={"github:issue/80": snap})
@@ -545,7 +545,7 @@ class TestTend:
     def test_tend_audit_log_written_on_surface(self, registry: Registry) -> None:
         """Audit log records surface event for diagnosing UoW whose source closes."""
         import sqlite3
-        upsert_result = registry.upsert(issue_number=90, title="Surface audit", success_criteria="Test completion.")
+        upsert_result = registry.upsert(issue_number=90, title="Surface audit", success_criteria="Test completion.", source_ref="github:issue/90")
         # Use 'diagnosing' — still in _SURFACE_ON_CLOSE_STATES (not EXECUTING_STATES).
         # 'active' is now protected (EXECUTING_STATES) and yields no_op on close.
         registry.set_status_direct(upsert_result.id, "diagnosing")
@@ -569,7 +569,7 @@ class TestTend:
     def test_tend_archives_proposed_uow_when_source_deleted(
         self, registry: Registry
     ) -> None:
-        registry.upsert(issue_number=100, title="Deleted source", success_criteria="Test completion.")
+        registry.upsert(issue_number=100, title="Deleted source", success_criteria="Test completion.", source_ref="github:issue/100")
 
         source = _make_source(issue_map={"github:issue/100": None})
         caretaker = GardenCaretaker(source=source, registry=registry)
@@ -620,7 +620,8 @@ class TestRequalifyProposed:
     ) -> None:
         """A proposed UoW whose source now carries a qualifying label advances to ready-for-steward."""
         upsert_result = registry.upsert(
-            issue_number=300, title="Now has bug label", success_criteria="Fix the bug."
+            issue_number=300, title="Now has bug label", success_criteria="Fix the bug.",
+            source_ref="github:issue/300",
         )
         snap = _snapshot(
             source_ref="github:issue/300",
@@ -649,7 +650,8 @@ class TestRequalifyProposed:
         Blocking labels still suppress promotion at any age.
         """
         upsert_result = registry.upsert(
-            issue_number=301, title="Old issue", success_criteria="Do something."
+            issue_number=301, title="Old issue", success_criteria="Do something.",
+            source_ref="github:issue/301",
         )
         snap = _snapshot(
             source_ref="github:issue/301",
@@ -786,7 +788,8 @@ class TestRequalifyProposed:
         """Audit log records 'auto_qualified' event to distinguish from seed-time qualification."""
         import sqlite3
         upsert_result = registry.upsert(
-            issue_number=307, title="Audit event check", success_criteria="Verify audit."
+            issue_number=307, title="Audit event check", success_criteria="Verify audit.",
+            source_ref="github:issue/307",
         )
         snap = _snapshot(
             source_ref="github:issue/307",
@@ -841,7 +844,8 @@ class TestRequalifyProposed:
     ) -> None:
         """run() merges requalify_proposed() output — 'requalified' key is present and correct."""
         upsert_result = registry.upsert(
-            issue_number=309, title="Run integration", success_criteria="Check run output."
+            issue_number=309, title="Run integration", success_criteria="Check run output.",
+            source_ref="github:issue/309",
         )
         snap = _snapshot(
             source_ref="github:issue/309",


### PR DESCRIPTION
## Summary

- `tend()` and `requalify_proposed()` in `garden_caretaker.py` were checking `if not uow.source` as a guard before calling `self.source.get_issue(uow.source)`. The `source` column holds origin labels like `"ralph-test"` or `"manual"` — strings without `:`, which cause `source_ref_from_str()` to raise `ValueError: not enough values to unpack`.
- The correct guard is `if not uow.source_ref` (nullable). UoWs with no GitHub issue to track have `source_ref = NULL`.
- The `get_issue()` call is updated to pass `uow.source_ref` (the canonical `"github:issue/N"` ref) instead of `uow.source`.
- All audit log entries that wrote `uow.source` into a `"source_ref"` field are corrected to use `uow.source_ref`.
- Test fixtures updated to supply `source_ref=` on `upsert()` calls for UoWs that should be processed by `tend()` and `requalify_proposed()`.

**Root cause:** 5 UoWs with `source_ref = NULL` had `source` values like `"ralph-test"` or `"manual"`. The old guard `if not uow.source` passed (truthy strings), then `get_issue(uow.source)` blew up inside `source_ref_from_str()`.

Fixes uow_20260522_77ad15.

## Test plan

- [x] All 62 `test_garden_caretaker.py` tests pass
- [x] No regressions in the broader `tests/unit/test_orchestration/` suite (pre-existing failures in `test_dispatcher_integration` and `test_executor_subprocess` confirmed pre-exist on main)

WOS-UoW: uow_20260522_77ad15

🤖 Generated with [Claude Code](https://claude.com/claude-code)