### PR TITLE
fix: make wos_prescribe visible to dispatcher — text synthesis + dispatcher_hint

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -5301,6 +5301,10 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         if msg_type == "wos_execute":
             _uow_id = msg.get("uow_id", "?")
             text = f"wos_execute: uow_id={_uow_id}"
+        elif msg_type == "wos_prescribe":
+            _uow_id = msg.get("uow_id", "?")
+            _summary = str(msg.get("uow_summary", "?"))[:60]
+            text = f"wos_prescribe: uow_id={_uow_id}, summary={_summary}"
         else:
             text = msg.get("text", "(no text)")
 
@@ -5341,6 +5345,9 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         elif msg_type == "wos_execute":
             uow_id = msg.get("uow_id", "?")
             output += f"🔧 **[WOS EXECUTE]** uow_id=`{uow_id}`\n"
+        elif msg_type == "wos_prescribe":
+            uow_id = msg.get("uow_id", "?")
+            output += f"📋 **[WOS PRESCRIBE]** uow_id=`{uow_id}`\n"
         elif msg_type == "reaction":
             emoji = msg.get("emoji", "?")
             reacted_to_text = msg.get("reacted_to_text", "")
@@ -5363,6 +5370,13 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         if msg_type == "wos_execute":
             uow_id = msg.get("uow_id", "?")
             output += f"dispatcher_hint: WOS_EXECUTE — call route_wos_message(msg) from src/orchestration/dispatcher_handlers.py. uow_id={uow_id}. Do not read prose — use the structural route.\n"
+        if msg_type == "wos_prescribe":
+            _uow_id = msg.get("uow_id", "?")
+            output += (
+                f"dispatcher_hint: WOS_PRESCRIBE — call route_wos_message(msg) from "
+                f"src/orchestration/dispatcher_handlers.py. uow_id={_uow_id}. "
+                f"Spawns prescription subagent.\n"
+            )
         _has_file = msg_type in ("voice", "photo", "document") or bool(
             msg.get("image_file") or msg.get("image_files") or
             msg.get("file_path") or msg.get("audio_file")

--- a/src/mcp/message_types.py
+++ b/src/mcp/message_types.py
@@ -56,6 +56,13 @@ INBOX_SYSTEM_TYPES: frozenset[str] = frozenset({
     "debug_observation",      # debug output from inbox_server.py internals; excluded from skill processing
     "session_note_reminder",  # MCP counter reached 20 user messages — dispatcher should spawn session-note-appender
     "wos_execute",            # WOS executor dispatched a UoW — dispatcher must call route_wos_message() to spawn subagent (issue #856)
+    "wos_prescribe",          # WOS steward dispatched a prescription task — dispatcher must call route_wos_message() to spawn prescription subagent
+    "wos_escalate",           # WOS subagent escalated a UoW for owner attention
+    "wos_done",               # WOS UoW reached terminal done state
+    "wos_surface",            # WOS surfacing event — steward surfacing a completed/notable UoW result
+    "steward_trigger",        # WOS steward-heartbeat trigger message
+    "wos_uow_completed",      # WOS UoW completed and result is ready
+    "wos_capacity_available", # WOS executor capacity became available (slot freed after completion)
     "wos_owner_required",     # WOS subagent escalated with outcome=owner_decision_required; UoW is awaiting-owner; dispatcher relays to Dan
     "scheduled_task_crash",   # heartbeat script caught an unhandled exception and wrote a crash alert (fields: job_name, text)
     "pr_review_request",      # PR-review sweeper coordinator requests oracle review for a specific PR (source: pr_review_sweeper)


### PR DESCRIPTION
## Summary

- `wos_prescribe` messages were arriving as `(no text)` with no `dispatcher_hint`, causing them to be silently dropped and prescription subagents never spawned
- Same bug class as the April `wos_execute` fix — applied the identical pattern (text synthesis + display label + `dispatcher_hint`) for `wos_prescribe` in `inbox_server.py`
- Added `wos_prescribe` and 6 other missing WOS message types to `INBOX_SYSTEM_TYPES` in `message_types.py`

Fixes #1410.

## Changes

**`src/mcp/inbox_server.py`** (3 hunks):
1. Text synthesis: `wos_prescribe: uow_id=X, summary=Y` (prevents `(no text)` display)
2. Display label: `[WOS PRESCRIBE]` in the formatted message output
3. `dispatcher_hint`: `WOS_PRESCRIBE — call route_wos_message(msg)...` structural routing signal

**`src/mcp/message_types.py`** (1 hunk):
- Added `wos_prescribe`, `wos_escalate`, `wos_done`, `wos_surface`, `steward_trigger`, `wos_uow_completed`, `wos_capacity_available` to `INBOX_SYSTEM_TYPES`

## Test plan

- [x] All 91 WOS-related tests pass (`test_wos_execute_gate.py`, `test_wos_execute_router.py`, `test_wos_stage2_event_native.py`)
- [x] Both changed files pass Python syntax check (`ast.parse`)
- [x] Pre-existing unrelated failure in `test_dispatch_job_sh.py::TestRunJobShDisabledFlag` confirmed not introduced by this PR
- [ ] Manual: restart MCP and verify `wos_prescribe` messages now show correct text and dispatcher_hint in `check_inbox` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)