### PR TITLE
docs(oracle): enforce single-pass execution constraint in lobster-oracle.md

### DIFF
--- a/.claude/agents/lobster-oracle.md
+++ b/.claude/agents/lobster-oracle.md
@@ -30,6 +30,8 @@ Do not let the quality of the implementation resolve your Stage 1 question. Good
 
 ## Invocation modes
 
+**All modes complete in a single pass.** Gather all inputs before writing any output. Do not iterate within the session.
+
 Your task prompt specifies one of:
 
 **Standard (post-PR):** You receive issue description + vision.yaml. You do NOT yet read the implementation. Complete Stage 1, write findings. Then receive PR diff for Stage 2.
@@ -57,6 +59,29 @@ Before entering Stage 1, classify the review target:
 - **Validation mode**: the artifact has no external adjudicator (design docs, specs, bootup files, prescriptions, UoW documents). The oracle's attending is the primary mechanism for surfacing what the document occludes — what it presupposes without stating, defers without naming, or resolves prematurely. A vague NEEDS_CHANGES in validation mode is an oracle failure, not a document failure. Genuine attunement is required; checklists cannot substitute for it.
 
 State your mode classification at the top of every verdict file, immediately after the VERDICT line, before any other content.
+
+---
+
+## Single-pass execution constraint
+
+Complete this entire review — Stage 1, Stage 2, all file writes (verdict, learnings, golden-patterns, premise-review if applicable), and `write_result` — in a single agent session with no multi-turn deliberation within the session.
+
+**Do not** pause, re-read files you already read, or iterate on your findings within this session. Gather all inputs first in order, then produce all outputs in sequence.
+
+Execution order (one pass):
+1. Read vision.yaml
+2. Read oracle/learnings.md and oracle/golden-patterns.md
+3. Read the implementation (diff, code, or document) — Stage 2 input
+4. Produce Stage 1 findings (do not revise after seeing implementation)
+5. Produce Stage 2 findings
+6. Write oracle/verdicts/pr-{number}.md (or document verdict file)
+7. Append to oracle/verdicts/index.md
+8. Append to oracle/learnings.md (if applicable)
+9. Append to oracle/golden-patterns.md (if applicable)
+10. Emit oracle_approved audit event if APPROVED and uow_id provided
+11. Call write_result
+
+If you realize mid-review that you need more context, include the gap as a named NEEDS_CHANGES finding rather than looping back to gather more input.
 
 ---
 


### PR DESCRIPTION
## What this solves

Oracle review sessions were accumulating multi-turn context within a single session. Reviews on PRs #738 and #739 contributed significantly to hitting the weekly API cap. The oracle agent had no structural constraint on how it should sequence its work — it could read, revisit, revise, and deliberate freely within a session, burning tokens on intra-session loops.

The outer wos-pr-coordinator already caps oracle/fix rounds (1-4). This change addresses the inner oracle session itself: one pass from input-gathering to output-writing, no back-and-forth.

## What changed

Two additions to `.claude/agents/lobster-oracle.md`:

**1. `## Single-pass execution constraint` section** (inserted immediately before `## Stage 1: Vision alignment`): specifies a fixed 11-step execution order — read all inputs first (vision.yaml, learnings, golden-patterns, implementation), produce all outputs in sequence (findings, verdict file, index, learnings, golden-patterns, audit event), call `write_result` last. Includes an explicit rule: if more context is needed mid-review, surface it as a NEEDS_CHANGES finding rather than looping back.

**2. Single-pass note at the top of `## Invocation modes`**: one sentence flagging the constraint early in the prompt so it's seen before the mode descriptions.

## What this does NOT change

- The two-stage review structure (Stage 1 / Stage 2) is unchanged
- The verdict format and output protocol are unchanged
- The outer wos-pr-coordinator round cap is unchanged
- No other agent definitions or orchestration files are modified

## Tests run

- [x] File diff reviewed — structure intact, no accidental deletions, constraint section appears immediately before `## Stage 1`
- [ ] Live oracle run — blocked: requires a new PR to trigger oracle review; the constraint is behavioral, not code, so unit tests are not applicable

**Blocked items needing attention before merge:** None — the constraint is doc-only.

## Manual test

N/A — this change modifies an agent definition document only. The constraint takes effect the next time the oracle agent is dispatched. No file I/O, external service calls, or DB changes.

## Definition of Done
- [x] Unit tests pass with proper mocking — not applicable (doc-only change)
- [x] Integration/manual test — not applicable (doc-only; behavioral change takes effect on next oracle dispatch)
- [x] User-visible outcome — not applicable (internal oracle constraint; outcome is reduced API token consumption on oracle sessions)
- [x] Side-effect audit — no floods, no writes, no volume impact
- [x] External service calls — none

Closes #741