### PR TITLE
docs: add wos_prescribe handler section to dispatcher bootup doc

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -809,6 +809,32 @@ Implementation: `route_wos_message` is the single entry point. The handler is `h
 
 ---
 
+### wos_prescribe (`type: "wos_prescribe"`)
+
+Written by `steward-heartbeat.py` when it offloads a blocking LLM prescription call to an async inbox dispatch. The UoW is in `prescribing` state. This message carries the full prescription context as non-text fields.
+
+**Important:** `text` is always `''` and `chat_id` is always `0` — this is expected and correct. Do NOT treat this as an empty/unknown message and force-`mark_processed`. The payload is in the non-text fields (`uow_id`, `uow_summary`, `reentry_posture`, `completion_gap`, `issue_body`, `cycles`, `new_cycles`, `selected_executor_type`, `prescribed_skills`, `vision_orientation`, `dan_register`, `steward_log`, `now_iso`).
+
+```
+1. mark_processing(message_id)
+2. result = route_wos_message(msg)
+   # Always returns action="spawn_subagent"
+3. Task(
+       subagent_type=result["agent_type"],
+       run_in_background=True,
+       prompt=result["prompt"],
+   )
+4. mark_processed(message_id)
+```
+
+The spawned subagent (`lobster-generalist`, task_id `wos-prescribe-{uow_id[:8]}`) generates the prescription directly as the LLM, writes it via `scheduled-tasks/wos-write-artifact.py`, and transitions the UoW from `prescribing` → `ready-for-executor`.
+
+Implementation: `route_wos_message` is the single entry point. The handler is `handle_wos_prescribe` in `src/orchestration/dispatcher_handlers.py`. Call `route_wos_message(msg)` — do not call `handle_wos_prescribe` directly.
+
+Rules: never `send_reply` (chat_id is 0 — no user to notify).
+
+---
+
 ### scheduled_job_trigger (`type: "scheduled_job_trigger"`)
 
 Written by `scheduled-tasks/post-job-trigger.sh` when a cron entry fires. Each trigger identifies a job by name; the dispatcher reads the corresponding task file and spawns a subagent.


### PR DESCRIPTION
## Summary

`wos_prescribe` messages were being silently dropped. The dispatcher had no documented handler for this message type, so when it encountered a message with `text=''` and `chat_id=0`, it treated it as an empty/unknown system message and called `mark_processed` directly — bypassing the `handle_wos_prescribe` handler in `dispatcher_handlers.py` entirely. This left UoWs stranded in `prescribing` state indefinitely.

The handler already existed in code (`handle_wos_prescribe`), but had never been documented in the bootup doc, so the LLM-dispatcher had no mental model for this message type.

## What this changes

Adds a `### wos_prescribe` section to `.claude/sys.dispatcher.bootup.md`, positioned after `wos_owner_required` and before `scheduled_job_trigger`. The section documents:

- Source: written by `steward-heartbeat.py` when offloading a blocking LLM prescription call
- `text=''` and `chat_id=0` are **expected and correct** — not a signal to drop the message
- Payload is in non-text fields (`uow_id`, `uow_summary`, `reentry_posture`, etc.)
- Correct routing: call `route_wos_message(msg)` (which returns `action="spawn_subagent"`)
- Never call `handle_wos_prescribe` directly — `route_wos_message` is the single entry point
- Never `send_reply` — chat_id is 0, no user to notify

## What this does not change

No Python source files are touched. The `handle_wos_prescribe` implementation in `src/orchestration/dispatcher_handlers.py` is unchanged — this PR only adds the missing dispatcher mental model documentation.

## Tests run
- [x] `grep -n "wos_prescribe"` in the modified file — confirms section added at correct position (after line 808, before `scheduled_job_trigger` at line 838)
- [ ] Live dispatcher routing test — not run; this is a documentation-only change with no code path modified. The handler was already implemented and tested; this PR adds the missing doc so the dispatcher routes to it.

## Manual test
N/A — documentation-only change, no external services, no file I/O affecting runtime state, no systemd/cron changes.

Closes #1389