### PR TITLE
fix(wos): swap wos:executing ↔ wos:paused labels on pause/resume

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -47,7 +47,11 @@ if TYPE_CHECKING:
 from .registry import ApproveConfirmed, ApproveExpired, ApproveNotFound, ApproveSkipped
 from .paths import LOBSTER_WORKSPACE as _LOBSTER_WORKSPACE, WOS_CONFIG as _WOS_CONFIG_PATH_FROM_PATHS, WOS_GATE_CLEARED_FLAG as _GATE_CLEARED_FLAG, JOBS_JSON as _JOBS_JSON_PATH
 from .steward import ReturnReasonClassification, MAX_RETRIES as _STEWARD_MAX_RETRIES, _HARD_CAP_CYCLES
-from .wos_issue_lifecycle import HUMAN_GATE_LABELS as _HUMAN_GATE_LABELS
+from .wos_issue_lifecycle import (
+    HUMAN_GATE_LABELS as _HUMAN_GATE_LABELS,
+    bulk_swap_executing_to_paused as _bulk_swap_executing_to_paused,
+    bulk_swap_paused_to_executing as _bulk_swap_paused_to_executing,
+)
 from src.utils.timezone import format_iso_for_user as _format_iso_for_user, get_owner_tz_name as _get_owner_tz_name
 
 
@@ -840,6 +844,10 @@ def handle_wos_start(*, registry: "Registry | None" = None) -> str:
     enable leaves the steward (or other core jobs) disabled while the system
     believes the pipeline is running.
 
+    After enabling jobs, bulk-swaps wos:paused → wos:executing on all GitHub
+    issues whose UoWs are currently in executing status, restoring label state
+    to accurately reflect active execution.
+
     Idempotent: calling /wos start when already fully started (all wos_core jobs
     enabled) returns a notice without calling toggle_wos_core_jobs.
 
@@ -893,7 +901,21 @@ def handle_wos_start(*, registry: "Registry | None" = None) -> str:
                 f"(may be systemd-only): {', '.join(sorted(result['not_found']))}"
             )
 
+        # Restore wos:paused → wos:executing on all currently-executing issues.
         reg = registry if registry is not None else _Registry()
+        executing_uows = reg.list(status="executing")
+        issue_numbers = [
+            uow.source_issue_number
+            for uow in executing_uows
+            if uow.source_issue_number is not None
+        ]
+        wos_repo = os.environ.get("LOBSTER_WOS_REPO", "dcetlin/Lobster")
+        label_success, label_failure = _bulk_swap_paused_to_executing(issue_numbers, repo=wos_repo)
+        lines.append(
+            f"Labels restored: {label_success} wos:paused → wos:executing "
+            f"(failures: {label_failure})"
+        )
+
         reg.log_control_event(
             ControlEventType.WOS_START,
             {
@@ -902,6 +924,7 @@ def handle_wos_start(*, registry: "Registry | None" = None) -> str:
                 "toggled": sorted(result["toggled"]),
                 "not_found": sorted(result["not_found"]),
                 "timers_toggled": sorted(timer_toggled),
+                "label_swap": {"success": label_success, "failed": label_failure},
             },
         )
 
@@ -934,13 +957,28 @@ def handle_wos_start(*, registry: "Registry | None" = None) -> str:
             f"(may be systemd-only): {', '.join(sorted(result['not_found']))}"
         )
 
+    # Restore wos:paused → wos:executing on all currently-executing issues.
     reg = registry if registry is not None else _Registry()
+    executing_uows = reg.list(status="executing")
+    issue_numbers = [
+        uow.source_issue_number
+        for uow in executing_uows
+        if uow.source_issue_number is not None
+    ]
+    wos_repo = os.environ.get("LOBSTER_WOS_REPO", "dcetlin/Lobster")
+    label_success, label_failure = _bulk_swap_paused_to_executing(issue_numbers, repo=wos_repo)
+    lines.append(
+        f"Labels restored: {label_success} wos:paused → wos:executing "
+        f"(failures: {label_failure})"
+    )
+
     reg.log_control_event(
         ControlEventType.WOS_START,
         {
             "toggled": sorted(result["toggled"]),
             "not_found": sorted(result["not_found"]),
             "timers_toggled": sorted(timer_toggled),
+            "label_swap": {"success": label_success, "failed": label_failure},
         },
     )
 
@@ -956,6 +994,10 @@ def handle_wos_stop(*, registry: "Registry | None" = None) -> str:
     in wos-config.json so that executor-heartbeat skips dispatch on its next
     cycle. UoWs already active are not affected — TTL recovery will handle
     any that stall.
+
+    After disabling jobs, bulk-swaps wos:executing → wos:paused on all GitHub
+    issues whose UoWs are currently in executing status, so label state stays
+    aligned with execution reality during the pause.
 
     Idempotent: calling /wos stop when already stopped returns a notice.
 
@@ -1002,13 +1044,28 @@ def handle_wos_stop(*, registry: "Registry | None" = None) -> str:
             f"(may be systemd-only): {', '.join(sorted(result['not_found']))}"
         )
 
+    # Bulk-swap wos:executing → wos:paused on all currently-executing issues.
     reg = registry if registry is not None else _Registry()
+    executing_uows = reg.list(status="executing")
+    issue_numbers = [
+        uow.source_issue_number
+        for uow in executing_uows
+        if uow.source_issue_number is not None
+    ]
+    wos_repo = os.environ.get("LOBSTER_WOS_REPO", "dcetlin/Lobster")
+    label_success, label_failure = _bulk_swap_executing_to_paused(issue_numbers, repo=wos_repo)
+    lines.append(
+        f"Labels swapped: {label_success} wos:executing → wos:paused "
+        f"(failures: {label_failure})"
+    )
+
     reg.log_control_event(
         ControlEventType.WOS_STOP,
         {
             "toggled": sorted(result["toggled"]),
             "not_found": sorted(result["not_found"]),
             "timers_toggled": sorted(timer_toggled),
+            "label_swap": {"success": label_success, "failed": label_failure},
         },
     )
 

--- a/src/orchestration/wos_issue_lifecycle.py
+++ b/src/orchestration/wos_issue_lifecycle.py
@@ -47,6 +47,12 @@ WOS_EXECUTING_LABEL: str = "wos:executing"
 #: Label color (hex, no leading #) — blue to indicate active machine work.
 WOS_EXECUTING_LABEL_COLOR: str = "0052cc"
 
+#: GitHub label applied when execution is paused (swap target for wos:executing).
+WOS_PAUSED_LABEL: str = "wos:paused"
+
+#: Label color (hex, no leading #) — grey to indicate suspended machine work.
+WOS_PAUSED_LABEL_COLOR: str = "e4e669"
+
 #: Subprocess timeout for gh CLI calls (seconds).
 _GH_TIMEOUT: int = 30
 
@@ -134,6 +140,69 @@ def _ensure_wos_executing_label_exists(repo: str, gh_bin: str = "gh") -> bool:
     except Exception as exc:
         log.warning(
             "wos_issue_lifecycle: _ensure_wos_executing_label_exists unexpected error "
+            "for %s — %s: %s",
+            repo, type(exc).__name__, exc,
+        )
+        return False
+
+
+def _ensure_wos_paused_label_exists(repo: str, gh_bin: str = "gh") -> bool:
+    """
+    Ensure the wos:paused label exists on the repo.
+
+    If the label is absent, creates it with WOS_PAUSED_LABEL_COLOR.
+    Returns True on success or if label already exists. Returns False if
+    any gh CLI call fails (non-blocking — callers proceed without the label
+    in that case, with a warning logged).
+
+    Pure side effect: no registry access, no UoW state.
+    """
+    try:
+        result = _run_gh(
+            ["label", "list", "--repo", repo, "--json", "name"],
+            gh_bin=gh_bin,
+        )
+        labels_json = json.loads(result.stdout.decode(errors="replace"))
+        existing_names = {lbl["name"] for lbl in labels_json}
+
+        if WOS_PAUSED_LABEL in existing_names:
+            log.debug(
+                "wos_issue_lifecycle: label %r already exists on %s — no-op",
+                WOS_PAUSED_LABEL,
+                repo,
+            )
+            return True
+
+        # Label is absent — create it.
+        log.info(
+            "wos_issue_lifecycle: creating label %r on %s (color #%s)",
+            WOS_PAUSED_LABEL,
+            repo,
+            WOS_PAUSED_LABEL_COLOR,
+        )
+        _run_gh(
+            [
+                "label", "create", WOS_PAUSED_LABEL,
+                "--repo", repo,
+                "--color", WOS_PAUSED_LABEL_COLOR,
+                "--description", "WOS execution paused — was wos:executing before pause",
+            ],
+            gh_bin=gh_bin,
+        )
+        return True
+
+    except subprocess.CalledProcessError as exc:
+        log.warning(
+            "wos_issue_lifecycle: _ensure_wos_paused_label_exists failed for %s "
+            "— exit %d: %s",
+            repo,
+            exc.returncode,
+            (exc.stderr or b"").decode(errors="replace")[:300],
+        )
+        return False
+    except Exception as exc:
+        log.warning(
+            "wos_issue_lifecycle: _ensure_wos_paused_label_exists unexpected error "
             "for %s — %s: %s",
             repo, type(exc).__name__, exc,
         )
@@ -535,3 +604,137 @@ def stamp_issue_unverifiable(
             repo, issue_number, uow_id, type(exc).__name__, exc,
         )
         return False
+
+
+# ---------------------------------------------------------------------------
+# Bulk control-plane label swap functions (pause/resume)
+# ---------------------------------------------------------------------------
+
+def bulk_swap_executing_to_paused(
+    issue_numbers: list[int],
+    repo: str = "dcetlin/Lobster",
+    gh_bin: str = "gh",
+) -> tuple[int, int]:
+    """
+    For each issue in issue_numbers:
+      - Remove wos:executing label
+      - Add wos:paused label
+
+    Called by handle_wos_stop to keep label state aligned with execution reality.
+    When execution is paused, wos:executing becomes misleading — this swap signals
+    that the issue was executing when the pipeline was deliberately halted.
+
+    Returns (success_count, failure_count). Never raises.
+
+    A single gh CLI failure on any issue does not abort the loop — remaining
+    issues are processed and counted in failure_count.
+    """
+    if not issue_numbers:
+        return (0, 0)
+
+    # Ensure the wos:paused label exists once before iterating over all issues.
+    _ensure_wos_paused_label_exists(repo, gh_bin=gh_bin)
+
+    success_count = 0
+    failure_count = 0
+
+    for issue_number in issue_numbers:
+        try:
+            _run_gh(
+                [
+                    "issue", "edit", str(issue_number),
+                    "--repo", repo,
+                    "--remove-label", WOS_EXECUTING_LABEL,
+                    "--add-label", WOS_PAUSED_LABEL,
+                ],
+                gh_bin=gh_bin,
+            )
+            log.info(
+                "wos_issue_lifecycle: bulk_swap_executing_to_paused: swapped %s#%d "
+                "wos:executing → wos:paused",
+                repo, issue_number,
+            )
+            success_count += 1
+        except subprocess.CalledProcessError as exc:
+            log.warning(
+                "wos_issue_lifecycle: bulk_swap_executing_to_paused: failed for %s#%d "
+                "— exit %d: %s",
+                repo, issue_number,
+                exc.returncode,
+                (exc.stderr or b"").decode(errors="replace")[:300],
+            )
+            failure_count += 1
+        except Exception as exc:
+            log.warning(
+                "wos_issue_lifecycle: bulk_swap_executing_to_paused: unexpected error "
+                "for %s#%d — %s: %s",
+                repo, issue_number, type(exc).__name__, exc,
+            )
+            failure_count += 1
+
+    return (success_count, failure_count)
+
+
+def bulk_swap_paused_to_executing(
+    issue_numbers: list[int],
+    repo: str = "dcetlin/Lobster",
+    gh_bin: str = "gh",
+) -> tuple[int, int]:
+    """
+    For each issue in issue_numbers:
+      - Remove wos:paused label
+      - Add wos:executing label
+
+    Called by handle_wos_start to restore label state after a pause.
+    Issues that carried wos:executing before the pause are restored to that
+    state so consumers of the GitHub label accurately see what is executing.
+
+    Returns (success_count, failure_count). Never raises.
+
+    A single gh CLI failure on any issue does not abort the loop — remaining
+    issues are processed and counted in failure_count.
+    """
+    if not issue_numbers:
+        return (0, 0)
+
+    # Ensure the wos:executing label exists once before iterating over all issues.
+    _ensure_wos_executing_label_exists(repo, gh_bin=gh_bin)
+
+    success_count = 0
+    failure_count = 0
+
+    for issue_number in issue_numbers:
+        try:
+            _run_gh(
+                [
+                    "issue", "edit", str(issue_number),
+                    "--repo", repo,
+                    "--remove-label", WOS_PAUSED_LABEL,
+                    "--add-label", WOS_EXECUTING_LABEL,
+                ],
+                gh_bin=gh_bin,
+            )
+            log.info(
+                "wos_issue_lifecycle: bulk_swap_paused_to_executing: restored %s#%d "
+                "wos:paused → wos:executing",
+                repo, issue_number,
+            )
+            success_count += 1
+        except subprocess.CalledProcessError as exc:
+            log.warning(
+                "wos_issue_lifecycle: bulk_swap_paused_to_executing: failed for %s#%d "
+                "— exit %d: %s",
+                repo, issue_number,
+                exc.returncode,
+                (exc.stderr or b"").decode(errors="replace")[:300],
+            )
+            failure_count += 1
+        except Exception as exc:
+            log.warning(
+                "wos_issue_lifecycle: bulk_swap_paused_to_executing: unexpected error "
+                "for %s#%d — %s: %s",
+                repo, issue_number, type(exc).__name__, exc,
+            )
+            failure_count += 1
+
+    return (success_count, failure_count)

--- a/tests/unit/test_orchestration/test_wos_label_swap.py
+++ b/tests/unit/test_orchestration/test_wos_label_swap.py
@@ -1,0 +1,489 @@
+"""
+Unit tests for the wos:executing ↔ wos:paused bulk label swap.
+
+Behavior under test:
+
+bulk_swap_executing_to_paused:
+- Calls gh issue edit --remove-label wos:executing --add-label wos:paused for each issue
+- Returns (success_count, failure_count) counting per-issue outcomes
+- A single gh CLI failure does not abort the loop — remaining issues are processed
+- Returns (0, 0) immediately for an empty issue_numbers list
+
+bulk_swap_paused_to_executing:
+- Calls the reverse gh issue edit for each issue
+- Returns (success_count, failure_count) counting per-issue outcomes
+- A single gh CLI failure does not abort the loop — remaining issues are processed
+- Returns (0, 0) immediately for an empty issue_numbers list
+
+handle_wos_stop:
+- Includes label swap stats in its return message
+- Includes label_swap key in the log_control_event payload
+
+handle_wos_start:
+- Includes label restore stats in its return message (normal start path)
+- Includes label restore stats in its return message (partial-recovery path)
+- Includes label_swap key in the log_control_event payload
+
+Named constants mirror spec values for self-documenting test failures.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from orchestration.wos_issue_lifecycle import (
+    WOS_EXECUTING_LABEL,
+    WOS_PAUSED_LABEL,
+    WOS_PAUSED_LABEL_COLOR,
+    bulk_swap_executing_to_paused,
+    bulk_swap_paused_to_executing,
+    _ensure_wos_paused_label_exists,
+)
+
+
+# ---------------------------------------------------------------------------
+# Named constants from spec
+# ---------------------------------------------------------------------------
+
+#: Issues per the spec description that were "executing when paused"
+_TEST_ISSUE_NUMBERS = [100, 200, 300]
+_TEST_REPO = "owner/test-repo"
+
+#: How many issues should succeed in the happy path
+_ALL_SUCCESS = len(_TEST_ISSUE_NUMBERS)
+_NO_FAILURES = 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_completed_process(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    cp = MagicMock(spec=subprocess.CompletedProcess)
+    cp.returncode = returncode
+    cp.stdout = stdout.encode()
+    cp.stderr = stderr.encode()
+    return cp
+
+
+def _label_list_result(labels: list[str]) -> subprocess.CompletedProcess:
+    import json
+    return _make_completed_process(stdout=json.dumps([{"name": l} for l in labels]))
+
+
+def _ok() -> subprocess.CompletedProcess:
+    return _make_completed_process(returncode=0)
+
+
+def _gh_error(msg: str = "API error") -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(1, "gh", stderr=msg.encode())
+
+
+# ---------------------------------------------------------------------------
+# _ensure_wos_paused_label_exists
+# ---------------------------------------------------------------------------
+
+class TestEnsureWosPausedLabelExists:
+    """Tests for the wos:paused label creation helper."""
+
+    def test_label_already_exists_no_create_call(self) -> None:
+        """When wos:paused exists on the repo, no create call is made."""
+        list_result = _label_list_result([WOS_PAUSED_LABEL, "bug"])
+
+        with patch("subprocess.run", return_value=list_result) as mock_run:
+            result = _ensure_wos_paused_label_exists(_TEST_REPO)
+
+        assert result is True
+        assert mock_run.call_count == 1
+        args = mock_run.call_args[0][0]
+        assert "label" in args
+        assert "list" in args
+
+    def test_label_missing_creates_with_correct_color(self) -> None:
+        """When wos:paused is absent, creates it with WOS_PAUSED_LABEL_COLOR."""
+        list_result = _label_list_result(["bug", "enhancement"])
+        create_result = _ok()
+
+        with patch("subprocess.run", side_effect=[list_result, create_result]) as mock_run:
+            result = _ensure_wos_paused_label_exists(_TEST_REPO)
+
+        assert result is True
+        assert mock_run.call_count == 2
+        create_args = mock_run.call_args_list[1][0][0]
+        assert "label" in create_args
+        assert "create" in create_args
+        assert WOS_PAUSED_LABEL in create_args
+        assert WOS_PAUSED_LABEL_COLOR in create_args
+
+    def test_gh_list_failure_returns_false(self) -> None:
+        with patch("subprocess.run", side_effect=_gh_error()):
+            result = _ensure_wos_paused_label_exists(_TEST_REPO)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# bulk_swap_executing_to_paused
+# ---------------------------------------------------------------------------
+
+class TestBulkSwapExecutingToPaused:
+    """Tests for pause-time bulk label swap (wos:executing → wos:paused)."""
+
+    def test_empty_list_returns_zero_zero(self) -> None:
+        """No gh calls are made and (0, 0) is returned for an empty list."""
+        with patch("subprocess.run") as mock_run:
+            success, failure = bulk_swap_executing_to_paused([], repo=_TEST_REPO)
+
+        assert (success, failure) == (0, 0)
+        assert mock_run.call_count == 0
+
+    def test_calls_correct_gh_command_for_each_issue(self) -> None:
+        """Each issue gets a gh issue edit call to remove executing + add paused."""
+        # First call: ensure paused label exists (label list)
+        list_result = _label_list_result([WOS_PAUSED_LABEL])
+        # Subsequent calls: one per issue
+        issue_results = [_ok() for _ in _TEST_ISSUE_NUMBERS]
+
+        with patch("subprocess.run", side_effect=[list_result] + issue_results) as mock_run:
+            success, failure = bulk_swap_executing_to_paused(
+                _TEST_ISSUE_NUMBERS, repo=_TEST_REPO
+            )
+
+        assert (success, failure) == (_ALL_SUCCESS, _NO_FAILURES)
+
+        # Verify each issue edit call contains the right label operations
+        # Call at index 0 is the label-list for _ensure_wos_paused_label_exists
+        for idx, issue_number in enumerate(_TEST_ISSUE_NUMBERS):
+            call_args = mock_run.call_args_list[idx + 1][0][0]
+            assert "issue" in call_args
+            assert "edit" in call_args
+            assert str(issue_number) in call_args
+            assert "--remove-label" in call_args
+            assert WOS_EXECUTING_LABEL in call_args
+            assert "--add-label" in call_args
+            assert WOS_PAUSED_LABEL in call_args
+
+    def test_single_failure_does_not_abort_loop(self) -> None:
+        """A gh CLI failure on one issue does not stop processing of remaining issues."""
+        list_result = _label_list_result([WOS_PAUSED_LABEL])
+        # Second issue fails; first and third succeed
+        side_effects = [
+            list_result,
+            _ok(),           # issue 100 — success
+            _gh_error(),     # issue 200 — failure
+            _ok(),           # issue 300 — success
+        ]
+
+        with patch("subprocess.run", side_effect=side_effects):
+            success, failure = bulk_swap_executing_to_paused(
+                _TEST_ISSUE_NUMBERS, repo=_TEST_REPO
+            )
+
+        assert success == 2
+        assert failure == 1
+
+    def test_all_failures_returns_zero_all_fail(self) -> None:
+        """When all issues fail, success_count=0, failure_count=N."""
+        list_result = _label_list_result([WOS_PAUSED_LABEL])
+        error_side_effects = [list_result] + [_gh_error() for _ in _TEST_ISSUE_NUMBERS]
+
+        with patch("subprocess.run", side_effect=error_side_effects):
+            success, failure = bulk_swap_executing_to_paused(
+                _TEST_ISSUE_NUMBERS, repo=_TEST_REPO
+            )
+
+        assert success == 0
+        assert failure == _ALL_SUCCESS
+
+    def test_unexpected_exception_counted_as_failure(self) -> None:
+        """An unexpected non-subprocess exception is counted in failure_count."""
+        list_result = _label_list_result([WOS_PAUSED_LABEL])
+
+        with patch("subprocess.run", side_effect=[list_result, OSError("network error")]):
+            success, failure = bulk_swap_executing_to_paused([42], repo=_TEST_REPO)
+
+        assert success == 0
+        assert failure == 1
+
+
+# ---------------------------------------------------------------------------
+# bulk_swap_paused_to_executing
+# ---------------------------------------------------------------------------
+
+class TestBulkSwapPausedToExecuting:
+    """Tests for resume-time bulk label swap (wos:paused → wos:executing)."""
+
+    def test_empty_list_returns_zero_zero(self) -> None:
+        """No gh calls are made and (0, 0) is returned for an empty list."""
+        with patch("subprocess.run") as mock_run:
+            success, failure = bulk_swap_paused_to_executing([], repo=_TEST_REPO)
+
+        assert (success, failure) == (0, 0)
+        assert mock_run.call_count == 0
+
+    def test_calls_reverse_gh_command_for_each_issue(self) -> None:
+        """Each issue gets a gh issue edit call to remove paused + add executing."""
+        # First call: ensure executing label exists (label list)
+        list_result = _label_list_result([WOS_EXECUTING_LABEL])
+        issue_results = [_ok() for _ in _TEST_ISSUE_NUMBERS]
+
+        with patch("subprocess.run", side_effect=[list_result] + issue_results) as mock_run:
+            success, failure = bulk_swap_paused_to_executing(
+                _TEST_ISSUE_NUMBERS, repo=_TEST_REPO
+            )
+
+        assert (success, failure) == (_ALL_SUCCESS, _NO_FAILURES)
+
+        for idx, issue_number in enumerate(_TEST_ISSUE_NUMBERS):
+            call_args = mock_run.call_args_list[idx + 1][0][0]
+            assert "issue" in call_args
+            assert "edit" in call_args
+            assert str(issue_number) in call_args
+            assert "--remove-label" in call_args
+            assert WOS_PAUSED_LABEL in call_args
+            assert "--add-label" in call_args
+            assert WOS_EXECUTING_LABEL in call_args
+
+    def test_single_failure_does_not_abort_loop(self) -> None:
+        """A gh CLI failure on one issue does not stop processing of remaining issues."""
+        list_result = _label_list_result([WOS_EXECUTING_LABEL])
+        side_effects = [
+            list_result,
+            _gh_error(),     # issue 100 — failure
+            _ok(),           # issue 200 — success
+            _ok(),           # issue 300 — success
+        ]
+
+        with patch("subprocess.run", side_effect=side_effects):
+            success, failure = bulk_swap_paused_to_executing(
+                _TEST_ISSUE_NUMBERS, repo=_TEST_REPO
+            )
+
+        assert success == 2
+        assert failure == 1
+
+    def test_all_failures_returns_zero_all_fail(self) -> None:
+        """When all issues fail, success_count=0, failure_count=N."""
+        list_result = _label_list_result([WOS_EXECUTING_LABEL])
+        error_side_effects = [list_result] + [_gh_error() for _ in _TEST_ISSUE_NUMBERS]
+
+        with patch("subprocess.run", side_effect=error_side_effects):
+            success, failure = bulk_swap_paused_to_executing(
+                _TEST_ISSUE_NUMBERS, repo=_TEST_REPO
+            )
+
+        assert success == 0
+        assert failure == _ALL_SUCCESS
+
+    def test_unexpected_exception_counted_as_failure(self) -> None:
+        """An unexpected non-subprocess exception is counted in failure_count."""
+        list_result = _label_list_result([WOS_EXECUTING_LABEL])
+
+        with patch("subprocess.run", side_effect=[list_result, RuntimeError("timeout")]):
+            success, failure = bulk_swap_paused_to_executing([42], repo=_TEST_REPO)
+
+        assert success == 0
+        assert failure == 1
+
+
+# ---------------------------------------------------------------------------
+# handle_wos_stop — label swap stats in response
+# ---------------------------------------------------------------------------
+
+class TestHandleWosStopLabelSwap:
+    """Tests that handle_wos_stop includes label swap stats in its response."""
+
+    def _make_mock_registry(self, executing_issue_numbers: list[int]) -> MagicMock:
+        """Build a mock Registry with executing UoWs that have source_issue_numbers."""
+        from unittest.mock import MagicMock
+
+        mock_uow_list = []
+        for n in executing_issue_numbers:
+            u = MagicMock()
+            u.source_issue_number = n
+            mock_uow_list.append(u)
+
+        reg = MagicMock()
+        reg.list.return_value = mock_uow_list
+        return reg
+
+    def test_stop_includes_label_swap_line_in_response(self, tmp_path) -> None:
+        """handle_wos_stop includes 'Labels swapped: N wos:executing → wos:paused' in response."""
+        from orchestration.dispatcher_handlers import handle_wos_stop
+
+        mock_reg = self._make_mock_registry([101, 202])
+
+        with (
+            patch("orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": True}),
+            patch("orchestration.dispatcher_handlers.toggle_wos_core_jobs",
+                  return_value={"toggled": ["executor-heartbeat"], "not_found": []}),
+            patch("orchestration.dispatcher_handlers._toggle_systemd_timers",
+                  return_value=[]),
+            patch("orchestration.dispatcher_handlers._bulk_swap_executing_to_paused",
+                  return_value=(2, 0)) as mock_swap,
+        ):
+            response = handle_wos_stop(registry=mock_reg)
+
+        assert "Labels swapped: 2 wos:executing → wos:paused" in response
+        assert "(failures: 0)" in response
+        mock_swap.assert_called_once_with([101, 202], repo="dcetlin/Lobster")
+
+    def test_stop_includes_label_swap_in_control_event(self, tmp_path) -> None:
+        """handle_wos_stop includes label_swap key in the log_control_event payload."""
+        from orchestration.dispatcher_handlers import handle_wos_stop
+
+        mock_reg = self._make_mock_registry([55])
+
+        with (
+            patch("orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": True}),
+            patch("orchestration.dispatcher_handlers.toggle_wos_core_jobs",
+                  return_value={"toggled": [], "not_found": []}),
+            patch("orchestration.dispatcher_handlers._toggle_systemd_timers",
+                  return_value=[]),
+            patch("orchestration.dispatcher_handlers._bulk_swap_executing_to_paused",
+                  return_value=(1, 0)),
+        ):
+            handle_wos_stop(registry=mock_reg)
+
+        mock_reg.log_control_event.assert_called_once()
+        _, payload = mock_reg.log_control_event.call_args[0]
+        assert "label_swap" in payload
+        assert payload["label_swap"] == {"success": 1, "failed": 0}
+
+    def test_stop_with_no_executing_issues_still_includes_label_line(self) -> None:
+        """When no issues are executing, swap still reports '0 swapped'."""
+        from orchestration.dispatcher_handlers import handle_wos_stop
+
+        mock_reg = self._make_mock_registry([])
+
+        with (
+            patch("orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": True}),
+            patch("orchestration.dispatcher_handlers.toggle_wos_core_jobs",
+                  return_value={"toggled": [], "not_found": []}),
+            patch("orchestration.dispatcher_handlers._toggle_systemd_timers",
+                  return_value=[]),
+            patch("orchestration.dispatcher_handlers._bulk_swap_executing_to_paused",
+                  return_value=(0, 0)),
+        ):
+            response = handle_wos_stop(registry=mock_reg)
+
+        assert "Labels swapped: 0" in response
+
+
+# ---------------------------------------------------------------------------
+# handle_wos_start — label restore stats in response
+# ---------------------------------------------------------------------------
+
+class TestHandleWosStartLabelSwap:
+    """Tests that handle_wos_start includes label restore stats in its response."""
+
+    def _make_mock_registry(self, executing_issue_numbers: list[int]) -> MagicMock:
+        mock_uow_list = []
+        for n in executing_issue_numbers:
+            u = MagicMock()
+            u.source_issue_number = n
+            mock_uow_list.append(u)
+
+        reg = MagicMock()
+        reg.list.return_value = mock_uow_list
+        return reg
+
+    def test_start_includes_label_restore_line_in_response(self) -> None:
+        """handle_wos_start includes 'Labels restored: N wos:paused → wos:executing' in response."""
+        from orchestration.dispatcher_handlers import handle_wos_start
+
+        mock_reg = self._make_mock_registry([101, 202, 303])
+
+        with (
+            patch("orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": False}),
+            patch("orchestration.dispatcher_handlers.toggle_wos_core_jobs",
+                  return_value={"toggled": ["executor-heartbeat"], "not_found": []}),
+            patch("orchestration.dispatcher_handlers._toggle_systemd_timers",
+                  return_value=[]),
+            patch("orchestration.dispatcher_handlers._bulk_swap_paused_to_executing",
+                  return_value=(3, 0)) as mock_swap,
+        ):
+            response = handle_wos_start(registry=mock_reg)
+
+        assert "Labels restored: 3 wos:paused → wos:executing" in response
+        assert "(failures: 0)" in response
+        mock_swap.assert_called_once_with([101, 202, 303], repo="dcetlin/Lobster")
+
+    def test_start_includes_label_swap_in_control_event(self) -> None:
+        """handle_wos_start includes label_swap key in the log_control_event payload."""
+        from orchestration.dispatcher_handlers import handle_wos_start
+
+        mock_reg = self._make_mock_registry([77])
+
+        with (
+            patch("orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": False}),
+            patch("orchestration.dispatcher_handlers.toggle_wos_core_jobs",
+                  return_value={"toggled": [], "not_found": []}),
+            patch("orchestration.dispatcher_handlers._toggle_systemd_timers",
+                  return_value=[]),
+            patch("orchestration.dispatcher_handlers._bulk_swap_paused_to_executing",
+                  return_value=(1, 0)),
+        ):
+            handle_wos_start(registry=mock_reg)
+
+        mock_reg.log_control_event.assert_called_once()
+        _, payload = mock_reg.log_control_event.call_args[0]
+        assert "label_swap" in payload
+        assert payload["label_swap"] == {"success": 1, "failed": 0}
+
+    def test_start_partial_recovery_path_includes_label_restore(self) -> None:
+        """Partial-recovery path of handle_wos_start also includes label restore stats."""
+        from orchestration.dispatcher_handlers import handle_wos_start
+
+        mock_reg = self._make_mock_registry([500])
+
+        with (
+            patch("orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": True}),
+            patch("orchestration.dispatcher_handlers.get_disabled_wos_core_jobs",
+                  return_value=["issue-sweeper"]),
+            patch("orchestration.dispatcher_handlers.toggle_wos_core_jobs",
+                  return_value={"toggled": ["issue-sweeper"], "not_found": []}),
+            patch("orchestration.dispatcher_handlers._toggle_systemd_timers",
+                  return_value=[]),
+            patch("orchestration.dispatcher_handlers._bulk_swap_paused_to_executing",
+                  return_value=(1, 0)) as mock_swap,
+        ):
+            response = handle_wos_start(registry=mock_reg)
+
+        assert "Labels restored: 1 wos:paused → wos:executing" in response
+        mock_swap.assert_called_once()
+
+    def test_start_with_no_executing_issues_still_includes_label_line(self) -> None:
+        """When no issues are executing, restore still reports '0 restored'."""
+        from orchestration.dispatcher_handlers import handle_wos_start
+
+        mock_reg = self._make_mock_registry([])
+
+        with (
+            patch("orchestration.dispatcher_handlers.read_wos_config",
+                  return_value={"execution_enabled": False}),
+            patch("orchestration.dispatcher_handlers.toggle_wos_core_jobs",
+                  return_value={"toggled": [], "not_found": []}),
+            patch("orchestration.dispatcher_handlers._toggle_systemd_timers",
+                  return_value=[]),
+            patch("orchestration.dispatcher_handlers._bulk_swap_paused_to_executing",
+                  return_value=(0, 0)),
+        ):
+            response = handle_wos_start(registry=mock_reg)
+
+        assert "Labels restored: 0" in response


### PR DESCRIPTION
## Summary

When the WOS executor is paused via `/wos stop`, issues retained their `wos:executing` labels even though no execution was happening. Any consumer querying GitHub label state received a misleading picture — 58 issues were stale as of issue #1348.

This implements Option A: `handle_wos_stop` now bulk-swaps `wos:executing → wos:paused` on all issues whose UoWs are in `executing` status, and `handle_wos_start` reverses that swap (`wos:paused → wos:executing`). Label state stays aligned with execution reality throughout pause/resume cycles.

## What changed

**`src/orchestration/wos_issue_lifecycle.py`**
- Added `WOS_PAUSED_LABEL` and `WOS_PAUSED_LABEL_COLOR` constants (grey, to signal suspended machine work)
- Added `_ensure_wos_paused_label_exists` — mirrors the existing `_ensure_wos_executing_label_exists` helper
- Added `bulk_swap_executing_to_paused(issue_numbers, repo, gh_bin)` — called by `handle_wos_stop`
- Added `bulk_swap_paused_to_executing(issue_numbers, repo, gh_bin)` — called by `handle_wos_start`

Both bulk functions: call the appropriate label-ensure helper once before iterating; use `gh issue edit --remove-label / --add-label` per issue; log INFO on success, WARNING on failure; return `(success_count, failure_count)` and never raise.

**`src/orchestration/dispatcher_handlers.py`**
- Updated import to include `_bulk_swap_executing_to_paused` and `_bulk_swap_paused_to_executing`
- `handle_wos_stop`: after `toggle_wos_core_jobs`, queries registry for `executing` UoWs with non-null `source_issue_number`, calls the swap, appends `"Labels swapped: N wos:executing → wos:paused (failures: M)"` to the response, includes `label_swap` in `log_control_event` payload
- `handle_wos_start`: same pattern applied to both the normal start path and the partial-recovery path (execution_enabled=True with some jobs disabled), swapping `wos:paused → wos:executing`

## What was not changed

- `stamp_issue_executing`, `stamp_issue_complete`, `stamp_issue_failed`, `stamp_issue_unverifiable` — per-UoW lifecycle stamps are untouched
- UoW registry status transitions — this is GitHub label state only, no DB changes
- The `wos:executing` label creation/color — unchanged

## Functional patterns

Pure functions with explicit `(success_count, failure_count)` return tuples; side effects isolated at the iteration boundary so a single gh CLI failure never aborts the loop; composition of existing `_run_gh` and `_ensure_*_label_exists` helpers.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_wos_label_swap.py -x -v` — 20 passed, 0 failed (new test file)
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_issue_lifecycle.py tests/unit/test_orchestration/test_toggle_wos_core_jobs.py tests/unit/test_orchestration/test_dispatcher_commands.py -x` — 92 passed, 0 failed (no regressions)
- [x] `python -m py_compile` on all changed files — syntax clean

## Manual test

N/A — this change affects only code paths triggered by `/wos stop` and `/wos start` operator commands. No external service calls are made in automated tests (all mocked via `unittest.mock.patch`). The `gh issue edit` calls that would reach the GitHub API at runtime are not invoked during test execution.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (label swaps are operator-triggered, no automated run needed)
- [x] User-visible outcome verified — not applicable (no user-facing output; label changes are visible in GitHub issues but require live execution)
- [x] Side-effect audit complete: bulk swap is bounded by the set of `executing` UoWs (finite, typically single-digit count); no loops, no floods
- [x] External service calls: mocked in tests; explicitly scoped in runtime (per-issue `gh issue edit`)

Closes #1348