### PR TITLE
feat(wos): merge-pr idempotency pre-flight check — already-merged PR skips as heat (#927)

### DIFF
--- a/src/orchestration/wos_preflight.py
+++ b/src/orchestration/wos_preflight.py
@@ -51,6 +51,15 @@ These issues are absorbed as sub-tasks of this architectural interface; their
 implementations will register checks here rather than adding per-type logic to
 the dispatch core.
 
+Type key derivation
+-------------------
+``is_still_needed`` uses ``_derive_preflight_key(uow)`` rather than the raw
+``type`` attribute to determine which check function to call.  This allows
+semantic sub-types (e.g. "merge-pr") to be derived from other UoW fields:
+
+- UoWs with ``source_ref`` starting with ``"github:pr/"`` → key "merge-pr".
+- All other UoWs → key from ``str(uow.type)`` (backwards-compatible default).
+
 Public API
 ----------
 ``is_still_needed(uow: UoW) -> bool``
@@ -60,6 +69,9 @@ Public API
     Register a type-specific check.  Idempotent: re-registering the same type
     overwrites the previous entry (useful for tests and hot-reloading).
 
+``_derive_preflight_key(uow: object) -> str``
+    Private helper used by ``is_still_needed``. Exported for test access.
+
 ``PreflightCheck``
     Protocol type: ``(uow: UoW) -> bool``.
 """
@@ -67,6 +79,7 @@ Public API
 from __future__ import annotations
 
 import logging
+import subprocess as _subprocess
 from typing import Protocol, runtime_checkable
 
 log = logging.getLogger("wos_preflight")
@@ -149,6 +162,99 @@ def _default_check(uow: object) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Key derivation
+# ---------------------------------------------------------------------------
+
+def _derive_preflight_key(uow: object) -> str:
+    """
+    Derive the preflight registry key for a UoW.
+
+    Most UoWs use str(uow.type) directly. The exception is UoWs whose
+    source_ref starts with "github:pr/" — these represent PRs to merge and
+    use the semantic key "merge-pr" regardless of their .type field.
+
+    This indirection lets is_still_needed dispatch to the merge-pr check
+    without requiring a dedicated UoWType enum value.
+    """
+    source_ref: str = getattr(uow, "source_ref", "") or ""
+    if source_ref.startswith("github:pr/"):
+        return "merge-pr"
+    uow_type: str = str(getattr(uow, "type", "") or "")
+    return uow_type
+
+
+# ---------------------------------------------------------------------------
+# Merge-pr idempotency check (issue #927)
+# ---------------------------------------------------------------------------
+
+def _check_merge_pr(uow: object) -> bool:
+    """
+    Pre-flight check for merge-pr UoWs.
+
+    Extracts the PR number from uow.source_ref ("github:pr/<number>"),
+    calls ``gh pr view <number> --repo <repo> --json state``, and returns
+    False (work no longer needed) when state == "MERGED".
+
+    Fail-open: any gh failure, parse error, or missing field returns True
+    so the executor proceeds with dispatch rather than silently suppressing
+    a legitimate merge.
+
+    The repo is read from the LOBSTER_WOS_REPO environment variable
+    (default: "dcetlin/Lobster").
+    """
+    import json as _json
+    import os as _os
+
+    source_ref: str = getattr(uow, "source_ref", "") or ""
+    if not source_ref.startswith("github:pr/"):
+        return True
+    try:
+        pr_number = int(source_ref.split("/")[-1])
+    except (ValueError, IndexError):
+        log.warning(
+            "_check_merge_pr: could not parse PR number from source_ref=%r — fail-open",
+            source_ref,
+        )
+        return True
+
+    repo = _os.environ.get("LOBSTER_WOS_REPO", "dcetlin/Lobster")
+    try:
+        result = _subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "state"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            log.warning(
+                "_check_merge_pr: gh pr view failed for PR #%d (exit %d) — fail-open",
+                pr_number, result.returncode,
+            )
+            return True
+        data = _json.loads(result.stdout)
+        state = data.get("state", "")
+        if state == "MERGED":
+            log.info(
+                "_check_merge_pr: PR #%d is already MERGED — short-circuiting dispatch (heat)",
+                pr_number,
+            )
+            return False
+        return True
+    except Exception as exc:
+        log.warning(
+            "_check_merge_pr: error checking PR #%d state — %s: %s — fail-open",
+            pr_number, type(exc).__name__, exc,
+        )
+        return True
+
+
+# Register the merge-pr idempotency check (issue #927).
+# Must be registered at module load time so the executor's is_still_needed
+# call picks it up without requiring any additional wiring.
+register_preflight_check("merge-pr", _check_merge_pr)
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -176,15 +282,15 @@ def is_still_needed(uow: object) -> bool:
         A failing check must not block dispatch — the executor must proceed
         unless explicitly told the work is not needed.
     """
-    uow_type: str = getattr(uow, "type", "") or ""
-    check_fn = _REGISTRY.get(uow_type, _default_check)
+    uow_key: str = _derive_preflight_key(uow)
+    check_fn = _REGISTRY.get(uow_key, _default_check)
 
     try:
         result = check_fn(uow)
     except Exception as exc:
         log.warning(
-            "wos_preflight: check for uow_type=%r raised %s: %s — defaulting to True (fail-open)",
-            uow_type,
+            "wos_preflight: check for key=%r raised %s: %s — defaulting to True (fail-open)",
+            uow_key,
             type(exc).__name__,
             exc,
         )

--- a/tests/unit/test_orchestration/test_wos_preflight.py
+++ b/tests/unit/test_orchestration/test_wos_preflight.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,7 @@ import orchestration.wos_preflight as preflight_mod
 from orchestration.wos_preflight import (
     is_still_needed,
     register_preflight_check,
+    _derive_preflight_key,
 )
 
 
@@ -48,6 +50,15 @@ class _StubUoW:
     def __init__(self, uow_type: str = "executable") -> None:
         self.type = uow_type
         self.id = "stub-uow-id"
+
+
+class _StubMergeUoW:
+    """Stub UoW with source_ref for merge-pr preflight tests."""
+
+    def __init__(self, source_ref: str = "github:pr/42", uow_type: str = "executable") -> None:
+        self.source_ref = source_ref
+        self.type = uow_type
+        self.id = "stub-merge-uow"
 
 
 def _make_artifact(
@@ -427,3 +438,87 @@ class TestExecutorPreflightFalsePath:
         assert len(injected_called) == 0, (
             "Injected dispatcher must NOT be called when pre-flight returns False"
         )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: merge-pr idempotency pre-flight check (issue #927)
+# ---------------------------------------------------------------------------
+
+
+class TestMergePrPreflightCheck:
+    """Tests for the merge-pr idempotency pre-flight check (issue #927)."""
+
+    def _make_gh_result(self, state: str, returncode: int = 0) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(
+            args=["gh", "pr", "view"],
+            returncode=returncode,
+            stdout=json.dumps({"state": state}),
+            stderr="",
+        )
+
+    def test_merged_pr_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MERGED PR: is_still_needed returns False — executor short-circuits."""
+        monkeypatch.setattr(
+            "orchestration.wos_preflight._subprocess.run",
+            lambda *a, **kw: self._make_gh_result("MERGED"),
+        )
+        uow = _StubMergeUoW(source_ref="github:pr/42")
+        assert is_still_needed(uow) is False
+
+    def test_open_pr_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OPEN PR: is_still_needed returns True — executor dispatches normally."""
+        monkeypatch.setattr(
+            "orchestration.wos_preflight._subprocess.run",
+            lambda *a, **kw: self._make_gh_result("OPEN"),
+        )
+        uow = _StubMergeUoW(source_ref="github:pr/42")
+        assert is_still_needed(uow) is True
+
+    def test_closed_pr_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CLOSED PR: is_still_needed returns True (CLOSED != MERGED)."""
+        monkeypatch.setattr(
+            "orchestration.wos_preflight._subprocess.run",
+            lambda *a, **kw: self._make_gh_result("CLOSED"),
+        )
+        uow = _StubMergeUoW(source_ref="github:pr/42")
+        assert is_still_needed(uow) is True
+
+    def test_gh_failure_returns_true_fail_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gh exit non-zero: is_still_needed returns True (fail-open)."""
+        monkeypatch.setattr(
+            "orchestration.wos_preflight._subprocess.run",
+            lambda *a, **kw: self._make_gh_result("", returncode=1),
+        )
+        uow = _StubMergeUoW(source_ref="github:pr/42")
+        assert is_still_needed(uow) is True
+
+    def test_gh_exception_returns_true_fail_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """subprocess.run raises: is_still_needed returns True (fail-open)."""
+        def raise_timeout(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=15)
+        monkeypatch.setattr("orchestration.wos_preflight._subprocess.run", raise_timeout)
+        uow = _StubMergeUoW(source_ref="github:pr/42")
+        assert is_still_needed(uow) is True
+
+    def test_source_ref_without_pr_prefix_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-PR source_ref: check returns True without calling gh."""
+        calls: list = []
+
+        def should_not_call(*a, **kw):
+            calls.append(True)
+            return self._make_gh_result("MERGED")
+
+        monkeypatch.setattr("orchestration.wos_preflight._subprocess.run", should_not_call)
+        uow = _StubMergeUoW(source_ref="github:issue/123")
+        assert is_still_needed(uow) is True
+        assert len(calls) == 0, "gh must not be called for non-PR source_ref"
+
+    def test_derive_preflight_key_pr_source(self) -> None:
+        """source_ref='github:pr/99' maps to key 'merge-pr'."""
+        uow = _StubMergeUoW(source_ref="github:pr/99")
+        assert _derive_preflight_key(uow) == "merge-pr"
+
+    def test_derive_preflight_key_non_pr_source(self) -> None:
+        """source_ref='github:issue/99', type='executable' maps to key 'executable'."""
+        uow = _StubMergeUoW(source_ref="github:issue/99", uow_type="executable")
+        assert _derive_preflight_key(uow) == "executable"


### PR DESCRIPTION
## What problem this solves

~8% of heat outcomes trace to merge-pr UoWs retrying PRs that were already merged. The executor had no way to detect this before spawning the merge agent — it dispatched based on queue state alone, not the actual PR state.

## What changed

The `register_preflight_check` extension point (added in PR #1396 / issue #929) now has its first consumer:

**`_derive_preflight_key(uow)`** — maps UoWs with `source_ref` starting with `"github:pr/"` to the registry key `"merge-pr"`, without requiring a new `UoWType` enum value. All other UoWs continue to derive their key from `str(uow.type)` (backwards-compatible).

**`_check_merge_pr(uow)`** — calls `gh pr view <number> --repo <repo> --json state` and returns `False` when `state == "MERGED"`. This triggers the existing `outcome_category="heat"` short-circuit in the executor — no subagent is spawned. Fail-open: any `gh` error, parse failure, timeout, or missing field returns `True` so the executor proceeds with dispatch rather than silently suppressing a legitimate merge.

**`is_still_needed()`** — updated to dispatch via `_derive_preflight_key(uow)` instead of reading `uow.type` directly. The warning log line was updated to use `key=` to reflect this indirection.

The check is registered at module load time via `register_preflight_check("merge-pr", _check_merge_pr)`, so no wiring changes to the executor dispatch core are needed.

`import subprocess as _subprocess` was moved to module level (from inside the function) so monkeypatching works deterministically in tests.

## Files changed

Only the two files specified in the artifact:
- `src/orchestration/wos_preflight.py`
- `tests/unit/test_orchestration/test_wos_preflight.py`

No changes to `executor.py`, `registry.py`, or any other file.

## Functional patterns used

Pure functions (`_derive_preflight_key`, `_check_merge_pr`), fail-open error handling (exceptions return `True` rather than propagating), composition via the existing registry extension point.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_preflight.py -v` — 26 passed (18 existing + 8 new), 0 failed

## Manual test

N/A — this change is entirely internal to the pre-flight module. No external service is called in the tests (subprocess is monkeypatched). Production calls to `gh pr view` happen only at executor dispatch time, which is gated by `wos-config.json`.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, no infrastructure changes
- [x] User-visible outcome verified — N/A, executor output unchanged; heat short-circuit was already wired
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: `gh pr view` mocked in tests via monkeypatch

WOS-UoW: uow_20260603_c67fe7
Closes #927