### PR TITLE
fix(wos): raise DEFAULT_MAX_PARALLEL from 2 to 5

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -75,8 +75,12 @@ _DEFAULT_WOS_CONFIG: dict = {
     # max_parallel: maximum number of UoWs that may execute concurrently.
     # The steward shard-stream gate enforces this cap before dispatching
     # a new UoW to ready-for-executor. Requires non-overlapping file_scope
-    # annotations on concurrent candidates. Default 2 (conservative).
-    "max_parallel": 2,
+    # annotations on concurrent candidates.
+    # Raised from 2 to 5 (2026-06-03): original value was conservative
+    # with no Attunement evidence at higher scale; matches
+    # MAX_CONCURRENT_PRESCRIPTIONS=5 (PR #1391). Additional throttles
+    # (ScalingGovernor, CC quota gate, context pressure threshold) remain.
+    "max_parallel": 5,
 }
 
 

--- a/src/orchestration/shard_dispatch.py
+++ b/src/orchestration/shard_dispatch.py
@@ -50,9 +50,25 @@ class PathSelection(StrEnum):
     FAST = "fast"
     THOROUGH = "thorough"
 
-# Default cap: two non-overlapping UoWs may run in parallel before any
-# Attunement evidence exists at higher concurrency.
-DEFAULT_MAX_PARALLEL: int = 2
+# Default cap: five non-overlapping UoWs may run in parallel.
+#
+# Rationale for 5 (raised from 2 on 2026-06-03):
+# - The original value of 2 was intentionally conservative — set when the
+#   shard-stream feature shipped (PR #904, April 2026) with no Attunement
+#   evidence at higher concurrency.
+# - Production observation: with 5 UoWs in executing state simultaneously
+#   (observed 2026-06-03), system stability was not degraded. The
+#   ScalingGovernor, CC quota gate, GitHub rate limit gate, and context
+#   pressure threshold (20 active sessions) remain as independent throttles.
+# - The value 2 caused UoWs to queue behind long-running peers for entire
+#   days (e.g. uow_20260522_fa2150: blocked 34 cycles before shard slots
+#   freed). The constraint is file-scope conflict, not global serialization.
+# - Set to match MAX_CONCURRENT_PRESCRIPTIONS=5 (steward-side cap, PR #1391)
+#   so that execution parallelism is consistent with prescription parallelism.
+# - Override at runtime via wos-config.json "max_parallel" key without
+#   restart. The ScalingGovernor still applies its own progressive cap on top
+#   of this value when Attunement evidence at scale is absent.
+DEFAULT_MAX_PARALLEL: int = 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestration/test_shard_dispatch.py
+++ b/tests/unit/test_orchestration/test_shard_dispatch.py
@@ -7,7 +7,7 @@ Design:
   verify, not the mechanism.
 
 Named constants used (from shard_dispatch.py):
-  DEFAULT_MAX_PARALLEL = 2
+  DEFAULT_MAX_PARALLEL = 5
 
 Behaviors verified (issue #912 semantics — null file_scope = independent):
 - No in-flight UoWs: any candidate is allowed (regardless of scope)
@@ -159,22 +159,22 @@ class TestMaxParallelCap:
     def test_at_max_parallel_blocks_dispatch(self):
         """When executing count equals max_parallel, candidate is blocked."""
         executing = [
-            _stub("uow_a", file_scope=["src/foo.py"]),
-            _stub("uow_b", file_scope=["src/bar.py"]),
+            _stub(f"uow_{i}", file_scope=[f"src/file{i}.py"])
+            for i in range(DEFAULT_MAX_PARALLEL)
         ]
         decision = check_shard_dispatch_eligibility(
-            candidate_file_scope=["src/baz.py"],  # no overlap — gate 1 fires first
+            candidate_file_scope=["src/other.py"],  # no overlap — gate 1 fires first
             candidate_shard_id=None,
             executing_uows=executing,
-            max_parallel=DEFAULT_MAX_PARALLEL,  # == 2
+            max_parallel=DEFAULT_MAX_PARALLEL,
         )
         assert isinstance(decision, DispatchBlocked)
-        assert "max_parallel=2" in decision.reason
+        assert f"max_parallel={DEFAULT_MAX_PARALLEL}" in decision.reason
 
     def test_below_max_parallel_proceeds_to_next_gate(self):
-        """One in-flight with max_parallel=2 — gate 1 does not fire."""
+        """One in-flight with max_parallel=DEFAULT_MAX_PARALLEL — gate 1 does not fire."""
         executing = [_stub("uow_a", file_scope=["src/foo.py"])]
-        # Use non-overlapping scope so gate 4 also passes
+        # Use non-overlapping scope so gate 3 also passes
         decision = check_shard_dispatch_eligibility(
             candidate_file_scope=["src/bar.py"],
             candidate_shard_id=None,
@@ -268,14 +268,14 @@ class TestNullScopeIndependent:
     def test_null_scope_still_blocked_by_max_parallel(self):
         """Null-scope candidate is still blocked when max_parallel cap is reached."""
         executing = [
-            _stub("uow_a", file_scope=None),
-            _stub("uow_b", file_scope=None),
+            _stub(f"uow_{i}", file_scope=None)
+            for i in range(DEFAULT_MAX_PARALLEL)
         ]
         decision = check_shard_dispatch_eligibility(
             candidate_file_scope=None,
             candidate_shard_id=None,
             executing_uows=executing,
-            max_parallel=DEFAULT_MAX_PARALLEL,  # == 2, both slots filled
+            max_parallel=DEFAULT_MAX_PARALLEL,  # all slots filled
         )
         assert isinstance(decision, DispatchBlocked)
         assert "max_parallel" in decision.reason
@@ -566,6 +566,6 @@ class TestWithinCycleAccumulation:
 # ---------------------------------------------------------------------------
 
 class TestDefaultMaxParallel:
-    def test_default_is_two(self):
-        """DEFAULT_MAX_PARALLEL must be 2 per spec."""
-        assert DEFAULT_MAX_PARALLEL == 2
+    def test_default_is_five(self):
+        """DEFAULT_MAX_PARALLEL must be 5 (raised from 2 on 2026-06-03 after production evidence)."""
+        assert DEFAULT_MAX_PARALLEL == 5


### PR DESCRIPTION
## Summary

- DEFAULT_MAX_PARALLEL raised from 2 to 5 in shard_dispatch.py (with full rationale in comment)
- _DEFAULT_WOS_CONFIG["max_parallel"] raised from 2 to 5 in dispatcher_handlers.py
- Test assertions that hardcoded the old default value updated to use DEFAULT_MAX_PARALLEL dynamically
- wos-config.json updated at runtime to max_parallel: 5 (runtime file, not committed)

## Root Cause

The cap of 2 was set at PR #904 (April 2026) with the comment "conservative before any Attunement evidence at higher concurrency." It was never revisited after the system accumulated production history.

## Why 2 Was Wrong

uow_20260522_fa2150 was blocked 34 consecutive cycles (an entire day) waiting for shard slots, despite having a distinct file_scope from the in-flight UoWs. The shard gate's job is to prevent file-scope conflicts — not to serialize all execution globally. With max_parallel=2, any two long-running UoWs would pin the cap and starve the queue indefinitely.

## Why 5 Is Right

- Matches MAX_CONCURRENT_PRESCRIPTIONS=5 (PR #1391) — execution parallelism is now consistent with prescription parallelism
- Production evidence: 5 UoWs simultaneously in executing state observed 2026-06-03 without system degradation
- Remaining throttles keep this from overloading the system: ScalingGovernor (N/5 cap when Attunement evidence absent), CC quota gate (90%), GitHub rate limit gate, context pressure threshold (20 active sessions)

## Test Plan

- [x] All 36 shard_dispatch tests pass
- [x] read_max_parallel() returns 5 from wos-config.json
- [x] DEFAULT_MAX_PARALLEL constant is 5

Generated with Claude Code