### PR TITLE
fix: disable vestigial lobster-mcp.service restart loop (#1437)

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4841,6 +4841,59 @@ finally:
     substep "Migration 133: prescribing-silence TTL auto-reset (no schema change, no action required)"
     # Not counted in migrated — there is nothing to apply.
 
+    # Migration 134: Disable and stop lobster-mcp.service (vestigial HTTP bridge unit).
+    #
+    # lobster-mcp.service runs inbox_server_http.py and requires MCP_HTTP_TOKEN.
+    # The token was never added to the unit's environment, causing it to exit immediately
+    # with "No MCP_HTTP_TOKEN configured" on every start and re-enter the Restart=always
+    # cycle (~every 10s). At audit time (2026-06-06) the unit had restarted 43,894 times.
+    #
+    # This unit is vestigial: the live MCP server is inbox_server.py launched by the
+    # claude binary as a child of lobster-claude.service — NOT managed by this systemd
+    # unit. Confirmed: no other unit has Requires= or Wants= on lobster-mcp.service.
+    # lobster-wos-router.service had an After= ordering reference (already removed in this
+    # PR's services/lobster-wos-router.service), but After= is an ordering constraint only —
+    # it does not start the dependency.
+    #
+    # Fix: disable (prevent boot start) and stop (halt the current restart loop).
+    # The unit file is left in place so the history is visible, but it will no longer
+    # auto-start or restart. Reference: dcetlin/Lobster#1437.
+    if systemctl list-unit-files lobster-mcp.service --no-pager 2>/dev/null | grep -q "lobster-mcp.service"; then
+        local _mcp_enabled
+        _mcp_enabled=$(systemctl is-enabled lobster-mcp.service 2>/dev/null || echo "unknown")
+        local _mcp_active
+        _mcp_active=$(systemctl is-active lobster-mcp.service 2>/dev/null || echo "unknown")
+
+        if [ "$_mcp_active" != "inactive" ] && [ "$_mcp_active" != "unknown" ]; then
+            sudo systemctl stop lobster-mcp.service 2>/dev/null || true
+            substep "Migration 134: stopped lobster-mcp.service (was: $_mcp_active)"
+            migrated=$((migrated + 1))
+        fi
+
+        if [ "$_mcp_enabled" != "disabled" ] && [ "$_mcp_enabled" != "unknown" ]; then
+            sudo systemctl disable lobster-mcp.service 2>/dev/null || true
+            substep "Migration 134: disabled lobster-mcp.service (was: $_mcp_enabled)"
+            migrated=$((migrated + 1))
+        fi
+
+        # Also remove the stale After=lobster-mcp.service ordering from the installed
+        # wos-router unit, if it is present. The services/ directory file is already
+        # updated; this fixes the installed copy without requiring a full re-install.
+        local _wos_router_unit="/etc/systemd/system/lobster-wos-router.service"
+        if [ -f "$_wos_router_unit" ] && grep -q "lobster-mcp.service" "$_wos_router_unit"; then
+            sudo sed -i 's/After=network\.target lobster-mcp\.service/After=network.target/' "$_wos_router_unit"
+            sudo systemctl daemon-reload 2>/dev/null || true
+            substep "Migration 134: removed stale After=lobster-mcp.service from $_wos_router_unit"
+            migrated=$((migrated + 1))
+        fi
+
+        if [ "$_mcp_active" = "inactive" ] && [ "$_mcp_enabled" = "disabled" ]; then
+            substep "Migration 134: lobster-mcp.service already stopped and disabled — skipping"
+        fi
+    else
+        substep "Migration 134: lobster-mcp.service not installed — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/services/lobster-wos-router.service
+++ b/services/lobster-wos-router.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Lobster WOS Execute Router — mechanical wos_execute inbox routing daemon
 Documentation=https://github.com/dcetlin/Lobster/issues/940
-After=network.target lobster-mcp.service
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
## What this fixes

`lobster-mcp.service` has been restart-looping ~43,894 times (every ~10 seconds) because `MCP_HTTP_TOKEN` is missing from its systemd environment. The unit attempts to start `inbox_server_http.py`, fails immediately on the missing token check, exits with code 1, and systemd restarts it 10 seconds later — permanently.

This is pure noise in the journal that masks real restart signals from `lobster-claude.service`.

## Why it is safe to disable

Pre-merge verification confirms high confidence across three independent checks:

**1. The live MCP server is not this unit.** The live MCP server is `inbox_server.py` (PID 2080861), running in cgroup `/system.slice/lobster-claude.service`. It is launched by the claude binary as part of MCP connection initialization — not managed by any separate systemd unit.

**2. No other unit depends on `lobster-mcp.service` being up.** `systemctl show lobster-mcp.service --property=RequiredBy,WantedBy,BoundBy` returns empty for all three fields. Nothing pulls this unit up at boot or as a dependency.

**3. The one apparent reference is an ordering constraint, not a start dependency.** `lobster-wos-router.service` had `After=network.target lobster-mcp.service`. `After=` is a sequencing constraint only — it says "start after X if X is also starting," not "start X." `lobster-wos-router.service` has no `Requires=` or `Wants=` on `lobster-mcp.service`, and it has been running for 11+ hours without the lobster-mcp unit being functional (which exits in ~1 second and restarts).

## What changes

**`services/lobster-wos-router.service`** — removes the stale `After=lobster-mcp.service` ordering reference. The unit continues to work exactly as before; this cleans up the dead dependency.

**`scripts/upgrade.sh` — Migration 134** — on existing installs:
1. Stops `lobster-mcp.service` if active (halts the restart loop immediately)
2. Disables `lobster-mcp.service` if enabled (prevents boot-time start)
3. Removes the stale `After=lobster-mcp.service` from the installed `/etc/systemd/system/lobster-wos-router.service` via `sed -i` and calls `daemon-reload`
4. All steps are idempotent: each checks current state before acting and skips if already in the correct state

The unit file at `/etc/systemd/system/lobster-mcp.service` is not deleted — left in place for audit trail visibility, but the unit will no longer auto-start or restart.

## Flow (before vs after)

```
Before:
  lobster-mcp.service
    -> starts inbox_server_http.py
    -> exits immediately (MCP_HTTP_TOKEN missing)
    -> systemd restarts after 10s
    -> repeat every 10s, forever
    [43,894 restarts, journal flooding]

After:
  lobster-mcp.service  [disabled, stopped]
    -> no auto-start at boot
    -> no restart loop
    [unit file present for audit trail]

  lobster-wos-router.service
    -> After=network.target  (lobster-mcp.service reference removed)
    -> no behavioral change (After= was ordering-only, not a hard dep)
```

## Tests run
- [x] `systemctl show lobster-mcp.service --property=RequiredBy,WantedBy,BoundBy` — all empty; confirmed no reverse dependencies
- [x] `systemctl show lobster-wos-router.service --property=Requires,After,Wants,BindsTo` — Requires= does not include lobster-mcp.service; only After= reference; BindsTo= empty
- [x] Live MCP server cgroup check: `cat /proc/$(pgrep -f inbox_server.py)/cgroup` returns `/system.slice/lobster-claude.service` — live MCP is in lobster-claude cgroup, not managed by lobster-mcp.service
- [x] `lobster-wos-router.service` confirmed running for 11h without functional lobster-mcp.service (confirms After= is ordering-only, not a live dependency)
- [x] Migration idempotency: stop/disable/sed each guarded by current-state check before acting
- [ ] Running upgrade.sh migration 134 end-to-end — not run pre-merge (requires sudo in the production environment); the migration logic is `|| true`-guarded and idempotent

## Manual test

The change disables a systemd unit that has been start-failing every 10 seconds. The user-visible outcome is the absence of `lobster-mcp.service` restart entries in `journalctl`. I cannot self-verify the Telegram-visible outcome (no message is sent to the user for this fix). Verification after merge: `journalctl -u lobster-mcp.service -f` should show no new entries.

The migration does not touch `inbox_server.py`, `lobster-claude.service`, `lobster-mcp-local.service`, or any running MCP path. The live system is unaffected.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A: no Python changed
- [x] Integration/manual test run (if applicable) — dependency audit run live on production system
- [x] User-visible outcome verified OR not applicable — user-visible outcome is absence of journal noise, not a Telegram message; cannot self-verify but mechanism is structurally clear
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — migration is stop+disable+sed, all bounded
- [x] External service calls: mocked in tests, explicitly scoped in any manual runs — N/A

Closes #1437