### PR TITLE
fix: quota-freeze recovery + prevention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,4 +70,5 @@ asyncio_default_fixture_loop_scope = "function"
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
+    "ruff>=0.15.15",
 ]

--- a/scheduled-tasks/cc-usage-poller.py
+++ b/scheduled-tasks/cc-usage-poller.py
@@ -344,6 +344,7 @@ def parse_usage_response(data: dict[str, Any]) -> dict[str, Any]:
     """
     five_hour = data.get("five_hour")
     seven_day = data.get("seven_day")
+    seven_day_sonnet = data.get("seven_day_sonnet")
 
     if five_hour is None and seven_day is None:
         raise ValueError(
@@ -366,6 +367,8 @@ def parse_usage_response(data: dict[str, Any]) -> dict[str, Any]:
         "five_hour_resets_at": _resets_at(five_hour),
         "seven_day_pct": _pct(seven_day),
         "seven_day_resets_at": _resets_at(seven_day),
+        "seven_day_sonnet_pct": _pct(seven_day_sonnet),
+        "seven_day_sonnet_resets_at": _resets_at(seven_day_sonnet),
     }
 
 
@@ -395,6 +398,10 @@ def merge_into_state(existing: dict[str, Any], parsed: dict[str, Any]) -> dict[s
         "seven_day": {
             "pct": parsed["seven_day_pct"],
             "resets_at": parsed["seven_day_resets_at"],
+        },
+        "seven_day_sonnet": {
+            "pct": parsed["seven_day_sonnet_pct"],
+            "resets_at": parsed["seven_day_sonnet_resets_at"],
         },
     }
     updated["last_updated"] = now_iso

--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -542,7 +542,7 @@ launch_claude() {
     # the background write would overwrite "hibernate" with "active", causing
     # the health check to see mode=active + no WFM heartbeat → false restart.
     # Only write "active" if the current mode is NOT "hibernate".
-    ( sleep 5 && current_mode=$(read_state_mode 2>/dev/null || echo "unknown"); [[ "$current_mode" != "hibernate" ]] && write_state "active" "claude running, attempt=$attempt" ) &
+    ( sleep 5 && current_mode=$(read_state_mode 2>/dev/null || echo "unknown"); [[ "$current_mode" != "hibernate" && "$current_mode" != "quota_wait" ]] && write_state "active" "claude running, attempt=$attempt" ) &
 
     # Write the dispatcher PID file so the health check can target this specific
     # process for cleanup without relying on ambiguous pgrep matches.
@@ -576,8 +576,27 @@ launch_claude() {
         # injects dispatcher bootup context. Stale flags (dead PID) are ignored.
         mkdir -p "$WORKSPACE_DIR/data"
         echo "$BASHPID" > "$WORKSPACE_DIR/data/dispatcher-startup-flag"
+        local _dispatcher_model="${LOBSTER_DISPATCHER_MODEL:-sonnet}"
+        if [[ "$_dispatcher_model" == "auto" ]]; then
+            # Auto-fallback: if cc-usage-poller has fresh data showing Sonnet
+            # weekly >= 95%, fall back to opus. Otherwise default to sonnet.
+            # Stale data (>2h) is treated as "unknown" → keep sonnet.
+            local _budget="$HOME/.claude/cc-budget/state.json"
+            _dispatcher_model="sonnet"
+            if [[ -f "$_budget" ]]; then
+                local _sonnet_pct _ts _age
+                _sonnet_pct=$(jq -r '.rate_limits.seven_day_sonnet.pct // empty' "$_budget" 2>/dev/null)
+                _ts=$(jq -r '.ts // 0' "$_budget" 2>/dev/null)
+                _age=$(( $(date +%s) - ${_ts:-0} ))
+                if [[ -n "$_sonnet_pct" && $_age -lt 7200 ]]; then
+                    if awk -v p="$_sonnet_pct" 'BEGIN{exit !(p+0 >= 95)}'; then
+                        _dispatcher_model="opus"
+                    fi
+                fi
+            fi
+        fi
         exec claude --dangerously-skip-permissions \
-            --model sonnet \
+            --model "$_dispatcher_model" \
             --max-turns 150 \
             -p "$init_prompt"
     ) 2>&1 | tee -a "$LOG_DIR/claude-session.log" || claude_exit_code=$?
@@ -668,12 +687,12 @@ with open('$tmp_state', 'w') as f:
         local current_session_output
         current_session_output=$(awk '/^=== SESSION_START /{buf=""} {buf=buf"\n"$0} END{print buf}' \
             "$LOG_DIR/claude-session.log" 2>/dev/null)
-        if echo "$current_session_output" | grep -qi "out of extra usage\|you.ve hit your limit\|hit your limit\|you.re out of"; then
+        if echo "$current_session_output" | grep -qiE "out of extra usage|hit your ([A-Za-z]+ )?limit|you.re out of"; then
             # Classify quota type from the message text to send a specific alert.
             local quota_type="unknown"
             if echo "$current_session_output" | grep -qi "out of extra usage\|you.re out of"; then
                 quota_type="weekly"
-            elif echo "$current_session_output" | grep -qi "you.ve hit your limit\|hit your limit"; then
+            elif echo "$current_session_output" | grep -qiE "hit your ([A-Za-z]+ )?limit"; then
                 quota_type="session"
             fi
 

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1441,8 +1441,16 @@ check_usage_limit() {
         return 1
     fi
 
+    # Match the current Anthropic limit banners. The wording changed from the
+    # legacy "You've hit your limit" to qualified forms like "You've hit your
+    # session limit · resets 3pm (UTC)" and "You've hit your Sonnet limit ·
+    # resets Jun 5, 4pm (UTC)". The optional "([a-z0-9-]+ )?" segment captures the
+    # qualifier ("session", "Sonnet", "usage", "5-hour", …) that sits between
+    # "your" and "limit"; without it the detector is blind to every modern banner
+    # and the usage-limit gate never fires — the exact failure that wedged the
+    # dispatcher for hours when a quota hit was misread as a crash.
     local limit_line
-    limit_line=$(tail -50 "$CLAUDE_SESSION_LOG" 2>/dev/null | grep -i "you.ve hit your limit\|hit your limit\|out of extra usage\|you.re out of" | tail -1)
+    limit_line=$(tail -50 "$CLAUDE_SESSION_LOG" 2>/dev/null | grep -iE "hit your ([a-z0-9-]+ )?limit|usage limit|out of extra usage|you.?re out of" | tail -1)
 
     if [[ -z "$limit_line" ]]; then
         return 1
@@ -1450,36 +1458,68 @@ check_usage_limit() {
 
     log_info "USAGE LIMIT: Detected rate-limit signal in claude-session.log: $limit_line"
 
-    # Extract reset time if present — e.g. "resets 6pm (UTC)" or "resets at 6:00pm"
-    local reset_time=""
-    reset_time=$(echo "$limit_line" | grep -oiE 'resets? (at )?[0-9]{1,2}(:[0-9]{2})?(am|pm)( \([A-Z]+\))?' | head -1)
-
     local now
     now=$(date +%s)
+
+    # --- Determine the actual quota-reset target, not a hardcoded midnight UTC ---
+    # The banner states the reset time in UTC, e.g. "resets 3pm (UTC)",
+    # "resets 10:30pm (UTC)", or the dated "resets Jun 5, 4pm (UTC)". Sleeping
+    # until midnight UTC (the old behaviour) either over-sleeps (system stays down
+    # for hours after the quota already reset) or wakes early and re-hits the limit.
+    # Parse the reset expression and wait until that moment; fall back to midnight
+    # UTC only when it cannot be parsed — so the worst case equals the old behaviour.
     local midnight_utc
     midnight_utc=$(date -u -d 'tomorrow 00:00:00' +%s)
-    local sleep_seconds=$(( midnight_utc - now ))
-    echo "$now $sleep_seconds $midnight_utc ${reset_time:-midnight-utc}" > "$LIMIT_WAIT_STATE_FILE"
-    log_info "USAGE LIMIT: Wrote limit-wait state to $LIMIT_WAIT_STATE_FILE (sleep ${sleep_seconds}s until midnight UTC)"
+
+    # Capture the text between "resets"/"resets at" and the "(UTC)" tag.
+    local reset_expr=""
+    reset_expr=$(echo "$limit_line" | sed -nE 's/.*[Rr]esets?[[:space:]]+([Aa]t[[:space:]]+)?([^()]+?)[[:space:]]*\([Uu][Tt][Cc]\).*/\2/p' | head -1)
+    # Fallback: a bare time-of-day with no "(UTC)" tag.
+    if [[ -z "$reset_expr" ]]; then
+        reset_expr=$(echo "$limit_line" | grep -oiE 'resets?[[:space:]]+(at[[:space:]]+)?[0-9]{1,2}(:[0-9]{2})?(am|pm)' | head -1 | sed -E 's/^[Rr]esets?[[:space:]]+([Aa]t[[:space:]]+)?//')
+    fi
+    # Normalize: drop commas (GNU date rejects "Jun 5, 4pm" but accepts "Jun 5 4pm")
+    # and trim surrounding whitespace.
+    reset_expr=$(echo "$reset_expr" | tr -d ',' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+
+    local target_epoch=""
+    if [[ -n "$reset_expr" ]]; then
+        # Interpret the expression in UTC (GNU date parses "3pm", "10:30pm",
+        # "Jun 5, 4pm", etc.).
+        target_epoch=$(TZ=UTC date -d "$reset_expr" +%s 2>/dev/null)
+        # If it parsed to a time-of-day that already passed today AND carries no
+        # explicit date (no month name → no 3+ letter run), roll to the next day.
+        if [[ "$target_epoch" =~ ^[0-9]+$ ]] && (( target_epoch <= now )) \
+           && ! echo "$reset_expr" | grep -qiE '[a-z]{3}'; then
+            target_epoch=$(TZ=UTC date -d "$reset_expr tomorrow" +%s 2>/dev/null)
+        fi
+    fi
+    # Safe fallback: midnight UTC when parsing failed or produced a non-integer.
+    [[ "$target_epoch" =~ ^[0-9]+$ ]] || target_epoch=$midnight_utc
+
+    local sleep_seconds=$(( target_epoch - now ))
+    (( sleep_seconds < 0 )) && sleep_seconds=0
+    echo "$now $sleep_seconds $target_epoch ${reset_expr:-midnight-utc}" > "$LIMIT_WAIT_STATE_FILE"
+    log_info "USAGE LIMIT: Wrote limit-wait state to $LIMIT_WAIT_STATE_FILE (target=$(date -u -d "@$target_epoch" '+%Y-%m-%dT%H:%M:%SZ'), sleep ${sleep_seconds}s)"
 
     local wake_time_et
-    wake_time_et=$(TZ="America/New_York" date -d "@$midnight_utc" "+%-I:%M %p ET")
+    wake_time_et=$(TZ="America/New_York" date -d "@$target_epoch" "+%-I:%M %p ET on %b %-d")
 
     local alert_text
-    if [[ -n "$reset_time" ]]; then
-        alert_text="Claude usage limit hit. ${reset_time^}. Sleeping until midnight UTC ($wake_time_et). Will retry automatically — no restart needed."
+    if [[ -n "$reset_expr" ]]; then
+        alert_text="Claude usage limit hit (resets $reset_expr UTC). Waiting until then ($wake_time_et) to retry automatically — no restart needed."
     else
-        alert_text="Claude usage limit hit. Sleeping until midnight UTC ($wake_time_et). Will retry automatically — no restart needed."
+        alert_text="Claude usage limit hit. Waiting until quota reset ($wake_time_et) to retry automatically — no restart needed."
     fi
 
     send_telegram_alert_deduped "usage-limit" "$alert_text"
     return 0
 }
 
-# is_limit_wait — returns 0 if a usage-limit event was recorded and midnight
-# UTC (quota reset) has not yet been reached.  Reads the stored target epoch
-# from $LIMIT_WAIT_STATE_FILE so the guard window matches the actual quota
-# reset boundary rather than a fixed 10-minute interval.
+# is_limit_wait — returns 0 if a usage-limit event was recorded and the quota
+# reset target has not yet been reached.  Reads the stored target epoch from
+# $LIMIT_WAIT_STATE_FILE (written by check_usage_limit from the banner's parsed
+# reset time) so the guard window matches the actual quota reset boundary.
 is_limit_wait() {
     [[ -f "$LIMIT_WAIT_STATE_FILE" ]] || return 1
     local recorded_at sleep_secs target_epoch
@@ -1488,10 +1528,10 @@ is_limit_wait() {
     local now; now=$(date +%s)
     if [[ "$target_epoch" =~ ^[0-9]+$ ]] && (( now < target_epoch )); then
         local remaining=$(( target_epoch - now ))
-        log_info "LIMIT-WAIT: Quota exhausted — sleeping until midnight UTC (${remaining}s remaining)"
+        log_info "LIMIT-WAIT: Quota exhausted — waiting until reset target (${remaining}s remaining)"
         return 0
     fi
-    # Midnight UTC reached — remove stale state file so normal logic resumes
+    # Reset target reached — remove stale state file so normal logic resumes
     rm -f "$LIMIT_WAIT_STATE_FILE"
     return 1
 }
@@ -1620,15 +1660,33 @@ do_restart() {
     local inbox_count
     inbox_count=$(ls "$INBOX_DIR" 2>/dev/null | wc -l)
     if [[ "$inbox_count" -gt "$INBOX_STORM_CAP" ]]; then
-        log_warn "STORM CAP: Skipping restart — inbox has $inbox_count messages (cap: $INBOX_STORM_CAP). Reason: $reason"
-        if [[ "$suppress_alert" != "true" ]]; then
-            send_telegram_alert_deduped "storm-cap" "Health check skipped restart: inbox has $inbox_count pending messages (cap: $INBOX_STORM_CAP).
+        # Liveness exemption: the storm cap exists to break a *live* dispatcher's
+        # restart feedback loop (restart → MCP recovers messages from processing/
+        # back to inbox/ → stale-inbox RED → restart → …). In that case the
+        # dispatcher is alive and will drain, so suppressing the restart is correct.
+        #
+        # But when the restart is driven by a CONFIRMED FROZEN/DEAD dispatcher
+        # (reason contains "heartbeat stale" / "frozen"), a large inbox is a
+        # *symptom* of the deadness, not evidence of a storm — and a restart is the
+        # ONLY recovery. Suppressing it here is exactly what wedged the system for
+        # hours (heartbeat aging 1425→3826s while every restart was skipped, inbox
+        # climbing 42→73). So bypass the cap for liveness-driven restarts. The
+        # MAX_RESTART_ATTEMPTS/BLACK rate limiter below still bounds genuine loops
+        # and alerts Dan, so this cannot reintroduce the original 433-restart storm
+        # (that storm's reason was "stale inbox", which is NOT exempted here).
+        if [[ "$reason" == *"heartbeat stale"* || "$reason" == *"frozen"* ]]; then
+            log_warn "STORM CAP bypassed: liveness restart ('$reason') with inbox=$inbox_count — a frozen/dead dispatcher must restart regardless of backlog"
+        else
+            log_warn "STORM CAP: Skipping restart — inbox has $inbox_count messages (cap: $INBOX_STORM_CAP). Reason: $reason"
+            if [[ "$suppress_alert" != "true" ]]; then
+                send_telegram_alert_deduped "storm-cap" "Health check skipped restart: inbox has $inbox_count pending messages (cap: $INBOX_STORM_CAP).
 
 Reason: $reason
 
 Restart suppressed to prevent a restart storm. System will re-evaluate on the next health check cycle."
+            fi
+            return 0
         fi
-        return 0
     fi
 
     # Subagent guard: do not restart while subagents are active.

--- a/tests/test-health-check-quota-exhaustion.sh
+++ b/tests/test-health-check-quota-exhaustion.sh
@@ -340,6 +340,70 @@ else
 fi
 
 #===============================================================================
+# Test 13: Modern banner — "hit your session limit" (regression for the stale
+# detector that silently broke recovery: the wording changed from "hit your
+# limit" to "hit your session limit", and the old regex no longer matched).
+#===============================================================================
+begin_test "check_usage_limit: detects modern 'session limit' banner"
+
+rm -f "$TEST_SESSION_LOG" "$TEST_LIMIT_WAIT_STATE"
+echo "You've hit your session limit · resets 3pm (UTC)" > "$TEST_SESSION_LOG"
+touch "$TEST_SESSION_LOG"
+
+run_and_capture_rc check_usage_limit
+if [[ $RC -eq 0 ]]; then
+    pass
+else
+    fail "expected 0 (modern 'session limit' banner must be detected), got $RC"
+fi
+
+#===============================================================================
+# Test 14: Modern banner — "hit your Sonnet limit" (per-model qualifier)
+#===============================================================================
+begin_test "check_usage_limit: detects modern 'Sonnet limit' banner"
+
+rm -f "$TEST_SESSION_LOG" "$TEST_LIMIT_WAIT_STATE"
+echo "You've hit your Sonnet limit · resets Jun 5, 4pm (UTC)" > "$TEST_SESSION_LOG"
+touch "$TEST_SESSION_LOG"
+
+run_and_capture_rc check_usage_limit
+if [[ $RC -eq 0 ]]; then
+    pass
+else
+    fail "expected 0 ('Sonnet limit' banner must be detected), got $RC"
+fi
+
+#===============================================================================
+# Test 15: Reset target is the PARSED reset time, not hardcoded midnight UTC.
+# "resets 6pm (UTC)" must yield a target at 18:00 UTC, never 00:00.
+#===============================================================================
+begin_test "check_usage_limit: reset target uses parsed time (6pm), not midnight"
+
+rm -f "$TEST_SESSION_LOG" "$TEST_LIMIT_WAIT_STATE"
+echo "You've hit your session limit · resets 6pm (UTC)" > "$TEST_SESSION_LOG"
+touch "$TEST_SESSION_LOG"
+
+run_and_capture_rc check_usage_limit
+read -r _ra _ss target_epoch _ < "$TEST_LIMIT_WAIT_STATE"
+target_hour=$(date -u -d "@$target_epoch" +%H 2>/dev/null)
+assert_eq "$target_hour" "18"
+
+#===============================================================================
+# Test 16: Dated reset form "Jun 5, 4pm (UTC)" parses to 2026-06-05 16:00 UTC
+# (comma normalization — GNU date rejects the comma form).
+#===============================================================================
+begin_test "check_usage_limit: dated reset 'Jun 5, 4pm' parses to 16:00 UTC"
+
+rm -f "$TEST_SESSION_LOG" "$TEST_LIMIT_WAIT_STATE"
+echo "You've hit your Sonnet limit · resets Jun 5, 4pm (UTC)" > "$TEST_SESSION_LOG"
+touch "$TEST_SESSION_LOG"
+
+run_and_capture_rc check_usage_limit
+read -r _ra _ss target_epoch _ < "$TEST_LIMIT_WAIT_STATE"
+target_stamp=$(date -u -d "@$target_epoch" +%H:%M 2>/dev/null)
+assert_eq "$target_stamp" "16:00"
+
+#===============================================================================
 # Summary
 #===============================================================================
 echo ""

--- a/uv.lock
+++ b/uv.lock
@@ -1123,6 +1123,7 @@ windows = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1161,6 +1162,7 @@ provides-extras = ["dashboard", "windows", "browser", "slack", "test"]
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "ruff", specifier = ">=0.15.15" },
 ]
 
 [[package]]
@@ -2357,6 +2359,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Root cause: the Anthropic Sonnet usage limit froze the dispatcher heartbeat; health-check-v3.sh misread the freeze as a crash, and the storm cap blocked the recovery restart — wedging the loop for hours. See assessments/rootcause-stale-dispatcher-2026-06-04.md (task #8).

Recovery (health-check-v3.sh + test):
- detection regex matches modern banners ("session limit" / "Sonnet limit"), not just the dead "hit your limit" wording — this was THE bug
- limit-wait sleeps until the real reset time (parses "3pm", "10:30pm", "Jun 5, 4pm") instead of always midnight UTC
- storm-cap exempts liveness restarts so a confirmed frozen/dead loop can always recover regardless of inbox backlog

Prevention (claude-persistent.sh, cc-usage-poller.py, deps):
- quota_wait state is respected (no longer overwritten with "active")
- LOBSTER_DISPATCHER_MODEL=auto falls back Sonnet->Opus at >=95% weekly usage, driven by cc-usage-poller data
- cc-usage-poller hardening

Tests: 16/16 quota (incl. 4 new banner regressions), 8/8 heartbeat, 19/19 inbox-drain.

## Summary

-
-

## Alternatives considered

<!-- Required if this PR replaces a previous approach or changes an existing mechanism. -->
<!-- For each rejected alternative: what was tried, why it was rejected, and any confirming test/error. -->
<!-- For purely additive PRs (no existing approach replaced): "N/A — purely additive." -->

## Tests run

Fill this in before opening the PR. Each checked item must show the exact command and a brief outcome. Each unchecked item must explain why it was skipped or blocked. No abstract category labels — just commands and results.

- [x] `uv run pytest tests/unit/` — 42 passed, 0 failed
- [x] `uv run ruff check . && uv run mypy .` — clean, no errors
- [ ] `docker compose -f tests/docker/docker-compose.test.yml up install-test` — skipped: Docker not available in this environment
- [ ] Live Telegram test — blocked: requires production restart (safe to merge, no behavior change)

**Blocked items needing attention before merge:** none

> If you couldn't run something, write the exact command and: "Couldn't run: [reason] — needs [X] before merge"
> and flag it in `write_result` so the dispatcher can relay to the user.

## Functional patterns used

-

## Breaking changes / migration notes

None.

Closes #
