### PR TITLE
Scope golden-patterns mandatory read to functional-engineer only (fixes #1399)

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -20,6 +20,15 @@ You strongly prefer functional style in your implementations:
 - Isolate side effects at the boundaries of your system
 - Use pattern matching and algebraic data types where the language supports them
 
+## Golden Patterns (Required Read Before Any Code Work)
+
+**Read `~/lobster/oracle/golden-patterns.md` before writing or modifying any code.** This file is scoped to code-writing agents — it is not loaded by other subagents.
+
+Key patterns that have caused latent bugs in this codebase:
+- **StrEnum usage** — no raw string literals in SQL or discriminators; always import and use the canonical StrEnum.
+- **Dead-code analysis scope** — a full-repo grep across `src/`, `.claude/`, `scripts/`, `tests/`, `scheduled-tasks/`, and `hooks/` is required before removing any code.
+- **Canonicality / anti-staleness** — every file and module must live in one unambiguous home; stale canonical placements are active misdirection.
+
 ## Development Workflow: Issue → (Scope?) → TDD → Review
 
 Match the process overhead to the complexity of the change:

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -31,17 +31,6 @@ Do NOT call `wait_for_messages` — that is only for the main loop.
 
 These files are private and not in the git repo. They extend and override the defaults here.
 
-## Golden Patterns (Required Read Before Any Code Work)
-
-**You MUST read `~/lobster/oracle/golden-patterns.md` before writing or modifying any code.** This is mandatory, not advisory — load it before any code work begins, not as a reference to consult if something breaks.
-
-The patterns cover three structural areas that have caused latent bugs in this codebase:
-- **StrEnum usage** — no raw string literals in SQL or discriminators; always import and use the canonical StrEnum.
-- **Dead-code analysis scope** — a full-repo grep across `src/`, `.claude/`, `scripts/`, `tests/`, `scheduled-tasks/`, and `hooks/` is required before removing any code.
-- **Canonicality / anti-staleness** — every file and module must live in one unambiguous home; stale canonical placements are active misdirection.
-
-These are structural lessons that must survive context compaction. Reading the file once per session, before any code work, is the load-bearing behavior.
-
 ## Identity: Are You a Subagent?
 
 **You are a subagent if:**


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

Every subagent session was loading a 360-line append-only file (`oracle/golden-patterns.md`) as a mandatory pre-read, including research agents, brain-dump agents, ops agents, and any other subagent that does not write code. The oracle review of PR #1395 flagged this as self-defeating: the root cause of the failures this file was meant to prevent is context growth, and a blanket mandatory read compounds that pressure for every session.

The three patterns the file encodes (StrEnum usage, dead-code analysis scope, canonicality) are exclusively relevant to agents that write or modify production code. The correct home for this directive is not the shared subagent bootup file — it is the `functional-engineer` agent definition, which is the only agent that writes code.

## What changed

- **Removed** the `## Golden Patterns (Required Read Before Any Code Work)` section from `.claude/sys.subagent.bootup.md` (11 lines out). All non-code subagents (generalist, oracle, hygiene, ops, brain-dumps, etc.) no longer load this directive.
- **Added** an equivalent `## Golden Patterns (Required Read Before Any Code Work)` section to `.claude/agents/functional-engineer.md` (9 lines in), placed before the Development Workflow section so it fires before any code work begins.

The section text is slightly trimmed (the "mandatory, not advisory" escalation language is softened to match the scoped audience) but the three load-bearing rules are preserved verbatim.

## What is not changed

`oracle/golden-patterns.md` itself is not modified. No other agent definitions are touched. The `lobster-oracle` agent reads the golden-patterns file as part of its Stage 2 review protocol — that read is already in the oracle's own definition and is unaffected.

## Tests run
- [x] Manual diff review — change is exactly two files, 11 lines removed from sys.subagent.bootup.md, 9 lines added to functional-engineer.md
- [x] Verified functional-engineer.md placement: directive appears before `## Development Workflow`, which is before any code work instructions
- [ ] Live session test — not required; this is a context-loading configuration change with no runtime logic

## Manual test
N/A — this change is entirely configuration (which files are read when a subagent session starts). No external service calls, no file I/O, no DB changes.

## Definition of Done
- [x] Unit tests pass with proper mocking — N/A (no code logic)
- [x] User-visible outcome verified — N/A (internal context loading change)
- [x] Side-effect audit complete — no floods, no writes, no unintended volume; change reduces context load per session
- [x] External service calls — none

Closes #1399