### PR TITLE
fix: add registry status guard to wos-execute-router to stop infinite dispatch loop

### DIFF
--- a/src/daemons/wos_execute_router.py
+++ b/src/daemons/wos_execute_router.py
@@ -12,14 +12,17 @@ The daemon is a persistent systemd service.  On each poll cycle it:
 1. Reads all messages in the inbox directory (pure file I/O, no MCP).
 2. Filters to ``type == "wos_execute"`` client-side.
 3. For each matching message:
-   a. Claims it by moving it from inbox/ to processing/ (mark_processing).
-   b. Calls ``route_wos_message()`` — a pure function that returns a routing
+   a. Status guard: checks the UoW's registry status.  If the status is not
+      ACTIVE or READY_FOR_EXECUTOR (e.g. already EXECUTING), moves the message
+      directly to processed/ without dispatching — prevents duplicate dispatch.
+   b. Claims it by moving it from inbox/ to processing/ (mark_processing).
+   c. Calls ``route_wos_message()`` — a pure function that returns a routing
       decision dict without spawning anything.
-   c. If the decision is ``action == "spawn_subagent"``, dispatches via
+   d. If the decision is ``action == "spawn_subagent"``, dispatches via
       ``_dispatch_via_inbox()`` from ``executor.py`` (the canonical inbox
       dispatch path).
-   d. Moves the message from processing/ to processed/ (mark_processed).
-   e. On hard error: writes a system alert to inbox/ via inbox_write.py and
+   e. Moves the message from processing/ to processed/ (mark_processed).
+   f. On hard error: writes a system alert to inbox/ via inbox_write.py and
       moves the message to failed/.
 4. If a ``send_reply`` action is returned (spawn-gate alert from the pure
    router), writes a ``subagent_result`` inbox message so the dispatcher can
@@ -30,6 +33,10 @@ Gates
 - ``wos-config.json`` ``execution_enabled`` gate: if False, skip routing.
 - ``MAX_AGENTS_GATE``: if active agent count >= threshold, defer by leaving
   messages unclaimed and trying again on the next cycle.
+- ``_DISPATCHABLE_STATUSES`` status guard: if the UoW's registry status is not
+  ACTIVE or READY_FOR_EXECUTOR, the message is discarded (moved to processed/)
+  without dispatch.  Prevents the infinite re-emission loop where the router
+  re-dispatches already-executing UoWs every poll cycle.
 
 Awareness path
 --------------
@@ -51,7 +58,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shutil
 import signal
 import sys
 import time
@@ -76,6 +82,7 @@ for _p in [str(_REPO_ROOT), str(_SRC_ROOT)]:
 
 from orchestration.dispatcher_handlers import route_wos_message, read_wos_config  # noqa: E402
 from orchestration.executor import _dispatch_via_inbox  # noqa: E402
+from orchestration.registry import Registry as _Registry, UoWStatus  # noqa: E402
 from agents.session_store import get_active_sessions  # noqa: E402
 from utils.inbox_write import write_inbox_message  # noqa: E402
 
@@ -262,6 +269,38 @@ def _find_in_dir(directory: Path, message_id: str) -> Path | None:
     return None
 
 
+def _discard_inbox_message(msg: dict) -> None:
+    """
+    Move a message directly from inbox/ to processed/ without claiming it.
+
+    Used by the status guard to discard duplicate wos_execute messages for
+    UoWs that are already executing (or otherwise not dispatchable).  Bypasses
+    the claim/processing step so the message does not linger in processing/.
+
+    Locates the file by ``_filepath`` key stamped by ``_read_inbox_messages``.
+    Logs a warning but does not raise if the file is missing (another process
+    may have claimed it in a race condition).
+    """
+    PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+
+    filepath = msg.get("_filepath")
+    if not filepath:
+        log.warning("discard: no _filepath in message %s — cannot discard", msg.get("id", "?"))
+        return
+
+    src = Path(filepath)
+    if not src.exists():
+        log.debug("discard: %s no longer in inbox — already claimed or discarded", src.name)
+        return
+
+    dest = PROCESSED_DIR / src.name
+    try:
+        src.rename(dest)
+        log.debug("discard: moved %s -> processed/ (status guard)", src.name)
+    except OSError as exc:
+        log.warning("discard: could not move %s to processed/: %s", src.name, exc)
+
+
 # ---------------------------------------------------------------------------
 # Gate helpers
 # ---------------------------------------------------------------------------
@@ -280,6 +319,76 @@ def _active_agent_count() -> int:
     except Exception as exc:
         log.warning("active_agent_count: could not read session store: %s — assuming 0", exc)
         return 0
+
+
+# Statuses that indicate a UoW is ready to be dispatched by the router.
+# A wos_execute message whose UoW is NOT in one of these statuses must be
+# discarded (marked processed without spawning), because:
+#
+# - UoWStatus.ACTIVE: executor_heartbeat has claimed the UoW and is in the
+#   middle of the claim/dispatch transaction; dispatch is imminent and this
+#   message represents the in-flight request — safe to route.
+#
+# - UoWStatus.READY_FOR_EXECUTOR: the UoW is waiting to be claimed; this
+#   message is the initial dispatch request — safe to route.
+#
+# Any other status (EXECUTING, DONE, FAILED, READY_FOR_STEWARD, ...) means
+# the UoW has already been dispatched or has completed — routing again would
+# create a duplicate subagent and is the root cause of the observed loop.
+_DISPATCHABLE_STATUSES: frozenset[UoWStatus] = frozenset({
+    UoWStatus.ACTIVE,
+    UoWStatus.READY_FOR_EXECUTOR,
+})
+
+
+def _uow_status_allows_dispatch(uow_id: str) -> bool:
+    """
+    Return True if the UoW's registry status permits dispatch.
+
+    Queries the registry for the UoW's current status.  Returns True only when
+    the status is in ``_DISPATCHABLE_STATUSES``; returns False for any other
+    status (including EXECUTING, DONE, FAILED, etc.) and when the UoW is not
+    found.
+
+    On registry read error the function returns True (fail-open) so a transient
+    DB hiccup does not permanently suppress a legitimate dispatch.  The error
+    is logged at WARNING level.
+
+    The fail-open posture is the safer default here: a false-positive dispatch
+    (re-routing a genuinely in-flight UoW) is visible and recoverable via the
+    existing TTL/sweep path; a false-negative (suppressing a legitimate dispatch)
+    would silently stall the UoW with no recovery signal.
+    """
+    try:
+        reg = _Registry()
+        uow = reg.get(uow_id)
+    except Exception as exc:
+        log.warning(
+            "status_guard: registry read failed for uow_id=%s — failing open: %s",
+            uow_id, exc,
+        )
+        return True  # fail-open: allow dispatch on transient error
+
+    if uow is None:
+        # UoW not in registry — the message may reference a stale or deleted UoW.
+        # Suppress dispatch (fail-closed for unknown UoWs — nothing to recover).
+        log.info(
+            "status_guard: uow_id=%s not found in registry — discarding message",
+            uow_id,
+        )
+        return False
+
+    if uow.status in _DISPATCHABLE_STATUSES:
+        return True
+
+    log.info(
+        "status_guard: uow_id=%s has status=%s — not in dispatchable set %s; "
+        "discarding duplicate wos_execute message",
+        uow_id,
+        uow.status,
+        {s.value for s in _DISPATCHABLE_STATUSES},
+    )
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -369,16 +478,42 @@ def _route_single_message(msg: dict) -> None:
     """
     Route a single wos_execute message end-to-end.
 
-    Claim → route → dispatch (if spawn_subagent) → mark_processed.
+    Status guard → Claim → route → dispatch (if spawn_subagent) → mark_processed.
     On failure: mark_failed + write alert.
 
     All exceptions are caught and logged — never propagated to the poll loop.
+
+    Status guard: if the UoW's registry status is not in ``_DISPATCHABLE_STATUSES``
+    (i.e. it is already EXECUTING, DONE, FAILED, etc.), the message is discarded
+    by moving it to processed/ without dispatching.  This prevents the infinite
+    re-emission loop where the router repeatedly re-dispatches an already-executing
+    UoW every poll cycle.
     """
     message_id: str = msg.get("id", "")
     uow_id: str = msg.get("uow_id", "?")
 
     if not message_id:
         log.warning("route: message has no id field — skipping: %r", msg)
+        return
+
+    # -----------------------------------------------------------------------
+    # Status guard (loop-prevention): skip dispatch if UoW is already in-flight.
+    # A wos_execute message for a UoW that is already EXECUTING (or in any
+    # non-dispatchable status) is a duplicate produced by a prior router cycle.
+    # Claiming and re-dispatching it would spawn another subagent for the same
+    # UoW, compound inbox flooding, and prevent natural TTL/sweep recovery.
+    #
+    # The guard runs BEFORE claim so the message file is never moved to
+    # processing/ for duplicate messages — it moves directly to processed/.
+    # -----------------------------------------------------------------------
+    if not _uow_status_allows_dispatch(uow_id):
+        log.info(
+            "route: skipping duplicate wos_execute for uow_id=%s message_id=%s "
+            "(UoW status not dispatchable — discarding without spawning)",
+            uow_id, message_id,
+        )
+        # Move directly from inbox to processed — bypass claim/processing
+        _discard_inbox_message(msg)
         return
 
     log.info("route: claiming wos_execute message_id=%s uow_id=%s", message_id, uow_id)

--- a/tests/test_wos_execute_router.py
+++ b/tests/test_wos_execute_router.py
@@ -17,15 +17,19 @@ Coverage:
 - run_poll_cycle returns 0 when gated out
 - run_poll_cycle returns the count of wos_execute messages found
 - agent_type from routing decision is forwarded to _dispatch_via_inbox
+- Status guard: wos_execute for a UoW with status=executing is discarded without dispatch
+- Status guard: wos_execute for a UoW with status=ready-for-executor is dispatched
+- Status guard: wos_execute for a UoW with status=active is dispatched
+- Status guard: wos_execute for an unknown UoW is discarded without dispatch
+- Status guard: registry read failure is fail-open (dispatch proceeds)
 """
 
 from __future__ import annotations
 
 import json
 import sys
-import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 import pytest
 
 
@@ -43,6 +47,7 @@ def _get_router_module():
         "orchestration": MagicMock(),
         "orchestration.dispatcher_handlers": MagicMock(),
         "orchestration.executor": MagicMock(),
+        "orchestration.registry": MagicMock(),
         "orchestration.steward": MagicMock(),
         "agents": MagicMock(),
         "agents.session_store": MagicMock(),
@@ -95,6 +100,10 @@ def router(tmp_path):
     # Default: execution enabled, 0 active agents
     mod.read_wos_config.return_value = {"execution_enabled": True}
     mod.get_active_sessions.return_value = []
+
+    # Default: status guard passes (UoW is dispatchable).
+    # Tests that exercise the status guard behavior override this mock directly.
+    mod._uow_status_allows_dispatch = MagicMock(return_value=True)
 
     return mod
 
@@ -577,7 +586,7 @@ class TestClaimRaceCondition:
 
         # Inject directly into the read result by monkeypatching _read_inbox_messages
         with patch.object(router, "_read_inbox_messages", return_value=[msg]):
-            result = router.run_poll_cycle()
+            router.run_poll_cycle()
 
         # Should not crash; dispatch never called
         router._dispatch.assert_not_called()
@@ -633,6 +642,7 @@ class TestDispatch:
             "orchestration": MagicMock(),
             "orchestration.dispatcher_handlers": MagicMock(),
             "orchestration.executor": MagicMock(_dispatch_via_inbox=mock_inbox_dispatch),
+            "orchestration.registry": MagicMock(),
             "orchestration.steward": MagicMock(),
             "agents": MagicMock(),
             "agents.session_store": MagicMock(),
@@ -685,3 +695,269 @@ class TestDispatch:
         assert call_kwargs.get("agent_type") == "functional-engineer", (
             f"Default agent_type must be 'functional-engineer', got {call_kwargs.get('agent_type')!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests: status guard (_uow_status_allows_dispatch)
+# ---------------------------------------------------------------------------
+# These tests exercise _uow_status_allows_dispatch directly with a real
+# in-memory Registry, verifying the guard logic independently of the poll loop.
+# ---------------------------------------------------------------------------
+
+class TestUoWStatusGuard:
+    """_uow_status_allows_dispatch returns True only for dispatchable statuses."""
+
+    def _load_module_with_real_registry(self, registry_mock):
+        """Load the router module with a controlled Registry mock."""
+        import importlib.util
+
+        repo_root = Path(__file__).resolve().parent.parent
+
+        registry_module_mock = MagicMock()
+        registry_module_mock.Registry = registry_mock
+        # UoWStatus must be the real enum for the guard to work correctly —
+        # use the actual import from the registry module.
+        import sys
+        import importlib
+        # Load the real registry to get the real UoWStatus enum
+        sys.path.insert(0, str(repo_root))
+        sys.path.insert(0, str(repo_root / "src"))
+        from orchestration.registry import UoWStatus as _RealUoWStatus
+
+        registry_module_mock.UoWStatus = _RealUoWStatus
+
+        with patch.dict("sys.modules", {
+            "orchestration": MagicMock(),
+            "orchestration.dispatcher_handlers": MagicMock(),
+            "orchestration.executor": MagicMock(),
+            "orchestration.registry": registry_module_mock,
+            "orchestration.steward": MagicMock(),
+            "agents": MagicMock(),
+            "agents.session_store": MagicMock(),
+            "utils": MagicMock(),
+            "utils.inbox_write": MagicMock(),
+        }):
+            spec = importlib.util.spec_from_file_location(
+                "wos_execute_router_status_guard",
+                repo_root / "src" / "daemons" / "wos_execute_router.py",
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+
+    def _make_uow_mock(self, status_value: str):
+        """Create a mock UoW object with the given status string."""
+        import sys
+        from pathlib import Path
+        repo_root = Path(__file__).resolve().parent.parent
+        sys.path.insert(0, str(repo_root))
+        sys.path.insert(0, str(repo_root / "src"))
+        from orchestration.registry import UoWStatus
+        uow = MagicMock()
+        uow.status = UoWStatus(status_value)
+        return uow
+
+    def test_executing_status_blocks_dispatch(self):
+        """A UoW with status=executing must not be dispatched (loop prevention)."""
+        uow = self._make_uow_mock("executing")
+        registry_instance = MagicMock()
+        registry_instance.get.return_value = uow
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_20260603_5cc6fa")
+
+        assert result is False, (
+            "status=executing must return False — re-dispatching an executing UoW "
+            "is the root cause of the observed infinite loop."
+        )
+
+    def test_ready_for_executor_permits_dispatch(self):
+        """A UoW with status=ready-for-executor is the initial dispatch — must proceed."""
+        uow = self._make_uow_mock("ready-for-executor")
+        registry_instance = MagicMock()
+        registry_instance.get.return_value = uow
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_pending_123")
+
+        assert result is True, (
+            "status=ready-for-executor must return True — this is the normal dispatch path."
+        )
+
+    def test_active_status_permits_dispatch(self):
+        """A UoW with status=active is mid-claim — dispatch is safe."""
+        uow = self._make_uow_mock("active")
+        registry_instance = MagicMock()
+        registry_instance.get.return_value = uow
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_active_456")
+
+        assert result is True
+
+    def test_done_status_blocks_dispatch(self):
+        """A UoW with status=done must not be dispatched (already completed)."""
+        uow = self._make_uow_mock("done")
+        registry_instance = MagicMock()
+        registry_instance.get.return_value = uow
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_done_789")
+
+        assert result is False
+
+    def test_failed_status_blocks_dispatch(self):
+        """A UoW with status=failed must not be dispatched."""
+        uow = self._make_uow_mock("failed")
+        registry_instance = MagicMock()
+        registry_instance.get.return_value = uow
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_failed_000")
+
+        assert result is False
+
+    def test_ready_for_steward_blocks_dispatch(self):
+        """A UoW with status=ready-for-steward must not be re-dispatched."""
+        uow = self._make_uow_mock("ready-for-steward")
+        registry_instance = MagicMock()
+        registry_instance.get.return_value = uow
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_rfs_abc")
+
+        assert result is False
+
+    def test_unknown_uow_blocks_dispatch(self):
+        """A wos_execute message for a UoW not found in registry is discarded."""
+        registry_instance = MagicMock()
+        registry_instance.get.return_value = None  # not found
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_nonexistent_xyz")
+
+        assert result is False, (
+            "A wos_execute message for an unknown UoW must be discarded (fail-closed)."
+        )
+
+    def test_registry_error_is_fail_open(self):
+        """On registry read error, dispatch is allowed (fail-open to avoid silent stall)."""
+        registry_instance = MagicMock()
+        registry_instance.get.side_effect = Exception("DB locked")
+        registry_cls = MagicMock(return_value=registry_instance)
+
+        mod = self._load_module_with_real_registry(registry_cls)
+
+        result = mod._uow_status_allows_dispatch("uow_error_test")
+
+        assert result is True, (
+            "Registry read errors must fail-open: a stalled dispatch is recoverable; "
+            "a silently suppressed dispatch is not."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: status guard integration with poll loop
+# ---------------------------------------------------------------------------
+
+class TestStatusGuardInPollLoop:
+    """Status guard fires before claim, discarding duplicate wos_execute messages."""
+
+    def test_executing_uow_message_discarded_not_dispatched(self, router):
+        """wos_execute for an executing UoW is moved to processed/ without dispatch."""
+        router._uow_status_allows_dispatch.return_value = False
+
+        msg = _make_wos_execute_msg(uow_id="uow_executing_abc")
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.run_poll_cycle()
+
+        # Message must be in processed/ — not in inbox/ or failed/
+        assert not (router.INBOX_DIR / f"{msg['id']}.json").exists(), (
+            "Duplicate message must be removed from inbox"
+        )
+        assert (router.PROCESSED_DIR / f"{msg['id']}.json").exists(), (
+            "Duplicate message must be moved to processed/ (not failed/)"
+        )
+        # Dispatch must never be called
+        router._dispatch.assert_not_called()
+        # route_wos_message must never be called
+        router.route_wos_message.assert_not_called()
+
+    def test_executing_uow_does_not_write_alert(self, router):
+        """Discarding a duplicate wos_execute message does not write an alert."""
+        router._uow_status_allows_dispatch.return_value = False
+
+        msg = _make_wos_execute_msg(uow_id="uow_executing_noalert")
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.run_poll_cycle()
+
+        # No alert should be written for a normal status-guard discard
+        router.write_inbox_message.assert_not_called()
+
+    def test_ready_for_executor_uow_is_dispatched(self, router):
+        """wos_execute for a ready-for-executor UoW proceeds normally."""
+        router._uow_status_allows_dispatch.return_value = True
+
+        msg = _make_wos_execute_msg(uow_id="uow_rfe_dispatch")
+        _write_msg(router.INBOX_DIR, msg)
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg['uow_id']}",
+            "prompt": "run this",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch.return_value = "msg-id"
+
+        router.run_poll_cycle()
+
+        router._dispatch.assert_called_once()
+        assert (router.PROCESSED_DIR / f"{msg['id']}.json").exists()
+
+    def test_mixed_inbox_only_executing_skipped(self, router):
+        """
+        With two UoWs — one executing, one ready — only the ready one is dispatched.
+        """
+        msg_exec = _make_wos_execute_msg(uow_id="uow_executing_skip")
+        msg_ready = _make_wos_execute_msg(uow_id="uow_ready_dispatch")
+        _write_msg(router.INBOX_DIR, msg_exec)
+        _write_msg(router.INBOX_DIR, msg_ready)
+
+        def status_side_effect(uow_id: str) -> bool:
+            return uow_id == "uow_ready_dispatch"
+
+        router._uow_status_allows_dispatch.side_effect = status_side_effect
+
+        router.route_wos_message.return_value = {
+            "action": "spawn_subagent",
+            "task_id": f"wos-{msg_ready['uow_id']}",
+            "prompt": "run",
+            "agent_type": "functional-engineer",
+            "message_type": "wos_execute",
+        }
+        router._dispatch.return_value = "msg-id"
+
+        router.run_poll_cycle()
+
+        # Only one dispatch — the ready one
+        router._dispatch.assert_called_once()
+        # Both messages in processed/ — executing one discarded, ready one dispatched
+        assert (router.PROCESSED_DIR / f"{msg_exec['id']}.json").exists()
+        assert (router.PROCESSED_DIR / f"{msg_ready['id']}.json").exists()


### PR DESCRIPTION
## Problem

The `wos-execute-router` daemon (PID 12295, running since Jun 3) was flooding the dispatcher inbox with ~6 `wos_execute` messages per minute. Root cause investigation (2026-06-05) confirmed all three reported UoWs are `status=executing` in the registry but keep being re-emitted.

**The loop mechanism:** The router consumed each `wos_execute` message from the inbox and responded by calling `_dispatch_via_inbox`, which writes a NEW `wos_execute` message to the inbox. With no status check, the new message was picked up on the next poll cycle (30s) and dispatched again — indefinitely. Each dispatch emitted another message, producing the observed ~6/minute flood.

This is not a registry state issue — the executor correctly set all three UoWs to `executing` via `transition_to_executing`. The router had no awareness of that state.

## What changed

Added three purely functional components to `src/daemons/wos_execute_router.py`:

1. **`_DISPATCHABLE_STATUSES`** — a `frozenset` of `{UoWStatus.ACTIVE, UoWStatus.READY_FOR_EXECUTOR}`. This is the canonical set of states where a `wos_execute` message represents a legitimate first dispatch.

2. **`_uow_status_allows_dispatch(uow_id)`** — queries the registry for the UoW's current status and returns `True` only if it is in `_DISPATCHABLE_STATUSES`. Fail-open on DB error (transient hiccup → allow dispatch; a silently suppressed dispatch stalls the UoW with no recovery signal). Fail-closed for unknown UoWs (nothing to recover if the UoW doesn't exist).

3. **`_discard_inbox_message(msg)`** — moves a message directly from `inbox/` to `processed/` without going through `processing/`. Used by the status guard bypass path so duplicate messages are cleanly consumed without lingering in `processing/`.

The guard runs in `_route_single_message` BEFORE the claim step, so no duplicate message is ever stamped with `_processing_started_at` or moved to `processing/`.

## Before / After

```
Before:
  wos_execute (uow=X) arrives in inbox
    → router claims it
    → router calls _dispatch_via_inbox → NEW wos_execute (uow=X) in inbox
    → router marks original processed
    → 30s later: router claims NEW message
    → router calls _dispatch_via_inbox → ANOTHER wos_execute (uow=X)
    → [loop forever]

After:
  wos_execute (uow=X) arrives in inbox
    → router checks registry: status=executing?
    → status NOT in {active, ready-for-executor} → discard to processed/
    → no dispatch, no new message, loop ends
```

## What this does NOT change

- TTL/sweep recovery is untouched. Genuinely stuck UoWs still recover via `reset_expired_claims` → `ready-for-steward`.
- WOS config gate (`execution_enabled`) is untouched.
- MAX_AGENTS_GATE is untouched.
- No changes to the executor, steward, registry, or any other component.
- Does not re-enable WOS execution.

## Residual risk

If UoW state never advances to `executing` (e.g. the executor's `transition_to_executing` fails silently after writing the inbox message), the guard would allow repeated dispatch until TTL expiry. This pre-existing condition is unchanged — the guard adds no new failure mode here, and the TTL/sweep path still recovers it. The guard prevents the case we observed (status IS executing, router keeps re-dispatching anyway).

## Functional patterns used

Pure functions: `_uow_status_allows_dispatch` has no side effects — it reads the registry and returns a boolean. The frozenset constant `_DISPATCHABLE_STATUSES` is the canonical decision point, importable by tests without re-declaring values (golden-patterns: named constants dict + fallback constant). StrEnum usage follows the codebase convention (golden-patterns: StrEnum constants in all enum-backed logic).

## Tests run

- [x] `uv run pytest tests/test_wos_execute_router.py -v` — 43 passed, 0 failed
- [x] `uv run ruff check src/daemons/wos_execute_router.py tests/test_wos_execute_router.py` — clean, no errors
- [ ] Live daemon test — blocked: WOS is stopped (`execution_enabled=false`). Safe to merge; the guard only takes effect when WOS is re-enabled.

**Blocked items needing attention before merge:** none — the live daemon is stopped per task instructions.

## Manual test

N/A — this change is entirely internal to the routing daemon. The daemon is currently stopped (`execution_enabled=false`). Behavioral effect is observable only when WOS is re-enabled, which is a separate action gated on oracle review. The three affected UoWs (uow_20260603_5cc6fa, uow_20260604_e7a42d, uow_20260604_10f1c6) are confirmed `executing` in the registry — with this guard in place, any `wos_execute` messages for them will be discarded on the first poll cycle rather than re-emitted.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (daemon stopped; guard is purely in-process logic)
- [x] User-visible outcome verified — not applicable (this fixes a background daemon loop, no user-visible output)
- [x] Side-effect audit complete: the guard only discards messages to `processed/`; no writes to shared state, no volume increase, no sends
- [x] External service calls: registry is read (not written) in the guard; mocked in all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)