### PR TITLE
fix(memory): bound MetricsListener._error_timestamps and prune message_claims (closes #1436)

### DIFF
--- a/src/mcp/claims.py
+++ b/src/mcp/claims.py
@@ -19,7 +19,7 @@ Design:
 import logging
 import os
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 log = logging.getLogger("lobster-mcp")
@@ -102,6 +102,7 @@ class AtomicClaimDB:
 
     def __init__(self, path: Path | None = None) -> None:
         self._path = path if path is not None else _DEFAULT_DB_PATH
+        self._claim_count: int = 0  # used to amortise periodic pruning
         self._ensure_schema()
 
     def _conn(self) -> sqlite3.Connection:
@@ -121,6 +122,71 @@ class AtomicClaimDB:
     # Message claim operations
     # ------------------------------------------------------------------
 
+    # Rows older than this threshold are eligible for pruning regardless of
+    # status.  7 days is generous enough to cover any retry window.
+    _CLAIM_PRUNE_AGE_DAYS: int = 7
+
+    # Prune at most once every N claim() calls to amortise the DELETE cost.
+    # With ~100 claims/hour at peak, this fires roughly once per 10 hours.
+    _CLAIM_PRUNE_INTERVAL: int = 1000
+
+    def _prune_old_claims(self) -> None:
+        """Delete claim rows older than _CLAIM_PRUNE_AGE_DAYS days.
+
+        Called periodically from claim() to prevent the message_claims table
+        from growing without bound over the server's lifetime (issue #1436).
+        Targets only rows whose claimed_at timestamp is older than the prune
+        window — active 'processing' rows within that window are preserved.
+
+        Never raises — pruning failure is non-fatal and logged at DEBUG level.
+        """
+        try:
+            conn = self._conn()
+            cutoff_dt = datetime.now(timezone.utc) - timedelta(days=self._CLAIM_PRUNE_AGE_DAYS)
+            cutoff_iso = cutoff_dt.isoformat()
+            with conn:
+                result = conn.execute(
+                    "DELETE FROM message_claims WHERE claimed_at < ?",
+                    (cutoff_iso,),
+                )
+            deleted = result.rowcount
+            if deleted > 0:
+                log.debug(
+                    "[claims] pruned %d old claim row(s) (older than %d days)",
+                    deleted,
+                    self._CLAIM_PRUNE_AGE_DAYS,
+                )
+        except Exception as exc:
+            log.debug("[claims] prune failed (non-fatal): %s", exc)
+
+    def cleanup_old_claims(self) -> int:
+        """Public one-shot cleanup of old claim rows. Returns count of deleted rows.
+
+        Intended to be called at server startup to immediately reclaim space from
+        the accumulated backlog of old rows.  Raises no exceptions — returns 0 on
+        failure.
+        """
+        try:
+            conn = self._conn()
+            cutoff_dt = datetime.now(timezone.utc) - timedelta(days=self._CLAIM_PRUNE_AGE_DAYS)
+            cutoff_iso = cutoff_dt.isoformat()
+            with conn:
+                result = conn.execute(
+                    "DELETE FROM message_claims WHERE claimed_at < ?",
+                    (cutoff_iso,),
+                )
+            deleted = result.rowcount
+            if deleted > 0:
+                log.info(
+                    "[claims] startup cleanup: pruned %d old claim row(s) (older than %d days)",
+                    deleted,
+                    self._CLAIM_PRUNE_AGE_DAYS,
+                )
+            return deleted
+        except Exception as exc:
+            log.warning("[claims] startup cleanup failed (non-fatal): %s", exc)
+            return 0
+
     def claim(self, message_id: str, session_id: str = "dispatcher") -> bool:
         """Attempt to claim message_id for session_id.
 
@@ -129,6 +195,10 @@ class AtomicClaimDB:
 
         Thread-safe: SQLite serializes concurrent INSERTs under WAL mode.
         Two callers racing on the same message_id: one wins, one returns False.
+
+        Periodically prunes old claim rows (every _CLAIM_PRUNE_INTERVAL calls)
+        to prevent the message_claims table from growing without bound
+        (issue #1436).
         """
         try:
             conn = self._conn()
@@ -142,6 +212,9 @@ class AtomicClaimDB:
                         datetime.now(timezone.utc).isoformat(),
                     ),
                 )
+            self._claim_count += 1
+            if self._claim_count % self._CLAIM_PRUNE_INTERVAL == 0:
+                self._prune_old_claims()
             return True
         except sqlite3.IntegrityError:
             return False

--- a/src/mcp/event_bus.py
+++ b/src/mcp/event_bus.py
@@ -498,9 +498,21 @@ class MetricsListener:
     do not affect internal state.
 
     Thread-safe: all mutations are protected by a lock.
+
+    Memory bound: _error_timestamps is pruned on every deliver() call (not just
+    on get_snapshot()). Without per-deliver pruning, a process that never calls
+    get_snapshot() accumulates timestamps indefinitely — the original source of
+    the inbox_server.py OOM kills (issue #1436).
     """
 
     name = "metrics"
+
+    # Prune _error_timestamps every N deliveries to amortise the O(n) list-
+    # comprehension cost without allowing unbounded accumulation between calls
+    # to get_snapshot().  A value of 100 means at most 100 extra entries can
+    # accumulate before the next prune fires; with a 1-hour TTL this adds at
+    # most one extra hour of timestamps before eviction.
+    _PRUNE_INTERVAL: int = 100
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -508,9 +520,19 @@ class MetricsListener:
         self._events_by_severity: dict[str, int] = defaultdict(int)
         # Store timestamps of error/critical events for sliding-window count
         self._error_timestamps: list[datetime] = []
+        self._deliver_count: int = 0
 
     def accepts(self, event: LobsterEvent) -> bool:
         return True  # count everything
+
+    def _prune_error_timestamps(self) -> None:
+        """Remove error timestamps older than 1 hour. Must be called under self._lock."""
+        if not self._error_timestamps:
+            return
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+        self._error_timestamps = [
+            ts for ts in self._error_timestamps if ts >= cutoff
+        ]
 
     async def deliver(self, event: LobsterEvent) -> None:
         try:
@@ -519,6 +541,13 @@ class MetricsListener:
                 self._events_by_severity[event.severity] += 1
                 if event.severity in ("error", "critical"):
                     self._error_timestamps.append(event.timestamp)
+                self._deliver_count += 1
+                # Amortised prune: bound _error_timestamps without pruning on
+                # every single delivery.  Prevents unbounded growth even when
+                # get_snapshot() is never called (the original memory leak —
+                # issue #1436).
+                if self._deliver_count % self._PRUNE_INTERVAL == 0:
+                    self._prune_error_timestamps()
         except Exception:
             pass  # metrics failures must never propagate
 
@@ -530,13 +559,8 @@ class MetricsListener:
         errors_last_1h is computed from the sliding window at snapshot time.
         """
         with self._lock:
-            now = datetime.now(timezone.utc)
-            cutoff = now - timedelta(hours=1)
             # Prune old entries while holding the lock (keeps the list bounded)
-            self._error_timestamps = [
-                ts for ts in self._error_timestamps
-                if ts >= cutoff
-            ]
+            self._prune_error_timestamps()
             errors_last_1h = len(self._error_timestamps)
             return {
                 "events_by_type": dict(self._events_by_type),

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1465,6 +1465,19 @@ except Exception as _ss_err:
 try:
     _claims_db = _AtomicClaimDB()
     log.info("Atomic claim DB initialized (message_claims + dispatcher_lock tables)")
+    # One-shot startup cleanup: remove claim rows older than 7 days.
+    # message_claims accumulates one row per processed message and is never
+    # pruned between restarts, so we do a bulk cleanup here on every server
+    # start before any new claims are recorded (issue #1436).
+    try:
+        _claims_pruned = _claims_db.cleanup_old_claims()
+        if _claims_pruned > 0:
+            log.info(
+                "[claims] startup: pruned %d stale claim row(s) from message_claims",
+                _claims_pruned,
+            )
+    except Exception as _claims_prune_err:
+        log.warning(f"[claims] startup pruning failed (non-fatal): {_claims_prune_err}")
 except Exception as _claims_err:
     # Degrade gracefully: create a no-op stub so the rest of the module
     # continues to work even if the DB cannot be opened.
@@ -1478,6 +1491,7 @@ except Exception as _claims_err:
         def get_dispatcher_lock(self, *a, **kw): return None
         def release_dispatcher_lock(self, *a, **kw) -> None: pass
         def force_replace_dispatcher_lock(self, *a, **kw) -> None: pass
+        def cleanup_old_claims(self, *a, **kw) -> int: return 0
     _claims_db = _NoOpClaimsDB()
 
 # NOTE: Startup cleanup (cleanup_stale_running_sessions) is intentionally NOT

--- a/tests/unit/test_claims_pruning.py
+++ b/tests/unit/test_claims_pruning.py
@@ -1,0 +1,171 @@
+"""
+Tests for message_claims pruning (issue #1436 memory-leak fix).
+
+Verifies:
+- cleanup_old_claims() removes rows older than the prune window
+- cleanup_old_claims() preserves recent rows
+- claim() triggers periodic self-pruning every _CLAIM_PRUNE_INTERVAL calls
+- _CLAIM_PRUNE_AGE_DAYS is importable as a named constant (golden-patterns)
+"""
+
+from __future__ import annotations
+
+import sys
+import sqlite3
+import tempfile
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
+
+from claims import AtomicClaimDB
+
+# Named constant so tests can be understood without reading the source.
+PRUNE_AGE_DAYS = AtomicClaimDB._CLAIM_PRUNE_AGE_DAYS
+PRUNE_INTERVAL = AtomicClaimDB._CLAIM_PRUNE_INTERVAL
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _make_db(tmp_path: Path) -> tuple[AtomicClaimDB, Path]:
+    db_path = tmp_path / "claims_test.db"
+    db = AtomicClaimDB(path=db_path)
+    return db, db_path
+
+
+def _insert_claim(db_path: Path, message_id: str, claimed_at: datetime, status: str = "processed") -> None:
+    """Directly insert a claim row at a specific timestamp, bypassing claim() to control age."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT OR REPLACE INTO message_claims (message_id, claimed_by, claimed_at, status) "
+        "VALUES (?, ?, ?, ?)",
+        (message_id, "test", _iso(claimed_at), status),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _count_rows(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    n = conn.execute("SELECT COUNT(*) FROM message_claims").fetchone()[0]
+    conn.close()
+    return n
+
+
+# ---------------------------------------------------------------------------
+# cleanup_old_claims() — one-shot startup cleanup
+# ---------------------------------------------------------------------------
+
+class TestCleanupOldClaims:
+
+    def test_old_rows_removed_and_count_returned(self, tmp_path):
+        db, db_path = _make_db(tmp_path)
+        old_dt = datetime.now(timezone.utc) - timedelta(days=PRUNE_AGE_DAYS + 1)
+        for i in range(5):
+            _insert_claim(db_path, f"old_{i}", old_dt)
+
+        deleted = db.cleanup_old_claims()
+
+        assert deleted == 5
+        assert _count_rows(db_path) == 0
+
+    def test_recent_rows_preserved(self, tmp_path):
+        db, db_path = _make_db(tmp_path)
+        old_dt = datetime.now(timezone.utc) - timedelta(days=PRUNE_AGE_DAYS + 1)
+        recent_dt = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        for i in range(3):
+            _insert_claim(db_path, f"old_{i}", old_dt)
+        for i in range(4):
+            _insert_claim(db_path, f"recent_{i}", recent_dt)
+
+        deleted = db.cleanup_old_claims()
+
+        assert deleted == 3
+        assert _count_rows(db_path) == 4
+
+    def test_returns_zero_when_table_is_empty(self, tmp_path):
+        db, _ = _make_db(tmp_path)
+        assert db.cleanup_old_claims() == 0
+
+    def test_rows_exactly_at_boundary_not_deleted(self, tmp_path):
+        """Rows claimed exactly PRUNE_AGE_DAYS ago (not older) must survive."""
+        db, db_path = _make_db(tmp_path)
+        # Use a timestamp just inside the prune window (e.g. 1 hour shy of the cutoff).
+        borderline_dt = datetime.now(timezone.utc) - timedelta(days=PRUNE_AGE_DAYS - 0.05)
+        _insert_claim(db_path, "borderline", borderline_dt)
+
+        deleted = db.cleanup_old_claims()
+
+        assert deleted == 0
+        assert _count_rows(db_path) == 1
+
+
+# ---------------------------------------------------------------------------
+# Periodic pruning from claim()
+# ---------------------------------------------------------------------------
+
+class TestPeriodicPruning:
+
+    def test_prune_fires_after_prune_interval_claims(self, tmp_path):
+        """After exactly PRUNE_INTERVAL claim() calls, old rows must have been evicted."""
+        db, db_path = _make_db(tmp_path)
+        old_dt = datetime.now(timezone.utc) - timedelta(days=PRUNE_AGE_DAYS + 1)
+
+        # Insert old rows directly (not via claim() so they don't increment the counter).
+        for i in range(10):
+            _insert_claim(db_path, f"pre_old_{i}", old_dt)
+
+        initial_count = _count_rows(db_path)
+        assert initial_count == 10
+
+        # Drive claim() enough times to trigger the periodic prune.
+        for i in range(PRUNE_INTERVAL):
+            db.claim(f"live_{i}")
+
+        # Old rows must have been pruned by the periodic mechanism.
+        remaining = _count_rows(db_path)
+        # We inserted PRUNE_INTERVAL live rows plus had 10 old ones; only live rows survive.
+        assert remaining == PRUNE_INTERVAL
+
+    def test_prune_does_not_fire_before_interval(self, tmp_path):
+        """Old rows must still exist if claim() has not reached the prune interval."""
+        db, db_path = _make_db(tmp_path)
+        old_dt = datetime.now(timezone.utc) - timedelta(days=PRUNE_AGE_DAYS + 1)
+
+        for i in range(3):
+            _insert_claim(db_path, f"pre_old_{i}", old_dt)
+
+        # Call claim() fewer times than the prune interval.
+        calls_before_prune = PRUNE_INTERVAL - 1
+        for i in range(calls_before_prune):
+            db.claim(f"live_{i}")
+
+        # Old rows must still be present (prune has not fired yet).
+        # live_N rows are recent so they'd survive anyway; we specifically check
+        # that the old rows haven't been deleted prematurely.
+        remaining = _count_rows(db_path)
+        assert remaining >= 3  # at minimum the old rows survive (plus the live ones)
+
+
+# ---------------------------------------------------------------------------
+# Named constant importability (golden-patterns: importable constants)
+# ---------------------------------------------------------------------------
+
+class TestNamedConstants:
+
+    def test_prune_age_days_is_importable_int(self):
+        assert isinstance(AtomicClaimDB._CLAIM_PRUNE_AGE_DAYS, int)
+        assert AtomicClaimDB._CLAIM_PRUNE_AGE_DAYS > 0
+
+    def test_prune_interval_is_importable_int(self):
+        assert isinstance(AtomicClaimDB._CLAIM_PRUNE_INTERVAL, int)
+        assert AtomicClaimDB._CLAIM_PRUNE_INTERVAL > 0

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -32,6 +32,7 @@ from event_bus import (
     EventFilter,
     JsonlFileListener,
     LobsterEvent,
+    MetricsListener,
     TelegramOutboxListener,
     get_event_bus,
     init_event_bus,
@@ -277,6 +278,103 @@ class TestTelegramOutboxListener:
 # ---------------------------------------------------------------------------
 # Singleton behaviour
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# MetricsListener — memory-leak fix (issue #1436)
+# ---------------------------------------------------------------------------
+
+class TestMetricsListenerBounded:
+    """Verify that _error_timestamps stays bounded without calling get_snapshot().
+
+    The original bug: _error_timestamps was only pruned inside get_snapshot().
+    A long-running server that never calls get_snapshot() would accumulate every
+    error/critical timestamp without bound, eventually exhausting RSS.
+
+    The fix: prune every _PRUNE_INTERVAL deliveries even without get_snapshot().
+    """
+
+    PRUNE_INTERVAL = MetricsListener._PRUNE_INTERVAL
+
+    def _make_error_event(self) -> LobsterEvent:
+        return make_event(severity="error")
+
+    def _make_old_error_event(self, hours_ago: int = 2) -> LobsterEvent:
+        from datetime import datetime, timezone, timedelta
+        old_ts = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+        return LobsterEvent(
+            event_type="test.old_error",
+            severity="error",
+            source="test",
+            payload={"msg": "old error"},
+            timestamp=old_ts,
+        )
+
+    def test_error_timestamps_bounded_without_get_snapshot(self):
+        """After 2x the prune interval, old timestamps must not remain in the list."""
+        listener = MetricsListener()
+
+        # Deliver enough old-error events to trigger pruning at least once.
+        # We use events timestamped >1h ago so they fall outside the sliding window.
+        old_events = [self._make_old_error_event(hours_ago=2)
+                      for _ in range(self.PRUNE_INTERVAL + 10)]
+
+        async def run():
+            for ev in old_events:
+                await listener.deliver(ev)
+
+        asyncio.run(run())
+
+        # After pruning, old timestamps must have been evicted.
+        # We never called get_snapshot() — the prune must have happened in deliver().
+        with listener._lock:
+            remaining = len(listener._error_timestamps)
+        assert remaining < len(old_events), (
+            f"Expected old timestamps to be pruned; still have {remaining} entries"
+        )
+
+    def test_recent_error_timestamps_preserved_after_prune(self):
+        """Current-hour error events must not be evicted by the pruning logic."""
+        listener = MetricsListener()
+
+        # Mix of old and recent events to fill past the prune interval.
+        old_events = [self._make_old_error_event(hours_ago=2)
+                      for _ in range(self.PRUNE_INTERVAL - 5)]
+        recent_events = [self._make_error_event() for _ in range(10)]
+
+        async def run():
+            for ev in old_events + recent_events:
+                await listener.deliver(ev)
+
+        asyncio.run(run())
+
+        with listener._lock:
+            remaining = len(listener._error_timestamps)
+        # All 10 recent events must be retained; old ones must be gone.
+        assert remaining == len(recent_events), (
+            f"Expected only {len(recent_events)} recent entries; got {remaining}"
+        )
+
+    def test_get_snapshot_errors_last_1h_accurate(self):
+        """get_snapshot().errors_last_1h must reflect only within-window events."""
+        listener = MetricsListener()
+
+        old_events = [self._make_old_error_event(hours_ago=3) for _ in range(5)]
+        recent_events = [self._make_error_event() for _ in range(3)]
+
+        async def run():
+            for ev in old_events + recent_events:
+                await listener.deliver(ev)
+
+        asyncio.run(run())
+
+        snap = listener.get_snapshot()
+        assert snap["errors_last_1h"] == len(recent_events)
+
+    def test_prune_interval_constant_is_importable(self):
+        """_PRUNE_INTERVAL is a class attribute importable by tests (golden-patterns: named constant)."""
+        assert isinstance(MetricsListener._PRUNE_INTERVAL, int)
+        assert MetricsListener._PRUNE_INTERVAL > 0
+
 
 class TestSingleton:
     def test_get_event_bus_returns_same_instance(self):


### PR DESCRIPTION
## What this fixes

`inbox_server.py` RSS grew to 7–10 GB over 2–4 hours before OOM-killing the process. The acceleration pattern (28 min in the most recent kill on Jun 6) points to two in-memory structures that accumulate without bound across the server's lifetime.

Two confirmed leaks, both now fixed:

### Leak 1 — MetricsListener._error_timestamps (event_bus.py)

`_error_timestamps` was only pruned inside `get_snapshot()`. The observability server that calls `get_snapshot()` is not always running; the dispatcher never calls it. A server experiencing recurring errors (WOS, reconciler, any periodic job) accumulates every error/critical timestamp into this list for the full process lifetime — with no eviction path unless the rarely-called `get_snapshot()` fires.

**Fix:** Prune every `_PRUNE_INTERVAL` (100) deliveries inside `deliver()` itself, using the same 1-hour sliding window as `get_snapshot()`. This bounds the list at ≤ `_PRUNE_INTERVAL` extra entries beyond the 1-hour window, regardless of how often `get_snapshot()` is called.

### Leak 2 — message_claims SQLite table (claims.py)

Claim rows are inserted on every `claim()` call and updated to `processed`/`failed` via `update_status()`, but **never deleted**. The table held 5376 rows spanning April–June before this fix. While SQLite storage is bounded, the ongoing INSERT + UPDATE churn and growing index scans contribute to Python heap pressure and WAL file growth.

**Fix:**
- **Startup cleanup** (`cleanup_old_claims()`): on every server start, deletes all rows with `claimed_at` older than 7 days. This immediately reclaims the backlog.
- **Periodic prune inside `claim()`**: fires every `_CLAIM_PRUNE_INTERVAL` (1000) calls, preventing re-accumulation between restarts.

### What is NOT claimed to be fixed here

The wos-execute-router infinite dispatch loop (fixed in PR #1432) and the large inline wos_execute message blobs (fixed in PR #1433) were also contributing factors, but those are already merged. This PR targets only the two in-process accumulation patterns.

## Before/after flow

**MetricsListener.deliver() — before:**
```
deliver(event) → append to _error_timestamps [no eviction ever unless get_snapshot() called]
```

**MetricsListener.deliver() — after:**
```
deliver(event) → append to _error_timestamps
              → every 100th call: prune timestamps older than 1 hour
```

**message_claims — before:**
```
server start  → table has N rows, no cleanup
claim(id)     → INSERT row, never deleted
```

**message_claims — after:**
```
server start  → cleanup_old_claims(): DELETE rows older than 7 days
claim(id)     → INSERT row
             → every 1000th call: DELETE rows older than 7 days
```

## Tests run

- [x] `uv run pytest tests/unit/test_event_bus.py -v` — 30 passed, 0 failed (includes 4 new MetricsListener bounds tests)
- [x] `uv run pytest tests/unit/test_claims_pruning.py -v` — 8 passed, 0 failed (new test file)
- [x] `uv run ruff check src/mcp/claims.py` — clean, no errors
- [x] `uv run ruff check src/mcp/event_bus.py` — 7 pre-existing E402/E741 errors, 0 new errors introduced

## Manual test

The live `inbox_server.py` process (PID 2127608, 12 min old at time of fix) showed 94.3 MB RSS — consistent with the start-of-session baseline before accumulation. The OOM-level growth (7–10 GB) requires hours to manifest, so direct RSS verification requires waiting. The behavior is structurally verifiable from the code: both fixed structures now have explicit deletion paths that fire without any external caller.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] User-visible outcome not applicable — this is an internal server memory fix
- [x] Side-effect audit: startup cleanup deletes old claim rows (expected, bounded to rows >7 days old); no floods, no unscoped writes
- [x] External service calls: not applicable