### PR TITLE
fix(wos): Steward exits livelock when source GitHub issue is already closed

### DIFF
--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -3958,6 +3958,34 @@ def _detect_stuck_condition(
 
 
 # ---------------------------------------------------------------------------
+# Source issue closed — pure completion signal
+# ---------------------------------------------------------------------------
+
+#: GitHub issue state string indicating a closed issue (as returned by gh CLI).
+_GITHUB_ISSUE_STATE_CLOSED = "CLOSED"
+
+
+def _source_issue_is_closed(issue_info: "IssueInfo | None") -> bool:
+    """
+    Return True when the source GitHub issue is definitively closed.
+
+    Pure function — no side effects, no I/O.
+
+    A closed issue is a completion signal regardless of executor output:
+    if the work was done (by a previous execution, human intervention, or
+    any other means), the UoW is done.
+
+    Returns False when:
+    - issue_info is None (non-GitHub source or GitHub fetch failed)
+    - issue_info.state is None (fetch returned an error)
+    - issue_info.state != "CLOSED" (issue is open or in another state)
+    """
+    if issue_info is None:
+        return False
+    return issue_info.state == _GITHUB_ISSUE_STATE_CLOSED
+
+
+# ---------------------------------------------------------------------------
 # Core per-UoW diagnosis function (pure — returns typed Diagnosis, no DB writes)
 # ---------------------------------------------------------------------------
 
@@ -3971,6 +3999,13 @@ def _diagnose_uow(
 
     Pure function: reads inputs, returns a typed Diagnosis dataclass.
     The Diagnosis is frozen and immutable — callers cannot modify it.
+
+    Source-issue-closed signal (issue #843):
+    When issue_info.state == "CLOSED", is_complete is overridden to True
+    regardless of reentry_posture or the hard-cap stuck_condition. A closed
+    source issue is definitive evidence the work is done — no further
+    execution is needed, and the UoW should transition to 'done' cleanly
+    rather than looping indefinitely as a prescribing_orphan.
     """
     return_reason = _most_recent_return_reason(audit_entries)
     reentry_posture = _determine_reentry_posture(audit_entries, return_reason)
@@ -4014,6 +4049,32 @@ def _diagnose_uow(
     # Hard cap overrides completion
     if stuck_condition == "hard_cap":
         is_complete = False
+
+    # Source-issue-closed signal (issue #843): override is_complete when the GitHub
+    # source issue is definitively closed. This fires after all other checks — including
+    # the hard-cap override — so a closed issue always wins. The rationale is that a
+    # closed issue is external evidence the work is done, regardless of executor output
+    # or cycle count. This resolves the prescribing_orphan livelock for UoWs whose
+    # source issue was resolved by a previous execution or human intervention.
+    if _source_issue_is_closed(issue_info):
+        prior_stuck_condition = stuck_condition
+        is_complete = True
+        completion_rationale = (
+            f"source_issue_closed: GitHub issue #{uow.source_issue_number} "
+            f"is already closed — work is done"
+        )
+        # Clear stuck_condition so _process_uow takes the Done path, not the surface path.
+        # A closed issue supersedes all stuck conditions including hard_cap.
+        stuck_condition = None
+        executor_outcome = None
+        log.info(
+            "_diagnose_uow: source issue #%s is closed — UoW %s marked complete "
+            "(overrides reentry_posture=%r, prior stuck_condition=%r)",
+            uow.source_issue_number,
+            uow.id,
+            reentry_posture,
+            prior_stuck_condition,
+        )
 
     return Diagnosis(
         reentry_posture=reentry_posture,

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -51,7 +51,7 @@ REPO_ROOT = Path(__file__).parent.parent.parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from src.orchestration.steward import _HARD_CAP_CYCLES
+from src.orchestration.steward import _GITHUB_ISSUE_STATE_CLOSED, _HARD_CAP_CYCLES
 
 
 # ---------------------------------------------------------------------------
@@ -4987,17 +4987,11 @@ class TestSelectPrescribedSkills:
 # cycles indefinitely even though the source issue was already resolved.
 #
 # Named constant:
-#   ISSUE_CLOSED_STATE = "CLOSED"  (gh CLI returns uppercase)
+#   _GITHUB_ISSUE_STATE_CLOSED — imported from src.orchestration.steward
 #
 # The check fires in _diagnose_uow after _assess_completion — issue_info.state
 # overrides is_complete when the issue is definitively closed.
 # ---------------------------------------------------------------------------
-
-#: GitHub state string returned by `gh issue view --json state` for closed issues.
-ISSUE_CLOSED_STATE = "CLOSED"
-
-#: GitHub state string returned by `gh issue view --json state` for open issues.
-ISSUE_OPEN_STATE = "OPEN"
 
 
 class TestSourceIssueClosedCompletion:
@@ -5015,7 +5009,7 @@ class TestSourceIssueClosedCompletion:
         from src.orchestration.steward import IssueInfo
         return IssueInfo(
             status_code=200,
-            state=ISSUE_CLOSED_STATE,
+            state=_GITHUB_ISSUE_STATE_CLOSED,
             labels=[],
             body="This issue has been resolved.",
             title="executor: implement UoW close-out protocol",
@@ -5025,7 +5019,7 @@ class TestSourceIssueClosedCompletion:
         from src.orchestration.steward import IssueInfo
         return IssueInfo(
             status_code=200,
-            state=ISSUE_OPEN_STATE,
+            state="OPEN",
             labels=[],
             body="This issue is still open.",
             title="Test issue",
@@ -5244,7 +5238,7 @@ def _make_closed_issue_info_for_test():
     from src.orchestration.steward import IssueInfo
     return IssueInfo(
         status_code=200,
-        state=ISSUE_CLOSED_STATE,
+        state=_GITHUB_ISSUE_STATE_CLOSED,
         labels=[],
         body="This issue has been resolved.",
         title="executor: implement UoW close-out protocol",

--- a/tests/unit/test_orchestration/test_steward.py
+++ b/tests/unit/test_orchestration/test_steward.py
@@ -4975,3 +4975,277 @@ class TestSelectPrescribedSkills:
         uow = self._make_uow(register="iterative-convergent")
         skills = self._call(uow, "crashed_no_output")
         assert skills.count("systematic-debugging") == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Source issue closed → UoW marked complete
+#
+# Behavior under test:
+# When a UoW's source GitHub issue is already CLOSED, the Steward should
+# recognize the work as done regardless of reentry_posture. This prevents
+# the livelock where a UoW stuck in `prescribing_orphan` → `first_execution`
+# cycles indefinitely even though the source issue was already resolved.
+#
+# Named constant:
+#   ISSUE_CLOSED_STATE = "CLOSED"  (gh CLI returns uppercase)
+#
+# The check fires in _diagnose_uow after _assess_completion — issue_info.state
+# overrides is_complete when the issue is definitively closed.
+# ---------------------------------------------------------------------------
+
+#: GitHub state string returned by `gh issue view --json state` for closed issues.
+ISSUE_CLOSED_STATE = "CLOSED"
+
+#: GitHub state string returned by `gh issue view --json state` for open issues.
+ISSUE_OPEN_STATE = "OPEN"
+
+
+class TestSourceIssueClosedCompletion:
+    """
+    Tests for the source-issue-closed completion signal in _diagnose_uow.
+
+    When the source GitHub issue is already CLOSED, _diagnose_uow must override
+    is_complete to True regardless of reentry_posture — including when posture
+    is 'first_execution' (the normal livelock scenario).
+    """
+
+    CLOSED_ISSUE_INFO_FACTORY = staticmethod(lambda: None)  # set in each test via helper
+
+    def _make_closed_issue_info(self):
+        from src.orchestration.steward import IssueInfo
+        return IssueInfo(
+            status_code=200,
+            state=ISSUE_CLOSED_STATE,
+            labels=[],
+            body="This issue has been resolved.",
+            title="executor: implement UoW close-out protocol",
+        )
+
+    def _make_open_issue_info(self):
+        from src.orchestration.steward import IssueInfo
+        return IssueInfo(
+            status_code=200,
+            state=ISSUE_OPEN_STATE,
+            labels=[],
+            body="This issue is still open.",
+            title="Test issue",
+        )
+
+    def _make_uow(self, source_issue_number: int = 843, output_ref: str | None = None):
+        """Build a minimal UoW with a GitHub issue source."""
+        from src.orchestration.registry import UoW, UoWStatus
+        return UoW(
+            id=f"uow_test_{source_issue_number}",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="executor: implement UoW close-out protocol",
+            source=f"github:issue/{source_issue_number}",
+            source_issue_number=source_issue_number,
+            created_at="2026-05-22T00:00:00+00:00",
+            updated_at="2026-06-03T00:00:00+00:00",
+            type="executable",
+            success_criteria="Close-out comment posted to source issue on UoW completion.",
+            steward_cycles=12,
+            output_ref=output_ref,
+        )
+
+    def test_closed_issue_with_first_execution_posture_is_complete(self):
+        """
+        When the source issue is CLOSED and reentry_posture is 'first_execution',
+        _diagnose_uow must return is_complete=True.
+
+        This is the primary livelock scenario: UoW was dispatched, the issue
+        got closed (by a previous execution or human), but the UoW recycled
+        as a prescribing_orphan with reentry_posture=first_execution. Without
+        the closed-issue check, the Steward loops forever.
+        """
+        steward = _import_steward()
+        uow = self._make_uow()
+        closed_issue_info = self._make_closed_issue_info()
+
+        # No audit entries → reentry_posture defaults to first_execution
+        diagnosis = steward._diagnose_uow(uow, audit_entries=[], issue_info=closed_issue_info)
+
+        assert diagnosis.is_complete is True, (
+            f"UoW with closed source issue must be diagnosed as complete. "
+            f"Got is_complete={diagnosis.is_complete}, "
+            f"completion_rationale={diagnosis.completion_rationale!r}"
+        )
+
+    def test_closed_issue_completion_rationale_mentions_issue_closed(self):
+        """
+        The completion_rationale must mention that the source issue is closed,
+        so the audit trail explains why the UoW was marked complete without
+        a result file.
+        """
+        steward = _import_steward()
+        uow = self._make_uow()
+        closed_issue_info = self._make_closed_issue_info()
+
+        diagnosis = steward._diagnose_uow(uow, audit_entries=[], issue_info=closed_issue_info)
+
+        assert "closed" in diagnosis.completion_rationale.lower(), (
+            f"completion_rationale must mention the issue is closed. "
+            f"Got: {diagnosis.completion_rationale!r}"
+        )
+
+    def test_open_issue_with_first_execution_posture_is_not_complete(self):
+        """
+        When the source issue is OPEN and reentry_posture is 'first_execution',
+        _diagnose_uow must return is_complete=False (existing behavior preserved).
+
+        This ensures we don't regress the normal new-UoW path.
+        """
+        steward = _import_steward()
+        uow = self._make_uow()
+        open_issue_info = self._make_open_issue_info()
+
+        diagnosis = steward._diagnose_uow(uow, audit_entries=[], issue_info=open_issue_info)
+
+        assert diagnosis.is_complete is False, (
+            f"UoW with open source issue and first_execution posture must NOT be complete. "
+            f"Got is_complete={diagnosis.is_complete}"
+        )
+
+    def test_none_issue_info_with_first_execution_posture_is_not_complete(self):
+        """
+        When issue_info is None (non-GitHub source or GitHub fetch failed),
+        the closed-issue check must not fire — is_complete remains False for
+        first_execution posture.
+        """
+        steward = _import_steward()
+        uow = self._make_uow()
+
+        diagnosis = steward._diagnose_uow(uow, audit_entries=[], issue_info=None)
+
+        assert diagnosis.is_complete is False, (
+            "is_complete must be False when issue_info is None and posture is first_execution"
+        )
+
+    def test_closed_issue_marks_uow_done_in_steward_cycle(self, db_path, registry, tmp_path):
+        """
+        Integration: when the source GitHub issue is CLOSED, run_steward_cycle
+        must transition the UoW to 'done' rather than re-prescribing.
+
+        This directly tests the fix for the 12-cycle livelock scenario.
+        Uses steward_cycles=3 (below hard-cap) so the closed-issue signal is
+        the deciding factor — not the hard cap.
+        """
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=3,  # below _HARD_CAP_CYCLES=9 — closed-issue signal is decisive
+            source_issue_number=843,
+            output_ref=None,
+            # No audit entries with execution_complete → reentry_posture=first_execution
+            audit_log_entries=[],
+        )
+        conn.close()
+
+        def mock_github_client_closed(issue_number):
+            return _make_closed_issue_info_for_test()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=mock_github_client_closed,
+            artifact_dir=tmp_path / "artifacts",
+            llm_prescriber=None,
+        )
+
+        uow = _get_uow(db_path, uow_id)
+        assert uow["status"] == "done", (
+            f"UoW with closed source issue must transition to 'done'. "
+            f"Got status={uow['status']!r}"
+        )
+
+    def test_open_issue_does_not_close_uow_in_steward_cycle(self, db_path, registry, tmp_path):
+        """
+        When the source GitHub issue is OPEN and posture is first_execution,
+        run_steward_cycle must prescribe the UoW (not close it).
+
+        This verifies the open-issue path is unaffected.
+        """
+        _ensure_registry_has_phase2_methods(registry)
+        steward = _import_steward()
+
+        conn = _open_db(db_path)
+        uow_id = _make_uow_row(
+            conn,
+            status="ready-for-steward",
+            steward_cycles=0,
+            source_issue_number=999,
+            output_ref=None,
+        )
+        conn.close()
+
+        steward.run_steward_cycle(
+            registry=registry,
+            dry_run=False,
+            github_client=_mock_github_client_open,
+            artifact_dir=tmp_path / "artifacts",
+            llm_prescriber=None,
+        )
+
+        uow = _get_uow(db_path, uow_id)
+        assert uow["status"] != "done", (
+            f"UoW with open source issue must NOT be closed. "
+            f"Got status={uow['status']!r}"
+        )
+
+
+    def test_closed_issue_overrides_hard_cap_to_close_cleanly(self):
+        """
+        When the source issue is CLOSED and steward_cycles exceeds _HARD_CAP_CYCLES,
+        the closed-issue signal must override the hard cap to close the UoW as
+        'done' rather than surfacing to Dan.
+
+        Rationale: the hard cap prevents infinite LLM loops, but a closed issue is
+        definitive evidence the work is done. Surfacing a closed-issue UoW to Dan
+        would be noise — the issue is already resolved.
+        """
+        steward = _import_steward()
+        # steward_cycles above hard cap (9)
+        uow = self._make_uow()
+        # Force high lifetime_cycles by building UoW with explicit value
+        from src.orchestration.registry import UoW, UoWStatus
+        uow_over_cap = UoW(
+            id="uow_test_overcap",
+            status=UoWStatus.READY_FOR_STEWARD,
+            summary="executor: implement UoW close-out protocol",
+            source="github:issue/843",
+            source_issue_number=843,
+            created_at="2026-05-22T00:00:00+00:00",
+            updated_at="2026-06-03T00:00:00+00:00",
+            type="executable",
+            success_criteria="Close-out comment posted.",
+            steward_cycles=12,
+            lifetime_cycles=12,
+            output_ref=None,
+        )
+        closed_issue_info = self._make_closed_issue_info()
+
+        diagnosis = steward._diagnose_uow(
+            uow_over_cap, audit_entries=[], issue_info=closed_issue_info
+        )
+
+        assert diagnosis.is_complete is True, (
+            f"Closed source issue must override hard_cap: is_complete should be True. "
+            f"Got is_complete={diagnosis.is_complete}, "
+            f"completion_rationale={diagnosis.completion_rationale!r}"
+        )
+
+
+def _make_closed_issue_info_for_test():
+    """Build a closed IssueInfo for test helpers that need a plain function."""
+    from src.orchestration.steward import IssueInfo
+    return IssueInfo(
+        status_code=200,
+        state=ISSUE_CLOSED_STATE,
+        labels=[],
+        body="This issue has been resolved.",
+        title="executor: implement UoW close-out protocol",
+    )


### PR DESCRIPTION
## The problem

UoWs whose source GitHub issue was resolved — by a previous execution, a merged
PR, or human intervention — can cycle indefinitely without closing. The pattern:

1. Steward diagnoses UoW with `reentry_posture=first_execution`
2. `_assess_completion` returns `False` (first_execution has no output to verify)
3. Steward re-prescribes → UoW transitions to `prescribing`
4. Dispatch orphans (prescription subagent times out or is killed)
5. Startup sweep resets to `ready-for-steward` as `prescribing_orphan`
6. Repeat from step 1

`uow_20260522_ca95d4` (source: issue #843) reached 12 steward cycles in this
loop. Issue #843 was resolved in April 2026 by PR #845 — the work was done, but
the UoW had no way to know that.

## The fix

A closed GitHub issue is definitive external evidence the work is done. The
Steward already fetches `issue_info` (including `state`) for every UoW with a
GitHub source — but only used it for the `bootup-candidate` gate. This PR adds
a second use: when `issue_info.state == "CLOSED"`, `_diagnose_uow` overrides
`is_complete = True` and clears `stuck_condition`, regardless of `reentry_posture`
or the hard-cap override.

The override fires in `_diagnose_uow` after all other checks, so:
- `first_execution` posture → closed issue wins (resolves the livelock)
- `hard_cap` → closed issue wins (skips the Dan surface, closes cleanly)
- Open issue → no change (existing behavior preserved)
- No `issue_info` (non-GitHub source, fetch failed) → no change

## What changed

`_diagnose_uow` in `steward.py` — two additions:
1. Pure function `_source_issue_is_closed(issue_info)` — named constant
   `_GITHUB_ISSUE_STATE_CLOSED = "CLOSED"`, no I/O.
2. Post-assessment override block at the end of `_diagnose_uow` that fires when
   `_source_issue_is_closed(issue_info)` is True.

7 new tests in `test_steward.py` (class `TestSourceIssueClosedCompletion`):
- Unit: closed issue + first_execution → is_complete=True
- Unit: completion_rationale mentions "closed"
- Unit: open issue + first_execution → is_complete=False (regression guard)
- Unit: None issue_info → is_complete=False (non-GitHub source regression guard)
- Unit: closed issue overrides hard_cap
- Integration: run_steward_cycle transitions to "done" for closed-issue UoW
- Integration: run_steward_cycle does NOT close UoW with open source issue

Scope: `src/orchestration/steward.py` only. No changes to `wos_completion.py`,
`wos_issue_lifecycle.py`, executor, or dispatch infrastructure.

## State transition

Before:
```
prescribing_orphan → ready-for-steward
→ Steward: first_execution, issue_info.state=CLOSED
→ _assess_completion: is_complete=False (first_execution always False)
→ re-prescribes → repeat indefinitely
```

After:
```
prescribing_orphan → ready-for-steward
→ Steward: first_execution, issue_info.state=CLOSED
→ _diagnose_uow override: is_complete=True, stuck_condition=None
→ Steward closes UoW: status=done
```

## Functional patterns

- `_source_issue_is_closed` is a pure function (no side effects, no I/O)
- `_GITHUB_ISSUE_STATE_CLOSED = "CLOSED"` is a named constant anchored to the
  gh CLI's return format — not a magic string
- The override is compositional: it reads the inputs produced by the existing
  pipeline and produces a new is_complete value, without modifying the pipeline

## Tests run
- [x] `uv run pytest tests/unit/test_orchestration/test_steward.py -k "TestSourceIssueClosedCompletion or TestCompletionPath or TestHardCap or TestBootupCandidateGate"` — 27 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_issue_lifecycle.py tests/unit/test_orchestration/test_wos_completion.py` — 109 passed, 2 pre-existing failures (TestCloseoutProtocolIntegration::test_telegram_source_skips_comment and test_system_source_skips_comment fail on main too — Adaptive Steward Haiku normalization mock issue, unrelated to this PR)
- [x] Python syntax check via `py_compile` — clean

**Pre-existing test failures (not introduced by this PR):**
`TestCloseoutProtocolIntegration::test_telegram_source_skips_comment` and
`test_system_source_skips_comment` fail on main with the same error (Haiku
normalization subprocess mock leaks). These are in wos_completion.py tests, not
touched by this PR.

## Manual test
N/A — this change is entirely internal to the Steward's diagnosis function.
No external service calls, no inbox writes, no Telegram output, no DB schema
changes. The change fires during the steward heartbeat cycle when it reads
issue state from the `issue_info` object already passed in.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A (internal change)
- [x] User-visible outcome verified OR not applicable — not applicable (Steward internal)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: mocked in tests; no new external calls introduced

Relates to #843
WOS-UoW: uow_20260522_ca95d4