### PR TITLE
fix(wos): auto-reset prescribing UoWs after 30-min heartbeat silence (closes #1388)

### DIFF
--- a/scheduled-tasks/steward-heartbeat.py
+++ b/scheduled-tasks/steward-heartbeat.py
@@ -95,6 +95,12 @@ log = logging.getLogger("steward-heartbeat")
 _DEFAULT_STALL_SECONDS = 1800  # 30 minutes fallback when timeout_at is NULL
 HIGH_PRESCRIPTION_THRESHOLD = 10  # Alert when prescriptions per cycle exceeds this (#618)
 
+# Heartbeat-silence TTL for prescribing UoWs (issue #1388).
+# A UoW stuck in prescribing with no heartbeat for this many seconds is
+# automatically reset to ready-for-steward with a heartbeat_silence_ttl audit event.
+# 30 minutes balances recovery latency against false positives for long prescriptions.
+PRESCRIBING_SILENCE_TTL_SECONDS: int = 1800
+
 # Failure-traces cleanup caps (issue #947)
 TRACES_DIR: Path = Path(
     os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
@@ -251,6 +257,14 @@ class ObservationResult:
 @dataclass(frozen=True, slots=True)
 class HeartbeatStallResult:
     """Pure result value returned by recover_stale_heartbeat_uows."""
+    checked: int
+    recovered: int
+    skipped_dry_run: int
+
+
+@dataclass(frozen=True, slots=True)
+class PrescribingSilenceResult:
+    """Pure result value returned by recover_stale_prescribing_uows (issue #1388)."""
     checked: int
     recovered: int
     skipped_dry_run: int
@@ -671,6 +685,114 @@ def recover_stale_heartbeat_uows(
             )
 
     return HeartbeatStallResult(
+        checked=len(stale_uows),
+        recovered=recovered,
+        skipped_dry_run=skipped_dry_run,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prescribing-state heartbeat-silence recovery (issue #1388)
+# ---------------------------------------------------------------------------
+
+def recover_stale_prescribing_uows(
+    registry,
+    dry_run: bool = False,
+    ttl_seconds: int = PRESCRIBING_SILENCE_TTL_SECONDS,
+) -> PrescribingSilenceResult:
+    """
+    Scan for prescribing UoWs whose heartbeat has been silent for ttl_seconds
+    and reset them to ready-for-steward.
+
+    Called in the observation phase alongside recover_stale_heartbeat_uows.
+    This handles UoWs stuck in `prescribing` — a state entered when the steward
+    dispatches an async LLM prescription subagent. If the subagent stops writing
+    heartbeats (auth outage, process kill, network partition), the UoW can remain
+    in `prescribing` indefinitely.
+
+    Staleness condition:
+    - status = 'prescribing'
+    - heartbeat_at IS NULL (subagent never started)
+      OR (now - heartbeat_at) > ttl_seconds
+
+    Recovery action: transition to 'ready-for-steward' via
+    record_prescribing_silence_reset(), which writes a heartbeat_silence_ttl
+    audit entry. The steward's re-entry classifier treats the UoW as a fresh
+    prescription candidate on re-entry.
+
+    Healthy long-running prescriptions that write periodic heartbeats are NOT
+    reset — only genuinely silent UoWs trigger recovery. This prevents false
+    positives for prescriptions that legitimately take 60–90+ minutes.
+
+    In dry_run mode: detects stale UoWs but does NOT write audit entries or
+    transition status. Returns detected count in skipped_dry_run.
+
+    Args:
+        registry: Registry instance.
+        dry_run: If True, detect only — no state transitions.
+        ttl_seconds: Heartbeat silence threshold in seconds. Default 1800 (30 min).
+
+    Returns:
+        PrescribingSilenceResult(checked, recovered, skipped_dry_run).
+    """
+    try:
+        stale_uows = registry.get_stale_prescribing_uows(stale_after_seconds=ttl_seconds)
+    except Exception as e:
+        log.warning("Prescribing-silence recovery: failed to query stale UoWs — %s", e)
+        return PrescribingSilenceResult(checked=0, recovered=0, skipped_dry_run=0)
+
+    recovered = 0
+    skipped_dry_run = 0
+
+    for uow in stale_uows:
+        uow_id = uow.id
+        heartbeat_at = uow.heartbeat_at
+
+        # Compute silence duration for logging.
+        silence_seconds: float = 0.0
+        try:
+            if heartbeat_at:
+                silence_seconds = (_utc_now() - _parse_iso(heartbeat_at)).total_seconds()
+        except (ValueError, TypeError):
+            pass
+
+        if dry_run:
+            log.info(
+                "Prescribing-silence (DRY RUN): UoW %s would be reset to ready-for-steward "
+                "(heartbeat_at=%s, silence=%.0fs, ttl=%ds)",
+                uow_id, heartbeat_at, silence_seconds, ttl_seconds,
+            )
+            skipped_dry_run += 1
+            continue
+
+        try:
+            rows = registry.record_prescribing_silence_reset(
+                uow_id=uow_id,
+                heartbeat_at=heartbeat_at,
+                silence_seconds=silence_seconds,
+            )
+        except Exception as e:
+            log.warning(
+                "Prescribing-silence recovery: failed to reset UoW %s — %s",
+                uow_id, e,
+            )
+            continue
+
+        if rows == 1:
+            recovered += 1
+            log.info(
+                "Prescribing-silence recovery: auto-reset UoW %s from prescribing to "
+                "ready-for-steward (heartbeat_silence_ttl, silence=%.0fs, ttl=%ds)",
+                uow_id, silence_seconds, ttl_seconds,
+            )
+        else:
+            log.debug(
+                "Prescribing-silence recovery: race on UoW %s — already advanced by "
+                "another component (rows_affected=0)",
+                uow_id,
+            )
+
+    return PrescribingSilenceResult(
         checked=len(stale_uows),
         recovered=recovered,
         skipped_dry_run=skipped_dry_run,
@@ -1270,6 +1392,23 @@ def _main_inner() -> int:
         )
     except Exception:
         log.exception("Sidecar-masked detection failed — continuing to Steward main loop")
+
+    # Phase 2b-iii: Prescribing-state heartbeat-silence recovery (issue #1388).
+    # Detects UoWs stuck in prescribing with no heartbeat for PRESCRIBING_SILENCE_TTL_SECONDS.
+    # Complements Phase 2b (active/executing heartbeat stall recovery): that path handles
+    # UoWs in active/executing; this path handles UoWs in prescribing that stop heartbeating
+    # due to auth outages, process kills, or network partitions.
+    log.info("--- Phase 2b-iii: Prescribing-silence recovery ---")
+    try:
+        prescribing_result = recover_stale_prescribing_uows(registry, dry_run=dry_run)
+        log.info(
+            "Prescribing-silence recovery complete: %d checked, %d recovered, "
+            "%d skipped (dry-run)",
+            prescribing_result.checked, prescribing_result.recovered,
+            prescribing_result.skipped_dry_run,
+        )
+    except Exception:
+        log.exception("Prescribing-silence recovery failed — continuing to Steward main loop")
 
     # Phase 2c: Stuck-agent detection — progress governor (migration 0017, issue #994).
     # Agents that write heartbeats while consuming no tokens are alive but not progressing.

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4832,6 +4832,15 @@ finally:
         substep "Migration 132b: orchestration/checkpoints/ already exists — skipping"
     fi
 
+    # Migration 133: Prescribing-state heartbeat-silence TTL auto-reset (issue #1388).
+    # No schema change required — behavioral addition to steward-heartbeat.py only.
+    # Phase 2b-iii in the steward heartbeat loop now auto-resets prescribing UoWs
+    # whose heartbeat has been silent for 30+ minutes to ready-for-steward.
+    # This requires no operator action; the steward-heartbeat cron (*/3 * * * *) picks
+    # it up automatically on the next cycle after deploy.
+    substep "Migration 133: prescribing-silence TTL auto-reset (no schema change, no action required)"
+    # Not counted in migrated — there is nothing to apply.
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -3455,6 +3455,155 @@ class Registry:
             conn.close()
 
     # -----------------------------------------------------------------------
+    # Prescribing-state heartbeat-silence TTL (issue #1388)
+    # -----------------------------------------------------------------------
+
+    def get_stale_prescribing_uows(
+        self,
+        stale_after_seconds: int = 1800,
+    ) -> list["UoW"]:
+        """
+        Return UoWs in `prescribing` state whose heartbeat has been silent
+        for at least stale_after_seconds (default: 1800 s / 30 minutes).
+
+        A UoW is eligible when:
+        1. status = 'prescribing'
+        2. heartbeat_at IS NOT NULL and (now - heartbeat_at) > stale_after_seconds
+           — agent was alive but has since gone silent (auth outage, kill, partition)
+           OR heartbeat_at IS NULL and (now - updated_at) > stale_after_seconds
+           — no heartbeat was ever written and the UoW has been prescribing
+             for longer than the threshold (startup_sweep handles <660s cases)
+
+        Two staleness paths:
+        1. heartbeat_at IS NOT NULL and (now - heartbeat_at) > stale_after_seconds:
+           The prescription subagent was alive and writing heartbeats but has since
+           gone silent — auth outage, process kill, network partition.
+        2. heartbeat_at IS NULL and (now - updated_at) > stale_after_seconds:
+           The UoW entered prescribing but no heartbeat was ever written. The startup
+           sweep handles fresh NULL-heartbeat UoWs at 660 s (prescribing_orphan_threshold);
+           this method handles the longer 30-minute window for UoWs the startup sweep
+           did not yet reach or that recovered from a prior reset without writing heartbeats.
+
+        Contrast with get_stale_heartbeat_uows() (active/executing path):
+        - That method uses heartbeat_ttl + buffer_seconds per-UoW threshold.
+        - This method uses a single fixed stale_after_seconds for all prescribing
+          UoWs, because prescription subagents write heartbeats on a different
+          cadence and heartbeat_ttl is not set at prescribing transition time.
+
+        Args:
+            stale_after_seconds: Minimum silence threshold in seconds. Default 1800.
+
+        Returns:
+            List of UoW objects that are stale in prescribing state (may be empty).
+        """
+        conn = self._connect()
+        try:
+            now = _now_iso()
+            rows = conn.execute(
+                """
+                SELECT * FROM uow_registry
+                WHERE status = 'prescribing'
+                  AND (
+                    (
+                      heartbeat_at IS NOT NULL
+                      AND CAST(
+                            (julianday(?) - julianday(heartbeat_at)) * 86400 AS INTEGER
+                          ) > ?
+                    )
+                    OR (
+                      heartbeat_at IS NULL
+                      AND CAST(
+                            (julianday(?) - julianday(updated_at)) * 86400 AS INTEGER
+                          ) > ?
+                    )
+                  )
+                ORDER BY COALESCE(heartbeat_at, updated_at) ASC
+                """,
+                (now, stale_after_seconds, now, stale_after_seconds),
+            ).fetchall()
+            return [self._row_to_uow(r) for r in rows]
+        finally:
+            conn.close()
+
+    def record_prescribing_silence_reset(
+        self,
+        uow_id: str,
+        heartbeat_at: str | None,
+        silence_seconds: float,
+    ) -> int:
+        """
+        Atomically write a `heartbeat_silence_ttl` audit entry and transition
+        a UoW from `prescribing` to `ready-for-steward`.
+
+        Called by the steward heartbeat's prescribing-silence recovery loop
+        when get_stale_prescribing_uows() identifies a stale prescribing UoW.
+
+        Follows the same optimistic-lock + audit pattern used throughout the
+        registry (Principle 1: no silent transitions):
+        - UPDATE uses WHERE status = 'prescribing' as the optimistic lock.
+        - Audit INSERT is written in the same transaction only if rows == 1.
+        - Returns 1 on success, 0 if another component already advanced this
+          UoW (race-safe — no duplicate audit entry written).
+
+        The audit entry uses event='heartbeat_silence_ttl' with a structured
+        note payload so the steward's re-entry classifier and human operators
+        can distinguish this recovery reason from other ready-for-steward
+        transitions (e.g. stall_detected, startup_sweep, execution_complete).
+
+        Args:
+            uow_id: The UoW identifier.
+            heartbeat_at: Last known heartbeat_at timestamp (may be None).
+            silence_seconds: Computed silence duration in seconds (for audit note).
+
+        Returns:
+            1 if the transition succeeded; 0 on race (UoW already advanced).
+        """
+        now = _now_iso()
+        note_payload = json.dumps({
+            "event": "heartbeat_silence_ttl",
+            "actor": "steward_heartbeat",
+            "uow_id": uow_id,
+            "reason": "heartbeat_silence_ttl",
+            "heartbeat_at": heartbeat_at,
+            "silence_seconds": silence_seconds,
+            "timestamp": now,
+        })
+
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+
+            cursor = conn.execute(
+                """
+                UPDATE uow_registry
+                SET status = 'ready-for-steward', updated_at = ?
+                WHERE id = ? AND status = 'prescribing'
+                """,
+                (now, uow_id),
+            )
+            rows_affected = cursor.rowcount
+
+            if rows_affected == 1:
+                conn.execute(
+                    """
+                    INSERT INTO audit_log
+                        (ts, uow_id, event, from_status, to_status, agent, note)
+                    VALUES (?, ?, 'heartbeat_silence_ttl', 'prescribing',
+                            'ready-for-steward', 'steward_heartbeat', ?)
+                    """,
+                    (now, uow_id, note_payload),
+                )
+
+            conn.commit()
+            return rows_affected
+
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    # -----------------------------------------------------------------------
     # Time-window query (used by registry_cli report command)
     # -----------------------------------------------------------------------
 

--- a/tests/unit/test_orchestration/test_prescribing_silence_ttl.py
+++ b/tests/unit/test_orchestration/test_prescribing_silence_ttl.py
@@ -1,0 +1,571 @@
+"""
+Unit tests for prescribing-state heartbeat-silence TTL auto-reset (issue #1388).
+
+When a UoW is stuck in `prescribing` and its heartbeat has been silent for
+PRESCRIBING_SILENCE_TTL_SECONDS (30 minutes), the steward heartbeat should
+automatically reset it to `ready-for-steward` with a `heartbeat_silence_ttl`
+audit event.
+
+Tests are derived from the spec — each test name states the behavior being verified,
+not the mechanism.
+
+Test coverage:
+- test_stale_prescribing_uow_returned_when_heartbeat_silent: UoW in prescribing with
+  heartbeat older than 30 min IS returned by get_stale_prescribing_uows
+- test_fresh_prescribing_uow_not_returned_when_heartbeat_recent: UoW in prescribing
+  with recent heartbeat is NOT returned (healthy long-running case)
+- test_prescribing_uow_with_null_heartbeat_returned: prescribing UoW with NULL
+  heartbeat_at IS returned (null means never written — treat as stale)
+- test_non_prescribing_status_not_returned: UoWs in active/executing/done are
+  never returned, regardless of heartbeat age
+- test_record_prescribing_silence_transitions_to_ready_for_steward: state transition
+  succeeds and leaves the UoW in ready-for-steward
+- test_record_prescribing_silence_writes_heartbeat_silence_ttl_audit_event: audit
+  log contains heartbeat_silence_ttl event with structured payload
+- test_record_prescribing_silence_returns_zero_on_race: optimistic lock prevents
+  double-application when UoW has already been advanced
+- test_recover_stale_prescribing_requeues_uow: recover_stale_prescribing_uows
+  re-queues stale UoWs and returns correct result counts
+- test_recover_stale_prescribing_dry_run_no_transition: dry-run does not mutate state
+- test_recover_fresh_prescribing_not_requeued: UoW with recent heartbeat stays in
+  prescribing after recovery loop runs
+- test_only_prescribing_status_eligible_for_prescribing_recovery: active/executing
+  UoWs with stale heartbeats are NOT touched by the prescribing recovery path
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.orchestration.registry import Registry, UoWStatus
+
+# ---------------------------------------------------------------------------
+# Named constants from spec (issue #1388)
+# ---------------------------------------------------------------------------
+
+# Staleness threshold: 30 minutes of heartbeat silence triggers auto-reset
+PRESCRIBING_SILENCE_TTL_SECONDS = 1800  # 30 minutes
+
+# A buffer beyond the TTL to absorb scheduling jitter (mirrors heartbeat_stall pattern)
+DEFAULT_BUFFER_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.db"
+
+
+@pytest.fixture
+def registry(db_path: Path) -> Registry:
+    """Registry with all migrations applied."""
+    return Registry(db_path)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _iso_offset(seconds: float) -> str:
+    """Return an ISO timestamp offset by `seconds` from now (negative = past)."""
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+def _insert_prescribing_uow(
+    db_path: Path,
+    *,
+    heartbeat_at: str | None = None,
+    status: str = "prescribing",
+    updated_at: str | None = None,
+) -> str:
+    """Insert a UoW in prescribing (or specified) status directly via SQLite.
+
+    Returns the uow_id. Allows setting specific heartbeat_at/updated_at scenarios
+    that the normal steward dispatch path does not expose (e.g. stale or NULL).
+
+    When updated_at is None, uses the current time (a fresh UoW).
+    Pass an old timestamp via _iso_offset() to simulate a UoW that has been
+    in prescribing for longer than the TTL.
+    """
+    uow_id = f"uow_test_{uuid.uuid4().hex[:8]}"
+    now = _now_iso()
+    effective_updated_at = updated_at if updated_at is not None else now
+    issue_number = int(uuid.uuid4().int % 90000) + 10000
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute(
+            """
+            INSERT INTO uow_registry
+                (id, type, source, source_issue_number, sweep_date, status, posture,
+                 created_at, updated_at, summary, success_criteria,
+                 heartbeat_at, route_evidence, trigger, register, uow_mode)
+            VALUES (?, 'executable', ?, ?, '2026-01-01', ?, 'solo',
+                    ?, ?, 'Test UoW', 'Test done.',
+                    ?, '{}', '{"type": "immediate"}', 'operational', 'operational')
+            """,
+            (
+                uow_id,
+                f"github:issue/{issue_number}",
+                issue_number,
+                status,
+                now,
+                effective_updated_at,
+                heartbeat_at,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return uow_id
+
+
+def _get_uow_row(db_path: Path, uow_id: str) -> dict:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT * FROM uow_registry WHERE id = ?", (uow_id,)
+        ).fetchone()
+        return dict(row) if row else {}
+    finally:
+        conn.close()
+
+
+def _get_audit_entries(db_path: Path, uow_id: str) -> list[dict]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM audit_log WHERE uow_id = ? ORDER BY id ASC", (uow_id,)
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Inline recover_stale_prescribing_uows — avoids importing steward-heartbeat.py
+# which transitively requires src.ooda (not available in test environment).
+#
+# This is a faithful copy of the production function from steward-heartbeat.py.
+# Any behavioral change to the production function must be reflected here.
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class _PrescribingSilenceResult:
+    checked: int
+    recovered: int
+    skipped_dry_run: int
+
+
+def _recover_stale_prescribing_uows(
+    registry: Registry,
+    dry_run: bool = False,
+    ttl_seconds: int = PRESCRIBING_SILENCE_TTL_SECONDS,
+) -> _PrescribingSilenceResult:
+    """
+    Test-local copy of recover_stale_prescribing_uows from steward-heartbeat.py.
+
+    Verifies the behavior specified in issue #1388 without importing the full
+    steward module chain. Kept in sync with the production implementation.
+    """
+    try:
+        stale_uows = registry.get_stale_prescribing_uows(stale_after_seconds=ttl_seconds)
+    except Exception:
+        return _PrescribingSilenceResult(checked=0, recovered=0, skipped_dry_run=0)
+
+    recovered = 0
+    skipped_dry_run = 0
+
+    for uow in stale_uows:
+        uow_id = uow.id
+        heartbeat_at = uow.heartbeat_at
+
+        silence_seconds: float = 0.0
+        try:
+            if heartbeat_at:
+                now_dt = datetime.now(timezone.utc)
+                hb_dt = datetime.fromisoformat(heartbeat_at)
+                if hb_dt.tzinfo is None:
+                    hb_dt = hb_dt.replace(tzinfo=timezone.utc)
+                silence_seconds = (now_dt - hb_dt).total_seconds()
+        except (ValueError, TypeError):
+            pass
+
+        if dry_run:
+            skipped_dry_run += 1
+            continue
+
+        try:
+            rows = registry.record_prescribing_silence_reset(
+                uow_id=uow_id,
+                heartbeat_at=heartbeat_at,
+                silence_seconds=silence_seconds,
+            )
+        except Exception:
+            continue
+
+        if rows == 1:
+            recovered += 1
+        # rows == 0: race — another component already advanced this UoW
+
+    return _PrescribingSilenceResult(
+        checked=len(stale_uows),
+        recovered=recovered,
+        skipped_dry_run=skipped_dry_run,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_stale_prescribing_uows — detection logic
+# ---------------------------------------------------------------------------
+
+class TestGetStalePrescribingUows:
+    def test_stale_prescribing_uow_returned_when_heartbeat_silent(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """A prescribing UoW whose heartbeat is older than the TTL is returned."""
+        stale_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 60))
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=stale_heartbeat)
+
+        result = registry.get_stale_prescribing_uows(
+            stale_after_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        assert any(u.id == uow_id for u in result), (
+            f"Expected stale prescribing UoW {uow_id} to be returned, got: "
+            f"{[u.id for u in result]}"
+        )
+
+    def test_fresh_prescribing_uow_not_returned_when_heartbeat_recent(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """A prescribing UoW with a recent heartbeat is NOT returned (healthy long-running case)."""
+        fresh_heartbeat = _iso_offset(-60)  # 1 minute ago — well within 30-min TTL
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=fresh_heartbeat)
+
+        result = registry.get_stale_prescribing_uows(
+            stale_after_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        assert not any(u.id == uow_id for u in result), (
+            f"Fresh prescribing UoW {uow_id} should NOT be returned, but was"
+        )
+
+    def test_prescribing_uow_with_null_heartbeat_returned_when_updated_at_is_old(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """A prescribing UoW with NULL heartbeat_at and old updated_at is returned as stale.
+
+        When no heartbeat was ever written, updated_at (when the UoW entered prescribing)
+        is used as the staleness clock. A UoW that has been prescribing for more than
+        stale_after_seconds without any heartbeat is treated as stale.
+        """
+        stale_updated_at = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 60))
+        uow_id = _insert_prescribing_uow(
+            db_path, heartbeat_at=None, updated_at=stale_updated_at
+        )
+
+        result = registry.get_stale_prescribing_uows(
+            stale_after_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        assert any(u.id == uow_id for u in result), (
+            f"Prescribing UoW with NULL heartbeat_at and old updated_at {uow_id} "
+            f"should be returned as stale"
+        )
+
+    def test_prescribing_uow_with_null_heartbeat_not_returned_when_fresh(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """A prescribing UoW with NULL heartbeat_at but fresh updated_at is NOT returned.
+
+        The startup_sweep handles fresh NULL-heartbeat UoWs at 660s. This method
+        does not fire before the 30-minute window elapses.
+        """
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=None)
+        # updated_at defaults to now — well within 30-minute window
+
+        result = registry.get_stale_prescribing_uows(
+            stale_after_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        assert not any(u.id == uow_id for u in result), (
+            f"Fresh prescribing UoW with NULL heartbeat_at {uow_id} should NOT be returned"
+        )
+
+    def test_non_prescribing_status_not_returned(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """UoWs in non-prescribing status are not returned, regardless of heartbeat age."""
+        stale_ts = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 120))
+        active_id = _insert_prescribing_uow(
+            db_path, heartbeat_at=stale_ts, updated_at=stale_ts, status="active"
+        )
+        executing_id = _insert_prescribing_uow(
+            db_path, heartbeat_at=stale_ts, updated_at=stale_ts, status="executing"
+        )
+        rfs_id = _insert_prescribing_uow(
+            db_path, heartbeat_at=stale_ts, updated_at=stale_ts, status="ready-for-steward"
+        )
+
+        result = registry.get_stale_prescribing_uows(
+            stale_after_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+        returned_ids = {u.id for u in result}
+
+        assert active_id not in returned_ids, "active UoW should not be in stale-prescribing results"
+        assert executing_id not in returned_ids, "executing UoW should not be in stale-prescribing results"
+        assert rfs_id not in returned_ids, "ready-for-steward UoW should not be in stale-prescribing results"
+
+    def test_boundary_exactly_at_ttl_is_stale(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """A UoW with heartbeat at exactly TTL seconds ago is treated as stale."""
+        # Use TTL + 5s to avoid sub-second clock edge cases in the test
+        boundary_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 5))
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=boundary_heartbeat)
+
+        result = registry.get_stale_prescribing_uows(
+            stale_after_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        assert any(u.id == uow_id for u in result), (
+            f"UoW at TTL boundary should be returned as stale"
+        )
+
+    def test_boundary_one_second_before_ttl_is_fresh(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """A UoW with heartbeat just under the TTL threshold is NOT stale."""
+        # 30 seconds before TTL boundary — safely fresh
+        fresh_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS - 30))
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=fresh_heartbeat)
+
+        result = registry.get_stale_prescribing_uows(
+            stale_after_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        assert not any(u.id == uow_id for u in result), (
+            f"UoW with heartbeat before TTL boundary should NOT be stale"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: record_prescribing_silence_reset — atomic transition
+# ---------------------------------------------------------------------------
+
+class TestRecordPrescribingSilenceReset:
+    def test_record_prescribing_silence_transitions_to_ready_for_steward(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """record_prescribing_silence_reset transitions prescribing → ready-for-steward."""
+        stale_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 60))
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=stale_heartbeat)
+
+        rows = registry.record_prescribing_silence_reset(
+            uow_id=uow_id,
+            heartbeat_at=stale_heartbeat,
+            silence_seconds=PRESCRIBING_SILENCE_TTL_SECONDS + 60,
+        )
+
+        assert rows == 1, f"Expected 1 row affected, got {rows}"
+        row = _get_uow_row(db_path, uow_id)
+        assert row["status"] == "ready-for-steward", (
+            f"Expected status ready-for-steward, got {row['status']}"
+        )
+
+    def test_record_prescribing_silence_writes_heartbeat_silence_ttl_audit_event(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Audit log contains event='heartbeat_silence_ttl' with structured payload."""
+        stale_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 60))
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=stale_heartbeat)
+        silence = PRESCRIBING_SILENCE_TTL_SECONDS + 60
+
+        registry.record_prescribing_silence_reset(
+            uow_id=uow_id,
+            heartbeat_at=stale_heartbeat,
+            silence_seconds=float(silence),
+        )
+
+        entries = _get_audit_entries(db_path, uow_id)
+        ttl_entries = [e for e in entries if e["event"] == "heartbeat_silence_ttl"]
+        assert len(ttl_entries) >= 1, (
+            f"Expected at least one heartbeat_silence_ttl audit entry, got: "
+            f"{[e['event'] for e in entries]}"
+        )
+
+        entry = ttl_entries[-1]
+        assert entry["from_status"] == "prescribing"
+        assert entry["to_status"] == "ready-for-steward"
+
+        note = json.loads(entry["note"])
+        assert note.get("reason") == "heartbeat_silence_ttl", (
+            f"Expected reason=heartbeat_silence_ttl in note, got: {note}"
+        )
+        assert "silence_seconds" in note
+        assert "heartbeat_at" in note
+
+    def test_record_prescribing_silence_returns_zero_on_race(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """record_prescribing_silence_reset returns 0 when UoW is already advanced (optimistic lock)."""
+        stale_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 60))
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=stale_heartbeat)
+
+        # First call succeeds
+        first = registry.record_prescribing_silence_reset(
+            uow_id=uow_id,
+            heartbeat_at=stale_heartbeat,
+            silence_seconds=float(PRESCRIBING_SILENCE_TTL_SECONDS + 60),
+        )
+        assert first == 1
+
+        # Second call on the same UoW (now in ready-for-steward) returns 0
+        second = registry.record_prescribing_silence_reset(
+            uow_id=uow_id,
+            heartbeat_at=stale_heartbeat,
+            silence_seconds=float(PRESCRIBING_SILENCE_TTL_SECONDS + 60),
+        )
+        assert second == 0, f"Expected 0 on race, got {second}"
+
+        # Exactly one audit entry — no duplicate written for the race
+        entries = _get_audit_entries(db_path, uow_id)
+        ttl_entries = [e for e in entries if e["event"] == "heartbeat_silence_ttl"]
+        assert len(ttl_entries) == 1, (
+            f"Expected exactly 1 heartbeat_silence_ttl audit entry, got {len(ttl_entries)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: recover_stale_prescribing_uows — integration (using test-local copy)
+# ---------------------------------------------------------------------------
+
+class TestRecoverStalePrescribingUows:
+    def test_recover_stale_prescribing_requeues_uow(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """recover_stale_prescribing_uows transitions stale prescribing UoW to ready-for-steward."""
+        stale_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 120))
+        uow_id = _insert_prescribing_uow(
+            db_path,
+            heartbeat_at=stale_heartbeat,
+            updated_at=stale_heartbeat,
+        )
+
+        result = _recover_stale_prescribing_uows(registry, ttl_seconds=PRESCRIBING_SILENCE_TTL_SECONDS)
+
+        assert result.checked >= 1
+        assert result.recovered >= 1
+        assert result.skipped_dry_run == 0
+
+        row = _get_uow_row(db_path, uow_id)
+        assert row["status"] == "ready-for-steward", (
+            f"Expected ready-for-steward after recovery, got {row['status']}"
+        )
+
+    def test_recover_stale_prescribing_writes_heartbeat_silence_ttl_audit(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Recovery writes heartbeat_silence_ttl audit entry."""
+        stale_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 120))
+        uow_id = _insert_prescribing_uow(
+            db_path,
+            heartbeat_at=stale_heartbeat,
+            updated_at=stale_heartbeat,
+        )
+
+        _recover_stale_prescribing_uows(registry, ttl_seconds=PRESCRIBING_SILENCE_TTL_SECONDS)
+
+        entries = _get_audit_entries(db_path, uow_id)
+        ttl_entries = [e for e in entries if e["event"] == "heartbeat_silence_ttl"]
+        assert len(ttl_entries) >= 1, (
+            f"Expected heartbeat_silence_ttl audit entry after recovery"
+        )
+
+    def test_recover_stale_prescribing_dry_run_no_transition(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Dry-run mode detects stale UoWs but does NOT change their status."""
+        stale_heartbeat = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 120))
+        uow_id = _insert_prescribing_uow(
+            db_path,
+            heartbeat_at=stale_heartbeat,
+            updated_at=stale_heartbeat,
+        )
+
+        result = _recover_stale_prescribing_uows(
+            registry, dry_run=True, ttl_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        assert result.skipped_dry_run >= 1
+        assert result.recovered == 0
+
+        row = _get_uow_row(db_path, uow_id)
+        assert row["status"] == "prescribing", (
+            f"Dry-run should not change status, but got {row['status']}"
+        )
+
+    def test_recover_fresh_prescribing_not_requeued(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """A prescribing UoW with a recent heartbeat is NOT requeued."""
+        fresh_heartbeat = _iso_offset(-60)  # 1 minute ago — healthy
+        uow_id = _insert_prescribing_uow(db_path, heartbeat_at=fresh_heartbeat)
+
+        result = _recover_stale_prescribing_uows(
+            registry, ttl_seconds=PRESCRIBING_SILENCE_TTL_SECONDS
+        )
+
+        row = _get_uow_row(db_path, uow_id)
+        assert row["status"] == "prescribing", (
+            f"Fresh prescribing UoW should stay in prescribing, got {row['status']}"
+        )
+
+    def test_only_prescribing_status_eligible_for_prescribing_recovery(
+        self, registry: Registry, db_path: Path
+    ) -> None:
+        """Active/executing UoWs with stale heartbeats are NOT touched by prescribing recovery."""
+        stale_ts = _iso_offset(-(PRESCRIBING_SILENCE_TTL_SECONDS + 120))
+        active_id = _insert_prescribing_uow(
+            db_path, heartbeat_at=stale_ts, updated_at=stale_ts, status="active"
+        )
+        executing_id = _insert_prescribing_uow(
+            db_path, heartbeat_at=stale_ts, updated_at=stale_ts, status="executing"
+        )
+
+        _recover_stale_prescribing_uows(registry, ttl_seconds=PRESCRIBING_SILENCE_TTL_SECONDS)
+
+        active_row = _get_uow_row(db_path, active_id)
+        executing_row = _get_uow_row(db_path, executing_id)
+
+        assert active_row["status"] == "active", (
+            f"active UoW should remain active, got {active_row['status']}"
+        )
+        assert executing_row["status"] == "executing", (
+            f"executing UoW should remain executing, got {executing_row['status']}"
+        )

--- a/tests/unit/test_orchestration/test_prescribing_silence_ttl.py
+++ b/tests/unit/test_orchestration/test_prescribing_silence_ttl.py
@@ -35,6 +35,7 @@ Test coverage:
 
 from __future__ import annotations
 
+import ast
 import json
 import sqlite3
 import sys
@@ -568,4 +569,47 @@ class TestRecoverStalePrescribingUows:
         )
         assert executing_row["status"] == "executing", (
             f"executing UoW should remain executing, got {executing_row['status']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sync-guard: local test constant must match production source
+# ---------------------------------------------------------------------------
+
+class TestConstantSync:
+    """Verify that PRESCRIBING_SILENCE_TTL_SECONDS matches the production value.
+
+    Uses AST parsing to read the constant from steward-heartbeat.py without
+    importing the module (which has side-effect transitive imports unavailable
+    in the test environment). If the production value changes, this test fails
+    and forces a deliberate update to both places.
+    """
+
+    def test_prescribing_silence_ttl_matches_production(self) -> None:
+        """Local PRESCRIBING_SILENCE_TTL_SECONDS must equal the value in steward-heartbeat.py."""
+        production_file = REPO_ROOT / "scheduled-tasks" / "steward-heartbeat.py"
+        assert production_file.exists(), f"Production file not found: {production_file}"
+
+        source = production_file.read_text()
+        tree = ast.parse(source)
+
+        production_value: int | None = None
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and node.target.id == "PRESCRIBING_SILENCE_TTL_SECONDS"
+                and node.value is not None
+            ):
+                production_value = ast.literal_eval(node.value)
+                break
+
+        assert production_value is not None, (
+            "PRESCRIBING_SILENCE_TTL_SECONDS not found in steward-heartbeat.py — "
+            "was it renamed or removed?"
+        )
+        assert PRESCRIBING_SILENCE_TTL_SECONDS == production_value, (
+            f"Test constant ({PRESCRIBING_SILENCE_TTL_SECONDS}) does not match "
+            f"production value ({production_value}) in steward-heartbeat.py. "
+            "Update PRESCRIBING_SILENCE_TTL_SECONDS in this file to match."
         )


### PR DESCRIPTION
## What this fixes

On June 2, 2026, an OAuth token expiry caused 106 UoWs to become stuck in `prescribing` state indefinitely, requiring manual reset. When a prescription subagent stops writing heartbeats — due to auth failure, process kill, or network partition — there was no automatic recovery mechanism for the `prescribing` state. The existing heartbeat-stall recovery (Phase 2b) only covers `active` and `executing` states.

## How it works

This adds **Phase 2b-iii** to the steward heartbeat loop: a 30-minute heartbeat-silence TTL for `prescribing` state.

**Detection (two staleness paths):**
- `heartbeat_at IS NOT NULL` and `now - heartbeat_at > 30 min` — agent was alive but went silent
- `heartbeat_at IS NULL` and `now - updated_at > 30 min` — no heartbeat was ever written (startup_sweep handles the shorter <660s window)

**Recovery:** transition `prescribing → ready-for-steward` with a `heartbeat_silence_ttl` audit event, allowing the steward to re-prescribe on its next cycle.

**Healthy long-running prescriptions are not affected** — the signal is heartbeat silence, not total prescription duration. A prescription subagent writing periodic heartbeats will never be reset regardless of how long it runs.

## State transition diagram

```
Before this PR:
  prescribing ──[heartbeat stops]──> stuck indefinitely (requires manual reset)

After this PR:
  prescribing ──[heartbeat stops >= 30 min]──> ready-for-steward
                                                    │
                                                    └─> steward re-prescribes next cycle
```

## Changes

**`src/orchestration/registry.py`** — two new Registry methods:
- `get_stale_prescribing_uows(stale_after_seconds=1800)` — pure query returning prescribing UoWs past the TTL
- `record_prescribing_silence_reset(uow_id, heartbeat_at, silence_seconds)` — atomic optimistic-lock transition with `heartbeat_silence_ttl` audit entry (same pattern as `record_heartbeat_stall`)

**`scheduled-tasks/steward-heartbeat.py`** — integration:
- `PRESCRIBING_SILENCE_TTL_SECONDS = 1800` named constant
- `PrescribingSilenceResult` dataclass (pure value type)
- `recover_stale_prescribing_uows()` function (mirrors `recover_stale_heartbeat_uows`)
- Phase 2b-iii block in `_main_inner()`, positioned between sidecar-masked detection and stuck-agent detection

**`tests/unit/test_orchestration/test_prescribing_silence_ttl.py`** — 15 tests covering:
- Stale detection with non-NULL heartbeat_at (the auth-outage case)
- Fresh prescribing UoW not returned (healthy long-running protection)
- NULL heartbeat_at + stale updated_at returned; NULL + fresh updated_at not returned
- Non-prescribing statuses excluded from detection
- Boundary conditions (just inside/outside TTL)
- Atomic transition, audit entry content, optimistic lock race safety
- Dry-run mode, recovery loop integration

**`scripts/upgrade.sh`** — Migration 133 note (no schema change, no operator action required).

## Functional patterns

Pure functions (`get_stale_prescribing_uows` is a read-only query returning value objects), immutable result types (`PrescribingSilenceResult` frozen dataclass), optimistic-lock concurrency pattern (atomic UPDATE + audit INSERT in single transaction), composition over inheritance (new function composes existing registry methods).

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_prescribing_silence_ttl.py -v` — 15 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_heartbeat_locking.py tests/unit/test_orchestration/test_observation_loop.py tests/unit/test_orchestration/test_registry_cli.py tests/unit/test_orchestration/test_prescribing_silence_ttl.py -q` — 172 passed, 1 pre-existing failure (`test_approve_idempotent_on_pending` in test_registry_cli.py — unrelated, confirmed pre-existing on main)
- [x] `uv run python -m py_compile src/orchestration/registry.py scheduled-tasks/steward-heartbeat.py tests/unit/test_orchestration/test_prescribing_silence_ttl.py` — syntax OK

## Manual test

N/A — this change is entirely internal (no external service calls, no Telegram output, no systemd unit changes). The steward-heartbeat cron already runs; this adds a new phase to its existing loop. No restart or manual verification required.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (internal behavioral change to existing cron loop)
- [x] User-visible outcome — N/A (self-healing recovery; observable via audit_log and steward-heartbeat.log)
- [x] Side-effect audit: auto-reset fires only after 30 min silence; optimistic lock prevents double-application; does not touch active/executing UoWs; does not affect wos-config.json
- [x] External service calls: none