### PR TITLE
fix: suppress heartbeat check during quota_wait + raise stale threshold (Jun 5 alert storm)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -99,7 +99,10 @@ HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"   # legacy WFM-touch signa
 # Single file, single integer (Unix epoch seconds). No JSON parsing required.
 # Threshold is generous enough to cover compaction + catchup without suppression.
 DISPATCHER_HEARTBEAT_FILE="${LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-heartbeat}"
-DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) + catchup (~12m) + margin
+DISPATCHER_HEARTBEAT_STALE_SECONDS=1800   # TEMPORARY BUFFER (2026-06-05): raised from 1200s to 1800s while structural
+                                           # WOS quota_wait fixes land. 1800s = 30 min, covers the worst-case compaction
+                                           # + catchup window observed during the Jun 4-5 quota storm. Revert to 1200s
+                                           # once quota_wait mode correctly suppresses heartbeat checks in production.
 
 # Session age limit: CC enforces a hard 7440s session lifetime (issue #2059).
 # At this limit, CC kills the process without firing the Stop hook — no tombstone,
@@ -2283,9 +2286,9 @@ main() {
 
     if is_hibernating; then
         log_info "Dispatcher heartbeat suppressed (hibernating)"
-    elif [[ "$lobster_mode" == "starting" || "$lobster_mode" == "restarting" || \
-            "$lobster_mode" == "waking"    || "$lobster_mode" == "backoff"    || \
-            "$lobster_mode" == "stopped" ]]; then
+    elif [[ "$lobster_mode" == "starting"    || "$lobster_mode" == "restarting" || \
+            "$lobster_mode" == "waking"      || "$lobster_mode" == "backoff"    || \
+            "$lobster_mode" == "stopped"     || "$lobster_mode" == "quota_wait" ]]; then
         log_info "Dispatcher heartbeat suppressed (transient lifecycle state: $lobster_mode)"
     else
         check_dispatcher_heartbeat

--- a/tests/test-health-check-dispatcher-heartbeat.sh
+++ b/tests/test-health-check-dispatcher-heartbeat.sh
@@ -6,8 +6,8 @@
 #
 # Tests:
 #   1. Heartbeat file absent → GREEN (skipped, no false alarm on fresh install)
-#   2. Heartbeat file recent (< DISPATCHER_HEARTBEAT_STALE_SECONDS) → GREEN
-#   3. Heartbeat file stale (> DISPATCHER_HEARTBEAT_STALE_SECONDS) → RED (exit 2)
+#   2. Heartbeat file recent (< DISPATCHER_HEARTBEAT_STALE_SECONDS, currently 1800s) → GREEN
+#   3. Heartbeat file stale (> DISPATCHER_HEARTBEAT_STALE_SECONDS, currently 1800s) → RED (exit 2)
 #   4. Heartbeat file contains non-integer content → GREEN (graceful fallback)
 #   5. Heartbeat file exists but empty → GREEN (graceful fallback)
 #   6. LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE respected
@@ -55,7 +55,7 @@ assert_exit() {
 
 # Source check_dispatcher_heartbeat() from the health check script once.
 LOG_FILE="$TEST_LOG_DIR/health-check.log"
-DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
+DISPATCHER_HEARTBEAT_STALE_SECONDS=1800
 # WFM-active variables (issue #1713): must match the values in health-check-v3.sh.
 # Default to an absent file so existing heartbeat tests are unaffected.
 DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active-ABSENT"
@@ -98,10 +98,10 @@ run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
 assert_exit "$rc" 0
 
 # -------------------------------------------------------------------
-# Test 3: Stale heartbeat (> 1200s ago) → RED
+# Test 3: Stale heartbeat (> 1800s ago) → RED
 # -------------------------------------------------------------------
-begin_test "Stale heartbeat (1500s ago) → RED"
-echo "$(( $(date +%s) - 1500 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+begin_test "Stale heartbeat (2100s ago) → RED"
+echo "$(( $(date +%s) - 2100 ))" > "$DISPATCHER_HEARTBEAT_FILE"
 run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
 assert_exit "$rc" 2
 
@@ -133,16 +133,16 @@ assert_exit "$rc" 0
 # -------------------------------------------------------------------
 # Test 7: Exactly 1 second past threshold → RED (boundary)
 # -------------------------------------------------------------------
-begin_test "1s past threshold (1201s ago) → RED"
-echo "$(( $(date +%s) - 1201 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+begin_test "1s past threshold (1801s ago) → RED"
+echo "$(( $(date +%s) - 1801 ))" > "$DISPATCHER_HEARTBEAT_FILE"
 run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
 assert_exit "$rc" 2
 
 # -------------------------------------------------------------------
 # Test 8: Exactly 1 second before threshold → GREEN (boundary)
 # -------------------------------------------------------------------
-begin_test "1s before threshold (1199s ago) → GREEN"
-echo "$(( $(date +%s) - 1199 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+begin_test "1s before threshold (1799s ago) → GREEN"
+echo "$(( $(date +%s) - 1799 ))" > "$DISPATCHER_HEARTBEAT_FILE"
 run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
 assert_exit "$rc" 0
 


### PR DESCRIPTION
## What this fixes

During the Jun 5 quota exhaustion event (02:24–10:00 UTC), the health-check daemon fired 27 spurious RED restart alerts — one every ~4 minutes — because `quota_wait` mode was not included in the heartbeat-staleness suppression list. The dispatcher is intentionally asleep during `quota_wait`; its heartbeat legitimately goes stale. The health check did not know this and treated it as a crash.

Root cause documented in `assessments/resilience-audit-2026-06-05.md` (Defect D, section D3/P1). Both changes were explicitly called out in that audit but not yet applied.

## Changes

**Fix 2 (primary) — `quota_wait` added to heartbeat suppression list**

Previously `quota_wait` fell through to `check_dispatcher_heartbeat()` — the heartbeat aged, RED fired, and the SUBAGENT GUARD was the only thing preventing destructive restarts during the quota sleep. This closes the structural gap: the health daemon now recognizes `quota_wait` as a legitimate lifecycle state, not a crash. One-line change to the elif condition at the heartbeat-suppression gate (lines 2289–2292 of `health-check-v3.sh`).

**Fix 4 (buffer) — threshold raised 1200s → 1800s**

`DISPATCHER_HEARTBEAT_STALE_SECONDS` raised from 1200s (20 min) to 1800s (30 min) as a short-term buffer while structural WOS quota_wait fixes land. Clearly commented as temporary with a revert instruction pointing to what needs to land first.

## Before / after flow

```
Before:
  mode=quota_wait → check_dispatcher_heartbeat() called
    → heartbeat stale (dispatcher sleeping) → RED
    → 27 restart alerts in 90 min
    (SUBAGENT GUARD accidentally prevented actual restarts)

After:
  mode=quota_wait → falls into heartbeat-suppression elif
    → log_info "suppressed (transient lifecycle state: quota_wait)"
    → no RED, no restart attempt
```

## Tests run

- [x] `bash tests/test-health-check-dispatcher-heartbeat.sh` — 8/8 passed (boundary cases updated 1200→1800)
- [x] `bash tests/test-health-check-quota-exhaustion.sh` — 16/16 passed

## Manual test

N/A. The `quota_wait` suppression is structurally identical to the `stopping`/`backoff`/`restarting` suppression branches already in production. No new runtime path introduced — `quota_wait` is added to an existing elif that already handles 5 other lifecycle modes. The Jun 5 incident (27 false-positive REDs) is the evidence the guard was needed.

## Definition of Done

- [x] Unit tests pass (no production hits in automated tests)
- [x] Side-effect audit: suppress-only change, no writes, no message sends, no volume
- [x] External service calls: none
- [x] User-visible outcome: Dan stops receiving spurious restart alerts during quota_wait periods

Relates to: Jun 5 resilience audit (`assessments/resilience-audit-2026-06-05.md`) items D3 and the implicit Fix 4 threshold buffer.