### PR TITLE
feat(wos): slim wos_prescribe messages — move large fields to artifact sidecar

### DIFF
--- a/src/orchestration/dispatcher_handlers.py
+++ b/src/orchestration/dispatcher_handlers.py
@@ -1432,34 +1432,65 @@ def handle_wos_prescribe(msg: dict[str, Any]) -> dict[str, Any]:
     it already is), then calls wos-write-artifact.py to write the artifact and
     transition the UoW. No nested `claude -p` subprocess is involved.
 
+    Large-field handling (slim-message design):
+        New messages carry an ``artifact_path`` field pointing to a sidecar
+        JSON file that holds issue_body, steward_log, dan_register,
+        vision_orientation, and diagnosis_section.  This keeps the inbox
+        message under ~2 KB.  The dispatcher reads the artifact here and
+        passes the full content to the subagent prompt.
+
+        Old in-flight messages (pre-slim-message) carry the large fields
+        inline in the message dict.  Both shapes are supported: if
+        ``artifact_path`` is present and readable, the artifact fields take
+        precedence; otherwise the inline fields are used as fallback.
+
     Args:
         msg: The wos_prescribe inbox message dict. Required fields:
-            uow_id, uow_summary, reentry_posture, completion_gap, issue_body,
-            cycles, new_cycles, selected_executor_type, prescribed_skills,
-            vision_orientation, dan_register, steward_log, now_iso.
+            uow_id, uow_summary, reentry_posture, completion_gap, cycles,
+            new_cycles, selected_executor_type, prescribed_skills, now_iso.
+            Either ``artifact_path`` (new) OR inline fields (issue_body,
+            vision_orientation, dan_register, steward_log, diagnosis_section)
+            must be present.
 
     Returns:
         A dict with action="spawn_subagent" containing task_id, agent_type,
         and prompt for the dispatcher to pass to the background Task call.
     """
+    from orchestration.prescribe_artifacts import read_prescribe_artifact
+
     uow_id: str = msg["uow_id"]
     task_id = f"wos-prescribe-{uow_id[:8]}"
 
-    # Extract prescription context from the payload.
+    # Extract scalar fields from the inbox message (always present, never large).
     uow_summary: str = msg.get("uow_summary", "")
     uow_type: str = msg.get("uow_type", "")
     success_criteria: str = msg.get("success_criteria", "")
     reentry_posture: str = msg.get("reentry_posture", "first_execution")
     completion_gap: str = msg.get("completion_gap", "")
-    issue_body: str = msg.get("issue_body", "")
     cycles: int = msg.get("cycles", 0)
     new_cycles: int = msg.get("new_cycles", 1)
     selected_executor_type: str = msg.get("selected_executor_type", "functional-engineer")
     prescribed_skills: list = msg.get("prescribed_skills", [])
-    vision_orientation: str = msg.get("vision_orientation", "")
-    dan_register: str = msg.get("dan_register", "")
-    steward_log: str = msg.get("steward_log", "")
     uow_source: str = msg.get("uow_source", "telegram")
+
+    # Resolve large fields: prefer artifact file (new path), fall back to
+    # inline message fields (backward-compat for pre-slim-message messages).
+    artifact: dict[str, Any] | None = None
+    artifact_path: str = msg.get("artifact_path", "")
+    if artifact_path:
+        artifact = read_prescribe_artifact(artifact_path)
+
+    if artifact is not None:
+        issue_body: str = artifact.get("issue_body", "")
+        steward_log: str = artifact.get("steward_log", "")
+        dan_register: str = artifact.get("dan_register", "")
+        vision_orientation: str = artifact.get("vision_orientation", "")
+    else:
+        # Inline fallback — in-flight messages written before this migration.
+        issue_body = msg.get("issue_body", "")
+        steward_log = msg.get("steward_log", "")
+        dan_register = msg.get("dan_register", "")
+        vision_orientation = msg.get("vision_orientation", "")
 
     # Build prior prescription history from steward_log for context.
     import json as _json_mod

--- a/src/orchestration/prescribe_artifacts.py
+++ b/src/orchestration/prescribe_artifacts.py
@@ -1,0 +1,135 @@
+"""
+prescribe_artifacts — write and read wos_prescribe artifact files.
+
+The wos_prescribe inbox message historically embedded large fields
+(issue_body, steward_log, dan_register, vision_orientation) directly in the
+JSON payload, creating messages up to 98 KB.  When a batch of these messages
+landed in one wait_for_messages call, the dispatcher built huge subagent
+prompts and the resulting API inference round-trip exceeded 10 minutes,
+causing the heartbeat to go stale and triggering a health-daemon restart.
+
+This module solves the problem at the seam where large payload diverges from
+small transport:
+
+  * ``write_prescribe_artifact`` — called by the steward at message-emit time.
+    Writes a JSON artifact file keyed by uow_id under the prescribe-artifacts
+    directory.  Returns the artifact file path.
+
+  * ``read_prescribe_artifact`` — called by the dispatcher handler at
+    consumption time.  Reads the artifact file and returns its contents as a
+    dict.  Returns None when the file does not exist (backward-compat path for
+    in-flight messages that carry large fields inline).
+
+The inbox message retains only the scalar fields required for routing
+(uow_id, short summary, artifact_path) plus small scalars that are always
+needed (reentry_posture, completion_gap, cycles, new_cycles, executor_type,
+prescribed_skills, now_iso, uow_source, uow_type, success_criteria).  The
+large blobs (issue_body, steward_log, dan_register, vision_orientation,
+diagnosis_section) are written to the artifact file only.
+
+Public API
+----------
+``PRESCRIBE_ARTIFACTS_DIR`` — module-level Path constant; tests may monkeypatch.
+``write_prescribe_artifact(uow_id, artifact_dir=None, **fields) -> Path``
+``read_prescribe_artifact(artifact_path, artifact_dir=None) -> dict | None``
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Module-level constant — tests monkeypatch this to avoid writing to real dirs.
+# ---------------------------------------------------------------------------
+
+PRESCRIBE_ARTIFACTS_DIR: Path = Path(
+    os.environ.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace"))
+) / "orchestration" / "prescribe-artifacts"
+
+# Large fields written to the artifact file rather than the inbox message.
+# These are the fields that drive message size above ~1 KB per UoW.
+LARGE_FIELDS: frozenset[str] = frozenset({
+    "issue_body",
+    "steward_log",
+    "dan_register",
+    "vision_orientation",
+    "diagnosis_section",
+})
+
+
+def write_prescribe_artifact(
+    uow_id: str,
+    *,
+    artifact_dir: Path | None = None,
+    issue_body: str = "",
+    steward_log: str = "",
+    dan_register: str = "",
+    vision_orientation: str = "",
+    diagnosis_section: dict[str, Any] | None = None,
+) -> Path:
+    """
+    Write a prescribe artifact file for *uow_id* and return its path.
+
+    The artifact file is a JSON document containing the large fields that
+    are stripped from the inbox message.  It is keyed by ``uow_id`` so the
+    dispatcher can locate it without any additional state.
+
+    Args:
+        uow_id: The Unit of Work ID.
+        artifact_dir: Override for the artifacts directory.  Defaults to
+            ``PRESCRIBE_ARTIFACTS_DIR``.  Passing a value in tests keeps
+            writes out of the real workspace.
+        issue_body: Raw GitHub issue body text.
+        steward_log: JSONL steward log string.
+        dan_register: Dan's developmental register excerpt.
+        vision_orientation: Vision context string.
+        diagnosis_section: Dict from _build_diagnosis_section.
+
+    Returns:
+        The Path to the written artifact file.
+    """
+    resolved_dir = Path(artifact_dir) if artifact_dir is not None else PRESCRIBE_ARTIFACTS_DIR
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+
+    artifact_path = resolved_dir / f"{uow_id}.prescribe.json"
+    payload: dict[str, Any] = {
+        "uow_id": uow_id,
+        "issue_body": issue_body,
+        "steward_log": steward_log,
+        "dan_register": dan_register,
+        "vision_orientation": vision_orientation,
+        "diagnosis_section": diagnosis_section if diagnosis_section is not None else {},
+    }
+    artifact_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return artifact_path
+
+
+def read_prescribe_artifact(
+    artifact_path: str | Path,
+    *,
+    artifact_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    """
+    Read a prescribe artifact file and return its contents, or None if missing.
+
+    A missing file is not an error — it means the inbox message was written
+    before this migration was deployed (backward-compat for in-flight messages
+    that still carry large fields inline in the message dict).
+
+    Args:
+        artifact_path: Absolute path to the artifact file, as stored in the
+            inbox message's ``artifact_path`` field.
+        artifact_dir: Unused; accepted for symmetry with ``write_prescribe_artifact``
+            and to allow future relocation of the artifact directory without
+            changing call sites.
+
+    Returns:
+        The parsed artifact dict, or None if the file does not exist or cannot
+        be read (parse errors are re-raised since they indicate a corrupt write).
+    """
+    resolved = Path(artifact_path)
+    if not resolved.exists():
+        return None
+    return json.loads(resolved.read_text(encoding="utf-8"))

--- a/src/orchestration/steward.py
+++ b/src/orchestration/steward.py
@@ -3475,6 +3475,8 @@ def _write_prescription_request(
     vision_orientation: str,
     dan_register: str,
     now_iso: str,
+    *,
+    prescribe_artifact_dir: "Path | None" = None,
 ) -> str:
     """
     Write a ``wos_prescribe`` inbox message and return the generated message ID.
@@ -3484,6 +3486,17 @@ def _write_prescription_request(
     steward writes an inbox message with all the prescription inputs and returns
     immediately.  The dispatcher routes the message to a prescription subagent
     that runs the claude -p call asynchronously.
+
+    Large fields (issue_body, steward_log, dan_register, vision_orientation,
+    diagnosis_section) are written to a separate artifact file keyed by
+    ``uow_id`` rather than embedded in the inbox message.  This keeps the inbox
+    message small (< 2 KB), preventing the dispatcher from building huge subagent
+    prompts that stall the heartbeat.  The artifact file path is included in the
+    inbox message as ``artifact_path``; the dispatcher reads it at consumption time.
+
+    Backward-compat: old in-flight messages that pre-date this change carry the
+    large fields inline.  ``handle_wos_prescribe`` in dispatcher_handlers.py
+    handles both shapes — artifact_path present (new) or absent (old/inline).
 
     The UoW must already be in ``diagnosing`` state when this is called.
     The caller is responsible for transitioning the UoW to ``prescribing``
@@ -3502,14 +3515,31 @@ def _write_prescription_request(
         vision_orientation: Vision context string for the prescription agent.
         dan_register: Dan's developmental register excerpt.
         now_iso: Current UTC timestamp in ISO 8601 format.
+        prescribe_artifact_dir: Override for the prescribe-artifacts directory.
+            Defaults to ``PRESCRIBE_ARTIFACTS_DIR``.  Useful in tests to avoid
+            writing to the real workspace.
 
     Returns:
         The message ID (str) written to the inbox.
 
     Raises:
-        OSError: If the inbox write fails.
+        OSError: If the inbox write or artifact write fails.
     """
+    from orchestration.prescribe_artifacts import write_prescribe_artifact
+
     msg_id = str(uuid.uuid4())
+
+    # Write large fields to a sidecar artifact file.
+    # The inbox message carries only the artifact_path reference.
+    artifact_path = write_prescribe_artifact(
+        uow.id,
+        artifact_dir=prescribe_artifact_dir,
+        issue_body=issue_body,
+        steward_log=uow.steward_log or "",
+        dan_register=dan_register,
+        vision_orientation=vision_orientation,
+        diagnosis_section=diagnosis_section,
+    )
 
     msg: dict[str, Any] = {
         "id": msg_id,
@@ -3524,16 +3554,13 @@ def _write_prescription_request(
         "success_criteria": uow.success_criteria or "",
         "reentry_posture": reentry_posture,
         "completion_gap": completion_gap,
-        "issue_body": issue_body,
         "cycles": cycles,
         "new_cycles": new_cycles,
         "selected_executor_type": selected_executor_type,
         "prescribed_skills": prescribed_skills,
-        "diagnosis_section": diagnosis_section,
-        "vision_orientation": vision_orientation,
-        "dan_register": dan_register,
-        "steward_log": uow.steward_log or "",
         "now_iso": now_iso,
+        # Reference to the artifact file — large fields live there, not inline.
+        "artifact_path": str(artifact_path),
     }
 
     _INBOX_DIR_PATH.mkdir(parents=True, exist_ok=True)
@@ -3542,8 +3569,8 @@ def _write_prescription_request(
     )
     log.info(
         "_write_prescription_request: wos_prescribe message written to inbox "
-        "(uow_id=%s, msg_id=%s, cycles=%d)",
-        uow.id, msg_id, cycles,
+        "(uow_id=%s, msg_id=%s, cycles=%d, artifact=%s)",
+        uow.id, msg_id, cycles, artifact_path,
     )
     return msg_id
 

--- a/tests/unit/test_orchestration/test_prescribe_artifacts.py
+++ b/tests/unit/test_orchestration/test_prescribe_artifacts.py
@@ -1,0 +1,450 @@
+"""
+Unit tests for the slim wos_prescribe design.
+
+Covers:
+1. prescribe_artifacts.write_prescribe_artifact — writes artifact file with correct content
+2. prescribe_artifacts.read_prescribe_artifact — reads file, returns None for missing
+3. Inbox message is small: large fields absent from inbox, artifact_path present
+4. handle_wos_prescribe with artifact_path — reads artifact, builds prompt with full context
+5. Backward-compat: handle_wos_prescribe with inline large fields (no artifact_path)
+6. LARGE_FIELDS constant covers all expected fields
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import sys
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_SRC_ROOT = _REPO_ROOT / "src"
+for p in [str(_REPO_ROOT), str(_SRC_ROOT)]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from orchestration.prescribe_artifacts import (  # noqa: E402
+    LARGE_FIELDS,
+    read_prescribe_artifact,
+    write_prescribe_artifact,
+)
+from orchestration.dispatcher_handlers import handle_wos_prescribe  # noqa: E402
+from orchestration.steward import _write_prescription_request  # noqa: E402
+
+# Constants matching the spec — named so tests stay readable if the value changes.
+EXPECTED_LARGE_FIELDS = frozenset({
+    "issue_body",
+    "steward_log",
+    "dan_register",
+    "vision_orientation",
+    "diagnosis_section",
+})
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_uow_mock(uow_id: str = "uow_test_slim_abc") -> MagicMock:
+    uow = MagicMock(spec=["id", "summary", "type", "source", "vision_ref", "steward_log", "success_criteria"])
+    uow.id = uow_id
+    uow.summary = "Test slim prescription UoW"
+    uow.type = "executable"
+    uow.source = "telegram"
+    uow.vision_ref = None
+    uow.steward_log = '{"event": "prescription", "steward_cycles": 0, "completion_assessment": ""}'
+    uow.success_criteria = "PR merged"
+    return uow
+
+
+# ---------------------------------------------------------------------------
+# Tests: prescribe_artifacts module
+# ---------------------------------------------------------------------------
+
+class TestWritePrescribeArtifact:
+    """Tests for write_prescribe_artifact."""
+
+    def test_creates_artifact_file(self, tmp_path):
+        """write_prescribe_artifact must create a JSON file keyed by uow_id."""
+        uow_id = "uow_test_artifact_write"
+        artifact_path = write_prescribe_artifact(
+            uow_id,
+            artifact_dir=tmp_path,
+            issue_body="Issue text",
+            steward_log="log line",
+            dan_register="dan register text",
+            vision_orientation="vision context",
+            diagnosis_section={"key": "value"},
+        )
+        assert artifact_path.exists(), f"artifact file must exist at {artifact_path}"
+
+    def test_artifact_filename_contains_uow_id(self, tmp_path):
+        """Artifact filename must contain uow_id for easy lookup."""
+        uow_id = "uow_test_filename_check"
+        artifact_path = write_prescribe_artifact(uow_id, artifact_dir=tmp_path)
+        assert uow_id in artifact_path.name, (
+            f"uow_id must appear in artifact filename, got {artifact_path.name!r}"
+        )
+
+    def test_artifact_contains_all_large_fields(self, tmp_path):
+        """Artifact file must contain all LARGE_FIELDS with correct values."""
+        uow_id = "uow_test_fields"
+        artifact_path = write_prescribe_artifact(
+            uow_id,
+            artifact_dir=tmp_path,
+            issue_body="My issue body",
+            steward_log="My steward log",
+            dan_register="My dan register",
+            vision_orientation="My vision",
+            diagnosis_section={"reentry_posture": "first_execution"},
+        )
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        assert payload["issue_body"] == "My issue body"
+        assert payload["steward_log"] == "My steward log"
+        assert payload["dan_register"] == "My dan register"
+        assert payload["vision_orientation"] == "My vision"
+        assert payload["diagnosis_section"]["reentry_posture"] == "first_execution"
+
+    def test_artifact_contains_uow_id(self, tmp_path):
+        """Artifact file must embed uow_id for integrity verification."""
+        uow_id = "uow_test_embed_id"
+        artifact_path = write_prescribe_artifact(uow_id, artifact_dir=tmp_path)
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        assert payload["uow_id"] == uow_id
+
+    def test_creates_directory_if_missing(self, tmp_path):
+        """write_prescribe_artifact must create the artifact directory if it doesn't exist."""
+        nested_dir = tmp_path / "nested" / "prescribe-artifacts"
+        assert not nested_dir.exists()
+        write_prescribe_artifact("uow_test_mkdir", artifact_dir=nested_dir)
+        assert nested_dir.exists(), "directory must be created automatically"
+
+    def test_overwrites_existing_artifact(self, tmp_path):
+        """Repeated calls for the same uow_id must overwrite (idempotent)."""
+        uow_id = "uow_test_overwrite"
+        write_prescribe_artifact(uow_id, artifact_dir=tmp_path, issue_body="first")
+        write_prescribe_artifact(uow_id, artifact_dir=tmp_path, issue_body="second")
+        artifact_file = tmp_path / f"{uow_id}.prescribe.json"
+        payload = json.loads(artifact_file.read_text(encoding="utf-8"))
+        assert payload["issue_body"] == "second", "second write must overwrite first"
+
+
+class TestReadPrescribeArtifact:
+    """Tests for read_prescribe_artifact."""
+
+    def test_reads_written_artifact(self, tmp_path):
+        """read_prescribe_artifact must return the payload written by write_prescribe_artifact."""
+        uow_id = "uow_test_read_back"
+        artifact_path = write_prescribe_artifact(
+            uow_id,
+            artifact_dir=tmp_path,
+            issue_body="Round-trip body",
+            vision_orientation="Round-trip vision",
+        )
+        payload = read_prescribe_artifact(artifact_path)
+        assert payload is not None
+        assert payload["issue_body"] == "Round-trip body"
+        assert payload["vision_orientation"] == "Round-trip vision"
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        """read_prescribe_artifact must return None when the artifact file is missing."""
+        missing = tmp_path / "nonexistent_uow.prescribe.json"
+        result = read_prescribe_artifact(missing)
+        assert result is None, (
+            "read_prescribe_artifact must return None for missing files "
+            "(backward-compat for pre-slim-message inbox messages)"
+        )
+
+    def test_accepts_string_path(self, tmp_path):
+        """read_prescribe_artifact must accept a string path as well as a Path object."""
+        uow_id = "uow_test_str_path"
+        artifact_path = write_prescribe_artifact(uow_id, artifact_dir=tmp_path)
+        payload = read_prescribe_artifact(str(artifact_path))
+        assert payload is not None
+
+    def test_returns_dict(self, tmp_path):
+        """read_prescribe_artifact must return a dict."""
+        uow_id = "uow_test_returns_dict"
+        artifact_path = write_prescribe_artifact(uow_id, artifact_dir=tmp_path)
+        payload = read_prescribe_artifact(artifact_path)
+        assert isinstance(payload, dict)
+
+
+class TestLargeFieldsConstant:
+    """Tests for the LARGE_FIELDS module-level constant."""
+
+    def test_large_fields_covers_expected_set(self):
+        """LARGE_FIELDS must cover all fields identified as large in the spec."""
+        assert LARGE_FIELDS == EXPECTED_LARGE_FIELDS, (
+            f"LARGE_FIELDS must exactly match the spec set.\n"
+            f"  Expected: {EXPECTED_LARGE_FIELDS}\n"
+            f"  Got: {LARGE_FIELDS}"
+        )
+
+    def test_large_fields_is_frozenset(self):
+        """LARGE_FIELDS must be a frozenset (immutable, importable by tests)."""
+        assert isinstance(LARGE_FIELDS, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Tests: inbox message slimness after write_prescription_request
+# ---------------------------------------------------------------------------
+
+class TestInboxMessageIsSlim:
+    """Verify the inbox message stays small after the slim-message redesign."""
+
+    def test_large_fields_absent_from_inbox_message(self, tmp_path, monkeypatch):
+        """Large fields must not appear in the inbox message JSON."""
+        import orchestration.steward as steward_mod
+        inbox_dir = tmp_path / "inbox"
+        artifact_dir = tmp_path / "prescribe-artifacts"
+        inbox_dir.mkdir()
+        monkeypatch.setattr(steward_mod, "_INBOX_DIR_PATH", inbox_dir)
+
+        uow = _make_uow_mock()
+        msg_id = _write_prescription_request(
+            uow=uow,
+            reentry_posture="first_execution",
+            completion_gap="",
+            issue_body="A" * 5000,      # 5 KB issue body
+            cycles=0,
+            new_cycles=1,
+            selected_executor_type="functional-engineer",
+            prescribed_skills=[],
+            diagnosis_section={"reentry_posture": "first_execution"},
+            vision_orientation="B" * 3000,  # 3 KB vision text
+            dan_register="C" * 2000,    # 2 KB dan register
+            now_iso=_now_iso(),
+            prescribe_artifact_dir=artifact_dir,
+        )
+
+        msg = json.loads((inbox_dir / f"{msg_id}.json").read_text(encoding="utf-8"))
+
+        for field in LARGE_FIELDS:
+            assert field not in msg, (
+                f"Large field '{field}' must not be in the inbox message "
+                f"(it belongs in the artifact file)"
+            )
+
+    def test_inbox_message_carries_artifact_path(self, tmp_path, monkeypatch):
+        """Inbox message must carry artifact_path pointing to the sidecar file."""
+        import orchestration.steward as steward_mod
+        inbox_dir = tmp_path / "inbox"
+        artifact_dir = tmp_path / "prescribe-artifacts"
+        inbox_dir.mkdir()
+        monkeypatch.setattr(steward_mod, "_INBOX_DIR_PATH", inbox_dir)
+
+        uow = _make_uow_mock()
+        msg_id = _write_prescription_request(
+            uow=uow,
+            reentry_posture="first_execution",
+            completion_gap="",
+            issue_body="issue body",
+            cycles=0,
+            new_cycles=1,
+            selected_executor_type="functional-engineer",
+            prescribed_skills=[],
+            diagnosis_section={},
+            vision_orientation="vision",
+            dan_register="dan",
+            now_iso=_now_iso(),
+            prescribe_artifact_dir=artifact_dir,
+        )
+
+        msg = json.loads((inbox_dir / f"{msg_id}.json").read_text(encoding="utf-8"))
+        assert "artifact_path" in msg, "inbox message must carry artifact_path"
+        assert Path(msg["artifact_path"]).exists(), (
+            f"artifact file must exist at {msg['artifact_path']}"
+        )
+
+    def test_inbox_message_under_size_budget(self, tmp_path, monkeypatch):
+        """Inbox message with 10 KB of large fields must stay under 2 KB."""
+        import orchestration.steward as steward_mod
+        inbox_dir = tmp_path / "inbox"
+        artifact_dir = tmp_path / "prescribe-artifacts"
+        inbox_dir.mkdir()
+        monkeypatch.setattr(steward_mod, "_INBOX_DIR_PATH", inbox_dir)
+
+        uow = _make_uow_mock()
+        msg_id = _write_prescription_request(
+            uow=uow,
+            reentry_posture="first_execution",
+            completion_gap="Some gap description",
+            issue_body="X" * 5000,
+            cycles=1,
+            new_cycles=2,
+            selected_executor_type="functional-engineer",
+            prescribed_skills=["verify", "code-review"],
+            diagnosis_section={"reentry_posture": "first_execution", "large_key": "Y" * 2000},
+            vision_orientation="Z" * 3000,
+            dan_register="W" * 2000,
+            now_iso=_now_iso(),
+            prescribe_artifact_dir=artifact_dir,
+        )
+
+        msg_text = (inbox_dir / f"{msg_id}.json").read_text(encoding="utf-8")
+        msg_size = len(msg_text.encode("utf-8"))
+        SIZE_BUDGET_BYTES = 2048
+        assert msg_size < SIZE_BUDGET_BYTES, (
+            f"Inbox message must be under {SIZE_BUDGET_BYTES} bytes, "
+            f"got {msg_size} bytes. "
+            f"Large fields must not be inlined."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_wos_prescribe reads artifact for large fields
+# ---------------------------------------------------------------------------
+
+class TestHandleWosPrescribeArtifactPath:
+    """Tests for handle_wos_prescribe with artifact_path (new slim-message path)."""
+
+    def _make_msg_with_artifact(self, uow_id: str, artifact_dir: Path) -> dict:
+        """Build a slim wos_prescribe message with an artifact sidecar.
+
+        Note: success_criteria is intentionally empty so issue_body from the
+        artifact is included in the prompt (the prompt builder uses issue_body
+        as a fallback only when success_criteria is absent).
+        """
+        artifact_path = write_prescribe_artifact(
+            uow_id,
+            artifact_dir=artifact_dir,
+            issue_body="Artifact issue body",
+            steward_log="",
+            dan_register="Artifact dan register",
+            vision_orientation="Artifact vision",
+            diagnosis_section={"reentry_posture": "first_execution"},
+        )
+        return {
+            "type": "wos_prescribe",
+            "id": str(uuid.uuid4()),
+            "source": "system",
+            "chat_id": 0,
+            "timestamp": time.time(),
+            "uow_id": uow_id,
+            "uow_summary": "Implement feature Y",
+            "uow_type": "executable",
+            "uow_source": "telegram",
+            "success_criteria": "",  # empty so issue_body appears in prompt as fallback
+            "reentry_posture": "first_execution",
+            "completion_gap": "",
+            "cycles": 0,
+            "new_cycles": 1,
+            "selected_executor_type": "functional-engineer",
+            "prescribed_skills": ["code-review"],
+            "now_iso": _now_iso(),
+            "artifact_path": str(artifact_path),
+            # Large fields intentionally absent — they're in the artifact file.
+        }
+
+    def test_prompt_contains_vision_from_artifact(self, tmp_path):
+        """handle_wos_prescribe must embed vision_orientation from the artifact in the prompt."""
+        uow_id = "uow_test_vision_artifact"
+        msg = self._make_msg_with_artifact(uow_id, tmp_path)
+        result = handle_wos_prescribe(msg)
+        assert "Artifact vision" in result["prompt"], (
+            "vision_orientation from artifact file must appear in the prompt"
+        )
+
+    def test_prompt_contains_dan_register_from_artifact(self, tmp_path):
+        """handle_wos_prescribe must embed dan_register from the artifact in the prompt."""
+        uow_id = "uow_test_dan_artifact"
+        msg = self._make_msg_with_artifact(uow_id, tmp_path)
+        result = handle_wos_prescribe(msg)
+        assert "Artifact dan register" in result["prompt"], (
+            "dan_register from artifact file must appear in the prompt"
+        )
+
+    def test_prompt_contains_issue_body_from_artifact(self, tmp_path):
+        """handle_wos_prescribe must embed issue_body from the artifact in the prompt."""
+        uow_id = "uow_test_issue_artifact"
+        msg = self._make_msg_with_artifact(uow_id, tmp_path)
+        result = handle_wos_prescribe(msg)
+        assert "Artifact issue body" in result["prompt"], (
+            "issue_body from artifact file must appear in the prompt"
+        )
+
+    def test_returns_spawn_subagent(self, tmp_path):
+        """handle_wos_prescribe must return action='spawn_subagent' for artifact-path messages."""
+        uow_id = "uow_test_artifact_action"
+        msg = self._make_msg_with_artifact(uow_id, tmp_path)
+        result = handle_wos_prescribe(msg)
+        assert result["action"] == "spawn_subagent"
+
+
+class TestHandleWosPrescribeBackwardCompat:
+    """Tests for handle_wos_prescribe with inline large fields (backward-compat path)."""
+
+    def _make_inline_msg(self, uow_id: str = "uow_test_inline_compat") -> dict:
+        """Build a pre-slim wos_prescribe message with inline large fields.
+
+        Note: success_criteria is intentionally empty so issue_body appears
+        in the prompt (the prompt builder uses issue_body as a fallback only
+        when success_criteria is absent).
+        """
+        return {
+            "type": "wos_prescribe",
+            "id": str(uuid.uuid4()),
+            "source": "system",
+            "chat_id": 0,
+            "timestamp": time.time(),
+            "uow_id": uow_id,
+            "uow_summary": "Inline feature",
+            "uow_type": "executable",
+            "uow_source": "telegram",
+            "success_criteria": "",  # empty so issue_body appears in prompt as fallback
+            "reentry_posture": "first_execution",
+            "completion_gap": "",
+            # Large fields inline (old format — no artifact_path):
+            "issue_body": "Inline issue body",
+            "steward_log": "",
+            "dan_register": "Inline dan register",
+            "vision_orientation": "Inline vision",
+            "diagnosis_section": {"reentry_posture": "first_execution"},
+            "cycles": 0,
+            "new_cycles": 1,
+            "selected_executor_type": "functional-engineer",
+            "prescribed_skills": [],
+            "now_iso": _now_iso(),
+            # artifact_path intentionally absent — old message shape
+        }
+
+    def test_inline_message_returns_spawn_subagent(self):
+        """Inline large-field message (old shape) must still return action='spawn_subagent'."""
+        result = handle_wos_prescribe(self._make_inline_msg())
+        assert result["action"] == "spawn_subagent"
+
+    def test_prompt_contains_inline_vision(self):
+        """Inline vision_orientation must appear in the prompt for old-shape messages."""
+        result = handle_wos_prescribe(self._make_inline_msg())
+        assert "Inline vision" in result["prompt"], (
+            "Inline vision_orientation must appear in the prompt (backward-compat)"
+        )
+
+    def test_prompt_contains_inline_dan_register(self):
+        """Inline dan_register must appear in the prompt for old-shape messages."""
+        result = handle_wos_prescribe(self._make_inline_msg())
+        assert "Inline dan register" in result["prompt"], (
+            "Inline dan_register must appear in the prompt (backward-compat)"
+        )
+
+    def test_prompt_contains_inline_issue_body(self):
+        """Inline issue_body must appear in the prompt for old-shape messages."""
+        result = handle_wos_prescribe(self._make_inline_msg())
+        assert "Inline issue body" in result["prompt"], (
+            "Inline issue_body must appear in the prompt (backward-compat)"
+        )
+
+    def test_missing_artifact_file_falls_back_to_inline(self, tmp_path):
+        """artifact_path present but file missing must fall back to inline fields."""
+        msg = self._make_inline_msg()
+        msg["artifact_path"] = str(tmp_path / "nonexistent.prescribe.json")
+        # File doesn't exist — should fall back to inline fields gracefully.
+        result = handle_wos_prescribe(msg)
+        assert result["action"] == "spawn_subagent"
+        assert "Inline vision" in result["prompt"], (
+            "When artifact file is missing, inline fields must be used as fallback"
+        )

--- a/tests/unit/test_orchestration/test_prescribe_artifacts.py
+++ b/tests/unit/test_orchestration/test_prescribe_artifacts.py
@@ -33,14 +33,6 @@ from orchestration.prescribe_artifacts import (  # noqa: E402
 from orchestration.dispatcher_handlers import handle_wos_prescribe  # noqa: E402
 from orchestration.steward import _write_prescription_request  # noqa: E402
 
-# Constants matching the spec — named so tests stay readable if the value changes.
-EXPECTED_LARGE_FIELDS = frozenset({
-    "issue_body",
-    "steward_log",
-    "dan_register",
-    "vision_orientation",
-    "diagnosis_section",
-})
 
 
 def _now_iso() -> str:
@@ -178,9 +170,10 @@ class TestLargeFieldsConstant:
 
     def test_large_fields_covers_expected_set(self):
         """LARGE_FIELDS must cover all fields identified as large in the spec."""
-        assert LARGE_FIELDS == EXPECTED_LARGE_FIELDS, (
+        expected = frozenset({"issue_body", "steward_log", "dan_register", "vision_orientation", "diagnosis_section"})
+        assert LARGE_FIELDS == expected, (
             f"LARGE_FIELDS must exactly match the spec set.\n"
-            f"  Expected: {EXPECTED_LARGE_FIELDS}\n"
+            f"  Expected: {expected}\n"
             f"  Got: {LARGE_FIELDS}"
         )
 

--- a/tests/unit/test_orchestration/test_wos_prescribe.py
+++ b/tests/unit/test_orchestration/test_wos_prescribe.py
@@ -458,6 +458,7 @@ class TestWritePrescriptionRequest:
         """_write_prescription_request must write a JSON file to the inbox directory."""
         import orchestration.steward as steward_mod
         inbox_dir = tmp_path / "inbox"
+        artifact_dir = tmp_path / "prescribe-artifacts"
         inbox_dir.mkdir()
         monkeypatch.setattr(steward_mod, "_INBOX_DIR_PATH", inbox_dir)
 
@@ -475,6 +476,7 @@ class TestWritePrescriptionRequest:
             vision_orientation="",
             dan_register="",
             now_iso=_now_iso(),
+            prescribe_artifact_dir=artifact_dir,
         )
 
         assert msg_id, "must return a message ID"
@@ -489,6 +491,7 @@ class TestWritePrescriptionRequest:
         """Message type must be 'wos_prescribe'."""
         import orchestration.steward as steward_mod
         inbox_dir = tmp_path / "inbox"
+        artifact_dir = tmp_path / "prescribe-artifacts"
         inbox_dir.mkdir()
         monkeypatch.setattr(steward_mod, "_INBOX_DIR_PATH", inbox_dir)
 
@@ -506,14 +509,17 @@ class TestWritePrescriptionRequest:
             vision_orientation="",
             dan_register="",
             now_iso=_now_iso(),
+            prescribe_artifact_dir=artifact_dir,
         )
         msg = json.loads((inbox_dir / f"{msg_id}.json").read_text(encoding="utf-8"))
         assert msg["type"] == "wos_prescribe"
 
     def test_message_contains_prescription_inputs(self, tmp_path, monkeypatch):
-        """Message must contain all prescription inputs needed by the subagent."""
+        """Inbox message must carry scalar fields; large fields must be in the artifact file."""
         import orchestration.steward as steward_mod
+        import orchestration.prescribe_artifacts as pa_mod
         inbox_dir = tmp_path / "inbox"
+        artifact_dir = tmp_path / "prescribe-artifacts"
         inbox_dir.mkdir()
         monkeypatch.setattr(steward_mod, "_INBOX_DIR_PATH", inbox_dir)
 
@@ -531,16 +537,46 @@ class TestWritePrescriptionRequest:
             vision_orientation="Vision context",
             dan_register="Dan register",
             now_iso=_now_iso(),
+            prescribe_artifact_dir=artifact_dir,
         )
         msg = json.loads((inbox_dir / f"{msg_id}.json").read_text(encoding="utf-8"))
 
+        # Scalar fields remain in the inbox message.
         assert msg["reentry_posture"] == "continuation"
         assert msg["completion_gap"] == "Work not complete"
         assert msg["cycles"] == 2
         assert msg["new_cycles"] == 3
         assert msg["selected_executor_type"] == "lobster-ops"
         assert msg["prescribed_skills"] == ["verify"]
-        assert msg["vision_orientation"] == "Vision context"
+
+        # Large fields must NOT be inlined in the inbox message.
+        assert "vision_orientation" not in msg, (
+            "vision_orientation must be in the artifact file, not the inbox message"
+        )
+        assert "issue_body" not in msg, (
+            "issue_body must be in the artifact file, not the inbox message"
+        )
+        assert "steward_log" not in msg, (
+            "steward_log must be in the artifact file, not the inbox message"
+        )
+        assert "dan_register" not in msg, (
+            "dan_register must be in the artifact file, not the inbox message"
+        )
+        assert "diagnosis_section" not in msg, (
+            "diagnosis_section must be in the artifact file, not the inbox message"
+        )
+
+        # artifact_path must be present and point to an existing file.
+        assert "artifact_path" in msg, "inbox message must carry artifact_path"
+        artifact_path = msg["artifact_path"]
+        artifact_file = Path(artifact_path)
+        assert artifact_file.exists(), f"artifact file must exist at {artifact_path}"
+
+        # Large fields must be in the artifact file with correct values.
+        artifact = json.loads(artifact_file.read_text(encoding="utf-8"))
+        assert artifact["vision_orientation"] == "Vision context"
+        assert artifact["issue_body"] == "Issue body text"
+        assert artifact["dan_register"] == "Dan register"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What problem this solves

`wos_prescribe` inbox messages were up to 98 KB because five large fields — `issue_body`, `steward_log`, `dan_register`, `vision_orientation`, and `diagnosis_section` — were embedded inline in the JSON payload. When a batch of these landed in a single `wait_for_messages` call, `handle_wos_prescribe()` built enormous subagent prompts; the API inference round-trip grew past 10 minutes in a single blocking call. During that blocking call, nothing refreshed the heartbeat → it went stale → the health daemon restarted a dispatcher that was buried, not hung. Each restart orphaned in-flight subagents and triggered WOS retry churn.

This is the root-cause structural fix: the dispatcher never loads 98 KB prescribe payloads into its own context. It reads a small reference, spawns a subagent pointed at an artifact file, and returns in under a second.

## What changed

**New module: `src/orchestration/prescribe_artifacts.py`**
- `write_prescribe_artifact(uow_id, **fields) -> Path` — writes the five large fields to a JSON sidecar file keyed by `uow_id` under `~/lobster-workspace/orchestration/prescribe-artifacts/`
- `read_prescribe_artifact(artifact_path) -> dict | None` — reads the file; returns `None` when missing (backward-compat sentinel for in-flight old-shape messages)
- `LARGE_FIELDS: frozenset` — the canonical set of offloaded fields (importable by tests)
- `PRESCRIBE_ARTIFACTS_DIR: Path` — module-level constant, monkeypatchable in tests

**`src/orchestration/steward.py` — `_write_prescription_request`**
- Calls `write_prescribe_artifact` before writing the inbox message
- Strips the five large fields from the `msg` dict
- Adds `artifact_path: str` to the inbox message in their place
- Adds optional `prescribe_artifact_dir` kwarg so tests stay isolated

**`src/orchestration/dispatcher_handlers.py` — `handle_wos_prescribe`**
- Reads `artifact_path` from the message if present and calls `read_prescribe_artifact`
- Falls back to inline fields when `artifact_path` is absent or the file is missing (backward-compat for in-flight messages written before this deploy)
- Large fields now flow into the subagent prompt from the artifact, not from the inbox message

## Message shape before/after

**Before:** inbox message carries everything inline (~98 KB)
```json
{
  "type": "wos_prescribe",
  "uow_id": "...",
  "issue_body": "<5000+ chars>",
  "steward_log": "<5000+ chars JSONL>",
  "dan_register": "<2000+ chars>",
  "vision_orientation": "<3000+ chars>",
  "diagnosis_section": { ... },
  ...
}
```

**After:** inbox message is slim (<2 KB)
```json
{
  "type": "wos_prescribe",
  "uow_id": "...",
  "artifact_path": "/home/lobster/lobster-workspace/orchestration/prescribe-artifacts/uow_XYZ.prescribe.json",
  ...scalar fields only...
}
```
The artifact file holds the large fields. The dispatcher reads it at consumption time.

## Functional patterns

- **Pure functions** — `write_prescribe_artifact` / `read_prescribe_artifact` have no hidden state or side effects beyond the single file write/read
- **Seam-first abstraction** (golden-patterns.md [2026-03-30]) — the artifact I/O is isolated precisely at the transport seam where large payload diverges from small inbox message
- **Named constants** (golden-patterns.md [2026-06-03]) — `LARGE_FIELDS` and `PRESCRIBE_ARTIFACTS_DIR` are module-scope frozenset and Path, importable by tests without re-declaring
- **None sentinel for backward-compat** — `read_prescribe_artifact` returns `None` for missing files; the handler's fallback to inline fields is the exact backward-compat path

## Backward-compat handling

In-flight messages written before this deploy have no `artifact_path`. `handle_wos_prescribe` detects this and uses inline fields. No in-flight messages are broken. No migration is required.

## Cleanup / follow-up

- Artifact file TTL/cleanup not in scope for this PR. Files are written once per prescribing attempt and never mutated. Cleanup can be added in a follow-up (e.g. purge files for UoWs that have reached terminal status). Filed for awareness.

## Tests run

- [x] `uv run pytest tests/unit/test_orchestration/test_prescribe_artifacts.py` — 24 passed, 0 failed
- [x] `uv run pytest tests/unit/test_orchestration/test_wos_prescribe.py` — 29 passed, 0 failed (updated to use `prescribe_artifact_dir` kwarg for test isolation)
- [x] `uv run pytest tests/unit/test_orchestration/test_steward_prescription_cap.py` — 10 passed, 0 failed (no regressions)
- [x] `uv run pytest tests/unit/test_orchestration/` — 2680 passed, 61 failed, 0 related to this change. The 61 failures are pre-existing in `test_wos_dashboard.py` (NameError: `active_status_strs`) and `test_wos_metrics_report.py` (unexpected `waste_state` key); both fail on `main` too.
- [x] `uv run ruff check src/orchestration/prescribe_artifacts.py tests/unit/test_orchestration/test_prescribe_artifacts.py` — clean

## Manual test

N/A for unit-level validation. This change is entirely internal to the inbox-message construction path. The user-visible outcome (prescription subagent receives correct context and produces a WorkflowArtifact) requires WOS execution to be enabled (`wos-config.json` `execution_enabled: true`), which is explicitly out of scope per the task boundary.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A: change is internal to message construction, WOS execution is disabled per task boundary
- [x] User-visible outcome — N/A: this is an infrastructure fix; the user-visible outcome is the absence of heartbeat-stall restarts, which cannot be verified without enabling WOS execution
- [x] Side-effect audit: no floods, no unscoped writes (artifact files are one-per-UoW writes, bounded by WOS queue size)
- [x] External service calls: none — this is pure file I/O