### PR TITLE
fix: move model field to top of review.md frontmatter

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,5 +1,7 @@
 ---
 name: review
+model: claude-opus-4-6
+color: blue
 description: "Review agent — handles two modes: (1) code review of a GitHub PR or commit, or (2) design review of a proposal, architecture idea, or approach. Auto-detects mode from context. Trigger phrases: 'review issue #X', 'review PR #Y', 'review BIS-Z', 'review #123', 'review this design', 'review this proposal'.
 
 <example>
@@ -36,8 +38,6 @@ user: \"Review the design in issue #42\"
 assistant: \"Pulling up issue #42 and reviewing the design.\"
 <Task tool invocation to launch review agent>
 </example>"
-model: claude-opus-4-6
-color: blue
 ---
 
 > **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(sent_reply_to_user=True)` when your task is complete.


### PR DESCRIPTION
## Problem

The `review` agent was dispatching at Sonnet tier instead of Opus tier. The `model: claude-opus-4-6` field existed in the file but appeared after a long multi-line quoted string in the `description:` field — positioned at lines 39-40, between the closing quote of the description value and the closing `---` of the frontmatter.

YAML parsers encountering a multi-line quoted string value spanning 35+ lines may not reliably parse fields that follow it in the same frontmatter block. The `model:` field was silently ignored, and Claude Code fell back to the session default (Sonnet).

## Fix

Moved `model: claude-opus-4-6` and `color: blue` to lines 3-4, immediately after `name:` and before the `description:` field. This matches the established pattern in `functional-engineer.md` and other agent definitions where short scalar fields precede the long description value.

The content of the file is entirely unchanged — only the field order within the frontmatter block is different.

## Before / After

```
Before:                          After:
---                              ---
name: review                     name: review
description: "..."   (35 lines)  model: claude-opus-4-6
model: claude-opus-4-6           color: blue
color: blue                      description: "..."   (35 lines)
---                              ---
```

No body content, behavior text, or logic changed.

## Tests run
- [x] `git diff` reviewed — 2 insertions, 2 deletions; only field order changed, zero content changes
- [ ] Live dispatch test — blocked: requires a live session; confirming the model field is parsed correctly is observable on next oracle/review invocation

**Blocked items needing attention before merge:** none — change is a pure reorder within the YAML frontmatter.

## Manual test
N/A — this change does not touch systemd, cron, external services, file I/O at runtime, or DB schema. The effect (Opus vs Sonnet dispatch) is observable on the next review agent invocation.

## Definition of Done
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none
- [ ] User-visible outcome verified — dispatch tier change will be visible on next oracle/review invocation

Closes #1339